### PR TITLE
Fix SMTLib2 syntax for floating-point conversions 

### DIFF
--- a/crucible-syntax/src/Lang/Crucible/Syntax/Atoms.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Atoms.hs
@@ -65,7 +65,7 @@ data Keyword = Defun | DefBlock | DefGlobal
              | VectorGetEntry_ | VectorSetEntry_ | VectorCons_
              | Deref | Ref | EmptyRef
              | Jump_ | Return_ | Branch_ | MaybeBranch_ | TailCall_ | Error_ | Output_ | Case
-             | Print_
+             | Print_ | PrintLn_
              | Let | Fresh
              | Assert_ | Assume_
              | SetRegister
@@ -104,6 +104,7 @@ keywords =
   , ("error", Error_)
   , ("output", Output_)
   , ("print" , Print_)
+  , ("println" , PrintLn_)
   , ("Ref", RefT)
   , ("deref", Deref)
   , ("ref", Ref)

--- a/crucible-syntax/src/Lang/Crucible/Syntax/Atoms.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Atoms.hs
@@ -46,16 +46,15 @@ data Keyword = Defun | DefBlock | DefGlobal
              | Start
              | SetGlobal
              | SetRef | DropRef_
-             | Unpack
              | Plus | Minus | Times | Div | Negate | Abs
              | Just_ | Nothing_ | FromJust
              | Inj | Proj
              | AnyT | UnitT | BoolT | NatT | IntegerT | RealT | ComplexRealT | CharT | StringT
-             | BitvectorT | VectorT | FunT | MaybeT | VariantT | RefT
+             | BitvectorT | VectorT | FPT | FunT | MaybeT | VariantT | RefT
+             | Half_ | Float_ | Double_ | Quad_ | X86_80_ | DoubleDouble_
              | The
              | Equalp | Integerp
              | If
-             | Pack
              | Not_ | And_ | Or_ | Xor_
              | Mod
              | Lt | Le
@@ -76,20 +75,85 @@ data Keyword = Defun | DefBlock | DefGlobal
              | BVCarry_ | BVSCarry_ | BVSBorrow_
              | BVNot_ | BVAnd_ | BVOr_ | BVXor_ | BVShl_ | BVLshr_ | BVAshr_
              | Sle | Slt | Sdiv | Smod | ZeroExt | SignExt
+             | RNE_ | RNA_ | RTP_ | RTN_ | RTZ_
+             | FPToUBV_ | FPToSBV_ | UBVToFP_ | SBVToFP_ | BinaryToFP_ | FPToBinary_
+             | FPToReal_ | RealToFP_
   deriving (Eq, Ord)
 
 keywords :: [(Text, Keyword)]
 keywords =
+    -- function/block defintion
   [ ("defun" , Defun)
+  , ("start" , Start)
   , ("defblock", DefBlock)
   , ("defglobal", DefGlobal)
   , ("registers", Registers)
+
+    -- statements
   , ("let", Let)
   , ("set-global!", SetGlobal)
   , ("set-ref!", SetRef)
   , ("drop-ref!", DropRef_)
-  , ("start" , Start)
-  , ("unpack" , Unpack)
+  , ("fresh", Fresh)
+  , ("jump" , Jump_)
+  , ("case", Case)
+  , ("return" , Return_)
+  , ("branch" , Branch_)
+  , ("maybe-branch" , MaybeBranch_)
+  , ("tail-call" , TailCall_)
+  , ("error", Error_)
+  , ("output", Output_)
+  , ("print" , Print_)
+  , ("Ref", RefT)
+  , ("deref", Deref)
+  , ("ref", Ref)
+  , ("empty-ref", EmptyRef)
+  , ("set-register!", SetRegister)
+  , ("assert!", Assert_)
+  , ("assume!", Assume_)
+  , ("funcall", Funcall)
+
+    -- types
+  , ("Any" , AnyT)
+  , ("Unit" , UnitT)
+  , ("Bool" , BoolT)
+  , ("Nat" , NatT)
+  , ("Integer" , IntegerT)
+  , ("FP", FPT)
+  , ("Real" , RealT)
+  , ("ComplexReal" , ComplexRealT)
+  , ("Char" , CharT)
+  , ("String" , StringT)
+  , ("Bitvector" , BitvectorT)
+  , ("Vector", VectorT)
+  , ("->", FunT)
+  , ("Maybe", MaybeT)
+  , ("Variant", VariantT)
+
+    -- floating-point variants
+  , ("Half", Half_)
+  , ("Float", Float_)
+  , ("Double", Double_)
+  , ("Quad", Quad_)
+  , ("X86_80", X86_80_)
+  , ("DoubleDouble", DoubleDouble_)
+
+    -- misc
+  , ("the" , The)
+  , ("equal?" , Equalp)
+  , ("if" , If)
+
+    -- ANY types
+  , ("to-any", ToAny)
+  , ("from-any", FromAny)
+
+    -- booleans
+  , ("not" , Not_)
+  , ("and" , And_)
+  , ("or" , Or_)
+  , ("xor" , Xor_)
+
+    -- arithmetic
   , ("+" , Plus)
   , ("-" , Minus)
   , ("*" , Times)
@@ -102,31 +166,19 @@ keywords =
   , ("smod", Smod)
   , ("negate", Negate)
   , ("abs", Abs)
-  , ("show", Show)
+  , ("mod" , Mod)
+  , ("integer?" , Integerp)
+
+    -- Variants
   , ("inj", Inj)
   , ("proj", Proj)
+
+    -- Maybe
   , ("just" , Just_)
   , ("nothing" , Nothing_)
   , ("from-just" , FromJust)
-  , ("to-any", ToAny)
-  , ("from-any", FromAny)
-  , ("the" , The)
-  , ("equal?" , Equalp)
-  , ("integer?" , Integerp)
-  , ("Any" , AnyT)
-  , ("Unit" , UnitT)
-  , ("Bool" , BoolT)
-  , ("Nat" , NatT)
-  , ("Integer" , IntegerT)
-  , ("Real" , RealT)
-  , ("ComplexReal" , ComplexRealT)
-  , ("Char" , CharT)
-  , ("String" , StringT)
-  , ("Bitvector" , BitvectorT)
-  , ("Vector", VectorT)
-  , ("->", FunT)
-  , ("Maybe", MaybeT)
-  , ("Variant", VariantT)
+
+    -- Vectors
   , ("vector", VectorLit_)
   , ("vector-replicate", VectorReplicate_)
   , ("vector-empty?", VectorIsEmpty_)
@@ -134,32 +186,12 @@ keywords =
   , ("vector-get", VectorGetEntry_)
   , ("vector-set", VectorSetEntry_)
   , ("vector-cons", VectorCons_)
-  , ("if" , If)
-  , ("pack" , Pack)
-  , ("not" , Not_)
-  , ("and" , And_)
-  , ("or" , Or_)
-  , ("xor" , Xor_)
-  , ("mod" , Mod)
-  , ("fresh", Fresh)
-  , ("jump" , Jump_)
-  , ("case", Case)
-  , ("return" , Return_)
-  , ("branch" , Branch_)
-  , ("maybe-branch" , MaybeBranch_)
-  , ("tail-call" , TailCall_)
-  , ("error", Error_)
-  , ("output", Output_)
-  , ("print" , Print_)
+
+    -- strings
+  , ("show", Show)
   , ("string-append", StringAppend)
-  , ("Ref", RefT)
-  , ("deref", Deref)
-  , ("ref", Ref)
-  , ("empty-ref", EmptyRef)
-  , ("set-register!", SetRegister)
-  , ("assert!", Assert_)
-  , ("assume!", Assume_)
-  , ("funcall", Funcall)
+
+    -- bitvector
   , ("bv", BV)
   , ("bv-concat", BVConcat_)
   , ("bv-select", BVSelect_)
@@ -178,8 +210,22 @@ keywords =
   , ("shl", BVShl_)
   , ("lshr", BVLshr_)
   , ("ashr", BVAshr_)
-  ]
 
