### PR TITLE
Find allocations with a given number

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
@@ -148,6 +148,9 @@ module Lang.Crucible.LLVM.MemModel
   , G.pushStackFrameMem
   , G.popStackFrameMem
   , SomeFnHandle(..)
+  , G.SomeAlloc(..)
+  , G.possibleAllocs
+  , G.ppSomeAlloc
 
     -- * PtrWidth (re-exports)
   , HasPtrWidth

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Generic.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Generic.hs
@@ -1325,19 +1325,18 @@ possibleAllocs ::
   Natural              ->
   Mem sym              ->
   [SomeAlloc sym]
-possibleAllocs n =
-  let helper m =
-        foldMap $
-          \case
-            MemFree _ -> []
-            Alloc atp base sz mut alignment loc ->
-              if base == m
-              then [SomeAlloc atp base sz mut alignment loc]
-              else []
-            AllocMerge (asConstantPred -> Just True) as1 as2 -> helper m as1
-            AllocMerge (asConstantPred -> Just False) as1 as2 -> helper m as2
-            AllocMerge _ as1 as2 -> helper m as1 ++ helper m as2
-  in helper n . memAllocs
+possibleAllocs n = helper . memAllocs
+  where helper =
+          foldMap $
+            \case
+              MemFree _ -> []
+              Alloc atp base sz mut alignment loc ->
+                if base == n
+                then [SomeAlloc atp base sz mut alignment loc]
+                else []
+              AllocMerge (asConstantPred -> Just True) as1 as2 -> helper as1
+              AllocMerge (asConstantPred -> Just False) as1 as2 -> helper as2
+              AllocMerge _ as1 as2 -> helper as1 ++ helper as2
 
 --------------------------------------------------------------------------------
 -- Pretty printing


### PR DESCRIPTION
The purpose of this is to display better error messages when loads through a pointer fail. For instance, it may fail because there are no matching allocations, or the matching allocation(s) didn't have the right size. 

This is complementary information to #178, which exposed information about _writes_, whereas here we expose information about _allocations_, which should be a little easier to digest, if a little less revealing. 