### PR TITLE
Fix SimpleBuilder.boundVars when the expression is just a bound var

### DIFF
--- a/crucible/src/Lang/Crucible/Solver/SimpleBuilder.hs
+++ b/crucible/src/Lang/Crucible/Solver/SimpleBuilder.hs
@@ -1680,8 +1680,11 @@ boundVars' visited (NonceAppElt e) = do
   cache visited (ExprPPIndex idx) $ do
     sums <- sequence (toListFC (boundVars' visited) (nonceEltApp e))
     return $ foldl' Set.union Set.empty sums
-boundVars' _ (BoundVarElt v)
-  | QuantifierVarKind <- bvarKind v = return (Set.singleton (Some v))
+boundVars' visited (BoundVarElt v)
+  | QuantifierVarKind <- bvarKind v = do
+      let idx = indexValue (bvarId v)
+      cache visited (ExprPPIndex idx) $
+        return (Set.singleton (Some v))
 boundVars' _ _ = return Set.empty
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
Arguably, we should also insert `Set.empty` into the hash table for all other elements, but I think it's a reasonable default to assume that if an ID isn't in the table, then it's empty.