### PR TITLE
Reimplement Crucible.CFG.Generator api using an indexed state monad.

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation.hs
@@ -1621,11 +1621,9 @@ caseptr w tpr bvCase ptrCase x =
   where
   ptrSwitch blk off =
     do cond <- mkAtom (blk .== litExpr 0)
-       bv_label  <- newLabel
-       ptr_label <- newLabel
        c_label  <- newLambdaLabel' tpr
-       defineBlock bv_label  (bvCase off >>= jumpToLambda c_label)
-       defineBlock ptr_label (ptrCase blk off >>= jumpToLambda c_label)
+       bv_label <- defineBlockLabel (bvCase off >>= jumpToLambda c_label)
+       ptr_label <- defineBlockLabel (ptrCase blk off >>= jumpToLambda c_label)
        resume (Br cond bv_label ptr_label) c_label
 
 intcmp :: (1 <= w)
@@ -2083,10 +2081,8 @@ generateInstr retType lab instr assign_f k =
                  Scalar (LLVMPointerRepr w) e -> notExpr <$> callIsNull w e
                  _ -> fail "expected boolean condition on branch"
 
-        phi1 <- newLabel
-        phi2 <- newLabel
-        defineBlock phi1 (definePhiBlock lab l1)
-        defineBlock phi2 (definePhiBlock lab l2)
+        phi1 <- defineBlockLabel (definePhiBlock lab l1)
+        phi2 <- defineBlockLabel (definePhiBlock lab l2)
         branch e' phi1 phi2
 
     L.Switch x def branches -> do

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation.hs
@@ -1620,11 +1620,11 @@ caseptr w tpr bvCase ptrCase x =
             ptrSwitch blk off
   where
   ptrSwitch blk off =
-    do cond <- mkAtom (blk .== litExpr 0)
+    do let cond = (blk .== litExpr 0)
        c_label  <- newLambdaLabel' tpr
        bv_label <- defineBlockLabel (bvCase off >>= jumpToLambda c_label)
        ptr_label <- defineBlockLabel (ptrCase blk off >>= jumpToLambda c_label)
-       continueLambda (Br cond bv_label ptr_label) c_label
+       continueLambda c_label (branch cond bv_label ptr_label)
 
 intcmp :: (1 <= w)
     => NatRepr w

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation.hs
@@ -2373,7 +2373,7 @@ genDefn defn retType =
         Nothing -> fail $ unwords ["entry label not found in label map:", show entry_lab]
         Just entry_bi -> do
           mapM_ (defineLLVMBlock retType bim) (L.defBody defn)
-          terminateEarly =<< jump (block_label entry_bi)
+          jump (block_label entry_bi)
 
 ------------------------------------------------------------------------
 -- transDefine

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation.hs
@@ -1624,7 +1624,7 @@ caseptr w tpr bvCase ptrCase x =
        c_label  <- newLambdaLabel' tpr
        bv_label <- defineBlockLabel (bvCase off >>= jumpToLambda c_label)
        ptr_label <- defineBlockLabel (ptrCase blk off >>= jumpToLambda c_label)
-       resume (Br cond bv_label ptr_label) c_label
+       continueLambda (Br cond bv_label ptr_label) c_label
 
 intcmp :: (1 <= w)
     => NatRepr w

--- a/crucible/src/Lang/Crucible/CFG/Generator.hs
+++ b/crucible/src/Lang/Crucible/CFG/Generator.hs
@@ -565,26 +565,6 @@ newLambdaLabelG' tpr = Generator $ do
                }
   return $! lbl
 
-{-
--- | Define the current block by defining the position and
--- final statement.  This returns the user state after the
--- block is finished.
-endCurrentBlock :: IsSyntaxExtension ext
-                => TermStmt s ret
-                -> End ext h s t ret ()
-endCurrentBlock term = End $ do
-  gs <- get
-  let p = gs^.gsPosition
-  let Just cbs = gs^.gsCurrent
-  -- Clear current state.
-  gsCurrent .= Nothing
-  -- Define block
-  let b = mkBlock (cbsBlockID cbs) (cbsInputValues cbs) (cbs^.cbsStmts) (Posd p term)
-  -- Store block
-  seq b $ do
-  gsBlocks %= (Seq.|> b)
--}
-
 -- | End the translation of the current block, and then start a new
 -- block with the given label.
 resume_ ::

--- a/crucible/src/Lang/Crucible/CFG/SSAConversion.hs
+++ b/crucible/src/Lang/Crucible/CFG/SSAConversion.hs
@@ -414,7 +414,7 @@ inferBlockInfo blocks = seq input_map $ go bi0 blocks
                   go bi' rest
 
 ------------------------------------------------------------------------
--- Translates from RTL with inference inforamtion to SSA.
+-- Translates from RTL with inference information to SSA.
 
 data MaybeF f tp where
   JustF :: f tp -> MaybeF f tp
@@ -520,7 +520,7 @@ bindValueReg r cr (TypedRegMap m) =
 
 #endif
 
--- | Assign new register to value in tpyed reg map.
+-- | Assign new register to value in typed reg map.
 assignRegister
     :: Value s tp
     -> Size ctx


### PR DESCRIPTION
The new API ensures that every block must end with exactly one
terminating statement, and avoids the use of continuations.

This patch still needs some work:
* The types of `newLabel` and `newLambdaLabel` need to be generalized so they can work in either monad. Currently there are variant functions with munged names for the `Generator` monad.
* We should consider renaming the `Generator` and `End` monads; also the `resume` and `resume_` operators could have better names.

A deeper issue that affects the `crucible-llvm` frontend (and probably also other translations into crucible) is that the return type of `reportError` is no longer `Generator ext h s t ret a` but `Generator ext h s t ret (TermStmt s ret)`. This means that it in the new API you can't use `reportError` the same way that `fail` is used to indicate an exception.

We could fix this limitation by adding support for exceptions to the `IxGenerator` monad, and have terminal-statement generator functions like `reportError` throw an exception containing the terminal statement.