### PR TITLE
Avoid dividing by zero while simplifying expressions

### DIFF
--- a/what4/src/What4/Expr/Builder.hs
+++ b/what4/src/What4/Expr/Builder.hs
@@ -2548,20 +2548,36 @@ bvBinOp1 f c sb x y = do
     (Just i, Just j) -> bvLit sb w $ f i j
     _ -> sbMakeExpr sb $ c w x y
 
-bvSignedBinOp :: (1 <= w)
-              => (Integer -> Integer -> Integer)
-              -> (NatRepr w -> BVExpr t w
-                            -> BVExpr t w
-                            -> App (Expr t) (BaseBVType w))
-              -> ExprBuilder t st
-              -> BVExpr t w
-              -> BVExpr t w
-              -> IO (BVExpr t w)
-bvSignedBinOp f c sym x y = do
+-- | A version of 'bvBinOp1' that avoids dividing by zero in the case where the
+-- divisor is zero
+bvBinDivOp1 :: (1 <= w)
+            => (Integer -> Integer -> Integer)
+            -> (NatRepr w -> BVExpr t w -> BVExpr t w -> App (Expr t) (BaseBVType w))
+            -> ExprBuilder t st
+            -> BVExpr t w
+            -> BVExpr t w
+            -> IO (BVExpr t w)
+bvBinDivOp1 f c sb x y = do
+  let w = bvWidth x
+  case (asUnsignedBV x, asUnsignedBV y) of
+    (Just i, Just j) | j /= 0 -> bvLit sb w $ f i j
+    _ -> sbMakeExpr sb $ c w x y
+
+bvSignedBinDivOp :: (1 <= w)
+                 => (Integer -> Integer -> Integer)
+                 -> (NatRepr w -> BVExpr t w
+                               -> BVExpr t w
+                               -> App (Expr t) (BaseBVType w))
+                 -> ExprBuilder t st
+                 -> BVExpr t w
+                 -> BVExpr t w
+                 -> IO (BVExpr t w)
+bvSignedBinDivOp f c sym x y = do
   let w = bvWidth x
   case (asSignedBV x, asSignedBV y) of
-    (Just i, Just j) -> bvLit sym w $ f i j
+    (Just i, Just j) | j /= 0 -> bvLit sym w $ f i j
     _ -> sbMakeExpr sym $ c w x y
+
 
 asConcreteIndices :: IsExpr e
                   => Ctx.Assignment e ctx
@@ -4284,10 +4300,10 @@ instance IsExprBuilder (ExprBuilder t st) where
           zro <- bvLit sym w 0
           notPred sym =<< bvEq sym x zro
 
-  bvUdiv = bvBinOp1 div BVUdiv
-  bvUrem = bvBinOp1 rem BVUrem
-  bvSdiv = bvSignedBinOp quot BVSdiv
-  bvSrem = bvSignedBinOp rem BVSrem
+  bvUdiv = bvBinDivOp1 div BVUdiv
+  bvUrem = bvBinDivOp1 rem BVUrem
+  bvSdiv = bvSignedBinDivOp div BVSdiv
+  bvSrem = bvSignedBinDivOp rem BVSrem
 
   mkStruct sym args = do
     sbMakeExpr sym $ StructCtor (fmapFC exprType args) args


### PR DESCRIPTION
The expression builder attempts to simplify expressions with constant
arguments (good).  Unfortunately, it will divide by zero and throw a
Haskell-level exception (bad).  This commit adds a check for zero in the case of
division and leaves the result un-simplified (which will later be sent to the
solver).