### PR TITLE
Aliases to global variables

### DIFF
--- a/crucible-llvm/crucible-llvm.cabal
+++ b/crucible-llvm/crucible-llvm.cabal
@@ -93,6 +93,7 @@ test-suite crucible-llvm-tests
     mtl,
     parameterized-utils,
     process,
+    what4,
     tasty,
     tasty-golden,
     tasty-hunit

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
@@ -1117,7 +1117,7 @@ constToLLVMVal sym mem (StructConst sInfo xs) =
 -- SymbolConsts are offsets from global pointers. We translate them into the
 -- pointer they represent.
 constToLLVMVal sym mem (SymbolConst symb i) = do
-  ptr <- doResolveGlobal sym mem symb     -- Pointer to the global "symb"
+  ptr <- doResolveGlobal sym mem symb  -- Pointer to the global "symb"
   ibv <- bvLit sym ?ptrWidth i         -- Offset to be added, as a bitvector
 
   -- blk is the allocation number that this global is stored in.

--- a/crucible-llvm/test/Tests.hs
+++ b/crucible-llvm/test/Tests.hs
@@ -1,39 +1,51 @@
 {-# LANGUAGE BangPatterns     #-}
 {-# LANGUAGE DataKinds        #-}
 {-# LANGUAGE ExplicitForAll   #-}
+{-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE LambdaCase       #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Main where
 
-import Control.Monad.ST
+import           Control.Monad.ST
 
 -- Crucible
-import           Lang.Crucible.FunctionHandle (newHandleAllocator, HandleAllocator)
+import           Lang.Crucible.Backend.Simple (newSimpleBackend, SimpleBackend)
+import           Lang.Crucible.FunctionHandle (newHandleAllocator, withHandleAllocator, HandleAllocator)
+import           Lang.Crucible.LLVM.Globals (initializeMemory)
 import           Lang.Crucible.LLVM.MemType (i32)
+import           Lang.Crucible.LLVM.MemModel
+import           Lang.Crucible.LLVM.Intrinsics (mkLLVMContext)
+import           Lang.Crucible.LLVM.Extension (ArchRepr(..))
+
 import           Data.Parameterized.Some (Some(..))
-import           Data.Parameterized.NatRepr (knownNat)
+import           Data.Parameterized.NatRepr (knownNat, LeqProof(..), NatRepr, testLeq)
+import           Data.Parameterized.Nonce (withIONonceGenerator, NonceGenerator)
+import           What4.Expr.Builder (ExprBuilder, Flags, FloatReal, newExprBuilder)
 
 -- LLVM
 import qualified Text.LLVM.AST as L
-import           Text.LLVM.AST     (Module)
+import           Text.LLVM.AST (Module)
 import           Data.LLVM.BitCode (parseBitCodeFromFile)
 
 
 -- Tasty
-import Test.Tasty (defaultMain, TestTree, testGroup)
-import Test.Tasty.HUnit
+import           Test.Tasty (defaultMain, TestTree, testGroup)
+import           Test.Tasty.HUnit (testCase, (@=?))
 
 -- General
 import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 import           Control.Monad (when, forM_)
 import           Control.Monad.Except
 import qualified System.Directory as Dir
-import qualified System.Process   as Proc
+import qualified System.Process as Proc
 import           System.Exit (exitFailure, ExitCode(..))
 
 -- Modules being tested
-import Lang.Crucible.LLVM.Translation
+import           Lang.Crucible.LLVM.Translation
 
 -- | Compile a C file with clang, returning the exit code
 compile :: FilePath -> IO (Int, String, String)
@@ -100,7 +112,7 @@ tests :: ModuleTranslation arch1
       -> ModuleTranslation arch4
       -> TestTree
 tests int struct uninitialized _ = do
-  testGroup "Tests"
+  testGroup "Tests" $
     [ testCase "int" $
         Map.singleton (L.Symbol "x") (Right $ (i32, Just $ IntConst (knownNat @32) 42)) @=?
            Map.map snd (globalInitMap int)
@@ -117,4 +129,75 @@ tests int struct uninitialized _ = do
     -- , testCase "extern" $
     --     Map.singleton (L.Symbol "x") (Left $ "") @=?
     --        (globalMap extern)
-    ]
+
+    ] ++
+      ------------- Unit tests
+      -- It would be nice to have access to the Arbitrary instances for L.AST from
+      -- llvm-pretty-bc-parser here.
+      let mkGlobal name = L.Global (L.Symbol name) L.emptyGlobalAttrs L.Opaque Nothing Nothing Map.empty
+          mkAlias  name global = L.GlobalAlias (L.Symbol name) L.Opaque (L.ValSymbol (L.Symbol global))
+          mkModule as   gs     = L.emptyModule { L.modGlobals = gs
+                                               , L.modAliases = as
+                                               }
+      in [ testCase "globalAliases: empty module" $
+             Map.empty @=? globalAliases L.emptyModule
+         , testCase "globalAliases: singletons, no alias" $
+             let g = mkGlobal "g0"
+                 a = mkAlias  "a" "g"
+             in Map.singleton g (Set.empty) @=? globalAliases (mkModule [a] [g])
+         , testCase "globalAliases: singletons, aliased" $
+             let g = mkGlobal "g"
+                 a = mkAlias  "a" "g"
+             in Map.singleton g (Set.singleton a) @=? globalAliases (mkModule [a] [g])
+         , testCase "globalAliases: one alias, one erroneous" $
+             let g  = mkGlobal "g"
+                 a1 = mkAlias  "a1" "g"
+                 a2 = mkAlias  "a2" "g0"
+             in Map.singleton g (Set.singleton a1) @=? globalAliases (mkModule [a1, a2] [g])
+         , testCase "globalAliases: one alias, one erroneous" $
+             let g  = mkGlobal "g"
+                 a1 = mkAlias  "a1" "g"
+                 a2 = mkAlias  "a2" "g"
+             in Map.singleton g (Set.fromList [a1, a2]) @=? globalAliases (mkModule [a1, a2] [g])
+         ]
+
+      ++
+      -- The following test ensures that SAW treats global aliases properly in that
+      -- they are present in the @Map@ of globals after initializing the memory.
+      let t = L.PrimType (L.Integer 2)
+          mkGlobal name = L.Global (L.Symbol name) L.emptyGlobalAttrs t Nothing Nothing Map.empty
+          mkAlias  name global = L.GlobalAlias (L.Symbol name) t (L.ValSymbol (L.Symbol global))
+          mkModule as   gs     = L.emptyModule { L.modGlobals = gs
+                                               , L.modAliases = as
+                                               }
+      in [ testCase "initializeMemory" $
+           let g       = mkGlobal "g"
+               a       = mkAlias  "a" "g"
+               mod     = mkModule [a] [g]
+               inMap k = (Just () @=?) . fmap (const ()) . Map.lookup k
+
+               -- This is a separate function because we need to use the scoped type variable
+               -- @s@ in the binding of @sym@, which is difficult to do inline.
+               with :: forall s. NonceGenerator IO s -> HandleAllocator RealWorld -> IO ()
+               with nonceGen halloc = do
+                 sym       <- newSimpleBackend nonceGen :: IO (SimpleBackend s (Flags FloatReal))
+                 Some ctx0 <- stToIO $ mkLLVMContext halloc mod
+                 case llvmArch ctx0                  of { X86Repr width ->
+                 case assertLeq (knownNat @1)  width of { LeqProof      ->
+                 case assertLeq (knownNat @16) width of { LeqProof      -> do
+                   let ?ptrWidth = width
+                   result <- initializeMemory sym ctx0 mod
+                   inMap (L.Symbol "a") (memImplGlobalMap result)
+                 }}}
+           in withIONonceGenerator $ \nonceGen ->
+              withHandleAllocator  $ \halloc   -> with nonceGen halloc
+         ]
+
+-- Copied from what4/test/ExprBuilderSMTLib2
+data State t = State
+
+assertLeq :: forall m n . NatRepr m -> NatRepr n -> LeqProof m n
+assertLeq m n =
+  case testLeq m n of
+    Just LeqProof -> LeqProof
+    Nothing       -> error $ "No LeqProof for " ++ show m ++ " and " ++ show n


### PR DESCRIPTION
See the commit messages and comments for a detailed explanation.

Fixes #123. That issue has some LLVM code which exhibits the bug with `master` but is fixed with this PR. 

I get a warning about inexhaustive pattern matches, but the matches look exhaustive to me. Is this caused by `ViewPatterns`?
```
src/Lang/Crucible/LLVM/MemModel.hs:1207:9: warning: [-Wincomplete-patterns]                                                                                  
    Pattern match(es) are non-exhaustive
    In an equation for ‘go’: Patterns not matched: _ (_ Seq.:<| _)
     |
1207 |   where go map_ Seq.Empty                           = pure map_
```
Here are the patterns:
```
  where go map_ Seq.Empty                           = 
        go map_ (a@(aliasOf -> Nothing) Seq.:<| as) = 
        go map_ (a@(aliasOf -> Just l)  Seq.:<| as) =
```