+    -- floating-point
+  , ("fp-to-ubv", FPToUBV_)
+  , ("fp-to-sbv", FPToSBV_)
+  , ("ubv-to-fp", UBVToFP_)
+  , ("sbv-to-fp", SBVToFP_)
+  , ("fp-to-binary", FPToBinary_)
+  , ("binary-to-fp", BinaryToFP_)
+  , ("real-to-fp", RealToFP_)
+  , ("fp-to-real", FPToReal_)
+  , ("rne" , RNE_)
+  , ("rna" , RNA_)
+  , ("rtp" , RTP_)
+  , ("rtn" , RTN_)
+  , ("rtz" , RTZ_)
+  ]
 
 instance Show Keyword where
   show k = case [str | (str, k') <- keywords, k == k'] of

--- a/crucible-syntax/src/Lang/Crucible/Syntax/Concrete.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Concrete.hs
@@ -896,7 +896,7 @@ synthExpr typeHint =
              return $ SomeE StringRepr $ EApp $ ShowFloat fi e
            _ | AsBaseType bt <- asBaseType t1 ->
              return $ SomeE StringRepr $ EApp $ ShowValue bt e
-           _ -> describe ("base or floating point type, but got " <> T.pack (show t1)) empty
+           _ -> later $ describe ("base or floating point type, but got " <> T.pack (show t1)) empty
 
 data NatHint
   = NoHint

--- a/crucible-syntax/src/Lang/Crucible/Syntax/Concrete.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Concrete.hs
@@ -799,7 +799,7 @@ synthExpr typeHint =
             (asBaseType -> AsBaseType bty) ->
                return $ SomeE tp $ EApp $ BaseIte bty c t f
             _ ->
-               let msg = T.concat [ "conditional where branches have base or floating point type (got "
+               let msg = T.concat [ "conditional where branches have base or floating point type, but got "
                                   , T.pack (show tp)
                                   ]
                in later $ describe msg empty
@@ -894,7 +894,7 @@ synthExpr typeHint =
          case t1 of
            FloatRepr fi ->
              return $ SomeE StringRepr $ EApp $ ShowFloat fi e
-           _ | AsBaseType bt <- asBaseType t1 ->
+           (asBaseType -> AsBaseType bt) ->
              return $ SomeE StringRepr $ EApp $ ShowValue bt e
            _ -> later $ describe ("base or floating point type, but got " <> T.pack (show t1)) empty
 

--- a/crucible-syntax/src/Lang/Crucible/Syntax/Concrete.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Concrete.hs
@@ -1331,15 +1331,20 @@ normStmt' :: forall h s m
            . (MonadWriter [Posd (Stmt () s)] m, MonadSyntax Atomic m, MonadState (SyntaxState h s) m, MonadST h m) =>
              m ()
 normStmt' =
-  call (printStmt <|> letStmt <|> (void funcall) <|>
+  call (printStmt <|> printLnStmt <|> letStmt <|> (void funcall) <|>
         setGlobal <|> setReg <|> setRef <|> dropRef <|>
         assertion <|> assumption)
 
   where
-    printStmt, letStmt, setGlobal, setReg, setRef, dropRef, assertion :: m ()
+    printStmt, printLnStmt, letStmt, setGlobal, setReg, setRef, dropRef, assertion :: m ()
     printStmt =
       do Posd loc e <- unary Print_ (located $ reading $ check StringRepr)
          strAtom <- eval loc e
+         tell [Posd loc (Print strAtom)]
+
+    printLnStmt =
+      do Posd loc e <- unary PrintLn_ (located $ reading $ check StringRepr)
+         strAtom <- eval loc (EApp (AppendString e (EApp (TextLit "\n"))))
          tell [Posd loc (Print strAtom)]
 
     letStmt =

--- a/crucible-syntax/test-data/parser-tests/floats.cbl
+++ b/crucible-syntax/test-data/parser-tests/floats.cbl
@@ -1,0 +1,74 @@
+;; exercise floating-point expression formers
+
+(defun @test-float () Unit
+  (start start:
+    (let a_f (fresh (FP Float)))
+    (let b_d (fresh (FP Double)))
+    (let c_h (fresh (FP Half)))
+    (let d_q (fresh (FP Quad)))
+    (let e_dd (fresh (FP DoubleDouble)))
+    (let f_x87 (fresh (FP X86_80)))
+
+    (let r1 (fresh Real))
+    (let r2 (fresh Real))
+    (let r3 (fresh Real))
+
+    (let bv16 (fresh (Bitvector 16)))
+    (let bv32 (fresh (Bitvector 32)))
+    (let bv64 (fresh (Bitvector 64)))
+    (let bv128 (fresh (Bitvector 128)))
+    (let bv80 (fresh (Bitvector 80)))
+
+    (let f16 (binary-to-fp Half bv16))
+    (let f32 (binary-to-fp Float bv32))
+    (let f64 (binary-to-fp Double bv64))
+    (let f128 (binary-to-fp Quad bv128))
+    (let fdd (binary-to-fp DoubleDouble bv128))
+    (let f80 (binary-to-fp X86_80 bv80))
+
+    (let n1 (fp-to-binary a_f))
+    (let n2 (fp-to-binary b_d))
+    (let n3 (fp-to-binary c_h))
+    (let n4 (fp-to-binary d_q))
+    (let n5 (fp-to-binary e_dd))
+    (let n6 (fp-to-binary f_x87))
+
+    (let u1 (ubv-to-fp Half rne bv64))
+    (let u2 (ubv-to-fp Float rna bv16))
+    (let u3 (ubv-to-fp Double rtp bv32))
+    (let u4 (ubv-to-fp Quad rtn bv80))
+    (let u5 (ubv-to-fp DoubleDouble rtz bv64))
+
+    (let s1 (sbv-to-fp Half rne bv64))
+    (let s2 (sbv-to-fp Float rna bv16))
+    (let s3 (sbv-to-fp Double rtp bv32))
+    (let s4 (sbv-to-fp Quad rtn bv80))
+    (let s5 (sbv-to-fp DoubleDouble rtz bv64))
+
+    (let x1 (fp-to-ubv 32 rne a_f))
+    (let x2 (fp-to-ubv 40 rna b_d))
+    (let x3 (fp-to-ubv 64 rtp c_h))
+    (let x4 (fp-to-ubv 16 rtn d_q))
+    (let x5 (fp-to-ubv 128 rtz e_dd))
+
+    (let y1 (fp-to-sbv 32 rne a_f))
+    (let y2 (fp-to-sbv 40 rna b_d))
+    (let y3 (fp-to-sbv 64 rtp c_h))
+    (let y4 (fp-to-sbv 16 rtn d_q))
+    (let y5 (fp-to-sbv 128 rtz e_dd))
+
+    (let w1 (fp-to-real a_f))
+    (let w2 (fp-to-real b_d))
+    (let w3 (fp-to-real c_h))
+    (let w4 (fp-to-real d_q))
+    (let w5 (fp-to-real e_dd))
+    (let w6 (fp-to-real f_x87))
+
+    (let q1 (real-to-fp Float rne r1))
+    (let q2 (real-to-fp Double rna r2))
+    (let q3 (real-to-fp Half rtp r3))
+    (let q4 (real-to-fp DoubleDouble rtn r1))
+    (let q5 (real-to-fp X86_80 rtz r2))
+
+    (return ()))
+)

--- a/crucible-syntax/test-data/parser-tests/floats.cbl
+++ b/crucible-syntax/test-data/parser-tests/floats.cbl
@@ -70,5 +70,8 @@
     (let q4 (real-to-fp DoubleDouble rtn r1))
     (let q5 (real-to-fp X86_80 rtz r2))
 
+    (let b (fresh Bool))
+    (let ite (if b u3 q2))
+
     (return ()))
 )

--- a/crucible-syntax/test-data/parser-tests/floats.out.good
+++ b/crucible-syntax/test-data/parser-tests/floats.out.good
@@ -57,6 +57,8 @@
       (let q3 (real-to-fp Half rtp r3))
       (let q4 (real-to-fp DoubleDouble rtn r1))
       (let q5 (real-to-fp X86_80 rtz r2))
+      (let b (fresh Bool))
+      (let ite (if b u3 q2))
       (return ())))
 
 test-float
