### PR TITLE
Fix/metadata

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation.hs
@@ -331,6 +331,8 @@ instrResultType instr =
     L.Conv _ _ ty -> ty
     L.Call _ (L.PtrTo (L.FunTy ty _ _)) _ _ -> ty
     L.Call _ ty _ _ -> error $ unwords ["unexpected function type in call:", show ty]
+    L.Invoke (L.FunTy ty _ _) _ _ _ _ -> ty
+    L.Invoke ty _ _ _ _ -> error $ unwords ["unexpected function type in invoke:", show ty]
     L.Alloca ty _ _ -> L.PtrTo ty
     L.Load x _ _ -> case L.typedType x of
                    L.PtrTo ty -> ty

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation.hs
@@ -2087,6 +2087,8 @@ processDbgDeclare = snd . go
               --error $ "Identifier not found: " ++ show x ++ "\nPossible identifiers: " ++ show (Map.keys m)
         L.Effect (L.Call _ _ (L.ValSymbol "llvm.dbg.declare") (L.Typed _ (L.ValMd (L.ValMdValue (L.Typed _ (L.ValIdent x)))) : _)) md ->
           (Map.insert x md m, stmt : stmts')
+        L.Effect (L.Call _ _ (L.ValSymbol "llvm.dbg.declare") (L.Typed _ (L.ValMd (L.ValMdValue (L.Typed _ L.ValUndef))) : _)) _md ->
+          (m, stmt:stmts') -- ignore Metadata when ValUndef.
         L.Effect (L.Call _ _ (L.ValSymbol "llvm.dbg.declare") args) md ->
           error $ "Ill-formed arguments to llvm.dbg.declare: " ++ show (args, md)
         _ -> (m, stmt : stmts')


### PR DESCRIPTION
Sometimes metadata does not include an explicit symbol and instead uses ValUndef.  It seems to occur in some situations when using `llvm-link`.  At the expense of less-useful error messages, we can simply ignore these sorts of calls.