### PR TITLE
Make bvConcat rewrites fire more often

### DIFF
--- a/crux-llvm/test-data/golden/float-cast2.c
+++ b/crux-llvm/test-data/golden/float-cast2.c
@@ -1,0 +1,26 @@
+#include <stdint.h>
+
+float __VERIFIER_nondet_float(void);
+void crucible_print_uint32( uint32_t x );
+
+union fb {
+  float f;
+  uint8_t b[4];
+};
+
+int main() {
+  union fb u;
+  float f = __VERIFIER_nondet_float();
+  u.f = f;
+
+  union fb u2;
+
+  u2.b[0] = u.b[0];
+  u2.b[1] = u.b[1];
+  u2.b[2] = u.b[2];
+  u2.b[3] = u.b[3];
+
+  crucible_print_uint32( u.f == u2.f );
+
+  return 0;
+}

--- a/crux-llvm/test-data/golden/float-cast2.good
+++ b/crux-llvm/test-data/golden/float-cast2.good
@@ -1,0 +1,2 @@
+[Crux] Simulating function "main"
+bvZext 32 (bvIte (floatIsNaN cX@3:f) 0x0:[1] 0x1:[1])

--- a/what4/src/What4/Expr/Builder.hs
+++ b/what4/src/What4/Expr/Builder.hs
@@ -3833,8 +3833,8 @@ foldIndicesInRangeBounds sym f0 a0 bnds0 = do
 #endif
 
 
--- | A slightly more aggressive syntaxtic equality check than testEquality,
---   `sameTerm` will recurse through a small collection syntax formers.
+-- | A slightly more aggressive syntactic equality check than testEquality,
+--   `sameTerm` will recurse through a small collection of known syntax formers.
 sameTerm :: Expr t a -> Expr t b -> Maybe (a :~: b)
 
 sameTerm (asApp -> Just (FloatToBinary fppx x)) (asApp -> Just (FloatToBinary fppy y)) =
@@ -5263,7 +5263,7 @@ instance IsExprBuilder (ExprBuilder t st fs) where
     let BaseFloatRepr fpp = exprType x in sbMakeExpr sym $ FloatFMA fpp r x y z
   floatEq sym x y
     | x == y = return $! truePred sym
-    | otherwise = (floatIEEELogicBinOp FloatEq) sym x y
+    | otherwise = floatIEEELogicBinOp FloatEq sym x y
   floatNe sym x y = notPred sym =<< floatEq sym x y
   floatFpEq sym x y
     | x == y = notPred sym =<< floatIsNaN sym x

--- a/what4/src/What4/Expr/Builder.hs
+++ b/what4/src/What4/Expr/Builder.hs
@@ -3832,15 +3832,17 @@ foldIndicesInRangeBounds sym f0 a0 bnds0 = do
     _ -> error "internal: invalid index to foldIndicesInRangeBounds"
 #endif
 
-{-
--- | Compute the weighted sum of two bitvectors.
-bvSum :: (1 <= w)
-      => sym
-      -> NatRepr w
-      -> WeightedSum Integer (SymBV sym w)
-      -> IO (SymBV sym w)
-bvSum = undefined
--}
+
+-- | A slightly more aggressive syntaxtic equality check than testEquality,
+--   `sameTerm` will recurse through a small collection syntax formers.
+sameTerm :: Expr t a -> Expr t b -> Maybe (a :~: b)
+
+sameTerm (asApp -> Just (FloatToBinary fppx x)) (asApp -> Just (FloatToBinary fppy y)) =
+  do Refl <- testEquality fppx fppy
+     Refl <- sameTerm x y
+     return Refl
+
+sameTerm x y = testEquality x y
 
 
 instance IsExprBuilder (ExprBuilder t st fs) where
@@ -4259,7 +4261,7 @@ instance IsExprBuilder (ExprBuilder t st fs) where
       -- concat two adjacent sub-selects just makes a single select
       _ | Just (BVSelect idx1 n1 a) <- asApp x
         , Just (BVSelect idx2 n2 b) <- asApp y
-        , Just Refl <- testEquality a b
+        , Just Refl <- sameTerm a b
         , Just Refl <- testEquality idx1 (addNat idx2 n2)
         , Just LeqProof <- isPosNat (addNat n1 n2)
         , Just LeqProof <- testLeq (addNat idx2 (addNat n1 n2)) (bvWidth a) ->
