### PR TITLE
Mux trees for reference values

### DIFF
--- a/crucible/crucible.cabal
+++ b/crucible/crucible.cabal
@@ -30,7 +30,7 @@ library
     base >= 4.8 && < 4.12,
     ansi-wl-pprint,
     bytestring,
-    containers >= 0.5.0.0,
+    containers >= 0.5.9.0,
     fgl,
     filepath,
     hashable,
@@ -90,6 +90,7 @@ library
     Lang.Crucible.Utils.BitSet
     Lang.Crucible.Utils.CoreRewrite
     Lang.Crucible.Utils.MonadVerbosity
+    Lang.Crucible.Utils.MuxTree
     Lang.Crucible.Utils.PrettyPrint
     Lang.Crucible.Utils.StateContT
     Lang.Crucible.Utils.Structural

--- a/crucible/src/Lang/Crucible/FunctionHandle.hs
+++ b/crucible/src/Lang/Crucible/FunctionHandle.hs
@@ -41,6 +41,7 @@ module Lang.Crucible.FunctionHandle
 
 import           Control.Monad.ST
 import           Data.Hashable
+import           Data.Ord (comparing)
 
 import qualified Data.Parameterized.Context as Ctx
 import           Data.Parameterized.Classes
@@ -71,6 +72,9 @@ data FnHandle (args :: Ctx CrucibleType) (ret :: CrucibleType)
 
 instance Eq (FnHandle args ret) where
   h1 == h2 = handleID h1 == handleID h2
+
+instance Ord (FnHandle args ret) where
+  compare h1 h2 = comparing handleID h1 h2
 
 instance Show (FnHandle args ret) where
   show h = show (handleName h)
@@ -152,6 +156,12 @@ instance OrdF RefCell where
       LTF -> LTF
       EQF -> EQF
       GTF -> GTF
+
+instance Eq (RefCell tp) where
+  x == y = isJust (testEquality x y)
+
+instance Ord (RefCell tp) where
+  compare x y = toOrdering (compareF x y)
 
 ------------------------------------------------------------------------
 -- FnHandleMap

--- a/crucible/src/Lang/Crucible/Simulator/Evaluation.hs
+++ b/crucible/src/Lang/Crucible/Simulator/Evaluation.hs
@@ -58,6 +58,7 @@ import           Lang.Crucible.Simulator.Intrinsics
 import           Lang.Crucible.Simulator.RegMap
 import           Lang.Crucible.Simulator.SimError
 import           Lang.Crucible.Types
+import           Lang.Crucible.Utils.MuxTree
 
 ------------------------------------------------------------------------
 -- Utilities
@@ -707,6 +708,5 @@ evalApp sym itefns _logFn evalExt evalSub a0 = do
     ReferenceEq _ ref1 ref2 -> do
       cell1 <- evalSub ref1
       cell2 <- evalSub ref2
-      case testEquality cell1 cell2 of
-        Just Refl -> return (truePred sym)
-        Nothing -> return (falsePred sym)
+      let f r1 r2 = return (backendPred sym (r1 == r2))
+      muxTreeCmpOp sym f cell1 cell2

--- a/crucible/src/Lang/Crucible/Simulator/GlobalState.hs
+++ b/crucible/src/Lang/Crucible/Simulator/GlobalState.hs
@@ -10,6 +10,7 @@ module Lang.Crucible.Simulator.GlobalState
   , insertRef
   , lookupRef
   , dropRef
+  , updateRef
   , globalPushBranch
   , globalAbortBranch
   , globalMuxFn
@@ -76,6 +77,18 @@ insertRef :: IsExprBuilder sym
 insertRef sym r v gst =
    let x = RefCellContents (truePred sym) v in
    gst{ globalReferenceMap = MapF.insert r x (globalReferenceMap gst) }
+
+
+updateRef ::
+  IsExprBuilder sym =>
+  RefCell tp ->
+  PartExpr (Pred sym) (RegValue sym tp) ->
+  SymGlobalState sym ->
+  SymGlobalState sym
+updateRef r Unassigned gst =
+  gst{ globalReferenceMap = MapF.delete r (globalReferenceMap gst) }
+updateRef r (PE p x) gst =
+  gst{ globalReferenceMap = MapF.insert r (RefCellContents p x) (globalReferenceMap gst) }
 
 dropRef :: RefCell tp
         -> SymGlobalState sym

--- a/crucible/src/Lang/Crucible/Simulator/RegMap.hs
+++ b/crucible/src/Lang/Crucible/Simulator/RegMap.hs
@@ -54,6 +54,7 @@ import           Lang.Crucible.CFG.Core (Reg(..))
 import           Lang.Crucible.Simulator.Intrinsics
 import           Lang.Crucible.Simulator.RegValue
 import           Lang.Crucible.Types
+import           Lang.Crucible.Utils.MuxTree
 
 ------------------------------------------------------------------------
 -- RegMap
@@ -107,9 +108,7 @@ muxAny s itefns p (AnyValue tpx x) (AnyValue tpy y)
 muxReference :: IsExprBuilder sym
              => sym
              -> ValMuxFn sym (ReferenceType tp)