@@ -175,8 +177,12 @@ test-float
   $55 = floatFromReal(DoubleDoubleFloatRepr, RTN, $6)
   % 71:13
   $56 = floatFromReal(X86_80FloatRepr, RTZ, $7)
-  % 73:13
-  $57 = emptyApp()
-  % 73:5
-  return $57
+  % 73:12
+  $57 = fresh BaseBoolRepr b
+  % 74:14
+  $58 = floatIte(DoubleFloatRepr, $57, $28, $53)
+  % 76:13
+  $59 = emptyApp()
+  % 76:5
+  return $59
   % no postdom

--- a/crucible-syntax/test-data/parser-tests/floats.out.good
+++ b/crucible-syntax/test-data/parser-tests/floats.out.good
@@ -1,0 +1,182 @@
+(defun @test-float () Unit
+   (start start:
+      (let a_f (fresh (FP Float)))
+      (let b_d (fresh (FP Double)))
+      (let c_h (fresh (FP Half)))
+      (let d_q (fresh (FP Quad)))
+      (let e_dd (fresh (FP DoubleDouble)))
+      (let f_x87 (fresh (FP X86_80)))
+      (let r1 (fresh Real))
+      (let r2 (fresh Real))
+      (let r3 (fresh Real))
+      (let bv16 (fresh (Bitvector 16)))
+      (let bv32 (fresh (Bitvector 32)))
+      (let bv64 (fresh (Bitvector 64)))
+      (let bv128 (fresh (Bitvector 128)))
+      (let bv80 (fresh (Bitvector 80)))
+      (let f16 (binary-to-fp Half bv16))
+      (let f32 (binary-to-fp Float bv32))
+      (let f64 (binary-to-fp Double bv64))
+      (let f128 (binary-to-fp Quad bv128))
+      (let fdd (binary-to-fp DoubleDouble bv128))
+      (let f80 (binary-to-fp X86_80 bv80))
+      (let n1 (fp-to-binary a_f))
+      (let n2 (fp-to-binary b_d))
+      (let n3 (fp-to-binary c_h))
+      (let n4 (fp-to-binary d_q))
+      (let n5 (fp-to-binary e_dd))
+      (let n6 (fp-to-binary f_x87))
+      (let u1 (ubv-to-fp Half rne bv64))
+      (let u2 (ubv-to-fp Float rna bv16))
+      (let u3 (ubv-to-fp Double rtp bv32))
+      (let u4 (ubv-to-fp Quad rtn bv80))
+      (let u5 (ubv-to-fp DoubleDouble rtz bv64))
+      (let s1 (sbv-to-fp Half rne bv64))
+      (let s2 (sbv-to-fp Float rna bv16))
+      (let s3 (sbv-to-fp Double rtp bv32))
+      (let s4 (sbv-to-fp Quad rtn bv80))
+      (let s5 (sbv-to-fp DoubleDouble rtz bv64))
+      (let x1 (fp-to-ubv 32 rne a_f))
+      (let x2 (fp-to-ubv 40 rna b_d))
+      (let x3 (fp-to-ubv 64 rtp c_h))
+      (let x4 (fp-to-ubv 16 rtn d_q))
+      (let x5 (fp-to-ubv 128 rtz e_dd))
+      (let y1 (fp-to-sbv 32 rne a_f))
+      (let y2 (fp-to-sbv 40 rna b_d))
+      (let y3 (fp-to-sbv 64 rtp c_h))
+      (let y4 (fp-to-sbv 16 rtn d_q))
+      (let y5 (fp-to-sbv 128 rtz e_dd))
+      (let w1 (fp-to-real a_f))
+      (let w2 (fp-to-real b_d))
+      (let w3 (fp-to-real c_h))
+      (let w4 (fp-to-real d_q))
+      (let w5 (fp-to-real e_dd))
+      (let w6 (fp-to-real f_x87))
+      (let q1 (real-to-fp Float rne r1))
+      (let q2 (real-to-fp Double rna r2))
+      (let q3 (real-to-fp Half rtp r3))
+      (let q4 (real-to-fp DoubleDouble rtn r1))
+      (let q5 (real-to-fp X86_80 rtz r2))
+      (return ())))
+
+test-float
+%0
+  % 5:14
+  $0 = fresh-float SingleFloatRepr a_f
+  % 6:14
+  $1 = fresh-float DoubleFloatRepr b_d
+  % 7:14
+  $2 = fresh-float HalfFloatRepr c_h
+  % 8:14
+  $3 = fresh-float QuadFloatRepr d_q
+  % 9:15
+  $4 = fresh-float DoubleDoubleFloatRepr e_dd
+  % 10:16
+  $5 = fresh-float X86_80FloatRepr f_x87
+  % 12:13
+  $6 = fresh BaseRealRepr r1
+  % 13:13
+  $7 = fresh BaseRealRepr r2
+  % 14:13
+  $8 = fresh BaseRealRepr r3
+  % 16:15
+  $9 = fresh BaseBVRepr 16 bv16
+  % 17:15
+  $10 = fresh BaseBVRepr 32 bv32
+  % 18:15
+  $11 = fresh BaseBVRepr 64 bv64
+  % 19:16
+  $12 = fresh BaseBVRepr 128 bv128
+  % 20:15
+  $13 = fresh BaseBVRepr 80 bv80
+  % 22:14
+  $14 = floatFromBinary(HalfFloatRepr, $9)
+  % 23:14
+  $15 = floatFromBinary(SingleFloatRepr, $10)
+  % 24:14
+  $16 = floatFromBinary(DoubleFloatRepr, $11)
+  % 25:15
+  $17 = floatFromBinary(QuadFloatRepr, $12)
+  % 26:14
+  $18 = floatFromBinary(DoubleDoubleFloatRepr, $12)
+  % 27:14
+  $19 = floatFromBinary(X86_80FloatRepr, $13)
+  % 29:13
+  $20 = floatToBinary(SingleFloatRepr, $0)
+  % 30:13
+  $21 = floatToBinary(DoubleFloatRepr, $1)
+  % 31:13
+  $22 = floatToBinary(HalfFloatRepr, $2)
+  % 32:13
+  $23 = floatToBinary(QuadFloatRepr, $3)
+  % 33:13
+  $24 = floatToBinary(DoubleDoubleFloatRepr, $4)
+  % 34:13
+  $25 = floatToBinary(X86_80FloatRepr, $5)
+  % 36:13
+  $26 = floatFromBV(HalfFloatRepr, RNE, $11)
+  % 37:13
+  $27 = floatFromBV(SingleFloatRepr, RNA, $9)
+  % 38:13
+  $28 = floatFromBV(DoubleFloatRepr, RTP, $10)
+  % 39:13
+  $29 = floatFromBV(QuadFloatRepr, RTN, $13)
+  % 40:13
+  $30 = floatFromBV(DoubleDoubleFloatRepr, RTZ, $11)
+  % 42:13
+  $31 = floatFromSBV(HalfFloatRepr, RNE, $11)
+  % 43:13
+  $32 = floatFromSBV(SingleFloatRepr, RNA, $9)
+  % 44:13
+  $33 = floatFromSBV(DoubleFloatRepr, RTP, $10)
+  % 45:13
+  $34 = floatFromSBV(QuadFloatRepr, RTN, $13)
+  % 46:13
+  $35 = floatFromSBV(DoubleDoubleFloatRepr, RTZ, $11)
+  % 48:13
+  $36 = floatToBV(32, RNE, $0)
+  % 49:13
+  $37 = floatToBV(40, RNA, $1)
+  % 50:13
+  $38 = floatToBV(64, RTP, $2)
+  % 51:13
+  $39 = floatToBV(16, RTN, $3)
+  % 52:13
+  $40 = floatToBV(128, RTZ, $4)
+  % 54:13
+  $41 = floatToSBV(32, RNE, $0)
+  % 55:13
+  $42 = floatToSBV(40, RNA, $1)
+  % 56:13
+  $43 = floatToSBV(64, RTP, $2)
+  % 57:13
+  $44 = floatToSBV(16, RTN, $3)
+  % 58:13
+  $45 = floatToSBV(128, RTZ, $4)
+  % 60:13
+  $46 = floatToReal($0)
+  % 61:13
+  $47 = floatToReal($1)
+  % 62:13
+  $48 = floatToReal($2)
+  % 63:13
+  $49 = floatToReal($3)
+  % 64:13
+  $50 = floatToReal($4)
+  % 65:13
+  $51 = floatToReal($5)
+  % 67:13
+  $52 = floatFromReal(SingleFloatRepr, RNE, $6)
+  % 68:13
+  $53 = floatFromReal(DoubleFloatRepr, RNA, $7)
+  % 69:13
+  $54 = floatFromReal(HalfFloatRepr, RTP, $8)
+  % 70:13
+  $55 = floatFromReal(DoubleDoubleFloatRepr, RTN, $6)
+  % 71:13
+  $56 = floatFromReal(X86_80FloatRepr, RTZ, $7)
+  % 73:13
+  $57 = emptyApp()
+  % 73:5
+  return $57
+  % no postdom