@@ -5263,10 +5265,18 @@ instance IsExprBuilder (ExprBuilder t st fs) where
     | x == y = return $! truePred sym
     | otherwise = (floatIEEELogicBinOp FloatEq) sym x y
   floatNe sym x y = notPred sym =<< floatEq sym x y
-  floatFpEq = floatIEEELogicBinOp FloatFpEq
-  floatFpNe = floatIEEELogicBinOp FloatFpNe
-  floatLe = floatIEEELogicBinOp FloatLe
-  floatLt = floatIEEELogicBinOp FloatLt
+  floatFpEq sym x y
+    | x == y = notPred sym =<< floatIsNaN sym x
+    | otherwise = floatIEEELogicBinOp FloatFpEq sym x y
+  floatFpNe sym x y
+    | x == y = return $ falsePred sym
+    | otherwise = floatIEEELogicBinOp FloatFpNe sym x y
+  floatLe sym x y
+    | x == y = notPred sym =<< floatIsNaN sym x
+    | otherwise = floatIEEELogicBinOp FloatLe sym x y
+  floatLt sym x y
+    | x == y = return $ falsePred sym
+    | otherwise = floatIEEELogicBinOp FloatLt sym x y
   floatGe sym x y = floatLe sym y x
   floatGt sym x y = floatLt sym y x
   floatIte sym c x y

--- a/what4/src/What4/Interface.hs
+++ b/what4/src/What4/Interface.hs
@@ -1786,19 +1786,22 @@ class (IsExpr (SymExpr sym), HashableF (SymExpr sym)) => IsExprBuilder sym where
     -> IO (Pred sym)
 
   -- | Check logical non-equality of two floating point numbers.
+  --
+  --   NOTE! This does NOT accurately represent the non-equality test on floating point
+  --   values typically found in programming languages.  See 'floatFpEq' instead.
   floatNe
     :: sym
     -> SymFloat sym fpp
     -> SymFloat sym fpp
     -> IO (Pred sym)
 
-  -- | Check IEEE equality of two floating point numbers.
+  -- | Check IEEE-754 equality of two floating point numbers.
   --
   --   NOTE! This test returns false if either value is @NaN@; in particular
   --   @NaN@ is not equal to itself!  Moreover, positive and negative 0 will
   --   compare equal, despite having different bit patterns.
   --
-  --   This test is most appropriate for interpreting the equalty tests of
+  --   This test is most appropriate for interpreting the equality tests of
   --   typical languages using floating point.  Moreover, not-equal tests
   --   are usually the negation of this test, rather than the `floatFpNe`
   --   test below.
@@ -1808,14 +1811,14 @@ class (IsExpr (SymExpr sym), HashableF (SymExpr sym)) => IsExprBuilder sym where
     -> SymFloat sym fpp
     -> IO (Pred sym)
 
-  -- | Check IEEE non-equality of two floating point numbers.
+  -- | Check IEEE-754 non-equality of two floating point numbers.
   --
   --   NOTE! This test returns false if either value is @NaN@; in particular
   --   @NaN@ is not distinct from any other value!  Moreover, positive and
   --   negative 0 will not compare distinct, despite having different
   --   bit patterns.
   --
-  --   This test usually does not correspond to the not-equal tests found
+  --   This test usually does NOT correspond to the not-equal tests found
   --   in programming languages.  Instead, one generally takes the logical
   --   negation of the `floatFpEq` test.
   floatFpNe
@@ -1824,40 +1827,71 @@ class (IsExpr (SymExpr sym), HashableF (SymExpr sym)) => IsExprBuilder sym where
     -> SymFloat sym fpp
     -> IO (Pred sym)
 
-  -- | Check @<=@ on two floating point numbers.
+  -- | Check IEEE-754 @<=@ on two floating point numbers.
+  --
+  --   NOTE! This test returns false if either value is @NaN@; in particular
+  --   @NaN@ is not less-than-or-equal-to any other value!  Moreover, positive
+  --   and negative 0 are considered equal, despite having different bit patterns.
   floatLe
     :: sym
     -> SymFloat sym fpp
     -> SymFloat sym fpp
     -> IO (Pred sym)
 
-  -- | Check @<@ on two floating point numbers.
+  -- | Check IEEE-754 @<@ on two floating point numbers.
+  --
+  --   NOTE! This test returns false if either value is @NaN@; in particular
+  --   @NaN@ is not less-than any other value! Moreover, positive
+  --   and negative 0 are considered equal, despite having different bit patterns.
   floatLt
     :: sym
     -> SymFloat sym fpp
     -> SymFloat sym fpp
     -> IO (Pred sym)
 
