### PR TITLE
Floating point

### DIFF
--- a/crucible/src/Lang/Crucible/CFG/Expr.hs
+++ b/crucible/src/Lang/Crucible/CFG/Expr.hs
@@ -260,6 +260,48 @@ data App (ext :: *) (f :: CrucibleType -> *) (tp :: CrucibleType) where
   RealIsInteger :: !(f RealValType) -> App ext f BoolType
 
   ----------------------------------------------------------------------
+  -- Float
+
+  -- Floating point constants
+  FloatLit :: !Float -> App ext f (FloatType SingleFloat)
+  DoubleLit :: !Double -> App ext f (FloatType DoubleFloat)
+  FloatNaN :: (FloatInfoRepr fi) -> App ext f (FloatType fi)
+  FloatPInf :: (FloatInfoRepr fi) -> App ext f (FloatType fi)
+  FloatNInf :: (FloatInfoRepr fi) -> App ext f (FloatType fi)
+
+  -- Arithmetic operations
+  FloatAdd :: (FloatInfoRepr fi) -> !(f (FloatType fi)) -> !(f (FloatType fi)) -> App ext f (FloatType fi)
+  FloatSub :: (FloatInfoRepr fi) -> !(f (FloatType fi)) -> !(f (FloatType fi)) -> App ext f (FloatType fi)
+  FloatMul :: (FloatInfoRepr fi) -> !(f (FloatType fi)) -> !(f (FloatType fi)) -> App ext f (FloatType fi)
+  FloatDiv :: (FloatInfoRepr fi) -> !(f (FloatType fi)) -> !(f (FloatType fi)) -> App ext f (FloatType fi)
+  -- Foating-point remainder of the two operands
+  FloatRem :: (FloatInfoRepr fi) -> !(f (FloatType fi)) -> !(f (FloatType fi)) -> App ext f (FloatType fi)
+
+  -- Comparison operations
+  FloatEq :: !(f (FloatType fi)) -> !(f (FloatType fi)) -> App ext f BoolType
+  FloatGt :: !(f (FloatType fi)) -> !(f (FloatType fi)) -> App ext f BoolType
+  FloatGe :: !(f (FloatType fi)) -> !(f (FloatType fi)) -> App ext f BoolType
+  FloatLt :: !(f (FloatType fi)) -> !(f (FloatType fi)) -> App ext f BoolType
+  FloatLe :: !(f (FloatType fi)) -> !(f (FloatType fi)) -> App ext f BoolType
+  FloatNe :: !(f (FloatType fi)) -> !(f (FloatType fi)) -> App ext f BoolType
+
+  -- Conversion operations
+  FloatCast :: (FloatInfoRepr fi) -> !(f (FloatType fi')) -> App ext f (FloatType fi)
+  FloatFromBV :: (1 <= w) => (FloatInfoRepr fi) -> !(f (BVType w)) -> App ext f (FloatType fi)
+  FloatFromSBV :: (1 <= w) => (FloatInfoRepr fi) -> !(f (BVType w)) -> App ext f (FloatType fi)
+  FloatFromReal :: (FloatInfoRepr fi) -> !(f RealValType) -> App ext f (FloatType fi)
+  FloatToBV :: (1 <= w) => !(NatRepr w) -> !(f (FloatType fi)) -> App ext f (BVType w)
+  FloatToSBV :: (1 <= w) => !(NatRepr w) -> !(f (FloatType fi)) -> App ext f (BVType w)
+  FloatToReal :: !(f (FloatType fi)) -> App ext f RealValType
+
+  -- Classification operations
+  FloatIsNaN :: !(f (FloatType fi)) -> App ext f BoolType
+  FloatIsInfinite :: !(f (FloatType fi)) -> App ext f BoolType
+  FloatIsZero :: !(f (FloatType fi)) -> App ext f BoolType
+  FloatIsPositive :: !(f (FloatType fi)) -> App ext f BoolType
+  FloatIsNegative :: !(f (FloatType fi)) -> App ext f BoolType
+
+  ----------------------------------------------------------------------
   -- Maybe
 
   JustValue :: !(TypeRepr tp)
@@ -791,6 +833,37 @@ instance TypeApp (ExprExtension ext) => TypeApp (App ext) where
     RealIsInteger{} -> knownRepr
 
     ----------------------------------------------------------------------
+    -- Float
+    FloatLit{} -> knownRepr
+    DoubleLit{} -> knownRepr
+    FloatNaN fi -> FloatRepr fi
+    FloatPInf fi -> FloatRepr fi
+    FloatNInf fi -> FloatRepr fi
+    FloatAdd fi _ _ -> FloatRepr fi
+    FloatSub fi _ _ -> FloatRepr fi
+    FloatMul fi _ _ -> FloatRepr fi
+    FloatDiv fi _ _ -> FloatRepr fi
+    FloatRem fi _ _ -> FloatRepr fi
+    FloatEq{} -> knownRepr
+    FloatLt{} -> knownRepr
+    FloatLe{} -> knownRepr
+    FloatGt{} -> knownRepr
+    FloatGe{} -> knownRepr
+    FloatNe{} -> knownRepr
+    FloatCast fi _ -> FloatRepr fi
+    FloatFromBV fi _ -> FloatRepr fi
+    FloatFromSBV fi _ -> FloatRepr fi
+    FloatFromReal fi _ -> FloatRepr fi
+    FloatToBV w _ -> BVRepr w
+    FloatToSBV w _ -> BVRepr w
+    FloatToReal{} -> knownRepr
+    FloatIsNaN{} -> knownRepr
+    FloatIsInfinite{} -> knownRepr
+    FloatIsZero{} -> knownRepr
+    FloatIsPositive{} -> knownRepr
+    FloatIsNegative{} -> knownRepr
+
+    ----------------------------------------------------------------------
     -- Maybe
 
     JustValue tp _ -> MaybeRepr tp
@@ -1041,6 +1114,7 @@ instance TestEqualityFC (ExprExtension ext) => TestEqualityFC (App ext) where
                    , (U.ConType [t|SymbolRepr |]    `U.TypeApp` U.AnyType, [|testEquality|])
                    , (U.ConType [t|TypeRepr|]       `U.TypeApp` U.AnyType, [|testEquality|])
                    , (U.ConType [t|BaseTypeRepr|]  `U.TypeApp` U.AnyType, [|testEquality|])
+                   , (U.ConType [t|FloatInfoRepr|]  `U.TypeApp` U.AnyType, [|testEquality|])
                    , (U.ConType [t|Ctx.Assignment|] `U.TypeApp`
                          (U.ConType [t|BaseTerm|] `U.TypeApp` U.AnyType) `U.TypeApp` U.AnyType
                      , [| testEqualityFC (testEqualityFC testSubterm) |]
@@ -1072,6 +1146,7 @@ instance OrdFC (ExprExtension ext) => OrdFC (App ext) where
                    , (U.ConType [t|SymbolRepr |] `U.TypeApp` U.AnyType, [|compareF|])
                    , (U.ConType [t|TypeRepr|] `U.TypeApp` U.AnyType, [|compareF|])
                    , (U.ConType [t|BaseTypeRepr|] `U.TypeApp` U.AnyType, [|compareF|])
+                   , (U.ConType [t|FloatInfoRepr|] `U.TypeApp` U.AnyType, [|compareF|])
                    , (U.ConType [t|Ctx.Assignment|] `U.TypeApp`
                          (U.ConType [t|BaseTerm|] `U.TypeApp` U.AnyType) `U.TypeApp` U.AnyType
                      , [| compareFC (compareFC compareSubterm) |]

--- a/crucible/src/Lang/Crucible/Simulator/Evaluation.hs
+++ b/crucible/src/Lang/Crucible/Simulator/Evaluation.hs
@@ -493,6 +493,94 @@ evalApp sym itefns _logFn evalExt evalSub a0 = do
       isInteger sym x
 
     ----------------------------------------------------------------------
+    -- Float
+
+    FloatLit f -> realLit sym $ toRational f
+    DoubleLit d -> realLit sym $ toRational d
+    FloatNaN _ -> addFailedAssertion sym $
+                Unsupported "NaN floating point"
+    FloatPInf _ -> addFailedAssertion sym $
+                 Unsupported "+Inf floating point"
+    FloatNInf _ -> addFailedAssertion sym $
+                 Unsupported "-Inf floating point"
+    FloatAdd _ xe ye -> do
+      x <- evalSub xe
+      y <- evalSub ye
+      realAdd sym x y
+    FloatSub _ xe ye -> do
+      x <- evalSub xe
+      y <- evalSub ye
+      realSub sym x y
+    FloatMul _ xe ye -> do
+      x <- evalSub xe
+      y <- evalSub ye
+      realMul sym x y
+    FloatDiv _ xe ye -> do
+      -- TODO: handle division by zero
+      x <- evalSub xe
+      y <- evalSub ye
+      realDiv sym x y
+    FloatRem _ xe ye -> do
+      x <- evalSub xe
+      y <- evalSub ye
+      realMod sym x y
+    FloatEq x_expr y_expr -> do
+      x <- evalSub x_expr
+      y <- evalSub y_expr
+      realEq sym x y
+    FloatLt x_expr y_expr -> do
+      x <- evalSub x_expr
+      y <- evalSub y_expr
+      realLt sym x y
+    FloatLe x_expr y_expr -> do
+      x <- evalSub x_expr
+      y <- evalSub y_expr
+      realLe sym x y
+    FloatGt x_expr y_expr -> do
+      x <- evalSub x_expr
+      y <- evalSub y_expr
+      realGt sym x y
+    FloatGe x_expr y_expr -> do
+      x <- evalSub x_expr
+      y <- evalSub y_expr
+      realGe sym x y
+    FloatNe x_expr y_expr -> do
+      x <- evalSub x_expr
+      y <- evalSub y_expr
+      realNe sym x y
+    FloatCast _ x_expr ->
+      -- nop
+      evalSub x_expr
+    FloatFromBV _ x_expr ->
+      uintToReal sym =<< evalSub x_expr
+    FloatFromSBV _ x_expr ->
+      sbvToReal sym =<< evalSub x_expr
+    FloatFromReal _ x_expr ->
+      -- nop
+      evalSub x_expr
+    FloatToBV w x_expr -> do
+      -- TODO: handle case when value does not fit
+      x <- evalSub x_expr
+      realToBV sym x w
+    FloatToSBV w x_expr -> do
+      -- TODO: handle case when value does not fit
+      x <- evalSub x_expr
+      realToSBV sym x w
+    FloatToReal x_expr ->
+      -- nop
+      evalSub x_expr
+    FloatIsNaN _ -> do
+      return $! falsePred sym
+    FloatIsInfinite _ -> do
+      return $! falsePred sym
+    FloatIsZero x_expr ->
+      realEq sym (realZero sym) =<< evalSub x_expr
+    FloatIsPositive x_expr -> do
+      realLt sym (realZero sym) =<< evalSub x_expr
+    FloatIsNegative x_expr -> do
+      realGt sym (realZero sym) =<< evalSub x_expr
+
+    ----------------------------------------------------------------------
     -- Conversions
 
     NatToInteger x_expr -> do

--- a/crucible/src/Lang/Crucible/Simulator/RegMap.hs
+++ b/crucible/src/Lang/Crucible/Simulator/RegMap.hs
@@ -177,6 +177,7 @@ muxRegForType s itefns p =
      NatRepr           -> muxReg s p
      IntegerRepr       -> muxReg s p
      RealValRepr       -> muxReg s p
+     FloatRepr _       -> muxReg s p
      ComplexRealRepr   -> muxReg s p
      CharRepr          -> muxReg s p
      BoolRepr          -> muxReg s p
@@ -207,10 +208,6 @@ muxRegForType s itefns p =
               [ "Unknown intrinsic type:"
               , "*** Name: " ++ show nm
               ]
-
-     FloatRepr _ -> \_ _ _ ->
-       addFailedAssertion s $
-         Unsupported "Float types are not supported by muxRegForType'"
 
 -- | Mux two register entries.
 {-# INLINE muxRegEntry #-}

--- a/crucible/src/Lang/Crucible/Simulator/RegValue.hs
+++ b/crucible/src/Lang/Crucible/Simulator/RegValue.hs
@@ -77,6 +77,7 @@ type MuxFn p v = p -> v -> v -> IO v
 -- | Maps register types to the associated value.
 type family RegValue (sym :: *) (tp :: CrucibleType) :: * where
   RegValue sym (BaseToType bt) = SymExpr sym bt
+  RegValue sym (FloatType _) = SymExpr sym BaseRealType
   RegValue sym AnyType = AnyValue sym
   RegValue sym UnitType = ()
   RegValue sym CharType = Word16
@@ -174,6 +175,10 @@ instance IsExprBuilder sym => CanMux sym IntegerType where
   muxReg s = \_ -> intIte s
 
 instance IsExprBuilder sym => CanMux sym RealValType where
+  {-# INLINE muxReg #-}
+  muxReg s = \_ -> realIte s
+
+instance IsExprBuilder sym => CanMux sym (FloatType fi) where
   {-# INLINE muxReg #-}
   muxReg s = \_ -> realIte s
 


### PR DESCRIPTION
Add floating-point operations in `Crucible` using the unused existing `FloatType` floating-point type. Evaluate the `Crucible` floating-points to `What4` reals. Update the `LLVM` to `Crucible` translation to use the newly introduces floating-point support.