### PR TITLE
Update `crucible-server` use the new path-satisfiability execution

### DIFF
--- a/crucible-server/crucible-server/Main_crucible.hs
+++ b/crucible-server/crucible-server/Main_crucible.hs
@@ -25,6 +25,7 @@ import           Data.Parameterized.Nonce
 
 import           Lang.Crucible.Backend.Simple
 import qualified Lang.Crucible.Backend.SAWCore as SAW
+import           Lang.Crucible.Simulator.PathSatisfiability
 
 import           What4.Expr.Builder(Flags,FloatReal)
 
@@ -90,7 +91,8 @@ runSAWSimulator hin hout =
        CryptolSAW.scLoadCryptolModule sc
        (sym :: SAWBack n) <- SAW.newSAWCoreBackend sc gen
        sawState <- initSAWServerPersonality sym
-       s <- newSimulator sym sawServerOptions sawState sawServerOverrides hin hout
+       pathSatFeat <- pathSatisfiabilityFeature sym (SAW.considerSatisfiability sym)
+       s <- newSimulator sym sawServerOptions sawState [pathSatFeat] sawServerOverrides hin hout
        putDelimited hout ok_resp
        -- Enter loop to start reading commands.
        fulfillRequests s sawBackendRequests
@@ -101,7 +103,7 @@ runSimpleSimulator hin hout = do
     let ok_resp = mempty
                   & P.handShakeResponse_code .~ P.HandShakeOK
     (sym :: SimpleBackend t (Flags FloatReal)) <- newSimpleBackend gen
-    s <- newSimulator sym simpleServerOptions CrucibleServerPersonality simpleServerOverrides hin hout
+    s <- newSimulator sym simpleServerOptions CrucibleServerPersonality [] simpleServerOverrides hin hout
     -- Enter loop to start reading commands.
     putDelimited hout ok_resp
     fulfillRequests s simpleBackendRequests

--- a/crucible-server/java_api/src/main/java/com/galois/crucible/SAWSimulator.java
+++ b/crucible-server/java_api/src/main/java/com/galois/crucible/SAWSimulator.java
@@ -57,7 +57,7 @@ public final class SAWSimulator extends Simulator {
 
         issueRequest( Protos.Request.newBuilder()
                       .setCode( Protos.RequestCode.SetConfigValue )
-                      .setConfigSettingName( "saw.check_path_sat" )
+                      .setConfigSettingName( "checkPathSat" )
                       .addArg( pathSatVal.getValueRep() ) );
 
         getNextAckResponse();
@@ -73,7 +73,7 @@ public final class SAWSimulator extends Simulator {
     public synchronized boolean getPathSatChecking() throws IOException {
         issueRequest( Protos.Request.newBuilder()
                       .setCode(Protos.RequestCode.GetConfigValue)
-                      .setConfigSettingName( "saw.check_path_sat" ) );
+                      .setConfigSettingName( "checkPathSat" ) );
 
         Protos.SimulatorValueResponse r = getNextSimulatorValueResponse();
 

--- a/crucible-server/proto/crucible.proto
+++ b/crucible-server/proto/crucible.proto
@@ -64,7 +64,7 @@ enum RequestCode {
   // Request code for running a function with a given list of arguments
   // (in Request.argument), and getting the result.  The first argument is
   // the function to call, and the remaining arguments are the arguments to pass
-  // to the function.  Since executing a function may take an arbitrary ammount of
+  // to the function.  Since executing a function may take an arbitrary amount of
   // time, this will transition the server into an Execution state, and the next message
   // returned will be a CallResponse message.
   RunCall = 6;

--- a/crucible-server/src/Lang/Crucible/Server/Requests.hs
+++ b/crucible-server/src/Lang/Crucible/Server/Requests.hs
@@ -71,7 +71,7 @@ import           Lang.Crucible.Backend
 import qualified Lang.Crucible.Proto as P
 import           Lang.Crucible.Simulator.CallFrame (SomeHandle(..))
 import qualified Lang.Crucible.Simulator.Evaluation as Sim
-import           Lang.Crucible.Simulator.EvalStmt (executeCrucible)
+import           Lang.Crucible.Simulator.EvalStmt (executeCrucible, genericToExecutionFeature)
 import           Lang.Crucible.Simulator.ExecutionTree
 import           Lang.Crucible.Simulator.GlobalState
 import           Lang.Crucible.Simulator.OverrideSim
@@ -175,7 +175,7 @@ fulfillRunCallRequest sim f_val encoded_args = do
       let simSt = InitialState ctx emptyGlobals (serverErrorHandler sim)
                     $ runOverrideSim res_tp (regValue <$> callFnVal f (RegMap args))
       -- Send messages to server with bytestring.
-      exec_res <- executeCrucible [] simSt
+      exec_res <- executeCrucible (map genericToExecutionFeature (simExecFeatures sim)) simSt
       case exec_res of
         FinishedResult ctx' (TotalRes (GlobalPair r _globals)) -> do
           writeIORef (simContext sim) $! ctx'

--- a/crucible-server/src/Lang/Crucible/Server/SAWOverrides.hs
+++ b/crucible-server/src/Lang/Crucible/Server/SAWOverrides.hs
@@ -53,7 +53,7 @@ import           Lang.Crucible.Server.Verification.Harness
 import           Lang.Crucible.Server.Verification.Override
 import           Lang.Crucible.Simulator.CallFrame (SomeHandle(..))
 import           Lang.Crucible.Simulator.ExecutionTree
-import           Lang.Crucible.Simulator.EvalStmt (executeCrucible)
+import           Lang.Crucible.Simulator.EvalStmt (executeCrucible,genericToExecutionFeature)
 import           Lang.Crucible.Simulator.GlobalState
 import           Lang.Crucible.Simulator.OverrideSim
 import           Lang.Crucible.Simulator.RegMap
@@ -166,7 +166,7 @@ sawFulfillSimulateVerificationHarnessRequest sim harness opts =
                                 $ runOverrideSim UnitRepr
                                     (simulateHarness sim rw w sc cryEnv' harness' pc sp ret fn)
 
-                  exec_res <- executeCrucible [] simSt
+                  exec_res <- executeCrucible (map genericToExecutionFeature (simExecFeatures sim)) simSt
                   case exec_res of
                     FinishedResult ctx' (TotalRes (GlobalPair _r _globals)) -> do
                       sendTextResponse sim "Finished!"


### PR DESCRIPTION
feature instead of the old, hard-coded path sat feature of the
saw backend.