--- a/crucible-syntax/test-data/simulator-tests/assert.out.good
+++ b/crucible-syntax/test-data/simulator-tests/assert.out.good
@@ -7,3 +7,4 @@ Prove:
   x is true
   in main at test-data/simulator-tests/assert.cbl:4:5
   cx@2:b
+COUNTEREXAMPLE

--- a/crucible-syntax/test-data/simulator-tests/assume-merge.out.good
+++ b/crucible-syntax/test-data/simulator-tests/assume-merge.out.good
@@ -11,6 +11,7 @@ Prove:
   oopsie!
   in main at test-data/simulator-tests/assume-merge.cbl:12:5
   false
+COUNTEREXAMPLE
 Assuming:
 * The branch in main from test-data/simulator-tests/assume-merge.cbl:4:5 to test-data/simulator-tests/assume-merge.cbl:9:14
     boolNot (intLe 0 cx@2:i)
@@ -20,3 +21,4 @@ Prove:
   oopsie!
   in main at test-data/simulator-tests/assume-merge.cbl:12:5
   false
+COUNTEREXAMPLE

--- a/crucible-syntax/test-data/simulator-tests/assume-merge2.out.good
+++ b/crucible-syntax/test-data/simulator-tests/assume-merge2.out.good
@@ -15,3 +15,4 @@ Prove:
   oopsie!
   in main at test-data/simulator-tests/assume-merge2.cbl:12:5
   false
