### PR TITLE
Change handling of global variables

### DIFF
--- a/crucible-llvm/crucible-llvm.cabal
+++ b/crucible-llvm/crucible-llvm.cabal
@@ -61,7 +61,30 @@ library
     Lang.Crucible.LLVM.MemModel.Value
     Lang.Crucible.LLVM.MemModel.Pointer
     Lang.Crucible.LLVM.MemModel.Type
+    Lang.Crucible.LLVM.Translation.Internal
     Lang.Crucible.LLVM.Types
 
   ghc-options: -Wall
   ghc-prof-options: -O2 -fprof-auto-top
+
+
+test-suite crucible-llvm-tests
+  type: exitcode-stdio-1.0
+  main-is: Tests.hs
+  hs-source-dirs: test
+  -- other-modules:
+  build-depends:
+    base,
+    containers,
+    crucible,
+    crucible-llvm,
+    directory,
+    filepath,
+    llvm-pretty,
+    llvm-pretty-bc-parser,
+    mtl,
+    parameterized-utils,
+    process,
+    tasty,
+    tasty-golden,
+    tasty-hunit

--- a/crucible-llvm/crucible-llvm.cabal
+++ b/crucible-llvm/crucible-llvm.cabal
@@ -1,5 +1,5 @@
 Name:          crucible-llvm
-Version:       0.1
+Version:       0.2
 Author:        Galois Inc.
 Copyright:     (c) Galois, Inc 2014-2018
 Maintainer:    rdockins@galois.com

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Value.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Value.hs
@@ -61,8 +61,10 @@ import           What4.Partial
 
 import           Lang.Crucible.Backend
 import qualified Lang.Crucible.LLVM.Bytes as G
+import           Lang.Crucible.LLVM.Extension (ArchWidth)
 import qualified Lang.Crucible.LLVM.MemModel.Type as G
 import           Lang.Crucible.LLVM.MemModel.Pointer
