### PR TITLE
Grouped logging information in What4 solver interface

### DIFF
--- a/crucible-server/src/Lang/Crucible/Server/SimpleOverrides.hs
+++ b/crucible-server/src/Lang/Crucible/Server/SimpleOverrides.hs
@@ -103,7 +103,8 @@ checkSatWithAbcOverride = do
     let p = regValue $ args^._1
     sym <- getSymInterface
     logLn <- getLogFunction
-    r <- liftIO $ ABC.checkSat sym logLn "checkSatWithABC" p
+    let logData = defaultLogData { logCallbackVerbose = logLn, logReason = "checkSatWithABC" }
+    r <- liftIO $ ABC.checkSat sym logData p
     return $ backendPred sym (isSat r)
 
 ------------------------------------------------------------------------
@@ -117,7 +118,8 @@ checkSatWithYicesOverride = do
     let p = regValue $ args^._1
     sym <- getSymInterface
     logLn <- getLogFunction
-    r <- liftIO $ Yices.runYicesInOverride sym logLn "checkSatWithYices" [p] Nothing (return . isSat)
+    let logData = defaultLogData { logCallbackVerbose = logLn, logReason = "checkSatWithYices" }
+    r <- liftIO $ Yices.runYicesInOverride sym logData [p] (return . isSat)
     return $ backendPred sym r
 
 ------------------------------------------------------------------------

--- a/crucible-syntax/src/Lang/Crucible/Syntax/Overrides.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Overrides.hs
@@ -24,6 +24,7 @@ import What4.Expr.Builder
 import What4.Interface
 import What4.ProgramLoc
 import What4.SatResult
+import What4.Solver (LogData(..), defaultLogData)
 import What4.Solver.Z3 (runZ3InOverride)
 
 import Lang.Crucible.Backend
@@ -57,7 +58,9 @@ proveObligations =
        forM_ obls $ \o ->
          do let asms = map (view labeledPred) $ toList $ proofAssumptions o
             gl <- notPred sym ((proofGoal o)^.labeledPred)
-            runZ3InOverride sym (\_ -> hPutStrLn h) "assertion proof" (asms ++ [gl]) Nothing $ \case
+            let logData = defaultLogData { logCallbackVerbose = \_ -> hPutStrLn h
+                                         , logReason = "assertion proof" }
+            runZ3InOverride sym logData (asms ++ [gl]) $ \case
               Unsat{}  -> hPutStrLn h $ unlines ["Proof Succeeded!", show $ ppSimError $ (proofGoal o)^.labeledPredMsg]
               Sat _mdl -> hPutStrLn h $ unlines ["Proof failed!", show $ ppSimError $ (proofGoal o)^.labeledPredMsg]
               Unknown  -> hPutStrLn h $ unlines ["Proof inconclusive!", show $ ppSimError $ (proofGoal o)^.labeledPredMsg]

--- a/what4/src/What4/Solver.hs
+++ b/what4/src/What4/Solver.hs
@@ -14,6 +14,9 @@ module What4.Solver
   , ExprRangeBindings
   , defaultSolverAdapter
   , solverAdapterOptions
+  , LogData(..)
+  , logCallback
+
 
     -- * Boolector
   , boolectorAdapter

--- a/what4/src/What4/Solver.hs
+++ b/what4/src/What4/Solver.hs
@@ -16,7 +16,7 @@ module What4.Solver
   , solverAdapterOptions
   , LogData(..)
   , logCallback
-
+  , defaultLogData
 
     -- * Boolector
   , boolectorAdapter

--- a/what4/src/What4/Solver/CVC4.hs
+++ b/what4/src/What4/Solver/CVC4.hs
@@ -132,10 +132,8 @@ instance SMT2.SMTLib2GenericSolver CVC4 where
 
 runCVC4InOverride
   :: ExprBuilder t st fs
-  -> (Int -> String -> IO ())
-  -> String
+  -> LogData
   -> [BoolExpr t]
-  -> Maybe Handle
   -> (SatResult (GroundEvalFn t, Maybe (ExprRangeBindings t)) () -> IO a)
   -> IO a
 runCVC4InOverride = SMT2.runSolverInOverride CVC4 nullAcknowledgementAction (SMT2.defaultFeatures CVC4)
@@ -146,9 +144,7 @@ withCVC4
   :: ExprBuilder t st fs
   -> FilePath
     -- ^ Path to CVC4 executable