+COUNTEREXAMPLE

--- a/crucible-syntax/test-data/simulator-tests/assume.out.good
+++ b/crucible-syntax/test-data/simulator-tests/assume.out.good
@@ -9,3 +9,4 @@ Prove:
   error statement
   in main at test-data/simulator-tests/assume.cbl:5:5
   false
+COUNTEREXAMPLE

--- a/crucible-syntax/test-data/simulator-tests/branch.out.good
+++ b/crucible-syntax/test-data/simulator-tests/branch.out.good
@@ -7,3 +7,4 @@ Prove:
   bogus condition
   in main at test-data/simulator-tests/branch.cbl:11:5
   boolAnd (intEq 42 cx@3:i) cp@2:b
+COUNTEREXAMPLE

--- a/crucible-syntax/test-data/simulator-tests/calls.cbl
+++ b/crucible-syntax/test-data/simulator-tests/calls.cbl
@@ -2,6 +2,8 @@
   (start start:
     (let x (fresh Integer))
     (let y (funcall @f x))
+    (println (show x))
+    (println (show y))
     (assert! (equal? x y) "bogus")
     (return ())))
 

--- a/crucible-syntax/test-data/simulator-tests/calls.out.good
+++ b/crucible-syntax/test-data/simulator-tests/calls.out.good
@@ -1,9 +1,12 @@
 ==== Begin Simulation ====
