### PR TITLE
Extend LLVM memory model to handle allocations and arrays of unbounded size

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
@@ -1074,6 +1074,9 @@ unpackMemValue sym tpr (LLVMValZero tp) = unpackZero sym tp tpr
 unpackMemValue _sym (LLVMPointerRepr w) (LLVMValInt blk bv)
   | Just Refl <- testEquality (bvWidth bv) w
   = return $ LLVMPointer blk bv
+unpackMemValue _sym (BVRepr w) (LLVMValInt _ bv) 
+  | Just Refl <- testEquality w (bvWidth bv) = return bv
+
 
 unpackMemValue _ (FloatRepr SingleFloatRepr) (LLVMValFloat SingleSize x) = return x
 unpackMemValue _ (FloatRepr DoubleFloatRepr) (LLVMValFloat DoubleSize x) = return x
@@ -1087,6 +1090,7 @@ unpackMemValue sym (StructRepr ctx) (LLVMValStruct xs)
 
 unpackMemValue sym (VectorRepr tpr) (LLVMValArray _tp xs)
   = traverse (unpackMemValue sym tpr) xs
+
 
 unpackMemValue _ tpr v =
   panic "MemModel.unpackMemValue"

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Common.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Common.hs
@@ -288,6 +288,8 @@ loadFromStoreStart pref tp i j = adjustOffset inFn outFn <$> rangeLoad 0 tp (R i
   where inFn = CValue
         outFn = fixLoadBeforeStoreOffset pref i
 
+-- | Produces a @Mux ValueCtor@ expression representing the range load conditions
+-- when the load and store values are concrete
 fixedSizeRangeLoad :: BasePreference -- ^ Whether addresses are based on store or load.
                    -> StorageType
                    -> Bytes
@@ -322,6 +324,8 @@ fixedSizeRangeLoad pref tp ssz =
     loadSucc = MuxVar (ValueCtorVar (InRange (Load .- Store) tp))
     loadFail = MuxVar (ValueCtorVar (OutOfRange Load tp))
 
+-- | Produces a @Mux ValueCtor@ expression representing the range load conditions
+-- when the load and store values are symbolic and the @StoreSize@ is bounded.
 symbolicRangeLoad :: BasePreference -> StorageType -> Mux (ValueCtor (RangeLoad OffsetExpr IntExpr))
 symbolicRangeLoad pref tp =
   Mux (Store .<= Load)
@@ -351,7 +355,8 @@ symbolicRangeLoad pref tp =
     loadVal i j = MuxVar (loadFromStoreStart pref tp i j)
     loadFail = MuxVar (ValueCtorVar (OutOfRange Load tp))
 
--- | Symbolic range load when the storagesize is unbounded
+-- | Produces a @Mux ValueCtor@ expression representing the RangeLoad conditions
+-- when the load and store values are symbolic and the @StoreSize@ is unbounded.
 symbolicUnboundedRangeLoad :: BasePreference -> StorageType -> Mux (ValueCtor (RangeLoad OffsetExpr IntExpr))
 symbolicUnboundedRangeLoad pref tp =
   Mux (Store .<= Load)

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Common.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Common.hs
@@ -37,6 +37,7 @@ module Lang.Crucible.LLVM.MemModel.Common
   , fixedOffsetRangeLoad
   , fixedSizeRangeLoad
   , symbolicRangeLoad
+  , symbolicUnboundedRangeLoad
 
   , ValueView(..)
 
@@ -332,6 +333,32 @@ symbolicRangeLoad pref tp =
     loadIter0 j
       | j > 0     = Mux (loadOffset j .== storeEnd) (loadVal0 j) (loadIter0 (j-1))
       | otherwise = loadFail
+
+    loadVal0 j = MuxVar $ adjustOffset inFn outFn <$> rangeLoad 0 tp (R 0 j)
+      where inFn k  = IntAdd (OffsetDiff Load Store) (CValue k)
+            outFn k = OffsetAdd Load (CValue k)
+
+    storeAfterLoad i
+      | i < sz = Mux (loadOffset i .== Store) (loadFromOffset i) (storeAfterLoad (i+1))
+      | otherwise = loadFail
+
+    loadFromOffset i =
+      assert (0 < i && i < sz) $
+      Mux (IntLe (CValue (sz - i)) StoreSize) (loadVal i (i+sz)) (f (sz-1))
+      where f j | j > i = Mux (IntEq (CValue (j-i)) StoreSize) (loadVal i j) (f (j-1))
+                | otherwise = loadFail
+
+    loadVal i j = MuxVar (loadFromStoreStart pref tp i j)
+    loadFail = MuxVar (ValueCtorVar (OutOfRange Load tp))
+
+-- | Symbolic range load when the storagesize is unbounded
+symbolicUnboundedRangeLoad :: BasePreference -> StorageType -> Mux (ValueCtor (RangeLoad OffsetExpr IntExpr))
+symbolicUnboundedRangeLoad pref tp =
+  Mux (Store .<= Load)
+  (loadVal0 sz)
+  (storeAfterLoad 1)
+  where
+    sz = typeEnd 0 tp
 
     loadVal0 j = MuxVar $ adjustOffset inFn outFn <$> rangeLoad 0 tp (R 0 j)
       where inFn k  = IntAdd (OffsetDiff Load Store) (CValue k)

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Generic.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Generic.hs
@@ -765,6 +765,7 @@ memEndian = memEndianForm
 --------------------------------------------------------------------------------
 -- Pointer validity
 
+
 -- | @isAllocatedMut isMut sym w p sz m@ returns the condition required to
 -- prove range @[p..p+sz)@ lies within a single allocation in @m@.
 --
@@ -788,46 +789,37 @@ isAllocatedMut ::
   Maybe (SymBV sym w)  ->
   Mem sym              ->
   IO (Pred sym)
-isAllocatedMut mutOk sym w minAlign (llvmPointerView -> (blk, off)) sz m = do
-      let step :: forall w'. Natural -> Maybe (SymBV sym w') -> IO (Pred sym) -> IO (Pred sym)
-          step a sze fallback
-            -- If the allocation is done at pointer width equal to 'w', check if this
-            -- allocation covers the required range.
-            | Just asz  <- sze
-            , Just Refl <- testEquality w (bvWidth asz) =
-                 do (_ov, end) <- addUnsignedOF sym off asz
-                    sameBlock <- natEq sym blk =<< natLit sym a
-                    inRange   <- bvUle sym end asz
-                    okNow     <- andPred sym sameBlock inRange
-                    case asConstantPred okNow of
-                      Just True  -> return okNow
-                      Just False -> fallback
-                      Nothing    -> orPred sym okNow =<< fallback
-
-          step a _sze fallback =
-            -- If the allocation is done at pointer width not equal to 'w', check that
-            -- this allocation is distinct from the base pointer.
-                 do sameBlock <- natEq sym blk =<< natLit sym a
-                    case asConstantPred sameBlock of
-                      Just True  -> return (falsePred sym)
-                      Just False -> fallback
-                      Nothing    ->
-                        do notSameBlock <- notPred sym sameBlock
-                           andPred sym notSameBlock =<< fallback
+isAllocatedMut mutOk sym w minAlign ptr@(llvmPointerView -> (blk, off)) sz m = do
+      -- @inThisAllocation a allocatedSz@ produces the precidate that records
+      -- whether the pointer @ptr@ of size @sz@ falls within the allocation of block @a@ of size @allocatedSz@
+      let inThisAllocation :: forall w'. Natural -> Maybe (SymBV sym w') -> IO (Pred sym)
+          inThisAllocation a Nothing = isSameBlock sym ptr a
+            -- If the allocation is unbounded, we just have to check we are in the right block
+          inThisAllocation a (Just allocatedSize)
+            -- If the allocation is done at pointer width is equal to @w@, check
+            -- if this allocation covers the required range
+            | Just Refl <- testEquality w (bvWidth allocatedSize)
+            , Just currSize <- sz = do
+                sameBlock <- isSameBlock sym ptr a           -- a == blockname(ptr)
+                (_ov,end) <- addPtrOffsetOF sym ptr currSize -- ptr+currSize
+                inRange    <- bvUle sym end allocatedSize    -- offset(ptr)+currSize <= allocatedSize
+                andPred sym sameBlock inRange
+          inThisAllocation a (Just _allocatedSize)
+            -- If the allocation is done at pointer width not equal to @w@,
+            -- check that this allocation is distinct from the base pointer.
+            | otherwise = notPred sym =<< isSameBlock sym ptr a
 
       let go :: IO (Pred sym) -> [MemAlloc sym] -> IO (Pred sym)
           go fallback [] = fallback
           go fallback (Alloc _ a asz mut alignment _ : r)
