### PR TITLE
Replce Natural with Integer in LLVM Bytes.

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/Bytes.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Bytes.hs
@@ -27,20 +27,20 @@ import Numeric.Natural
 -- | A newtype for expressing numbers of bytes.
 --   This newtype is explicitly introduced to avoid confusion
 --   between widths expressed as numbers of bits vs numbers of bytes.
-newtype Bytes = Bytes { unBytes :: Natural }
+newtype Bytes = Bytes { unBytes :: Integer }
   deriving (Eq, Ord, Num, Enum, Real, Integral)
 
 instance Show Bytes where
   show (Bytes n) = show n
 
 bytesToBits :: Bytes -> Natural
-bytesToBits (Bytes n) = 8 * n
+bytesToBits (Bytes n) = 8 * fromIntegral n
 
 bytesToNatural :: Bytes -> Natural
-bytesToNatural (Bytes n) = n
+bytesToNatural (Bytes n) = fromIntegral n
 
 bytesToInteger :: Bytes -> Integer
-bytesToInteger (Bytes n) = fromIntegral n
+bytesToInteger (Bytes n) = n
 
 toBytes :: Integral a => a -> Bytes
 toBytes = Bytes . fromIntegral


### PR DESCRIPTION
This avoids the arithmetic underflow error in the s2n saw proofs.