+cx@2:i
+intSum cx@2:i 42
 
 ==== Finish Simulation ====
 ==== Proof obligations ====
 
 Prove:
   bogus
-  in main at test-data/simulator-tests/calls.cbl:5:5
+  in main at test-data/simulator-tests/calls.cbl:7:5
   false
+COUNTEREXAMPLE

--- a/crucible-syntax/test-data/simulator-tests/double-branch.out.good
+++ b/crucible-syntax/test-data/simulator-tests/double-branch.out.good
@@ -11,3 +11,4 @@ Prove:
   assert
   in main at test-data/simulator-tests/double-branch.cbl:9:5
   intEq 5 ca@2:i
+PROVED

--- a/crucible-syntax/test-data/simulator-tests/float-cast.cbl
+++ b/crucible-syntax/test-data/simulator-tests/float-cast.cbl
@@ -1,0 +1,27 @@
+
+(defun @main () Unit
+  (start start:
+    (let a (fresh (FP Double)))
+    (let b (fp-to-binary a))   
+    (let c (binary-to-fp Double b))
+
+    (println (show b))
+    (println (show c))
+
+    (let x (fresh (Bitvector 64)))
+    (let y (binary-to-fp Double x))
+    (let z (fp-to-binary y))
+
+    (println (show y))
+    (println (show z))
+
+    (let u (fp-to-ubv 64 rne a))
+    (println (show u))
+    (assert! (equal? a (ubv-to-fp Double rne u)) "bad unsigned round trip")
+
+    (let s (fp-to-sbv 64 rne a))
+    (println (show s))
+    (assert! (equal? a (sbv-to-fp Double rne s)) "bad signed round trip")
+
+    (return ()))
+)

--- a/crucible-syntax/test-data/simulator-tests/float-cast.out.good
+++ b/crucible-syntax/test-data/simulator-tests/float-cast.out.good
@@ -1,0 +1,25 @@
+==== Begin Simulation ====
+floatToBinary ca@2:f
+ca@2:f
+floatFromBinary cx@4:bv
+floatToBinary (floatFromBinary cx@4:bv)
+floatToBV RNE ca@2:f
+floatToSBV RNE ca@2:f
+
+==== Finish Simulation ====
+==== Proof obligations ====
+
+Prove:
+  bad unsigned round trip
+  in main at test-data/simulator-tests/float-cast.cbl:20:5
+  floatEq ca@2:f (bvToFloat RNE (floatToBV RNE ca@2:f))
+COUNTEREXAMPLE
+Assuming:
+* bad unsigned round trip
+    in main at test-data/simulator-tests/float-cast.cbl:20:5
+    floatEq ca@2:f (bvToFloat RNE (floatToBV RNE ca@2:f))
+Prove:
+  bad signed round trip
+  in main at test-data/simulator-tests/float-cast.cbl:24:5
+  floatEq ca@2:f (sbvToFloat RNE (floatToSBV RNE ca@2:f))
+COUNTEREXAMPLE

--- a/crucible-syntax/test-data/simulator-tests/from-maybe.out.good
+++ b/crucible-syntax/test-data/simulator-tests/from-maybe.out.good
@@ -7,6 +7,7 @@ Prove:
   OK to project z
   in main at test-data/simulator-tests/from-maybe.cbl:11:12
   cp@2:b
+COUNTEREXAMPLE
 Assuming:
 * OK to project z
     in main at test-data/simulator-tests/from-maybe.cbl:11:12
@@ -15,3 +16,4 @@ Prove:
   from-just eq (bogus)
   in main at test-data/simulator-tests/from-maybe.cbl:12:5
   false
+COUNTEREXAMPLE

--- a/crucible-syntax/test-data/simulator-tests/loop-err.out.good
+++ b/crucible-syntax/test-data/simulator-tests/loop-err.out.good
@@ -11,6 +11,7 @@ Prove:
   oopsie!
   in main at test-data/simulator-tests/loop-err.cbl:27:5
   false
+COUNTEREXAMPLE
 Assuming:
 * in main test-data/simulator-tests/loop-err.cbl:10:5: nonzero start
     boolNot (natEq 0 cx@2:n)
