### PR TITLE
Constant folding for assertion trees

### DIFF
--- a/crucible/src/Lang/Crucible/CFG/Extension/Safety.hs
+++ b/crucible/src/Lang/Crucible/CFG/Extension/Safety.hs
@@ -250,14 +250,10 @@ class HasStructuredAssertions (ext :: Type) where
               -> Doc
   explainTree proxyExt proxySym =
     cataAT (detail proxyExt proxySym) -- may want to use 'explain'
-      (\factors ->
-         "All of "
-         <$$> indent 2 (vcat (toList factors)))
-      (\summands ->
-         "Any of "
-         <$$> indent 2 (vcat (toList summands)))
+      (\factors  -> "All of " <$$> indent 2 (vcat (toList factors)))
+      (\summands -> "Any of " <$$> indent 2 (vcat (toList summands)))
       (\cond doc1 doc2 ->
-         "If " <+> printSymExpr (unRV cond) <$$>
+        "If " <+> printSymExpr (unRV cond) <$$>
           vcat [ "then " <$$> indent 2 doc1
                , "else " <$$> indent 2 doc2
                ])

--- a/what4/src/What4/Partial/AssertionTree.hs
+++ b/what4/src/What4/Partial/AssertionTree.hs
@@ -31,6 +31,7 @@ module What4.Partial.AssertionTree
  , cataMAT
  , asConstAT_
  , asConstAT
+ , simplifyAT
  , collapseAT
  , absurdAT
  ) where
@@ -188,6 +189,13 @@ asConstAT :: (IsExprBuilder sym)
           -> AssertionTree c a
           -> Maybe Bool
 asConstAT sym f = snd . asConstAT_ sym f
+
+-- | Simplify an assertion tree by removing singleton 'And' and 'Or' applications.
+simplifyAT :: AssertionTree c a
+           -> AssertionTree c a
+simplifyAT = cataAT Leaf (simplifyNonEmpty And) (simplifyNonEmpty Or) Ite
+  where simplifyNonEmpty _ (x :| []) = x
+        simplifyNonEmpty f xs = f xs
 
 -- | A monadic catamorphism, collapsing everything to one predicate.
 collapseAT :: (IsExprBuilder sym)


### PR DESCRIPTION
When we use the `AssertionTree` datastructure to present errors to the user, they usually contain redundant information. I'm still brainstorming how to fix this, but these operations should be helpful. 

When displaying assertion trees to users we could: 
 - Throw out/collapse constantly/trivially true parts of the tree (since they won't have contributed to the problem the user needs to solve)
 - Traverse the tree, making lists of concretely false subtrees that cause the overall collapsed tree to be false. These assertions can be specially emphasized.

The first should at least be made possible by `constantFoldMAT_`. 