+import           Lang.Crucible.LLVM.Translation.Constant
 
 data FloatSize (fi :: FloatInfo) where
   SingleSize :: FloatSize SingleFloat

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Internal.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Internal.hs
@@ -1,0 +1,209 @@
+--------------------------------------------------------------
+-- |
+-- Module           : Lang.Crucible.LLVM.Translation.Internal
+-- Description      : Datastructures used while translating LLVM modules
+-- Copyright        : (c) Galois, Inc 2014-2018
+-- License          : BSD3
+-- Maintainer       : Rob Dockins <rdockins@galois.com>
+-- Stability        : provisional
+--
+-- This module defines datastructures used only during the translation of LLVM
+-- modules into Crucible CFGs.
+--------------------------------------------------------------
+
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Lang.Crucible.LLVM.Translation.Internal where
+
+import Control.Monad.Except
+import Control.Monad.Fail hiding (fail)
+import Control.Lens hiding (op, (:>) )
+import Data.Foldable (toList)
+import qualified Data.List as List
+import           Data.Maybe
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Sequence (Seq)
+import qualified Data.Sequence as Seq
+import qualified Data.Vector as V
+
+import qualified Text.LLVM.AST as L
+
+import           Data.Parameterized.Some
+
+import           Lang.Crucible.CFG.Generator
+import           Lang.Crucible.LLVM.Extension (ArchWidth)
+import           Lang.Crucible.LLVM.Intrinsics
+import           Lang.Crucible.LLVM.MemModel
+import           Lang.Crucible.LLVM.MemType
+import           Lang.Crucible.LLVM.Translation.Constant
+import           Lang.Crucible.LLVM.Translation.Types
+import           Lang.Crucible.Types
+import qualified Lang.Crucible.CFG.Core as C
+import qualified Lang.Crucible.LLVM.LLVMContext as TyCtx
+
+-------------------------------------------------------------------------
+-- LLVMExpr
+
+-- | A monad providing state and continuations for translating LLVM expressions
+-- to CFGs.
+type LLVMGenerator h s arch ret a =
+  (?lc :: TyCtx.LLVMContext, HasPtrWidth (ArchWidth arch)) =>
+    Generator (LLVM arch) h s (LLVMState arch) ret a
+
+-- | @LLVMGenerator@ without the constraint, can be nested further inside monads.
+type LLVMGenerator' h s arch ret a =
+  Generator (LLVM arch) h s (LLVMState arch) ret a
+
+-------------------------------------------------------------------------
+-- LLVMExpr
+
+-- | An intermediate form of LLVM expressions that retains some structure
+--   that would otherwise be more difficult to retain if we translated directly
+--   into crucible expressions.
+data LLVMExpr s arch where
+   BaseExpr   :: TypeRepr tp -> Expr (LLVM arch) s tp -> LLVMExpr s arch
+   ZeroExpr   :: MemType -> LLVMExpr s arch
+   UndefExpr  :: MemType -> LLVMExpr s arch
+   VecExpr    :: MemType -> Seq (LLVMExpr s arch) -> LLVMExpr s arch
+   StructExpr :: Seq (MemType, LLVMExpr s arch) -> LLVMExpr s arch
+
+instance Show (LLVMExpr s arch) where
+  show (BaseExpr _ x)   = C.showF x
+  show (ZeroExpr mt)    = "<zero :" ++ show mt ++ ">"
+  show (UndefExpr mt)   = "<undef :" ++ show mt ++ ">"
+  show (VecExpr _mt xs) = "[" ++ concat (List.intersperse ", " (map show (toList xs))) ++ "]"
+  show (StructExpr xs)  = "{" ++ concat (List.intersperse ", " (map f (toList xs))) ++ "}"
+    where f (_mt,x) = show x
+
+instrResultType ::
+  (?lc :: TyCtx.LLVMContext, MonadFail m, HasPtrWidth wptr) =>
+  L.Instr ->
+  m MemType
+instrResultType instr =
+  case instr of
+    L.Arith _ x _ -> liftMemType (L.typedType x)
+    L.Bit _ x _   -> liftMemType (L.typedType x)
+    L.Conv _ _ ty -> liftMemType ty
+    L.Call _ (L.PtrTo (L.FunTy ty _ _)) _ _ -> liftMemType ty
+    L.Call _ ty _ _ ->  fail $ unwords ["unexpected function type in call:", show ty]
+    L.Invoke (L.FunTy ty _ _) _ _ _ _ -> liftMemType ty
+    L.Invoke ty _ _ _ _ -> fail $ unwords ["unexpected function type in invoke:", show ty]
+    L.Alloca ty _ _ -> liftMemType (L.PtrTo ty)
+    L.Load x _ _ -> case L.typedType x of
+                   L.PtrTo ty -> liftMemType ty
+                   _ -> fail $ unwords ["load through non-pointer type", show (L.typedType x)]
+    L.ICmp _ _ _ -> liftMemType (L.PrimType (L.Integer 1))
+    L.FCmp _ _ _ -> liftMemType (L.PrimType (L.Integer 1))
+    L.Phi tp _   -> liftMemType tp
+
+    L.GEP inbounds base elts ->
+       do gepRes <- runExceptT (translateGEP inbounds base elts)
+          case gepRes of
+            Left err -> fail err
+            Right (GEPResult lanes tp _gep) ->
+              let n = fromInteger (natValue lanes) in
+              if n == 1 then
+                return (PtrType (MemType tp))
+              else
+                return (VecType n (PtrType (MemType tp)))
+
+    L.Select _ x _ -> liftMemType (L.typedType x)
+
+    L.ExtractValue x idxes -> liftMemType (L.typedType x) >>= go idxes
+         where go [] tp = return tp
+               go (i:is) (ArrayType n tp')
+                   | i < fromIntegral n = go is tp'
+                   | otherwise = fail $ unwords ["invalid index into array type", showInstr instr]
+               go (i:is) (StructType si) =
+                      case siFields si V.!? (fromIntegral i) of
+                        Just fi -> go is (fiType fi)
+                        Nothing -> error $ unwords ["invalid index into struct type", showInstr instr]
+               go _ _ = fail $ unwords ["invalid type in extract value instruction", showInstr instr]
+
+    L.InsertValue x _ _ -> liftMemType (L.typedType x)
+
+    L.ExtractElt x _ ->
+       do tp <- liftMemType (L.typedType x)
+          case tp of
+            VecType _n tp' -> return tp'
+            _ -> fail $ unwords ["extract element of non-vector type", showInstr instr]
+
+    L.InsertElt x _ _ -> liftMemType (L.typedType x)
+
+    L.ShuffleVector x _ i ->
+      do xtp <- liftMemType (L.typedType x)
+         itp <- liftMemType (L.typedType i)
+         case (xtp, itp) of
+           (VecType _n ty, VecType m _) -> return (VecType m ty)
+           _ -> fail $ unwords ["invalid shufflevector:", showInstr instr]
+
+    L.LandingPad x _ _ _ -> liftMemType x
+
+    _ -> fail $ unwords ["instrResultType, unsupported instruction:", showInstr instr]
+
+
+------------------------------------------------------------------------
+-- LLVMState
+
+-- | Maps identifiers to an associated register or defined expression.
+type IdentMap s = Map L.Ident (Either (Some (Reg s)) (Some (Atom s)))
+
+data LLVMState arch s
+   = LLVMState
+   { -- | Map from identifiers to associated register shape
+     _identMap :: !(IdentMap s)
+   , _blockInfoMap :: !(Map L.BlockLabel (LLVMBlockInfo s))
+   , llvmContext :: LLVMContext arch
+   }
+
+identMap :: Simple Lens (LLVMState arch s) (IdentMap s)
+identMap = lens _identMap (\s v -> s { _identMap = v })
+
+blockInfoMap :: Simple Lens (LLVMState arch s) (Map L.BlockLabel (LLVMBlockInfo s))
+blockInfoMap = lens _blockInfoMap (\s v -> s { _blockInfoMap = v })
+
+-- | Information about an LLVM basic block
+data LLVMBlockInfo s
+  = LLVMBlockInfo
+    {
+      -- The crucible block label corresponding to this LLVM block
+      block_label    :: Label s
+
+      -- map from labels to assignments that must be made before
+      -- jumping.  If this is the block info for label l',
+      -- and the map has [(i1,v1),(i2,v2)] in the phi_map for block l,
+      -- then basic block l is required to assign i1 = v1 and i2 = v2
+      -- before jumping to block l'.
+    , block_phi_map    :: !(Map L.BlockLabel (Seq (L.Ident, L.Type, L.Value)))
+    }
+
+buildBlockInfoMap :: L.Define -> LLVMGenerator h s arch ret (Map L.BlockLabel (LLVMBlockInfo s))
+buildBlockInfoMap d = Map.fromList <$> (mapM buildBlockInfo $ L.defBody d)
+
+buildBlockInfo :: L.BasicBlock -> LLVMGenerator h s arch ret (L.BlockLabel, LLVMBlockInfo s)
+buildBlockInfo bb = do
+  let phi_map = buildPhiMap (L.bbStmts bb)
+  let Just blk_lbl = L.bbLabel bb
+  lab <- newLabel
+  return (blk_lbl, LLVMBlockInfo{ block_phi_map = phi_map
+                                , block_label = lab
+                                })
+
+-- Given the statements in a basic block, find all the phi instructions and
+-- compute the list of assignments that must be made for each predecessor block.
+buildPhiMap :: [L.Stmt] -> Map L.BlockLabel (Seq (L.Ident, L.Type, L.Value))
+buildPhiMap ss = go ss Map.empty
+ where go (L.Result ident (L.Phi tp xs) _ : stmts) m = go stmts (go' ident tp xs m)
+       go _ m = m
+
+       f x mseq = Just (fromMaybe Seq.empty mseq Seq.|> x)
+
+       go' ident tp ((v, lbl) : xs) m = go' ident tp xs (Map.alter (f (ident,tp,v)) lbl m)
+       go' _ _ [] m = m

--- a/crucible-llvm/test/Tests.hs
+++ b/crucible-llvm/test/Tests.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE BangPatterns     #-}
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE ExplicitForAll   #-}
+{-# LANGUAGE LambdaCase       #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Main where
+
+import Control.Monad.ST
+
+-- Crucible
+import           Lang.Crucible.FunctionHandle (newHandleAllocator, HandleAllocator)
+import           Lang.Crucible.LLVM.MemType (i32)
+import           Data.Parameterized.Some (Some(..))
+import           Data.Parameterized.NatRepr (knownNat)
+
+-- LLVM
+import qualified Text.LLVM.AST as L
+import           Text.LLVM.AST     (Module)
+import           Data.LLVM.BitCode (parseBitCodeFromFile)
+
+
+-- Tasty
+import Test.Tasty (defaultMain, TestTree, testGroup)
+import Test.Tasty.HUnit
+
+-- General
+import qualified Data.Map.Strict as Map
+import           Control.Monad (when, forM_)
+import           Control.Monad.Except
+import qualified System.Directory as Dir
+import qualified System.Process   as Proc
+import           System.Exit (exitFailure, ExitCode(..))
+
+-- Modules being tested
+import Lang.Crucible.LLVM.Translation
+import Lang.Crucible.LLVM.Translation.Constant (LLVMConst(..))
+
+-- | Compile a C file with clang, returning the exit code
+compile :: FilePath -> IO (Int, String, String)
+compile !file = do
+  (exitCode, stdout, stderr) <-
+    Proc.readProcessWithExitCode
+      "clang" ["-emit-llvm", "-g", "-O0", "-c", file] ""
+  pure $ (exitCodeToInt exitCode, stdout, stderr)
+  where exitCodeToInt ExitSuccess     = 0
+        exitCodeToInt (ExitFailure i) = i
+
+-- | Parse an LLVM bit-code file.
+-- Mostly copied from crucible-c.
+parseLLVM :: FilePath -> IO (Either String Module)
+parseLLVM !file =
+  parseBitCodeFromFile file >>=
+    \case
+      Left err -> pure $ Left $ "Couldn't parse LLVM bitcode from file"
+                                ++ file ++ "\n" ++ show err
+      Right m  -> pure $ Right m
+
+main :: IO ()
+main = do wd <- Dir.getCurrentDirectory
+          putStrLn $ "Looking for tests in " ++ wd
+
+          let prepend pr = map (\s -> pr ++ s)
+          let files      = prepend "global" [ "-int", "-struct", "-uninitialized", "-extern" ]
+          let append ext = map (\s -> s ++ ext)
+
+          putStrLn "Compiling C code to LLVM bitcode with clang"
+          forM_ (prepend "test/data/" $ append ".c" files) $ \file -> do
+            (exitCode, stdout, stderr) <- compile file
+            when (exitCode /= 0) $ do
+              putStrLn $ "Failed to compile " ++ file
+              putStrLn stdout
+              putStrLn stderr
+              exitFailure
+            pure ()
+
+          putStrLn "Parsing LLVM bitcode"
+          -- parsed :: [Module]
+          parsed <- forM (append ".bc" files) $ \file -> do
+            parsed <- parseLLVM file
+            case parsed of
+              Left err -> do
+                putStrLn $ "Failed to parse " ++ file
+                putStrLn err
+                exitFailure
+              Right m  -> pure m
+
+          putStrLn "Translating LLVM modules"
+          halloc     <- newHandleAllocator
+          -- translated :: [ModuleTranslation]
+          translated <- stToIO $ traverse (translateModule halloc) parsed
+
+          -- Run tests on the results
+          case translated of
+            [Some g1, Some g2, Some g3, Some g4] ->
+              defaultMain (tests g1 g2 g3 g4)
+
+tests :: ModuleTranslation arch1
+      -> ModuleTranslation arch2
+      -> ModuleTranslation arch3
+      -> ModuleTranslation arch4
+      -> TestTree
+tests int struct uninitialized _ = do
+  testGroup "Tests"
+    [ testCase "int" $
+        Map.singleton (L.Symbol "x") (Right $ IntConst (knownNat @32) 42) @=?
+           (globalMap int)
+    , testCase "struct" $
+        IntConst (knownNat @32) 17 @=?
+           case Map.lookup (L.Symbol "z") (globalMap struct) of
+             Just (Right (StructConst _ (x : _))) -> x
+             _ -> IntConst (knownNat @1) 0
+    , testCase "unitialized" $
+        Map.singleton (L.Symbol "x") (Right $ ZeroConst i32) @=?
+           (globalMap uninitialized)
+    -- The actual value for this one contains the error message, so it's a pain
+    -- to type out. Uncomment this test to take a look.
+    -- , testCase "extern" $
+    --     Map.singleton (L.Symbol "x") (Left $ "") @=?
+    --        (globalMap extern)
+    ]

--- a/crucible-llvm/test/Tests.hs
+++ b/crucible-llvm/test/Tests.hs
@@ -104,15 +104,15 @@ tests int struct uninitialized _ = do
   testGroup "Tests"
     [ testCase "int" $
         Map.singleton (L.Symbol "x") (Right $ IntConst (knownNat @32) 42) @=?
-           (globalMap int)
+           Map.map snd (globalInitMap int)
     , testCase "struct" $
         IntConst (knownNat @32) 17 @=?
-           case Map.lookup (L.Symbol "z") (globalMap struct) of
+           case snd <$> Map.lookup (L.Symbol "z") (globalInitMap struct) of
              Just (Right (StructConst _ (x : _))) -> x
              _ -> IntConst (knownNat @1) 0
     , testCase "unitialized" $
         Map.singleton (L.Symbol "x") (Right $ ZeroConst i32) @=?
-           (globalMap uninitialized)
+           Map.map snd (globalInitMap uninitialized)
     -- The actual value for this one contains the error message, so it's a pain
     -- to type out. Uncomment this test to take a look.
     -- , testCase "extern" $

--- a/crucible-llvm/test/data/global-extern.c
+++ b/crucible-llvm/test/data/global-extern.c
@@ -1,0 +1,5 @@
+extern int extern_int;
+
+int main() {
+  return extern_int;
+}

--- a/crucible-llvm/test/data/global-int.c
+++ b/crucible-llvm/test/data/global-int.c
@@ -1,0 +1,5 @@
+int x = 42;
+
+int main() {
+  return x;
+}

--- a/crucible-llvm/test/data/global-struct.c
+++ b/crucible-llvm/test/data/global-struct.c
@@ -1,0 +1,13 @@
+const int x  = 17;
+const int y  = 11;
+
+typedef struct pair_s {
+  int xx;
+  int yy;
+} pair_t;
+
+pair_t z  = {x, y};
+
+int main() {
+  return z.xx;
+}

--- a/crucible-llvm/test/data/global-uninitialized.c
+++ b/crucible-llvm/test/data/global-uninitialized.c
@@ -1,0 +1,5 @@
+int x;
+
+int main() {
+  return x;
+}


### PR DESCRIPTION
**Note**: This is highly backwards-incompatible. SAW scripts that used to run will no longer with this change! Should we make a release note, or something similar? I've bumped the version so that library clients can select which behavior they need. 

Instead of providing a CFG that initializes all global variables, the result of translating a module now contains a map from symbols (the name of the global) to their initializers (represented as a constant LLVM value).

Clients to this API (e.g. saw-script) can now initialize globals at will by turning them into LLVM expressions.

Enables progress on https://github.com/GaloisInc/saw-script/issues/203. 