-            | mutOk mut && alignment >= minAlign = step a asz (go fallback r)
+            | mutOk mut && alignment >= minAlign = do
+                hereOK <- inThisAllocation a asz
+                thereOK <- go fallback r
+                orPred sym hereOK thereOK
             | otherwise = go fallback r
           go fallback (MemFree a : r) =
-            do sameBlock <- natEq sym blk a
-               case asConstantPred sameBlock of
-                 Just True  -> return (falsePred sym)
-                 Just False -> go fallback r
-                 Nothing    ->
-                   do notSameBlock <- notPred sym sameBlock
-                      andPred sym notSameBlock =<< go fallback r
+            do notSameBlock <- notPred sym =<< natEq sym blk a
+               andPred sym notSameBlock =<< go fallback r
           go fallback (AllocMerge _ [] [] : r) = go fallback r
           go fallback (AllocMerge c xr yr : r) =
             do p <- go fallback r -- TODO: wrap this in a delay
@@ -844,6 +836,25 @@ isAllocatedMut mutOk sym w minAlign (llvmPointerView -> (blk, off)) sz m = do
 
       andPred sym overflowPred =<< go (pure (falsePred sym)) (memAllocs m)
 
+
+-- | Checks if the block ID given as a natural number is the same as the block
+-- in which the pointer is located
+isSameBlock :: (IsSymInterface sym)
+            => sym
+            -> LLVMPtr sym w
+            -> Natural
+            -> IO (Pred sym)
+isSameBlock sym (llvmPointerView -> (blk,_off)) n = do
+  natEq sym blk =<< natLit sym n
+
+-- | Adds the offset of the current pointer to the bitvector, producing the
+-- result and an overflow bit
+addPtrOffsetOF :: (1 <= w, IsSymInterface sym)
+               => sym
+               -> LLVMPtr sym w
+               -> SymBV sym w
+               -> IO (Pred sym, SymBV sym w)
+addPtrOffsetOF sym (llvmPointerView -> (_blk,off)) x = addUnsignedOF sym off x
 
 -- | @isAllocated sym w p sz m@ returns the condition required to prove
 -- range @[p..p+sz)@ lies within a single allocation in @m@.

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Generic.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Generic.hs
@@ -593,7 +593,12 @@ readMemArrayStore sym w end (LLVMPointer blk read_off) tp write_off arr size rea
             | Just{} <- asUnsignedBV write_off = FixedStore
             | Just{} <- asUnsignedBV read_off = FixedLoad
             | otherwise = NeitherFixed
