### PR TITLE
NatRepr refactor

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/Arch/X86.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Arch/X86.hs
@@ -13,7 +13,7 @@ module Lang.Crucible.LLVM.Arch.X86 where
 import Data.Word(Word8)
 import Data.Bits
 import Data.Kind
-import GHC.TypeLits (type (<=))
+import GHC.TypeNats (type (<=))
 
 import Data.Parameterized.NatRepr(knownNat)
 import Data.Parameterized.Classes(testEquality,compareF)

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Bytes.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Bytes.hs
@@ -16,12 +16,14 @@ module Lang.Crucible.LLVM.Bytes
   , Addr
   , Offset
   , bytesToBits
+  , bytesToNatural
   , bytesToInteger
   , toBytes
   , bitsToBytes
   )  where
 
 import Data.Word
+import Numeric.Natural
 
 -- | A newtype for expressing numbers of bytes.
 --   This newtype is explicitly introduced to avoid confusion
@@ -32,11 +34,14 @@ newtype Bytes = Bytes { unBytes :: Word64 }
 instance Show Bytes where
   show (Bytes n) = show n
 
-bytesToBits :: Bytes -> Integer
-bytesToBits (Bytes n) = 8 * toInteger n
+bytesToBits :: Bytes -> Natural
+bytesToBits (Bytes n) = 8 * fromIntegral n
+
+bytesToNatural :: Bytes -> Natural
+bytesToNatural (Bytes n) = fromIntegral n
 
 bytesToInteger :: Bytes -> Integer
-bytesToInteger (Bytes n) = toInteger n
+bytesToInteger (Bytes n) = fromIntegral n
 
 toBytes :: Integral a => a -> Bytes
 toBytes = Bytes . fromIntegral

--- a/crucible-llvm/src/Lang/Crucible/LLVM/DataLayout.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/DataLayout.hs
@@ -69,7 +69,7 @@ noAlignment = Alignment 0
 -- | @padToAlignment x a@ returns the smallest value greater than or
 -- equal to @x@ that is aligned to @a@.
 padToAlignment :: Bytes -> Alignment -> Bytes
-padToAlignment x (Alignment n) = fromInteger (nextPow2Multiple (bytesToInteger x) (fromIntegral n))
+padToAlignment x (Alignment n) = toBytes (nextPow2Multiple (bytesToNatural x) (fromIntegral n))
 
 -- | Convert a number of bytes into an alignment, if it is a power of 2.
 toAlignment :: Bytes -> Maybe Alignment
@@ -82,11 +82,11 @@ fromAlignment :: Alignment -> Bytes
 fromAlignment (Alignment n) = Bytes (2 ^ n)
 
 -- | Convert an exponent @n@ to an alignment of @2^n@ bytes.
-exponentToAlignment :: Integer -> Alignment
+exponentToAlignment :: Natural -> Alignment
 exponentToAlignment n = Alignment (fromIntegral n)
 
-alignmentToExponent :: Alignment -> Integer
-alignmentToExponent (Alignment n) = toInteger n
+alignmentToExponent :: Alignment -> Natural
+alignmentToExponent (Alignment n) = fromIntegral n
 
 newtype AlignInfo = AT (Map Natural Alignment)
   deriving (Eq)
@@ -215,7 +215,7 @@ layoutWarnings :: Simple Lens DataLayout [L.LayoutSpec]
 layoutWarnings = lens _layoutWarnings (\s v -> s { _layoutWarnings = v})
 
 ptrBitwidth :: DataLayout -> Natural
-ptrBitwidth dl = fromInteger (bytesToBits (dl^.ptrSize))
+ptrBitwidth dl = bytesToBits (dl^.ptrSize)
 
 -- | Reduce the bit level alignment to a byte value, and error if it is not
 -- a multiple of 8.

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Extension.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Extension.hs
@@ -34,7 +34,7 @@ module Lang.Crucible.LLVM.Extension
   ) where
 
 import           Data.Kind
-import           GHC.TypeLits
+import           GHC.TypeNats
 import           Text.PrettyPrint.ANSI.Leijen hiding ((<$>))
 
 import           Data.Parameterized.Classes

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
@@ -162,7 +162,7 @@ import qualified Data.Sequence as Seq
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Word
-import           GHC.TypeLits
+import           GHC.TypeNats
 import           System.IO (Handle, hPutStrLn)
 import           Text.PrettyPrint.ANSI.Leijen hiding ((<$>))
 

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Generic.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Generic.hs
@@ -929,7 +929,7 @@ isAligned ::
 isAligned sym _w _p a
   | a == noAlignment = return (truePred sym)
 isAligned sym w (LLVMPointer _blk offset) a
-  | Just (Some bits) <- someNat (alignmentToExponent a)
+  | Some bits <- mkNatRepr (alignmentToExponent a)
   , Just LeqProof <- isPosNat bits
   , Just LeqProof <- testLeq bits w =
     do lowbits <- bvSelect sym (knownNat :: NatRepr 0) bits offset

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Pointer.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Pointer.hs
@@ -71,7 +71,8 @@ module Lang.Crucible.LLVM.MemModel.Pointer
 
 import           Text.PrettyPrint.ANSI.Leijen hiding ((<$>))
 
-import           GHC.TypeLits
+import           GHC.TypeLits (TypeError, ErrorMessage(..))
+import           GHC.TypeNats
 
 import           Data.Parameterized.Classes
 import qualified Data.Parameterized.Context as Ctx

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Value.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Value.hs
@@ -136,7 +136,7 @@ zeroInt ::
   (forall w. (1 <= w) => Maybe (SymNat sym, SymBV sym w) -> IO a) ->
   IO a
 zeroInt sym bytes k
-   | Just (Some w) <- someNat (bytesToBits bytes)
+   | Some w <- mkNatRepr (bytesToBits bytes)
    , Just LeqProof <- isPosNat w
    =   do blk <- natLit sym 0
           bv  <- bvLit sym w 0
