### PR TITLE
Bump upper bounds on th-abstraction package.

### DIFF
--- a/crucible/crucible.cabal
+++ b/crucible/crucible.cabal
@@ -47,7 +47,7 @@ library
     template-haskell,
     text,
     time >= 1.8 && < 2.0,
-    th-abstraction >=0.1 && <0.3,
+    th-abstraction >=0.1 && <0.4,
     transformers,
     unordered-containers,
     vector,

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -42,7 +42,7 @@ library
     temporary >= 1.2,
     template-haskell,
     text,
-    th-abstraction >=0.1 && <0.3,
+    th-abstraction >=0.1 && <0.4,
     transformers,
     unordered-containers,
     utf8-string,


### PR DESCRIPTION
Make it so that crucible/what4 will compile with `th-abstraction-0.3.1.0`.