-muxReference _s _p rx ry
-  | Just Refl <- testEquality rx ry = return rx
-  | otherwise = fail $ unwords ["Attempted to merge distinct reference cells"]
+muxReference s = mergeMuxTree s
 
 {-# INLINABLE pushBranchForType #-}
 pushBranchForType :: forall sym tp

--- a/crucible/src/Lang/Crucible/Simulator/RegValue.hs
+++ b/crucible/src/Lang/Crucible/Simulator/RegValue.hs
@@ -68,6 +68,7 @@ import           What4.WordMap
 import           Lang.Crucible.FunctionHandle
 import           Lang.Crucible.Simulator.Intrinsics
 import           Lang.Crucible.Types
+import           Lang.Crucible.Utils.MuxTree
 
 type MuxFn p v = p -> v -> v -> IO v
 
@@ -82,7 +83,7 @@ type family RegValue (sym :: *) (tp :: CrucibleType) :: * where
   RegValue sym (VectorType tp) = V.Vector (RegValue sym tp)
   RegValue sym (StructType ctx) = Ctx.Assignment (RegValue' sym) ctx
   RegValue sym (VariantType ctx) = Ctx.Assignment (VariantBranch sym) ctx
-  RegValue sym (ReferenceType a) = RefCell a
+  RegValue sym (ReferenceType a) = MuxTree sym (RefCell a)
   RegValue sym (WordMapType w tp) = WordMap sym w tp
   RegValue sym (RecursiveType nm ctx) = RolledType sym nm ctx
   RegValue sym (IntrinsicType nm ctx) = Intrinsic sym nm ctx
@@ -220,7 +221,7 @@ mergePartExpr :: IsExprBuilder sym
               -> PartExpr (Pred sym) v
               -> PartExpr (Pred sym) v
               -> IO (PartExpr (Pred sym) v)
-mergePartExpr sym fn c = mergePartial sym (\a b -> lift (fn c a b)) c
+mergePartExpr sym fn c = mergePartial sym (\c' a b -> lift (fn c' a b)) c
 
 instance (IsExprBuilder sym, CanMux sym tp) => CanMux sym (MaybeType tp) where
   {-# INLINE muxReg #-}

--- a/crucible/src/Lang/Crucible/Utils/MuxTree.hs
+++ b/crucible/src/Lang/Crucible/Utils/MuxTree.hs
@@ -1,0 +1,179 @@
+{-|
+Module           : Lang.Crucible.Utils.MuxTree
+Copyright        : (c) Galois, Inc 2018
+License          : BSD3
+Maintainer       : Rob Dockins <rdockins@galois.com>
+
+This module defines a @MuxTree@ type that notionally represents
+a collection of values organized into an if-then-else tree.  This
+data structure allows values that otherwise do not have a useful notion
+of symbolic values to nonetheless be merged as control flow merge points
+by simply remembering which concrete values were obtained, and the
+logical conditions under which they were found.
+
+Note that we require an @Ord@ instance on the type @a@ over which we are
+building the mux trees.  It is sufficent that this operation be merely
+syntactic equality; it is not necessary for correctness that terms with
+the same semantics compare equal.
+-}
+
+{-# LANGUAGE FlexibleContexts #-}
+module Lang.Crucible.Utils.MuxTree
+  ( MuxTree
+  , toMuxTree
+  , mergeMuxTree
+  , viewMuxTree
+  , muxTreeUnaryOp
+  , muxTreeBinOp
+  , muxTreeCmpOp
+  , collapseMuxTree
+  ) where
+
+import           Control.Lens (folded)
+
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import qualified Data.Map.Merge.Strict as Map
+
+import           What4.Interface
+
+-- | A mux tree represents a collection of if-then-else branches over
+--   a collection of values.  Generally, a mux tree is used to provide
+--   a way to conditionally merge values that otherwise do not
+--   naturally have a merge operation.
+newtype MuxTree sym a = MuxTree (Map a (Pred sym))
+
+-- Turn a single value into a trivial mux tree
+toMuxTree :: IsExprBuilder sym => sym -> a -> MuxTree sym a
+toMuxTree sym v = MuxTree (Map.singleton v (truePred sym))
+
+-- View all the leaf values of the mux tree, along with the
+-- conditions that lead to those values.
+viewMuxTree :: MuxTree sym a -> [(a, Pred sym)]
+viewMuxTree (MuxTree m) = Map.toList m
+
+_conditionMuxTree :: IsExprBuilder sym => sym -> Pred sym -> MuxTree sym a -> IO (MuxTree sym a)
+_conditionMuxTree sym p (MuxTree m) = MuxTree <$> Map.traverseMaybeWithKey (conditionMuxTreeLeaf sym p) m
+
+-- | Compute a binary boolean predicate between two mux trees.
+--   This operation decomposes the mux trees and compares the
+--   all combinations of the underlying values, conditional on
+--   the path conditions leading to those values.
+muxTreeCmpOp ::
+  IsExprBuilder sym =>
+  sym ->
+  (a -> a -> IO (Pred sym)) {- ^ compute the predicate on the underlying type -} ->
+  MuxTree sym a ->
+  MuxTree sym a ->
+  IO (Pred sym)
+muxTreeCmpOp sym f xt yt = orOneOf sym folded =<< sequence zs
+  where
+  zs = [ do pf <- f x y
+            andPred sym pf =<< andPred sym px py
+       | (x,px) <- xs
+       , (y,py) <- ys
+       ]
+  xs = viewMuxTree xt
+  ys = viewMuxTree yt
+
+-- | Use the provided if-then-else operation to collapse the given mux tree
+--   into its underlying type.
+collapseMuxTree ::
+  IsExprBuilder sym =>
+  sym ->
+  (Pred sym -> a -> a -> IO a) ->
+  MuxTree sym a ->
+  IO a
+collapseMuxTree _sym ite xt = go (viewMuxTree xt)
+  where
+  go []         = fail "Impossible: collapseMuxTree was given an empty mux tree"
+  go [(x,_p)]   = return x
+  go ((x,p):xs) = ite p x =<< go xs
+
+buildMuxTree ::
+  (Ord a, IsExprBuilder sym) =>
+  sym ->
+  [(a, Pred sym)] ->
+  IO (MuxTree sym a)
+buildMuxTree _sym [] = fail "buildMuxTree: cannot build an empty mux tree"
+buildMuxTree sym  xs = go Map.empty xs
+  where
+  go m [] = return (MuxTree m)
+  go m ((z,p):zs) =
+     case Map.lookup z m of
+       Nothing -> go (Map.insert z p m) zs
+       Just q -> do pq <- orPred sym p q
+                    case asConstantPred pq of
+                      Just False -> go m zs
+                      _ -> go (Map.insert z pq m) zs
+
+-- | Apply a unary operation through a mux tree.  The provided operation
+--   is applied to each leaf of the tree.
+muxTreeUnaryOp ::
+  (Ord b, IsExprBuilder sym) =>
+  sym ->
+  (a -> IO b) -> 
+  MuxTree sym a ->
+  IO (MuxTree sym b)
+muxTreeUnaryOp sym op xt =
+  do let xs = viewMuxTree xt
+     zs <- sequence
+            [ do z <- op x
+                 return (z,p)
+            | (x,p) <- xs
+            ]
+     buildMuxTree sym zs
+
+-- | Apply a binary operation through two mux trees.  The provided operation
+--   is applied pairwise to each leaf of the two trees, and appropriate path
+--   conditions are computed for the resulting values.
+muxTreeBinOp ::
+  (Ord c, IsExprBuilder sym) =>
+  sym ->
+  (a -> b -> IO c) ->
+  MuxTree sym a ->
+  MuxTree sym b ->
+  IO (MuxTree sym c)
+muxTreeBinOp sym op xt yt =
+  do let xs = viewMuxTree xt
+     let ys = viewMuxTree yt
+     zs <- sequence
+           [ do p <- andPred sym px py
+                z <- op x y
+                return (z,p)
+           | (x,px) <- xs
+           , (y,py) <- ys
+           ]
+     buildMuxTree sym zs
+
+
+conditionMuxTreeLeaf ::
+  IsExprBuilder sym => sym -> Pred sym -> a -> Pred sym -> IO (Maybe (Pred sym))
+conditionMuxTreeLeaf sym p _v pv =
+   do p' <- andPred sym p pv
+      case asConstantPred p' of
+        Just False -> return Nothing
+        _ -> return (Just p')
+
+-- | Compute the if-then-else operation on mux trees.
+mergeMuxTree ::
+  (Ord a, IsExprBuilder sym) =>
+  sym ->
+  Pred sym ->
+  MuxTree sym a ->
+  MuxTree sym a ->
+  IO (MuxTree sym a)
+mergeMuxTree sym p (MuxTree mx) (MuxTree my) =
+   do np <- notPred sym p
+      MuxTree <$> doMerge np mx my
+
+  where
+  f _v px py =
+    do p' <- itePred sym p px py
+       case asConstantPred p' of
+         Just False -> return Nothing
+         _ -> return (Just p')
+
+  doMerge np = Map.mergeA (Map.traverseMaybeMissing (conditionMuxTreeLeaf sym p))
+                          (Map.traverseMaybeMissing (conditionMuxTreeLeaf sym np))
+                          (Map.zipWithMaybeAMatched f)


### PR DESCRIPTION
This branch introduces a new `MuxTree` datastructure which allows the symbolic simulator to merge values which otherwise are difficult to handle.  Notionally, a mux tree is a tree of if-then-else expressions where the leaves are concrete values.  Operations that operate on mux-tree values can then simply apply the operation on all the leaves and condition the results on the conditions that lead to that leaf value.

Using this datastructure, I reimplemented reference values as mux trees.  Lookups and updates operations to reference cells are then applied to each of the cells that might be referenced by the mux tree, conditioned on the associated predicate.

I'm leaving this on a branch for the moment because I haven't yet had a chance to test the new implementation.