-  -> (String -> IO ())
-    -- ^ Function to print messages from CVC4 to.
-  -> Maybe Handle
+  -> LogData
   -> (SMT2.Session t CVC4 -> IO a)
     -- ^ Action to run
   -> IO a

--- a/what4/src/What4/Solver/STP.hs
+++ b/what4/src/What4/Solver/STP.hs
@@ -90,10 +90,8 @@ instance SMT2.SMTLib2GenericSolver STP where
 
 runSTPInOverride
   :: ExprBuilder t st fs
-  -> (Int -> String -> IO ())
-  -> String
+  -> LogData
   -> [BoolExpr t]
-  -> Maybe Handle
   -> (SatResult (GroundEvalFn t, Maybe (ExprRangeBindings t)) () -> IO a)
   -> IO a
 runSTPInOverride = SMT2.runSolverInOverride STP nullAcknowledgementAction (SMT2.defaultFeatures STP)
@@ -104,9 +102,7 @@ withSTP
   :: ExprBuilder t st fs
   -> FilePath
     -- ^ Path to STP executable
-  -> (String -> IO ())
-    -- ^ Function to print messages from STP to
-  -> Maybe Handle
+  -> LogData
   -> (SMT2.Session t STP -> IO a)
     -- ^ Action to run
   -> IO a

--- a/what4/src/What4/Solver/Z3.hs
+++ b/what4/src/What4/Solver/Z3.hs
@@ -117,10 +117,8 @@ instance SMT2.SMTLib2GenericSolver Z3 where
 
 runZ3InOverride
   :: ExprBuilder t st fs
-  -> (Int -> String -> IO ())
-  -> String
+  -> LogData
   -> [BoolExpr t]
-  -> Maybe Handle
   -> (SatResult (GroundEvalFn t, Maybe (ExprRangeBindings t)) () -> IO a)
   -> IO a
 runZ3InOverride = SMT2.runSolverInOverride Z3 nullAcknowledgementAction z3Features
@@ -131,9 +129,7 @@ withZ3
   :: ExprBuilder t st fs
   -> FilePath
     -- ^ Path to CVC4 executable
-  -> (String -> IO ())
-    -- ^ Function to print messages from CVC4 to.
-  -> Maybe Handle
+  -> LogData
   -> (SMT2.Session t Z3 -> IO a)
     -- ^ Action to run
   -> IO a

--- a/what4/test/ExprBuilderSMTLib2.hs
+++ b/what4/test/ExprBuilderSMTLib2.hs
@@ -15,7 +15,6 @@ import Test.Tasty.HUnit
 import           Control.Monad (void)
 import qualified Data.Binary.IEEE754 as IEEE754
 import           Data.Foldable
-import qualified Data.Text as T
 
 import qualified Data.Parameterized.Context as Ctx
 import           Data.Parameterized.Nonce
@@ -28,6 +27,7 @@ import What4.InterpretedFloatingPoint
 import What4.Protocol.Online
 import What4.Protocol.SMTLib2
 import What4.SatResult
+import What4.Solver.Adapter
 import What4.Solver.Z3
 
 data State t = State
@@ -47,7 +47,7 @@ withSym pred_gen = withIONonceGenerator $ \gen ->
 withZ3' :: (forall t . SimpleExprBuilder t fs -> Session t Z3 -> IO ()) -> IO ()
 withZ3' action = withIONonceGenerator $ \nonce_gen -> do
   sym <- newExprBuilder State nonce_gen
-  withZ3 sym "z3" putStrLn Nothing $ action sym
+  withZ3 sym "z3" defaultLogData{ logCallbackVerbose = (\_ -> putStrLn) } (action sym)
 
 withOnlineZ3'
   :: (forall t . SimpleExprBuilder t fs -> SolverProcess t (Writer Z3) -> IO a)


### PR DESCRIPTION
The solvers in What4 use four different pieces of data for logging purposes: a function `Int -> String -> IO ()` used for logging messages, a partially-applied version of this function `String -> IO ()`, a string recording the reason for a particular invocation of the solver, and a `Maybe Handle` on which to record transactions with the solver. Because these structures were commonly repeated and under-documented, this branch pulls all this data into a single data structure `LogData`. 

The main file changed is `What4.Solver.Adapter`, where `LogData` is defined based on its proximity to `solver_adapter_check_sat`. If there is a better place to put it please let me know.