-  -- | Check @>=@ on two floating point numbers.
+  -- | Check IEEE-754 @>=@ on two floating point numbers.
+  --
+  --   NOTE! This test returns false if either value is @NaN@; in particular
+  --   @NaN@ is not greater-than-or-equal-to any other value!  Moreover, positive
+  --   and negative 0 are considered equal, despite having different bit patterns.
   floatGe
     :: sym
     -> SymFloat sym fpp
     -> SymFloat sym fpp
     -> IO (Pred sym)
 
-  -- | Check @>@ on two floating point numbers.
+  -- | Check IEEE-754 @>@ on two floating point numbers.
+  --
+  --   NOTE! This test returns false if either value is @NaN@; in particular
+  --   @NaN@ is not greater-than any other value! Moreover, positive
+  --   and negative 0 are considered equal, despite having different bit patterns.
   floatGt
     :: sym
     -> SymFloat sym fpp
     -> SymFloat sym fpp
     -> IO (Pred sym)
 
+  -- | Test if a floating-point value is NaN.
   floatIsNaN :: sym -> SymFloat sym fpp -> IO (Pred sym)
+
+  -- | Test if a floating-point value is (positive or negative) infinity.
   floatIsInf :: sym -> SymFloat sym fpp -> IO (Pred sym)
+
+  -- | Test if a floaint-point value is (positive or negative) zero.
   floatIsZero :: sym -> SymFloat sym fpp -> IO (Pred sym)
+
+  -- | Test if a floaint-point value is positive.  NOTE!
+  --   NaN is considered neither positive nor negative.
   floatIsPos :: sym -> SymFloat sym fpp -> IO (Pred sym)
+
+  -- | Test if a floaint-point value is negative.  NOTE!
+  --   NaN is considered neither positive nor negative.
   floatIsNeg :: sym -> SymFloat sym fpp -> IO (Pred sym)
+
+  -- | Test if a floaint-point value is subnormal.
   floatIsSubnorm :: sym -> SymFloat sym fpp -> IO (Pred sym)
+
+  -- | Test if a floaint-point value is normal.
   floatIsNorm :: sym -> SymFloat sym fpp -> IO (Pred sym)
 
   -- | If-then-else on floating point numbers.

--- a/what4/src/What4/Interface.hs
+++ b/what4/src/What4/Interface.hs
@@ -1786,9 +1786,6 @@ class (IsExpr (SymExpr sym), HashableF (SymExpr sym)) => IsExprBuilder sym where
     -> IO (Pred sym)
 
   -- | Check logical non-equality of two floating point numbers.
-  --
-  --   NOTE! This does NOT accurately represent the non-equality test on floating point
-  --   values typically found in programming languages.  See 'floatFpEq' instead.
   floatNe
     :: sym
     -> SymFloat sym fpp
@@ -1799,9 +1796,12 @@ class (IsExpr (SymExpr sym), HashableF (SymExpr sym)) => IsExprBuilder sym where
   --
   --   NOTE! This test returns false if either value is @NaN@; in particular
   --   @NaN@ is not equal to itself!  Moreover, positive and negative 0 will
-  --   compare equal, despite having different bit patterns. This test is most
-  --   appropriate for interpreting the equalty tests of typical languages using
-  --   floating point.
+  --   compare equal, despite having different bit patterns.
+  --
+  --   This test is most appropriate for interpreting the equalty tests of
+  --   typical languages using floating point.  Moreover, not-equal tests
+  --   are usually the negation of this test, rather than the `floatFpNe`
+  --   test below.
   floatFpEq
     :: sym
     -> SymFloat sym fpp
@@ -1813,8 +1813,11 @@ class (IsExpr (SymExpr sym), HashableF (SymExpr sym)) => IsExprBuilder sym where
   --   NOTE! This test returns false if either value is @NaN@; in particular
   --   @NaN@ is not distinct from any other value!  Moreover, positive and
   --   negative 0 will not compare distinct, despite having different
-  --   bit patterns.  This test is most appropriate for interpreting
-  --   the non-equalty tests of typical languages using floating point.
+  --   bit patterns.
+  --
+  --   This test usually does not correspond to the not-equal tests found
+  --   in programming languages.  Instead, one generally takes the logical
+  --   negation of the `floatFpEq` test.
   floatFpNe
     :: sym
     -> SymFloat sym fpp


### PR DESCRIPTION
Be slightly more aggressive about deciding that terms are equal, so the rewrite rule fires in cases involving floating point casts that arise from LLVM memory model operations.