@@ -361,8 +361,8 @@ selectLowBvPartLLVMVal _sym low hi (PE p (LLVMValZero (StorageType (Bitvector by
       return $ PE p $ LLVMValZero (bitvectorType low)
 
 selectLowBvPartLLVMVal sym low hi (PE p (LLVMValInt blk bv))
-  | Just (Some (low_w)) <- someNat (bytesToBits low)
-  , Just (Some (hi_w))  <- someNat (bytesToBits hi)
+  | Some (low_w) <- mkNatRepr (bytesToBits low)
+  , Some (hi_w)  <- mkNatRepr (bytesToBits hi)
   , Just LeqProof <- isPosNat low_w
   , Just Refl <- testEquality (addNat low_w hi_w) w
   , Just LeqProof <- testLeq low_w w =
@@ -387,8 +387,8 @@ selectHighBvPartLLVMVal _sym low hi (PE p (LLVMValZero (StorageType (Bitvector b
       return $ PE p $ LLVMValZero (bitvectorType hi)
 
 selectHighBvPartLLVMVal sym low hi (PE p (LLVMValInt blk bv))
-  | Just (Some (low_w)) <- someNat (bytesToBits low)
-  , Just (Some (hi_w))  <- someNat (bytesToBits hi)
+  | Some (low_w) <- mkNatRepr (bytesToBits low)
+  , Some (hi_w)  <- mkNatRepr (bytesToBits hi)
   , Just LeqProof <- isPosNat hi_w
   , Just Refl <- testEquality (addNat low_w hi_w) w =
     do p' <- andPred sym p =<< natEq sym blk =<< natLit sym 0

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemType.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemType.hs
@@ -243,7 +243,7 @@ memTypeSize dl mtp =
     MetadataType -> 0
 
 memTypeSizeInBits :: DataLayout -> MemType -> Natural
-memTypeSizeInBits dl tp = fromInteger $ bytesToBits (memTypeSize dl tp)
+memTypeSizeInBits dl tp = bytesToBits (memTypeSize dl tp)
 
 -- | Returns ABI byte alignment constraint in bytes.
 memTypeAlign :: DataLayout -> MemType -> Alignment

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Expr.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Expr.hs
@@ -235,8 +235,8 @@ zeroExpand :: forall s arch a
            -> (forall tp. TypeRepr tp -> Expr (LLVM arch) s tp -> a)
            -> a
 zeroExpand (IntType w) k =
-  case someNat (fromIntegral w) of
-    Just (Some w') | Just LeqProof <- isPosNat w' ->
+  case mkNatRepr w of
+    Some w' | Just LeqProof <- isPosNat w' ->
       k (LLVMPointerRepr w') $
          BitvectorAsPointerExpr w' $
          App $ BVLit w' 0
@@ -261,8 +261,8 @@ undefExpand :: (?lc :: TypeContext, ?err :: String -> a, HasPtrWidth (ArchWidth 
             -> (forall tp. TypeRepr tp -> Expr (LLVM arch) s tp -> a)
             -> a
 undefExpand (IntType w) k =
-  case someNat (fromIntegral w) of
-    Just (Some w') | Just LeqProof <- isPosNat w' ->
+  case mkNatRepr w of
+    Some w' | Just LeqProof <- isPosNat w' ->
       k (LLVMPointerRepr w') $
          BitvectorAsPointerExpr w' $
          App $ BVUndef w'

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Instruction.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Instruction.hs
@@ -136,7 +136,7 @@ instrResultType instr =
           case gepRes of
             Left err -> fail err
             Right (GEPResult lanes tp _gep) ->
-              let n = fromInteger (natValue lanes) in
+              let n = natValue lanes in
               if n == 1 then
                 return (PtrType (MemType tp))
               else
@@ -399,13 +399,13 @@ evalGEP instr (GEPResult _lanes finalMemType gep0) = finish =<< go gep0
 
  go (GEP_vector_base n x) =
       do xs <- maybe badGEP (traverse asPtr) (asVector x)
-         unless (toInteger (Seq.length xs) == natValue n) badGEP
+         unless (fromIntegral (Seq.length xs) == natValue n) badGEP
          return xs
 
  go (GEP_scatter n gep) =
       do xs <- go gep
          unless (Seq.length xs == 1) badGEP
-         return (Seq.cycleTaking (fromInteger (natValue n)) xs)
+         return (Seq.cycleTaking (widthVal n) xs)
 
  go (GEP_field fi gep) =
       do xs <- go gep
@@ -671,7 +671,7 @@ bitCast srcT expr tgtT = mb =<< runMaybeT (
 castToInt :: (?lc::TypeContext,HasPtrWidth w, w ~ ArchWidth arch) =>
   MemType -> LLVMExpr s arch -> MaybeT (LLVMGenerator' h s arch ret) (LLVMExpr s arch)
 castToInt (IntType w) (BaseExpr (LLVMPointerRepr wrepr) x)
-  | toInteger w == natValue wrepr
+  | w == natValue wrepr
   = lift (BaseExpr (BVRepr wrepr) <$> pointerAsBitvectorExpr wrepr x)
 castToInt (VecType n tp) (explodeVector n -> Just xs) =
   do xs' <- traverse (castToInt tp) (toList xs)
@@ -681,11 +681,12 @@ castToInt _ _ = mzero
 castFromInt :: (?lc::TypeContext,HasPtrWidth w, w ~ ArchWidth arch) =>
   MemType -> Natural -> LLVMExpr s arch -> MaybeT (LLVMGenerator' h s arch ret) (LLVMExpr s arch)
 castFromInt (IntType w1) w2 (BaseExpr (BVRepr w) x)
-  | w1 == w2, toInteger w1 == natValue w
+  | w1 == w2, w1 == natValue w
   = return (BaseExpr (LLVMPointerRepr w) (BitvectorAsPointerExpr w x))
 castFromInt (VecType n tp) w expr
-  | (w',0) <- w `divMod` n
-  , Just (Some wrepr') <- someNat (toInteger w')
+  | n > 0
+  , (w',0) <- w `divMod` n
+  , Some wrepr' <- mkNatRepr w'
   , Just LeqProof <- isPosNat wrepr'
   = do xs <- MaybeT (return (vecSplit wrepr' expr))
        VecExpr tp . Seq.fromList <$> traverse (castFromInt tp w') xs
@@ -786,7 +787,7 @@ raw_bitop ubConfig op w a b =
       L.Xor -> return $ App (BVXor w a b)
 
       L.Shl nuw nsw -> do
-        let wlit = App (BVLit w (natValue w))
+        let wlit = App (BVLit w (intValue w))
         assertUndefined_ UB.ShlOp2Big (App (BVUlt w b wlit))
 
         res <- AtomExpr <$> mkAtom (App (BVShl w a b))
@@ -812,7 +813,7 @@ raw_bitop ubConfig op w a b =
         nuwCond =<< nswCond =<< return res
 
       L.Lshr exact -> do
-        let wlit = App (BVLit w (natValue w))
+        let wlit = App (BVLit w (intValue w))
         assertUndefined_ UB.LshrOp2Big (App (BVUlt w b wlit))
 
         res <- AtomExpr <$> mkAtom (App (BVLshr w a b))
@@ -830,7 +831,7 @@ raw_bitop ubConfig op w a b =
 
       L.Ashr exact
         | Just LeqProof <- isPosNat w -> do
-           let wlit = App (BVLit w (natValue w))
+           let wlit = App (BVLit w (intValue w))
            assertUndefined_ UB.AshrOp2Big (App (BVUlt w b wlit))
 
            res <- AtomExpr <$> mkAtom (App (BVAshr w a b))

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Types.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Types.hs
@@ -134,9 +134,9 @@ llvmTypeToRepr DoubleType   = Just $ Some (FloatRepr DoubleFloatRepr)
 llvmTypeToRepr X86_FP80Type = Just $ Some (FloatRepr X86_80FloatRepr)
 llvmTypeToRepr MetadataType = Nothing
 llvmTypeToRepr (IntType n) =
-   case someNat (fromIntegral n) of
-      Just (Some w) | Just LeqProof <- isPosNat w -> Just $ Some (LLVMPointerRepr w)
-      _ -> panic "Translation.Types.llvmTypeToRepr"
+   case mkNatRepr n of
+     Some w | Just LeqProof <- isPosNat w -> Just $ Some (LLVMPointerRepr w)
+     _ -> panic "Translation.Types.llvmTypeToRepr"
               [" *** invalid integer width " ++ show n]
 
 -- | Compute the function Crucible function signature

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Types.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Types.hs
@@ -37,7 +37,7 @@ module Lang.Crucible.LLVM.Types
   , globalSymbolName
   ) where
 
-import           GHC.TypeLits
+import           GHC.TypeNats
 import           Data.Typeable
 
 import           Data.Parameterized.Context

--- a/crucible-saw/src/Lang/Crucible/Backend/SAWCore.hs
+++ b/crucible-saw/src/Lang/Crucible/Backend/SAWCore.hs
@@ -583,7 +583,7 @@ evalIndexLit sc l =
     NatIndexLit n ->
       do SAWExpr <$> SC.scNat sc (fromInteger (toInteger n))
     BVIndexLit w n ->
-      do w' <- SC.scNat sc (fromInteger (natValue w))
+      do w' <- SC.scNat sc (natValue w)
          n' <- SC.scNat sc (fromInteger n)
          SAWExpr <$> SC.scBvNat sc w' n'
 
@@ -638,7 +638,7 @@ applyTable sym sc t0 maxidx vars ret fallback =
          ty' <- SC.scVecType sc len ty
          fb' <- SC.scGlobalApply sc (SC.mkIdent SC.preludeName "replicate") [len, ty, fb]
          vec <- go ty' imax xs fb'
-         x' <- SC.scBvToNat sc (fromInteger (natValue w)) x
+         x' <- SC.scBvToNat sc (natValue w) x
          SC.scGlobalApply sc (SC.mkIdent SC.preludeName "atWithDefault") [len, ty, fb, vec, x']
 
 applyExprSymFn ::
@@ -1007,19 +1007,19 @@ evaluateExpr sym sc cache = f
              SAWExpr <$> (SC.scIntEq sc z =<< SC.scIntegerConst sc 0)
 
         B.BVToNat x ->
-          let n = fromInteger (natValue (bvWidth x)) in
+          let n = natValue (bvWidth x) in
           SAWExpr <$> (SC.scBvToNat sc n =<< f x)
 
         B.IntegerToBV x w ->
-          do n <- SC.scNat sc (fromInteger (natValue w))
+          do n <- SC.scNat sc (natValue w)
              SAWExpr <$> (SC.scIntToBv sc n =<< f x)
 
         B.BVToInteger x ->
-          do n <- SC.scNat sc (fromInteger (natValue (bvWidth x)))
+          do n <- SC.scNat sc (natValue (bvWidth x))
              SAWExpr <$> (SC.scBvToInt sc n =<< f x)
 
         B.SBVToInteger x ->
-          do n <- SC.scNat sc (fromInteger (natValue (bvWidth x)))
+          do n <- SC.scNat sc (natValue (bvWidth x))
              SAWExpr <$> (SC.scSbvToInt sc n =<< f x)
 
         -- Proper support for real and complex numbers will require additional

--- a/crucible-server/src/Lang/Crucible/Server/SAWOverrides.hs
+++ b/crucible-server/src/Lang/Crucible/Server/SAWOverrides.hs
@@ -29,7 +29,7 @@ import           Data.Foldable (toList)
 import           Data.IORef
 import qualified Data.Parameterized.Context as Ctx
 import           Data.Parameterized.Some
-import           Data.Sequence (Seq)
+--import           Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
 import qualified Data.Text as Text
 import qualified Data.Vector as V

--- a/crucible-server/src/Lang/Crucible/Server/TypeConv.hs
+++ b/crucible-server/src/Lang/Crucible/Server/TypeConv.hs
@@ -104,7 +104,7 @@ varTypeFromProto tp =
       let wv = tp^.P.varType_width
       when (wv == 0) $ do
         fail $ "Bitvector variables must have a positive width."
-      case someNat (toInteger wv) of
+      case someNat wv of
         Just (Some w) | Just LeqProof <- isPosNat w -> do
           return $ Some (BaseBVRepr w)
         _ -> error "Illegal type width"
@@ -159,7 +159,7 @@ fromProtoType tp = do
     P.ComplexType -> do
       return $ Some ComplexRealRepr
     P.BitvectorType -> do
-      case someNat (toInteger (tp^.P.crucibleType_width)) of
+      case someNat (tp^.P.crucibleType_width) of
         Just (Some w) | Just LeqProof <- isPosNat w -> return $ Some $ BVRepr w
         _ -> error "Could not parse bitwidth."
 
@@ -205,7 +205,7 @@ fromProtoType tp = do
       Some etp <- fromProtoType (params `Seq.index` 0)
       case asBaseType etp of
         AsBaseType bt ->
-          case someNat (toInteger (tp^.P.crucibleType_width)) of
+          case someNat (tp^.P.crucibleType_width) of
             Just (Some w) | Just LeqProof <- isPosNat w ->
                 return $ Some $ WordMapRepr w bt
             _ -> error $ unwords ["Invalid word map type: ", show etp]

--- a/crucible-server/src/Lang/Crucible/Server/ValueConv.hs
+++ b/crucible-server/src/Lang/Crucible/Server/ValueConv.hs
@@ -153,9 +153,9 @@ toProtoValue sim e@(RegEntry tp v) =
                       & P.value_data .~ toByteString (encodeRational r)
     BVRepr w | Just r <- asSignedBV v
              , wv <- natValue w
-             , wv <= toInteger (maxBound :: Word64) -> do
+             , wv <= fromIntegral (maxBound :: Word64) -> do
       return $ mempty & P.value_code  .~ P.BitvectorValue
-                      & P.value_width .~ fromInteger wv
+                      & P.value_width .~ fromIntegral wv
                       & P.value_data  .~ toByteString (encodeSigned r)
     StringRepr
       | Just txt <- asString v -> do

--- a/crucible-server/src/Lang/Crucible/Server/Verification/Override.hs
+++ b/crucible-server/src/Lang/Crucible/Server/Verification/Override.hs
@@ -162,7 +162,7 @@ verificationHarnessOverride sim rw w sc cryEnv harness =
              pc' <- lookupWord sym w ReturnAddressVar sub
              return (Ctx.Empty Ctx.:> RV pc' Ctx.:> RV regs' Ctx.:> RV mem')
 
-        _ -> fail "Impossible! failed to deconstruct verification override arguments"
+       -- _ -> fail "Impossible! failed to deconstruct verification override arguments"
 
 assertConditions ::
    SharedContext ->

--- a/crucible-syntax/src/Lang/Crucible/Syntax/Concrete.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Concrete.hs
@@ -72,6 +72,7 @@ import qualified Data.Sequence as Seq
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Vector as V
+import Numeric.Natural
 
 import Lang.Crucible.Syntax.ExprParse hiding (SyntaxError)
 import qualified Lang.Crucible.Syntax.ExprParse as SP
@@ -155,6 +156,10 @@ int = sideCondition "integer literal" numeric atomic
   where numeric (Int i) = Just i
         numeric _ = Nothing
 
+nat :: MonadSyntax Atomic m => m Natural
+nat = sideCondition "natural literal" isNat atomic
+  where isNat (Int i) | i >= 0 = Just (fromInteger i)
+        isNat _ = Nothing
 
 labelName :: MonadSyntax Atomic m => m LabelName
 labelName = sideCondition "label name" lbl atomic
@@ -235,22 +240,15 @@ data PosNat =
 
 posNat :: MonadSyntax Atomic m => m PosNat
 posNat =
-   do i <- sideCondition "positive nat literal" checkPosNat int
-      maybe empty return $ do Some x <- someNat i
+   do i <- sideCondition "positive nat literal" checkPosNat nat
+      maybe empty return $ do Some x <- return $ mkNatRepr i
                               LeqProof <- isPosNat x
                               return $ PosNat x
   where checkPosNat i | i > 0 = Just i
         checkPosNat _ = Nothing
 
 natRepr :: MonadSyntax Atomic m => m (Some NatRepr)
-natRepr =
-   do i <- sideCondition "nat literal" checkNonneg int
-      case someNat i of
-        Just sx -> return sx
-        Nothing -> empty
-
-  where checkNonneg i | i >= 0 = Just i
-        checkNonneg _ = Nothing
+natRepr = mkNatRepr <$> nat
 
 isType :: MonadSyntax Atomic m => m (Some TypeRepr)
 isType =
@@ -273,7 +271,7 @@ isType =
     vector = unary VectorT isType <&> \(Some t) -> Some (VectorRepr t)
     ref    = unary RefT isType <&> \(Some t) -> Some (ReferenceRepr t)
     bv :: MonadSyntax Atomic m => m  (Some TypeRepr)
-    bv     = do (Some len) <- unary BitvectorT (sideCondition "natural number" someNat int)
+    bv     = do Some len <- unary BitvectorT (mkNatRepr <$> nat)
                 describe "positive number" $
                   case testLeq (knownNat :: NatRepr 1) len of
                     Nothing -> empty

--- a/crucible/crucible.cabal
+++ b/crucible/crucible.cabal
@@ -41,7 +41,7 @@ library
     lens,
     mtl,
     panic >= 0.3,
-    parameterized-utils >= 1.0.5 && < 1.1,
+    parameterized-utils >= 1.0.8 && < 1.1,
     process,
     template-haskell,
     text,
@@ -154,4 +154,3 @@ test-suite helper-tests
                  tasty-hunit >= 0.9,
                  tasty-quickcheck >= 0.8,
                  tasty-hspec >= 1.1
-

--- a/crucible/src/Lang/Crucible/Simulator/Intrinsics.hs
+++ b/crucible/src/Lang/Crucible/Simulator/Intrinsics.hs
@@ -34,7 +34,7 @@ module Lang.Crucible.Simulator.Intrinsics
 import           Data.Kind
 import qualified Data.Parameterized.Map as MapF
 import           Data.Parameterized.SymbolRepr
-import qualified GHC.TypeLits
+import qualified GHC.TypeLits (Symbol)
 import           GHC.Stack
 
 import           What4.Interface

--- a/crucible/src/Lang/Crucible/Simulator/RegValue.hs
+++ b/crucible/src/Lang/Crucible/Simulator/RegValue.hs
@@ -58,7 +58,7 @@ import qualified Data.Set as Set
 import           Data.Text (Text)
 import qualified Data.Vector as V
 import           Data.Word
-import           GHC.TypeLits
+import           GHC.TypeNats (KnownNat)
 
 import qualified Data.Parameterized.Context as Ctx
 

--- a/crucible/src/Lang/Crucible/Syntax.hs
+++ b/crucible/src/Lang/Crucible/Syntax.hs
@@ -399,7 +399,7 @@ bigEndianStore
 bigEndianStore addrWidth cellWidth valWidth num basePtr v wordMap = go num
   where go 0 = wordMap
         go n
-          | Just (Some idx) <- someNat $ (toInteger (num-n)) * (toInteger (natValue cellWidth))
+          | Just (Some idx) <- someNat $ (fromIntegral (num-n)) * (intValue cellWidth)
           , Just LeqProof <- testLeq (addNat idx cellWidth) valWidth
             = app $ InsertWordMap addrWidth (BaseBVRepr cellWidth)
                   (app $ BVAdd addrWidth basePtr (app $ BVLit addrWidth (toInteger (n-1))))
@@ -420,7 +420,7 @@ littleEndianStore
 littleEndianStore addrWidth cellWidth valWidth num basePtr v wordMap = go num
   where go 0 = wordMap
         go n
-          | Just (Some idx) <- someNat $ (toInteger (n-1)) * (toInteger (natValue cellWidth))
+          | Just (Some idx) <- someNat $ (fromIntegral (n-1)) * (intValue cellWidth)
           , Just LeqProof <- testLeq (addNat idx cellWidth) valWidth
             = app $ InsertWordMap addrWidth (BaseBVRepr cellWidth)
                   (app $ BVAdd addrWidth basePtr (app $ BVLit addrWidth (toInteger (n-1))))

--- a/crucible/src/Lang/Crucible/Types.hs
+++ b/crucible/src/Lang/Crucible/Types.hs
@@ -108,7 +108,8 @@ module Lang.Crucible.Types
 
 import           Data.Hashable
 import           Data.Type.Equality
-import           GHC.TypeLits
+import           GHC.TypeLits (Symbol)
+import           GHC.TypeNats (Nat, KnownNat)
 import           Data.Parameterized.Classes
 import qualified Data.Parameterized.Context as Ctx
 import           Data.Parameterized.Ctx

--- a/what4-abc/src/What4/Solver/ABC.hs
+++ b/what4-abc/src/What4/Solver/ABC.hs
@@ -284,8 +284,8 @@ bitblastExpr h ae = do
 
     RealIsInteger{} -> realFail
     PredToBV p -> BV . AIG.singleton <$> eval' h p
-    BVTestBit i xe -> assert (i <= toInteger (maxBound :: Int)) $
-       (\v -> B $ v AIG.! (fromInteger i)) <$> eval' h xe
+    BVTestBit i xe -> assert (i <= fromIntegral (maxBound :: Int)) $
+       (\v -> B $ v AIG.! (fromIntegral i)) <$> eval' h xe
     BVEq  x y -> B <$> join (AIG.bvEq g <$> eval' h x <*> eval' h y)
     BVSlt x y -> B <$> join (AIG.slt  g <$> eval' h x <*> eval' h y)
     BVUlt x y -> B <$> join (AIG.ult  g <$> eval' h x <*> eval' h y)
@@ -780,7 +780,7 @@ freshBinding ntk n l tp mbnds = do
         cond <- case mbnds of
             Nothing -> return GIA.true
             Just bnds ->
-              do let wint = fromInteger (natValue w)
+              do let wint = fromIntegral (natValue w)
                  let rangeCond (lo,hi) =
                        do lop <- if lo > 0 then
                                    AIG.ule g (AIG.bvFromInteger g wint lo) bv

--- a/what4/src/What4/BaseTypes.hs
+++ b/what4/src/What4/BaseTypes.hs
@@ -78,7 +78,7 @@ import           Data.Parameterized.Classes
 import qualified Data.Parameterized.Context as Ctx
 import           Data.Parameterized.NatRepr
 import           Data.Parameterized.TH.GADT
-import           GHC.TypeLits
+import           GHC.TypeNats as TypeNats
 import           Text.PrettyPrint.ANSI.Leijen
 
 --------------------------------------------------------------------------------
@@ -102,7 +102,7 @@ data BaseType
      -- | @BaseRealType@ denotes a real number.
    | BaseRealType
      -- | @BaseBVType n@ denotes a bitvector with @n@-bits.
-   | BaseBVType GHC.TypeLits.Nat
+   | BaseBVType TypeNats.Nat
      -- | @BaseFloatType fpp@ denotes a floating-point number with @fpp@
      -- precision.
    | BaseFloatType FloatPrecision
@@ -124,7 +124,7 @@ type BaseBoolType    = 'BaseBoolType    -- ^ @:: 'BaseType'@.
 type BaseIntegerType = 'BaseIntegerType -- ^ @:: 'BaseType'@.
 type BaseNatType     = 'BaseNatType     -- ^ @:: 'BaseType'@.
 type BaseRealType    = 'BaseRealType    -- ^ @:: 'BaseType'@.
-type BaseBVType      = 'BaseBVType      -- ^ @:: 'GHC.TypeLits.Nat' -> 'BaseType'@.
+type BaseBVType      = 'BaseBVType      -- ^ @:: 'TypeNats.Nat' -> 'BaseType'@.
 type BaseFloatType   = 'BaseFloatType   -- ^ @:: 'FloatPrecision' -> 'BaseType'@.
 type BaseStringType  = 'BaseStringType  -- ^ @:: 'BaseType'@.
 type BaseComplexType = 'BaseComplexType -- ^ @:: 'BaseType'@.
@@ -134,8 +134,8 @@ type BaseArrayType   = 'BaseArrayType   -- ^ @:: 'Ctx.Ctx' 'BaseType' -> 'BaseTy
 -- | This data kind describes the types of floating-point formats.
 -- This consist of the standard IEEE 754-2008 binary floating point formats.
 data FloatPrecision where
-  FloatingPointPrecision :: GHC.TypeLits.Nat -> GHC.TypeLits.Nat -> FloatPrecision
-type FloatingPointPrecision = 'FloatingPointPrecision -- ^ @:: 'GHC.TypeLits.Nat' -> 'GHC.TypeLits.Nat' -> 'FloatPrecision'@.
+  FloatingPointPrecision :: TypeNats.Nat -> TypeNats.Nat -> FloatPrecision
+type FloatingPointPrecision = 'FloatingPointPrecision -- ^ @:: 'GHC.TypeNats.Nat' -> 'GHC.TypeNats.Nat' -> 'FloatPrecision'@.
 
 -- | Floating-point precision aliases
 type Prec16  = FloatingPointPrecision  5  11

--- a/what4/src/What4/Expr/Builder.hs
+++ b/what4/src/What4/Expr/Builder.hs
@@ -438,7 +438,7 @@ data App (e :: BaseType -> Type) (tp :: BaseType) where
 
   -- Return value of bit at given index.
   BVTestBit :: (1 <= w)
-            => !Integer -- Index of bit to test
+            => !Natural -- Index of bit to test
                         -- (least-significant bit has index 0)
             -> !(e (BaseBVType w))
             -> App e BaseBoolType
@@ -1507,9 +1507,9 @@ abstractEval bvParams f a0 = do
     BVZext w x   -> BVD.zext (f x) w
     BVSext w x   -> BVD.sext bvParams (bvWidth x) (f x) w
 
-    BVPopcount w _ -> BVD.range w 0 (natValue w)
-    BVCountLeadingZeros w _ -> BVD.range w 0 (natValue w)
-    BVCountTrailingZeros w _ -> BVD.range w 0 (natValue w)
+    BVPopcount w _ -> BVD.range w 0 (intValue w)
+    BVCountLeadingZeros w _ -> BVD.range w 0 (intValue w)
+    BVCountTrailingZeros w _ -> BVD.range w 0 (intValue w)
 
     BVBitNot w x   -> BVD.not w (f x)
     BVBitAnd w x y -> BVD.and w (f x) (f y)
@@ -4431,8 +4431,8 @@ instance IsExprBuilder (ExprBuilder t st fs) where
 
       -- Constant evaluation
     | Just yc <- asUnsignedBV y
-    , i <= toInteger (maxBound :: Int) =
-      return $! backendPred sym (yc `Bits.testBit` fromInteger i)
+    , i <= fromIntegral (maxBound :: Int) =
+      return $! backendPred sym (yc `Bits.testBit` fromIntegral i)
 
     | Just (BVZext _w y') <- asApp y =
       if i >= natValue (bvWidth y') then

--- a/what4/src/What4/Expr/GroundEval.hs
+++ b/what4/src/What4/Expr/GroundEval.hs
@@ -211,8 +211,8 @@ evalGroundApp f0 a0 = do
       if xv then f y else f z
 
     RealIsInteger x -> (\xv -> denominator xv == 1) <$> f x
-    BVTestBit i x -> assert (i <= toInteger (maxBound :: Int)) $
-        (`testBit` (fromInteger i)) <$> f x
+    BVTestBit i x -> assert (i <= fromIntegral (maxBound :: Int)) $
+        (`testBit` (fromIntegral i)) <$> f x
     BVEq  x y -> (==) <$> f x <*> f y
     BVSlt x y -> (<) <$> (toSigned w <$> f x)
                      <*> (toSigned w <$> f y)

--- a/what4/src/What4/Expr/UnaryBV.hs
+++ b/what4/src/What4/Expr/UnaryBV.hs
@@ -61,7 +61,7 @@ import           Data.Bits
 import           Data.Hashable
 import           Data.Parameterized.Classes
 import           Data.Parameterized.NatRepr
-import qualified GHC.TypeLits as Type
+import qualified GHC.TypeNats as Type
 
 import           What4.BaseTypes
 import           What4.Interface

--- a/what4/src/What4/Interface.hs
+++ b/what4/src/What4/Interface.hs
@@ -753,7 +753,7 @@ class (IsExpr (SymExpr sym), HashableF (SymExpr sym)) => IsExprBuilder sym where
   -- | Returns true if the corresponding bit in the bitvector is set.
   testBitBV :: (1 <= w)
             => sym
-            -> Integer -- ^ Index of bit (0 is the least significant bit)
+            -> Natural -- ^ Index of bit (0 is the least significant bit)
             -> SymBV sym w
             -> IO (Pred sym)
 
@@ -895,10 +895,10 @@ class (IsExpr (SymExpr sym), HashableF (SymExpr sym)) => IsExprBuilder sym where
          . (1 <= w)
         => sym         -- ^ Symbolic interface
         -> SymBV sym w -- ^ Bitvector to updaate
-        -> Integer     -- ^ 0-based index to set
+        -> Natural     -- ^ 0-based index to set
         -> Pred sym    -- ^ Predicate to set.
         -> IO (SymBV sym w)
-  bvSet sym v i p = assert (0 <= i && i < natValue (bvWidth v)) $ do
+  bvSet sym v i p = assert (i < natValue (bvWidth v)) $ do
     let setCase :: IO (SymBV sym w)
         setCase = do
           bvOrBits sym v =<< bvLit sym (bvWidth v) (2^i)
@@ -1038,7 +1038,7 @@ class (IsExpr (SymExpr sym), HashableF (SymExpr sym)) => IsExprBuilder sym where
        xs <- sequence [ do p <- testBitBV sym i y
                            iteM bvIte sym
                              p
-                             (bvShl sym x' =<< bvLit sym w2 i)
+                             (bvShl sym x' =<< bvLit sym w2 (toInteger i))
                              (return z)
                       | i <- [ 0 .. natValue w - 1 ]
                       ]
@@ -1065,7 +1065,7 @@ class (IsExpr (SymExpr sym), HashableF (SymExpr sym)) => IsExprBuilder sym where
        y'  <- bvZext sym dbl_w y
        s   <- bvMul sym x' y'
        lo  <- bvTrunc sym w s
-       n   <- bvLit sym dbl_w (natValue w)
+       n   <- bvLit sym dbl_w (intValue w)
        hi  <- bvTrunc sym w =<< bvLshr sym s n
        return (hi, lo)
 

--- a/what4/src/What4/InterpretedFloatingPoint.hs
+++ b/what4/src/What4/InterpretedFloatingPoint.hs
@@ -42,7 +42,7 @@ import           Data.Hashable
 import           Data.Kind
 import           Data.Parameterized.Classes
 import           Data.Parameterized.TH.GADT
-import           GHC.TypeLits
+import           GHC.TypeNats
 import           Text.PrettyPrint.ANSI.Leijen
 
 import           What4.BaseTypes
@@ -113,7 +113,7 @@ type family FloatPrecisionToInfo (fpp :: FloatPrecision) :: FloatInfo where
   FloatPrecisionToInfo Prec64  = DoubleFloat
   FloatPrecisionToInfo Prec128 = QuadFloat
 
-type family FloatInfoToBitWidth (fi :: FloatInfo) :: GHC.TypeLits.Nat where
+type family FloatInfoToBitWidth (fi :: FloatInfo) :: GHC.TypeNats.Nat where
   FloatInfoToBitWidth HalfFloat         = 16
   FloatInfoToBitWidth SingleFloat       = 32
   FloatInfoToBitWidth DoubleFloat       = 64

--- a/what4/src/What4/Protocol/SMTLib2.hs
+++ b/what4/src/What4/Protocol/SMTLib2.hs
@@ -92,6 +92,7 @@ import           Data.Text.Lazy.Builder (Builder)
 import qualified Data.Text.Lazy.Builder as Builder
 import qualified Data.Text.Lazy.Builder.Int as Builder
 import           Numeric (readDec, readHex, readInt)
+import           Numeric.Natural
 import qualified System.Exit as Exit
 import qualified System.IO as IO
 import qualified System.IO.Streams as Streams
@@ -127,9 +128,9 @@ all_supported = SMT2.allSupported
 -- Floating point
 
 data SMTFloatPrecision =
-  SMTFloatPrecision { smtFloatExponentBits :: !Integer
+  SMTFloatPrecision { smtFloatExponentBits :: !Natural
                       -- ^ Number of bits in exponent
-                    , smtFloatSignificandBits :: !Integer
+                    , smtFloatSignificandBits :: !Natural
                       -- ^ Number of bits in the significand.
                     }
   deriving (Eq, Ord)

--- a/what4/src/What4/Protocol/SMTLib2/Syntax.hs
+++ b/what4/src/What4/Protocol/SMTLib2/Syntax.hs
@@ -135,6 +135,7 @@ import           Data.Text (Text)
 import           Data.Text.Lazy.Builder (Builder)
 import qualified Data.Text.Lazy.Builder as Builder
 import qualified Data.Text.Lazy.Builder.Int as Builder
+import           Numeric.Natural
 
 import qualified Prelude
 import           Prelude hiding (and, or, concat, negate, div, mod, abs, not)
@@ -186,7 +187,7 @@ boolSort :: Sort
 boolSort = Sort "Bool"
 
 -- | Bitvectors with the given number of bits.
-bvSort :: Integer -> Sort
+bvSort :: Natural -> Sort
 bvSort w | w >= 1 = Sort $ "(_ BitVec " <> fromString (show w) <> ")"
          | otherwise = error "bvSort expects a positive number."
 
@@ -490,10 +491,9 @@ bit1 = T "#b1"
 -- The width @w@ must be positive.
 --
 -- The literal uses a binary notation.
-bvbinary :: Integer -> Integer -> Term
+bvbinary :: Integer -> Natural -> Term
 bvbinary u w0
-    | w0 <= 0 = error $ "bvbinary width must be positive."
-    | w0 > toInteger (maxBound :: Int) = error $ "Integer width is too large."
+    | w0 > fromIntegral (maxBound :: Int) = error $ "Integer width is too large."
     | otherwise = T $ "#b" <> go (fromIntegral w0)
   where go :: Int -> Builder
         go 0 = mempty
@@ -508,9 +508,8 @@ bvbinary u w0
 -- The width @w@ must be positive.
 --
 -- The literal uses a decimal notation.
-bvdecimal :: Integer -> Integer -> Term
+bvdecimal :: Integer -> Natural -> Term
 bvdecimal u w
-    | w <= 0 = error "bvdecimal width must be positive."
     | otherwise = T $ mconcat [ "(_ bv", Builder.decimal d, " ", Builder.decimal w, ")"]
   where d = u .&. (2^w - 1)
 
@@ -538,9 +537,8 @@ concat :: Term -> Term -> Term
 concat = bin_app "concat"
 
 -- | @extract i j x@ returns the bitvector containing the bits @[j..i]@.
-extract :: Integer -> Integer -> Term -> Term
+extract :: Natural -> Natural -> Term -> Term
 extract i j x
-  | j < 0 = error "Initial bit is negative"
   | i < j = error $ "End of extract (" ++ show i ++ ") less than beginning (" ++ show j ++ ")."
   | otherwise = -- We cannot check that j is small enough.
     let e = "(_ extract " <> Builder.decimal i <> " " <> Builder.decimal j <> ")"

--- a/what4/src/What4/Utils/Arithmetic.hs
+++ b/what4/src/What4/Utils/Arithmetic.hs
@@ -51,7 +51,7 @@ ctz :: NatRepr w -> Integer -> Integer
 ctz w x = go 0
  where
  go !i
-   | i < natValue w && testBit x (fromInteger i) == False = go (i+1)
+   | i < toInteger (natValue w) && testBit x (fromInteger i) == False = go (i+1)
    | otherwise = i
 
 -- | Count leading zeros
@@ -59,7 +59,7 @@ clz :: NatRepr w -> Integer -> Integer
 clz w x = go 0
  where
  go !i
-   | i < natValue w && testBit x (fromInteger (natValue w - i - 1)) == False = go (i+1)
+   | i < toInteger (natValue w) && testBit x (widthVal w - fromInteger i - 1) == False = go (i+1)
    | otherwise = i
 
 

--- a/what4/src/What4/Utils/BVDomain/Empty.hs
+++ b/what4/src/What4/Utils/BVDomain/Empty.hs
@@ -60,8 +60,8 @@ module What4.Utils.BVDomain.Empty
 
 import Control.Exception (assert)
 import Data.Parameterized.NatRepr
-
-import GHC.TypeLits
+import Numeric.Natural
+import GHC.TypeNats
 
 import Prelude hiding (any, concat, negate, not, and, or)
 
@@ -101,7 +101,7 @@ ult _ _ _ = Nothing
 testBit :: (1 <= w)
         => NatRepr w
         -> BVDomain w
-        -> Integer -- ^ Index of bit (least-significant bit has index 0)
+        -> Natural -- ^ Index of bit (least-significant bit has index 0)
         -> Maybe Bool
 testBit _ _ _ = Nothing
 

--- a/what4/src/What4/Utils/BVDomain/Map.hs
+++ b/what4/src/What4/Utils/BVDomain/Map.hs
@@ -73,8 +73,8 @@ import qualified Data.Map.Strict as Map
 import           Data.Parameterized.NatRepr
 import           Data.Set (Set)
 import qualified Data.Set as Set
-
-import           GHC.TypeLits
+import           Numeric.Natural
+import           GHC.TypeNats
 
 import           Prelude hiding (any, concat, negate, and, or)
 
@@ -111,8 +111,8 @@ modRange w lbound ubound
         ExclusiveRange low_ubound low_lbound
       -- Otherwise return all elements.
     | otherwise = AnyRange
-  where high_lbound = lbound `shiftR` fromInteger (natValue w)
-        high_ubound = ubound `shiftR` fromInteger (natValue w)
+  where high_lbound = lbound `shiftR` widthVal w
+        high_ubound = ubound `shiftR` widthVal w
         low_lbound  = maxUnsigned w .&. lbound
         low_ubound  = maxUnsigned w .&. ubound
 
@@ -304,13 +304,13 @@ ult _ _ _ = Nothing
 -- | Return true if bits in domain are set.
 testBit :: NatRepr w
         -> BVDomain w
-        -> Integer -- ^ Index of bit (least-significant bit has index 0)
+        -> Natural -- ^ Index of bit (least-significant bit has index 0)
         -> Maybe Bool
 testBit w d i = assert (i < natValue w) $
     case uncurry testRange <$> toList d of
       (mb@Just{}:r) | all (== mb) r -> mb
       _ -> Nothing
-  where j = fromInteger i
+  where j = fromIntegral i
         testRange :: Integer -> Integer -> Maybe Bool
         testRange l h | (l `shiftR` j) == (h `shiftR` j) =
                         Just (l `Bits.testBit` j)
@@ -542,7 +542,7 @@ modList :: forall u
           -> BVDomain u
 modList nm params w rgs
     -- If the width exceeds maxInt, then just return anything (otherwise we can't even shift.
-  | natValue w > toInteger (maxBound :: Int) = any w
+  | natValue w > fromIntegral (maxBound :: Int) = any w
   | otherwise =
     -- This entries over each range, and returns either @Nothing@ if
     -- the range contains all elements or the range.

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -34,7 +34,7 @@ library
     io-streams,
     lens,
     mtl,
-    parameterized-utils >= 1.0.4 && < 1.1,
+    parameterized-utils >= 1.0.8 && < 1.1,
     process,
     scientific,
     temporary >= 1.2,


### PR DESCRIPTION
parameterized-utils now uses `Natural` instead of `Integer` for the runtime values of `NatRepr`, so some changes are needed in various places to accommodate.
