### PR TITLE
Small SimpleBoundVar changes

### DIFF
--- a/crucible/src/Lang/Crucible/Solver/SimpleBuilder.hs
+++ b/crucible/src/Lang/Crucible/Solver/SimpleBuilder.hs
@@ -95,6 +95,7 @@ module Lang.Crucible.Solver.SimpleBuilder
   , VarKind(..)
   , boundVars
   , ppBoundVar
+  , evalBoundVars
     -- * Symbolic Function
   , SimpleSymFn(..)
   , SymFnInfo(..)

--- a/crucible/src/Lang/Crucible/Solver/SimpleBuilder.hs
+++ b/crucible/src/Lang/Crucible/Solver/SimpleBuilder.hs
@@ -1625,8 +1625,8 @@ boundVars' _ _ = return Set.empty
 ------------------------------------------------------------------------
 -- Pretty printing
 
-ppVar :: String -> Nonce t tp -> BaseTypeRepr tp -> String
-ppVar pr i tp = pr ++ show (indexValue i) ++ ":" ++ ppVarTypeCode tp
+ppVar :: String -> SolverSymbol -> Nonce t tp -> BaseTypeRepr tp -> String
+ppVar pr sym i tp = pr ++ show sym ++ "@" ++ show (indexValue i) ++ ":" ++ ppVarTypeCode tp
 
 instance Show (Elt t tp) where
   show = show . pretty
@@ -1637,10 +1637,12 @@ instance Pretty (Elt t tp) where
 ppBoundVar :: SimpleBoundVar t tp -> String
 ppBoundVar v =
   case bvarKind v of
-    QuantifierVarKind -> ppVar "?" (bvarId  v) (bvarType v)
-    LatchVarKind   -> ppVar "l" (bvarId  v) (bvarType v)
-    UninterpVarKind -> ppVar "c" (bvarId  v) (bvarType v)
+    QuantifierVarKind -> ppVar "?" (bvarName v) (bvarId v) (bvarType v)
+    LatchVarKind   -> ppVar "l" (bvarName v) (bvarId v) (bvarType v)
+    UninterpVarKind -> ppVar "c" (bvarName v) (bvarId v) (bvarType v)
 
+instance ShowF (SimpleBoundVar t) where
+  showsF v = shows (ppBoundVar v)
 
 -- | @AppPPElt@ represents a an application, and it may be let bound.
 data AppPPElt


### PR DESCRIPTION
First commit exports `Lang.Crucible.Solver.SimpleBuilder.evalBoundVars`. This is pretty uncontroversial IMO.

Second commit adds the name when printing bound variables. This is very useful when debugging (semi-)manually created expressions, to be able to refer to a variable named "Reg1" rather than just a nonce. The nonce is still there, so the names are still unique. The commit also adds a `ShowF` instance to `SimpleBoundVar t` that does the obvious.