### PR TITLE
Test LLVMVals for equality

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Value.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Value.hs
@@ -9,7 +9,6 @@
 ------------------------------------------------------------------------
 
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Value.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Value.hs
@@ -9,10 +9,10 @@
 ------------------------------------------------------------------------
 
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE GADTs #-}
+{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -31,14 +31,17 @@ module Lang.Crucible.LLVM.MemModel.Value
   , zeroInt
 
   , llvmValStorableType
+  , testEqual
   ) where
 
+import           Control.Lens (view)
+import           Control.Monad (foldM)
 import           Data.List (intersperse)
 
 import           Data.Parameterized.Classes
 import           Data.Parameterized.NatRepr
 import           Data.Parameterized.Some
-import           Data.Vector( Vector )
+import           Data.Vector (Vector)
 import qualified Data.Vector as V
 
 import           What4.Interface
@@ -48,6 +51,7 @@ import           Lang.Crucible.Backend
 import           Lang.Crucible.LLVM.Bytes
 import           Lang.Crucible.LLVM.MemModel.Type
 import           Lang.Crucible.LLVM.MemModel.Pointer
+import           Lang.Crucible.Panic (panic)
 
 data FloatSize (fi :: FloatInfo) where
   SingleSize :: FloatSize SingleFloat
@@ -133,3 +137,75 @@ instance IsExpr (SymExpr sym) => Show (LLVMVal sym) where
     unwords $ [ "[" ]
            ++ intersperse ", " (map show $ V.toList xs)
            ++ [ "]" ]
+
+-- | This should be used with caution: it is very inefficient to expand zeroes,
+-- especially to large data structures (e.g. long arrays).
+zeroExpandLLVMVal :: (IsExprBuilder sym, IsInterpretedFloatExprBuilder sym)
+                  => sym -> StorageType -> IO (LLVMVal sym)
+zeroExpandLLVMVal sym (StorageType tpf _sz) =
+  case tpf of
+    Bitvector bytes ->
+      case mkNatRepr (bytesToBits bytes) of
+        Some (repr :: NatRepr w) ->
+          case testNatCases (knownNat @0) repr of
+            NatCaseLT (LeqProof :: LeqProof 1 w) ->
+              LLVMValInt <$> natLit sym 0 <*> bvLit sym repr 0
+            NatCaseEQ -> panic "zeroExpandLLVMVal" ["Zero value inside Bytes"]
+            NatCaseGT (LeqProof :: LeqProof (w + 1) 0) ->
+              panic "zeroExpandLLVMVal" ["Impossible: (w + 1) </= 0"]
+    Float    -> LLVMValFloat SingleSize <$> iFloatLit sym SingleFloatRepr 0
+    Double   -> LLVMValFloat DoubleSize <$> iFloatLit sym DoubleFloatRepr 0
+    X86_FP80 -> LLVMValFloat X86_FP80Size <$> iFloatLit sym X86_80FloatRepr 0
+    Array n ty ->
+      LLVMValArray ty . V.replicate (fromIntegral (bytesToInteger n)) <$>
+        zeroExpandLLVMVal sym ty
+    Struct vec ->
+      LLVMValStruct <$>
+        V.zipWithM (\f t -> (f,) <$> zeroExpandLLVMVal sym t) vec (fmap (view fieldVal) vec)
+
+-- | A predicate denoting the equality of two LLVMVals.
+--
+-- Returns 'Nothing' in the event that one of the values contains 'LLVMValUndef'.
+testEqual :: forall sym. (IsExprBuilder sym, IsInterpretedFloatExprBuilder sym)
+          => sym -> LLVMVal sym -> LLVMVal sym -> IO (Maybe (Pred sym))
+testEqual sym v1 v2 =
+  case (v1, v2) of
+    (LLVMValInt blk1 off1, LLVMValInt blk2 off2) ->
+      case testEquality (bvWidth off1) (bvWidth off2) of
+        Nothing   -> false
+        Just Refl ->
+          natEq sym blk1 blk2 >>= \p1 ->
+            Just <$> (andPred sym p1 =<< bvEq sym off1 off2)
+    (LLVMValFloat (sz1 :: FloatSize fi1) flt1, LLVMValFloat sz2 flt2) ->
+      case testEquality sz1 sz2 of
+        Nothing   -> false
+        Just Refl -> Just <$> iFloatEq @_ @fi1 sym flt1 flt2
+    (LLVMValArray tp1 vec1, LLVMValArray tp2 vec2) ->
+      andAlso (tp1 == tp2) (allEqual vec1 vec2)
+    (LLVMValStruct vec1, LLVMValStruct vec2) ->
+      let (si1, si2) = (fmap fst vec1, fmap fst vec2)
+          (fd1, fd2) = (fmap snd vec1, fmap snd vec2)
+      in andAlso (V.and (V.zipWith (==) si1 si2))
+                 (allEqual fd1 fd2)
+    (LLVMValZero tp1, LLVMValZero tp2) -> if tp1 == tp2 then true else false
+    (LLVMValZero tp, other) -> compareZero tp other
+    (other, LLVMValZero tp) -> compareZero tp other
+    (LLVMValUndef _, _) -> pure Nothing
+    (_, LLVMValUndef _) -> pure Nothing
+    (_, _) -> false -- type mismatch
+  where andAlso b x = if b then pure (Just $ falsePred sym) else x
+
+        allEqual vs1 vs2 =
+          foldM (\x y -> commuteMaybe (andPred sym <$> x <*> y)) (Just $ truePred sym) =<<
+            V.zipWithM (testEqual sym) vs1 vs2
+
+        -- This is probably inefficient:
+        compareZero tp other =
+          testEqual sym other =<< zeroExpandLLVMVal sym tp
+
+        -- | Commute an applicative with Maybe
+        commuteMaybe (Just val) = Just <$> val
+        commuteMaybe Nothing    = pure Nothing
+
+        true = pure (Just $ truePred sym)
+        false = pure (Just $ falsePred sym)


### PR DESCRIPTION
I believe this is necessary for https://github.com/GaloisInc/saw-script/issues/392. 

If `allOf` and `oneOf` seem useful, they should probably be put in `IsExprBuilder`. 