@@ -22,6 +23,7 @@ Prove:
   oopsie!
   in main at test-data/simulator-tests/loop-err.cbl:27:5
   false
+PROVED
 Assuming:
 * in main test-data/simulator-tests/loop-err.cbl:10:5: nonzero start
     boolNot (natEq 0 cx@2:n)
@@ -35,6 +37,7 @@ Prove:
   oopsie!
   in main at test-data/simulator-tests/loop-err.cbl:27:5
   false
+PROVED
 Assuming:
 * in main test-data/simulator-tests/loop-err.cbl:10:5: nonzero start
     boolNot (natEq 0 cx@2:n)
@@ -48,3 +51,4 @@ Prove:
   nonzero
   in main at test-data/simulator-tests/loop-err.cbl:23:5
   boolNot (natLe (natSum 8* cx@2:n) 0)
+PROVED

--- a/crucible-syntax/test-data/simulator-tests/loop.out.good
+++ b/crucible-syntax/test-data/simulator-tests/loop.out.good
@@ -9,3 +9,4 @@ Prove:
   nonzero
   in main at test-data/simulator-tests/loop.cbl:19:5
   boolNot (natLe (natSum 8* cx@2:n) 0)
+PROVED

--- a/crucible-syntax/test-data/simulator-tests/override-test.out.good
+++ b/crucible-syntax/test-data/simulator-tests/override-test.out.good
@@ -7,3 +7,4 @@ Prove:
   should be true!
   in main at test-data/simulator-tests/override-test.cbl:7:5
   intEq (intIte cp@2:b cx@3:i cy@4:i) (intIte cp@2:b cx@3:i cy@4:i)
+PROVED

--- a/crucible-syntax/test-data/simulator-tests/override-test2.out.good
+++ b/crucible-syntax/test-data/simulator-tests/override-test2.out.good
@@ -13,6 +13,7 @@ Prove:
   fall-through branch
   in symbolicBranchesTest at default branch
   false
+COUNTEREXAMPLE
 Assuming:
 * The branch in symbolicBranchesTest from after branch 1 to third branch
     let -- default branch
@@ -24,3 +25,4 @@ Prove:
   let -- default branch
       v23 = intSum 2* cx@2:i (intIte (intEq 2 cx@2:i) 0 cy@3:i)
    in intEq (intIte (intEq 1 cx@2:i) cy@3:i v23) cx@2:i
+COUNTEREXAMPLE

