### PR TITLE
Fixes for crucible-syntax

### DIFF
--- a/crucible-syntax/src/Lang/Crucible/Syntax/Atoms.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Atoms.hs
@@ -186,11 +186,11 @@ instance IsAtom Atomic where
 
 -- | Parse an atom
 atom :: Parser Atomic
-atom =  try (Lbl . LabelName <$> (identifier) <* char ':')
-    <|> kwOrAtom
+atom =  try (Lbl . LabelName <$> identifier <* char ':')
     <|> Fn . FunName <$> (char '@' *> identifier)
     <|> (char '$' *> ((char '$' *> (Gl . GlobalName <$> identifier)) <|> Rg . RegName <$> identifier))
-    <|> mkNum <$> signedPrefixedNumber <*> (try (Just <$> (char '/' *> prefixedNumber)) <|> pure Nothing)
+    <|> try (mkNum <$> signedPrefixedNumber <*> ((Just <$> (try (char '/') *> prefixedNumber)) <|> pure Nothing))
+    <|> kwOrAtom
     <|> char '#' *>  ((char 't' <|> char 'T') $> Bool True <|> (char 'f' <|> char 'F') $> Bool False)
     <|> char '"' *> (StrLit . T.pack <$> stringContents)
   where

--- a/crucible-syntax/src/Lang/Crucible/Syntax/Concrete.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Concrete.hs
@@ -39,6 +39,7 @@ import Prelude hiding (fail)
 
 import Data.Monoid ()
 import Data.Ratio
+import Data.Semigroup (Semigroup(..))
 
 import Control.Lens hiding (cons, backwards)
 import Control.Applicative
@@ -152,6 +153,10 @@ errPos (NotGlobal p _) = p
 errPos (SyntaxParseError (SP.SyntaxError (Reason e _ :| _))) = syntaxPos e
 
 deriving instance Show (ExprErr s)
+
+instance Semigroup (ExprErr s) where
+  (<>) = mappend
+
 instance Monoid (ExprErr s) where
   mempty = TrivialErr (OtherPos "mempty")
   mappend = Errs
@@ -740,6 +745,9 @@ instance Applicative (CFGParser h s ret) where
 instance Alternative (CFGParser h s ret) where
   empty = CFGParser $ throwError $ TrivialErr InternalPos
   (CFGParser x) <|> (CFGParser y) = CFGParser (x <|> y)
+
+instance Semigroup (CFGParser h s ret a) where
+  (<>) = (<|>)
 
 instance Monoid (CFGParser h s ret a) where
   mempty = empty
@@ -1415,6 +1423,9 @@ instance Alternative (TopParser h s) where
 instance MonadPlus (TopParser h s) where
   mzero = empty
   mplus = (<|>)
+
+instance Semigroup (TopParser h s a) where
+  (<>) = (<|>)
 
 instance Monoid (TopParser h s a) where
   mempty = empty

--- a/crucible-syntax/src/Lang/Crucible/Syntax/ExprParse.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/ExprParse.hs
@@ -120,6 +120,9 @@ instance MonadPlus Search where
   mzero = empty
   mplus = (<|>)
 
+instance Semigroup (Search a) where
+  (<>) = (<|>)
+
 instance Monoid (Search a) where
   mempty  = empty
   mappend = (<|>)
@@ -193,6 +196,9 @@ data Reason atom = Reason { expr :: Syntax atom
 data Failure atom = Ok | Oops Progress (NonEmpty (Reason atom))
   deriving (Functor, Show)
 
+instance Semigroup (Failure atom) where
+  (<>) = mappend
+
 instance Monoid (Failure atom) where
   mempty = Ok
   mappend Ok e2 = e2
@@ -207,6 +213,9 @@ data P atom a = P { _success :: Search a
                   , _failure :: Failure atom
                   }
   deriving Functor
+
+instance Semigroup (P atom a) where
+  (<>) = mappend
 
 instance Monoid (P atom a) where
   mempty = P mempty mempty

--- a/crucible-syntax/src/Lang/Crucible/Syntax/SExpr.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/SExpr.hs
@@ -27,7 +27,8 @@ module Lang.Crucible.Syntax.SExpr
   ) where
 
 import Data.Char (isDigit, isLetter)
-import Data.Monoid
+import Data.Monoid hiding ((<>))
+import Data.Semigroup (Semigroup(..))
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Void
@@ -147,6 +148,9 @@ data PrintStyle =
 -- | Printing rules describe how to specially format expressions that
 -- begin with particular atoms.
 newtype PrintRules a = PrintRules (a -> Maybe PrintStyle)
+
+instance Semigroup (PrintRules a) where
+  (<>) = mappend
 
 instance Monoid (PrintRules a) where
   mempty = PrintRules $ const Nothing

--- a/crucible-syntax/test-data/integer.cbl
+++ b/crucible-syntax/test-data/integer.cbl
@@ -14,4 +14,5 @@
     (let p3 (equal? x y))
     (let p (and p1 (and p2 p3)))
     (let za (if p q v))
+    (let neg-one (the Integer -1))
     (return za)))

--- a/crucible-syntax/test-data/integer.out.good
+++ b/crucible-syntax/test-data/integer.out.good
@@ -12,6 +12,7 @@
       (let p3 (equal? x y))
       (let p (and p1 (and p2 p3)))
       (let za (if p q v))
+      (let neg-one (the Integer -1))
       (return za)))
 
 test-integer
@@ -50,6 +51,8 @@ test-integer
   $15 = and($11, $14)
   % 16:13
   $16 = baseIte(BaseIntegerRepr, $15, $1, $2)
-  % 17:5
+  % 17:18
+  $17 = intLit(-1)
+  % 18:5
   return $16
   % no postdom


### PR DESCRIPTION
 * Make it build in GHC 8.4
 * Fix #64, which was caused by negative integers being read as atom names rather than negative integers