### PR TITLE
Add an undef constructor to LLVMConst and LLVMVal

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
@@ -1033,7 +1033,7 @@ unpackMemValue ::
   LLVMVal sym ->
   IO (RegValue sym tp)
 
-unpackMemValue sym tpr (LLVMValZero tp) = unpackZero sym tp tpr
+unpackMemValue sym tpr (LLVMValZero tp)  = unpackZero sym tp tpr
 
 unpackMemValue _sym (LLVMPointerRepr w) (LLVMValInt blk bv)
   | Just Refl <- testEquality (bvWidth bv) w
@@ -1051,6 +1051,13 @@ unpackMemValue sym (StructRepr ctx) (LLVMValStruct xs)
 
 unpackMemValue sym (VectorRepr tpr) (LLVMValArray _tp xs)
   = traverse (unpackMemValue sym tpr) xs
+
+unpackMemValue _ tpr v@(LLVMValUndef _) =
+  panic "MemModel.unpackMemValue"
+    [ "Cannot unpack an `undef` value"
+    , "*** Crucible type: " ++ show tpr
+    , "*** Undef value: " ++ show v
+    ]
 
 unpackMemValue _ tpr v =
   panic "MemModel.unpackMemValue"
@@ -1228,6 +1235,7 @@ constToLLVMVal sym mem (SymbolConst symb i) = do
   LLVMValInt blk <$> bvAdd sym offset ibv
 
 constToLLVMVal _sym _mem (ZeroConst memty) = LLVMValZero <$> toStorableType memty
+constToLLVMVal _sym _mem (UndefConst memty) = LLVMValUndef <$> toStorableType memty
 
 
 -- TODO are these types just identical? Maybe we should combine them.

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Generic.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Generic.hs
@@ -1132,6 +1132,7 @@ ppTermExpr
 ppTermExpr t = -- FIXME, do something with the predicate?
   case t of
     LLVMValZero _tp -> text "0"
+    LLVMValUndef tp -> text "<undef : " <> text (show tp) <> text ">"
     LLVMValInt base off -> ppPtr @sym (LLVMPointer base off)
     LLVMValFloat _ v -> printSymExpr v
     LLVMValStruct v -> encloseSep lbrace rbrace comma v''

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Expr.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Expr.hs
@@ -312,6 +312,8 @@ liftConstant ::
 liftConstant c = case c of
   ZeroConst mt ->
     return $ ZeroExpr mt
+  UndefConst mt ->
+    return $ UndefExpr mt
   IntConst w i ->
     return $ BaseExpr (LLVMPointerRepr w) (BitvectorAsPointerExpr w (App (BVLit w i)))
   FloatConst f ->


### PR DESCRIPTION
This allows for initializing `undef` globals, though it will still fail if the simulation does very much with them. It's a first step, we can see later if more support for manipulating `undef` values is necessary. 

Fixes #139, see motivation there.