--- a/crucible/src/Lang/Crucible/CFG/Core.hs
+++ b/crucible/src/Lang/Crucible/CFG/Core.hs
@@ -311,6 +311,11 @@ data Stmt ext (ctx :: Ctx CrucibleType) (ctx' :: Ctx CrucibleType) where
                 -> !(Maybe SolverSymbol)
                 -> Stmt ext ctx (ctx ::> BaseToType bt)
 
+  -- Create a fresh floating-point constant
+  FreshFloat :: !(FloatInfoRepr fi)
+             -> !(Maybe SolverSymbol)
+             -> Stmt ext ctx (ctx ::> FloatType fi)
+
   -- Allocate a new reference cell
   NewRefCell :: !(TypeRepr tp)
              -> !(Reg ctx tp)
@@ -467,6 +472,9 @@ applyEmbeddingStmt ctxe stmt =
     FreshConstant bt nm -> Pair (FreshConstant bt nm)
                                 (Ctx.extendEmbeddingBoth ctxe)
 
+    FreshFloat fi nm -> Pair (FreshFloat fi nm)
+                             (Ctx.extendEmbeddingBoth ctxe)
+
     NewRefCell tp r -> Pair (NewRefCell tp (reg r))
                             (Ctx.extendEmbeddingBoth ctxe)
     NewEmptyRefCell tp -> Pair (NewEmptyRefCell tp)
@@ -569,6 +577,7 @@ nextStmtHeight h s =
     ReadGlobal{} -> incSize h
     WriteGlobal{} -> h
     FreshConstant{} -> Ctx.incSize h
+    FreshFloat{} -> Ctx.incSize h
     NewRefCell{} -> Ctx.incSize h
     NewEmptyRefCell{} ->Ctx.incSize h
     ReadRefCell{} -> Ctx.incSize h
@@ -590,6 +599,7 @@ ppStmt r s =
     ReadGlobal v -> text "read" <+> ppReg r <+> pretty v
     WriteGlobal v e -> text "write" <+> pretty v <+> pretty e
     FreshConstant bt nm -> ppReg r <+> text "=" <+> text "fresh" <+> pretty bt <+> maybe mempty (text . show) nm
+    FreshFloat fi nm -> ppReg r <+> text "=" <+> text "fresh-float" <+> pretty fi <+> maybe mempty (text . show) nm
     NewRefCell _ e -> ppReg r <+> text "=" <+> ppFn "newref" [ pretty e ]
     NewEmptyRefCell tp -> ppReg r <+> text "=" <+> ppFn "emptyref" [ pretty tp ]
     ReadRefCell e -> ppReg r <+> text "= !" <> pretty e

--- a/crucible/src/Lang/Crucible/CFG/Expr.hs
+++ b/crucible/src/Lang/Crucible/CFG/Expr.hs
@@ -923,6 +923,10 @@ data App (ext :: Type) (f :: CrucibleType -> Type) (tp :: CrucibleType) where
             -> !(f (BaseToType bt))
             -> App ext f StringType
 
+  ShowFloat :: !(FloatInfoRepr fi)
+            -> !(f (FloatType fi))
+            -> App ext f StringType
+
   AppendString :: !(f StringType)
                -> !(f StringType)
                -> App ext f StringType
@@ -1203,6 +1207,7 @@ instance TypeApp (ExprExtension ext) => TypeApp (App ext) where
 
     TextLit{} -> knownRepr
     ShowValue{} -> knownRepr
+    ShowFloat{} -> knownRepr
     AppendString{} -> knownRepr
 
     ------------------------------------------------------------------------

--- a/crucible/src/Lang/Crucible/CFG/SSAConversion.hs
+++ b/crucible/src/Lang/Crucible/CFG/SSAConversion.hs
@@ -798,6 +798,14 @@ resolveStmts nm bi sz reg_map bindings appMap (Posd p s0:rest) t = do
           let stmt = C.FreshConstant bt cnm
           C.ConsStmt pl stmt (resolveStmts nm bi sz' reg_map' bindings' appMap' rest t)
 
+        FreshFloat fi cnm -> do
+          let sz' = incSize sz
+          let reg_map'  = reg_map  & assignRegister (AtomValue a) sz
+          let bindings' = bindings & extendRegExprs NothingF
+          let appMap'   = appMap   & appRegMap_extend
+          let stmt = C.FreshFloat fi cnm
+          C.ConsStmt pl stmt (resolveStmts nm bi sz' reg_map' bindings' appMap' rest t)
+
         Call h args _ -> do
           let return_type = typeOfAtom a
           let h' = resolveAtom reg_map h

--- a/crucible/src/Lang/Crucible/Simulator/EvalStmt.hs
+++ b/crucible/src/Lang/Crucible/Simulator/EvalStmt.hs
@@ -61,6 +61,7 @@ import           Text.PrettyPrint.ANSI.Leijen hiding ((<$>))
 
 import           What4.Config
 import           What4.Interface
+import           What4.InterpretedFloatingPoint (freshFloatConstant)
 import           What4.Partial
 import           What4.ProgramLoc
 import           What4.Symbol (emptySymbol)
@@ -273,6 +274,11 @@ stepStmt verb stmt rest =
          do let nm = fromMaybe emptySymbol mnm
             v <- liftIO $ freshConstant sym nm bt
             continueWith $ stateCrucibleFrame %~ extendFrame (baseToType bt) v rest
+
+       FreshFloat fi mnm ->
+         do let nm = fromMaybe emptySymbol mnm
+            v <- liftIO $ freshFloatConstant sym nm fi
+            continueWith $ stateCrucibleFrame %~ extendFrame (FloatRepr fi) v rest
 
        SetReg tp e ->
          do v <- evalExpr verb e

--- a/crucible/src/Lang/Crucible/Simulator/Evaluation.hs
+++ b/crucible/src/Lang/Crucible/Simulator/Evaluation.hs
@@ -923,6 +923,9 @@ evalApp sym itefns _logFn evalExt (evalSub :: forall tp. f tp -> IO (RegValue sy
     ShowValue _bt x_expr -> do
       x <- evalSub x_expr
       stringLit sym (Text.pack (show (printSymExpr x)))
+    ShowFloat _fi x_expr -> do
+      x <- evalSub x_expr
+      stringLit sym (Text.pack (show (printSymExpr x)))
     AppendString x y -> do
       x' <- evalSub x
       y' <- evalSub y

--- a/crucible/src/Lang/Crucible/Utils/CoreRewrite.hs
+++ b/crucible/src/Lang/Crucible/Utils/CoreRewrite.hs
@@ -103,6 +103,7 @@ stmtDiff stmt =
     ReadGlobal {}    -> Ctx.knownDiff
     WriteGlobal {}   -> Ctx.knownDiff
     FreshConstant{}  -> Ctx.knownDiff
+    FreshFloat{}     -> Ctx.knownDiff
     NewRefCell {}    -> Ctx.knownDiff
     NewEmptyRefCell{}-> Ctx.knownDiff
     ReadRefCell {}   -> Ctx.knownDiff

--- a/what4/src/What4/Protocol/SMTLib2.hs
+++ b/what4/src/What4/Protocol/SMTLib2.hs
@@ -388,9 +388,9 @@ instance SupportTermOps Term where
   realToFloat fpp r = un_app $ mkRoundingOp (mkFloatSymbol "to_fp" (asSMTFloatPrecision fpp)) r
 
   floatToBV w r =
-    un_app $ mkRoundingOp ("(fp.to_ubv " <> fromString (show w) <> ")") r
+    un_app $ mkRoundingOp ("(_ fp.to_ubv " <> fromString (show w) <> ")") r
   floatToSBV w r =
-    un_app $ mkRoundingOp ("(fp.to_sbv " <> fromString (show w) <> ")") r
+    un_app $ mkRoundingOp ("(_ fp.to_sbv " <> fromString (show w) <> ")") r
 
   floatToReal = un_app "fp.to_real"
 


### PR DESCRIPTION
The bugfix for SMTLib syntax is contained in 6ee9bcb.

The remainder of this pull request is basically about adding enough support to crucible-syntax and crucible proper to execute a test case verifying the bugfix.  This involves adding a syntax for the floating-point types, rounding modes, and a selection of the floating-point cast operations.

Further floating-point operations ought to be easier to add in the future, given this infrastructure.