### PR TITLE
Update built-in rewrite rules for crucible-server

### DIFF
--- a/crucible-server/src/Lang/Crucible/Server/Verification/Override.hs
+++ b/crucible-server/src/Lang/Crucible/Server/Verification/Override.hs
@@ -647,7 +647,7 @@ basic_ss sc = do
   where
     eqs = map (mkIdent preludeName)
       [ "not_not", "bvAddZeroL", "bvAddZeroR", "ite_eq"
-      , "not_not", "and_True", "and_False", "and_idem", "ite_eq"
+      , "and_True1", "and_True2", "and_False1", "and_False2", "and_idem"
       , "or_triv1", "and_triv1", "or_triv2", "and_triv2"
       ]
     defs = map (mkIdent preludeName)


### PR DESCRIPTION
The previous set had some duplicates, and at least one entry that didn't exist in the SAWCore prelude.