### PR TITLE
What4: New LabeledPred module

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/Extension/Safety.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Extension/Safety.hs
@@ -117,6 +117,7 @@ instance TraversableF BadBehavior where
 -- -----------------------------------------------------------------------
 -- ** LLVMSafetyAssertion
 
+-- TODO: Consider making this an instance of What4's 'LabeledPred'
 data LLVMSafetyAssertion (e :: CrucibleType -> Type) =
   LLVMSafetyAssertion
     { _classifier :: BadBehavior e -- ^ What could have gone wrong?

--- a/crucible/src/Lang/Crucible/Backend/AssumptionStack.hs
+++ b/crucible/src/Lang/Crucible/Backend/AssumptionStack.hs
@@ -76,26 +76,11 @@ import           Data.Sequence (Seq)
 import           Lang.Crucible.Backend.ProofGoals
 import           Lang.Crucible.Panic (panic)
 
+import           What4.LabeledPred
+
 #if !MIN_VERSION_base(4,11,0)
 import           Data.Semigroup
 #endif
-
--- | Information about an assertion that was previously made.
-data LabeledPred pred msg
-   = LabeledPred
-     { -- | Predicate that was asserted.
-       _labeledPred    :: !pred
-       -- | Message added when assumption/assertion was made.
-     , _labeledPredMsg :: !msg
-     }
-
--- | Predicate that was asserted.
-labeledPred :: Lens (LabeledPred pred msg) (LabeledPred pred' msg) pred pred'
-labeledPred = lens _labeledPred (\s v -> s { _labeledPred = v })
-
--- | Message added when assumption/assertion was made.
-labeledPredMsg :: Lens (LabeledPred pred msg) (LabeledPred pred msg') msg msg'
-labeledPredMsg = lens _labeledPredMsg (\s v -> s { _labeledPredMsg = v })
 
 -- | A single @AssumptionFrame@ represents a collection
 --   of assumtptions.  They will later be recinded when

--- a/what4/src/What4/LabeledPred.hs
+++ b/what4/src/What4/LabeledPred.hs
@@ -1,0 +1,80 @@
+-----------------------------------------------------------------------
+-- |
+-- Module           : What4.LabeledPred
+-- Description      : Predicates with some metadata (a tag or label).
+-- Copyright        : (c) Galois, Inc 2019
+-- License          : BSD3
+-- Maintainer       : Langston Barrett <langston@galois.com>
+-- Stability        : provisional
+--
+-- Predicates alone do not record their semantic content, thus it is often
+-- useful to attach some sort of descriptor to them.
+------------------------------------------------------------------------
+
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module What4.LabeledPred
+  ( LabeledPred(..)
+  , labeledPred
+  , labeledPredMsg
+  , partitionLabeledPreds
+  ) where
+
+import Control.Lens
+import Data.Bifunctor.TH (deriveBifunctor, deriveBifoldable, deriveBitraversable)
+import Data.Data (Data)
+import Data.Data (Typeable)
+import Data.Eq.Deriving (deriveEq1, deriveEq2)
+import Data.Foldable (Foldable(foldr))
+import Data.Ord.Deriving (deriveOrd1, deriveOrd2)
+import GHC.Generics (Generic, Generic1)
+import Text.Show.Deriving (deriveShow1, deriveShow2)
+
+import What4.Interface (IsExprBuilder, Pred, asConstantPred)
+
+-- | Information about an assertion that was previously made.
+data LabeledPred pred msg
+   = LabeledPred
+     { -- | Predicate that was asserted.
+       _labeledPred    :: !pred
+       -- | Message added when assumption/assertion was made.
+     , _labeledPredMsg :: !msg
+     }
+   deriving (Eq, Data, Functor, Generic, Generic1, Ord, Typeable)
+
+$(deriveBifunctor     ''LabeledPred)
+$(deriveBifoldable    ''LabeledPred)
+$(deriveBitraversable ''LabeledPred)
+$(deriveEq1           ''LabeledPred)
+$(deriveEq2           ''LabeledPred)
+$(deriveOrd1          ''LabeledPred)
+$(deriveOrd2          ''LabeledPred)
+$(deriveShow1         ''LabeledPred)
+$(deriveShow2         ''LabeledPred)
+
+-- | Predicate that was asserted.
+labeledPred :: Lens (LabeledPred pred msg) (LabeledPred pred' msg) pred pred'
+labeledPred = lens _labeledPred (\s v -> s { _labeledPred = v })
+
+-- | Message added when assumption/assertion was made.
+labeledPredMsg :: Lens (LabeledPred pred msg) (LabeledPred pred msg') msg msg'
+labeledPredMsg = lens _labeledPredMsg (\s v -> s { _labeledPredMsg = v })
+
+-- | Partition labeled predicates by their possibly concrete values.
+--
+-- The output format is (constantly true, constantly false, unknown/symbolic).
+partitionLabeledPreds ::
+  (Foldable t, IsExprBuilder sym) =>
+  proxy sym {- ^ avoid \"ambiguous type variable\" errors -}->
+  t (LabeledPred (Pred sym) msg) ->
+  ([LabeledPred (Pred sym) msg], [LabeledPred (Pred sym) msg], [LabeledPred (Pred sym) msg])
+partitionLabeledPreds _proxy xs =
+  let step p (true, false, unknown) =
+        case asConstantPred (p ^. labeledPred) of
+          Just True  -> (p:true, false, unknown)
+          Just False -> (true, p:false, unknown)
+          Nothing    -> (true, false, p:unknown)
+  in foldr step ([], [], []) xs

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -62,6 +62,7 @@ library
     What4.FunctionName
     What4.Interface
     What4.InterpretedFloatingPoint
+    What4.LabeledPred
     What4.Partial
     What4.Partial.AssertionTree
     What4.ProblemFeatures


### PR DESCRIPTION
- Take the LabeledPred type from Crucible.Backend and put it in What4
- Add a utility function
- Derive more classes

This is going to be useful in SAWscript for override matching: we would
like to be able to tell the user when an override failed because a specific
precondition was concretely false. By saving preconditions as `LabeledPred`s
and using `partitionLabeledPreds`, this will be easy.