### PR TITLE
add a cabal.project file for new-build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ TAGS
 unitTest.tix
 hpc_report
 stack.yaml
+/dist-newstyle

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,23 @@
+-- note: since new-build does not yet support adding custom
+-- (non-alex/happy/etc) build tools to the path, you will have to do
+-- something like this before building:
+--
+-- export PATH=$PWD/dist-newstyle/build/x86_64-linux/ghc-7.10.3/hpb-0.1.1/c/hpb/build/hpb:$PATH
+
+packages:
+  crucible/
+  crucible-abc/
+  crucible-blt/
+  crucible-saw/
+  crucible-server/
+  galois-matlab/
+
+optional-packages:
+  dependencies/abcBridge/
+  dependencies/aig/
+  dependencies/blt/
+  dependencies/hpb/
+  dependencies/llvm-pretty/
+  dependencies/llvm-pretty-bc-parser/
+  dependencies/parameterized-utils/
+  dependencies/saw-core/


### PR DESCRIPTION
Seems like `new-build` mostly works smoothly, just the noted issue with the path for `hpb`