-      evalMuxValueCtor sym w end varFn subFn $ symbolicRangeLoad pref tp
+      let rngLd
+            -- if the size of the data is bounded, use symbolicRangeLoad
+            | Just _  <- size = symbolicRangeLoad pref tp
+            -- otherwise, use symbolicUnboundedRangeLoad
+            | Nothing <- size = symbolicUnboundedRangeLoad pref tp
+      evalMuxValueCtor sym w end varFn subFn rngLd
 
 readMem ::
   (1 <= w, IsSymInterface sym) => sym ->

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Types.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Types.hs
@@ -111,7 +111,7 @@ llvmTypeAsRepr xs f = go (llvmTypeToRepr xs)
        go []       = f UnitRepr
        go [Some x] = f x
 
-       go _ = error $ unwords ["llvmTypesAsRepr: expected a single value type", show xs]
+       go _ = error $ unwords ["llvmTypeAsRepr: expected a single value type", show xs]
 
 -- | Translate an LLVM return type into a crucible type, which is passed into
 --   the given continuation


### PR DESCRIPTION
This branch extends the LLVM memory model to be able to allocate spaces of unbounded size, which can be used to simulate one unbounded virtual memory region with reads and writes that may overlap. This was useful in simulating the behavior of machine code instructions in SemMC.

This pull request adds too new operations to the API in `LLVM.MemModel` but otherwise does not change the interface.

In the internal model `LLVM.MemModel.Generic`, the constructors `Malloc` and `MemArrayStore` now encode the size not  as a bitvector, but as a `Maybe` bitvector, where `Nothing` represents an unbounded region/array. Since `IntExpr`s can refer to the size of an array, their interpretation as `SymBV`s must now return a `Maybe SymBV`.