### PR TITLE
Crucible-jvm numeric primitives

### DIFF
--- a/crucible-jvm/crucible-jvm.cabal
+++ b/crucible-jvm/crucible-jvm.cabal
@@ -47,7 +47,7 @@ executable crucible-jvm
   default-language: Haskell2010
 
 
-library 
+library
 
   build-depends:
     base >= 4 && < 5,
@@ -79,6 +79,7 @@ library
     Lang.Crucible.JVM.Translation
     Lang.Crucible.JVM.ClassRefs
     Lang.Crucible.JVM.Class
+    Lang.Crucible.JVM.Numeric
     Lang.Crucible.JVM.Overrides
     Lang.JVM.Codebase
   other-modules:

--- a/crucible-jvm/src/Lang/Crucible/JVM/Numeric.hs
+++ b/crucible-jvm/src/Lang/Crucible/JVM/Numeric.hs
@@ -88,15 +88,16 @@ lShiftMask i = App (BVAnd w64 i (lConst 63))
 lNeg :: JVMLong s -> JVMLong s
 lNeg e = App (BVSub w64 lZero e)
 
--- TODO: are these signed or unsigned integers?
--- | Takes two two-word long integers off the stack and compares them. If
--- the two integers are the same, the int 0 is pushed onto the stack. If
--- value2 is greater than value1, the int 1 is pushed onto the stack. If
--- value1 is greater than value2, the int -1 is pushed onto the stack.
-lCmp :: JVMLong s -> JVMLong s -> JVMGenerator h s ret (JVMInt s)
-lCmp e1 e2 = ifte (App (BVEq knownRepr e1 e2)) (return $ App $ BVLit w32 0)
-                  (ifte (App (BVSlt knownRepr e1 e2)) (return $ App $ BVLit w32 (-1))
-                        (return $ App $ BVLit w32 (1)))
+-- | Both value1 and value2 must be of type long. They are both popped
+-- from the operand stack, and a signed integer comparison is
+-- performed. If value1 is greater than value2, the int value 1 is
+-- pushed onto the operand stack. If value1 is equal to value2, the
+-- int value 0 is pushed onto the operand stack. If value1 is less
+-- than value2, the int value -1 is pushed onto the operand stack.
+lCmp :: JVMLong s -> JVMLong s -> JVMInt s
+lCmp e1 e2 =
+  App (BVIte (App (BVEq w64 e1 e2)) w32 (iConst 0)
+       (App (BVIte (App (BVSlt w64 e1 e2)) w32 (iConst (-1)) (iConst 1))))
 
 ----------------------------------------------------------------------
 -- * Float operations

--- a/crucible-jvm/src/Lang/Crucible/JVM/Numeric.hs
+++ b/crucible-jvm/src/Lang/Crucible/JVM/Numeric.hs
@@ -1,0 +1,165 @@
+{- |
+Module           : Lang.Crucible.JVM.Numeric
+Description      : Primitive JVM operations on numeric types
+Copyright        : (c) Galois, Inc 2018-2019
+License          : BSD3
+Maintainer       : huffman@galois.com, sweirich@galois.com
+Stability        : provisional
+-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Lang.Crucible.JVM.Numeric where
+
+import Lang.Crucible.CFG.Expr
+import Lang.Crucible.CFG.Generator
+import Lang.Crucible.Types
+
+import Lang.Crucible.JVM.Types
+import Lang.Crucible.JVM.Generator
+
+----------------------------------------------------------------------
+-- * Type conversions
+
+floatFromDouble :: JVMDouble s -> JVMFloat s
+floatFromDouble d = App (FloatCast SingleFloatRepr RNE d)
+
+intFromDouble :: JVMDouble s -> JVMInt s
+intFromDouble d = App (FloatToSBV w32 RTZ d)
+
+longFromDouble :: JVMDouble s -> JVMLong s
+longFromDouble d = App (FloatToSBV w64 RTZ d)
+
+doubleFromFloat :: JVMFloat s -> JVMDouble s
+doubleFromFloat f = App (FloatCast DoubleFloatRepr RNE f)
+
+intFromFloat :: JVMFloat s -> JVMInt s
+intFromFloat f = App (FloatToSBV w32 RTZ f)
+
+longFromFloat :: JVMFloat s -> JVMLong s
+longFromFloat f = App (FloatToSBV w64 RTZ f)
+
+doubleFromInt :: JVMInt s -> JVMDouble s
+doubleFromInt i = App (FloatFromSBV DoubleFloatRepr RNE i)
+
+floatFromInt :: JVMInt s -> JVMFloat s
+floatFromInt i = App (FloatFromSBV SingleFloatRepr RNE i)
+
+longFromInt :: JVMInt s -> JVMLong s
+longFromInt x = App (BVSext w64 w32 x)
+
+doubleFromLong :: JVMLong s -> JVMDouble s
+doubleFromLong l = App (FloatFromSBV DoubleFloatRepr RNE l)
+
+floatFromLong :: JVMLong s -> JVMFloat s
+floatFromLong l = App (FloatFromSBV SingleFloatRepr RNE l)
+
+intFromLong :: JVMLong s -> JVMInt s
+intFromLong l = App (BVTrunc w32 w64 l)
+
+----------------------------------------------------------------------
+-- * Basic Value Operations
+
+iConst :: Integer -> JVMInt s
+iConst i = App (BVLit w32 i)
+
+lConst :: Integer -> JVMLong s
+lConst i = App (BVLit w64 i)
+
+dConst :: Double -> JVMDouble s
+dConst d = App (DoubleLit d)
+
+fConst :: Float -> JVMFloat s
+fConst f = App (FloatLit f)
+
+iZero :: JVMInt s
+iZero = iConst 0
+
+lZero :: JVMLong s
+lZero = lConst 0
+
+-- | Mask the low 5 bits of a shift amount of type int.
+iShiftMask :: JVMInt s -> JVMInt s
+iShiftMask i = App (BVAnd w32 i (iConst 31))
+
+-- | Mask the low 6 bits of a shift amount of type long.
+lShiftMask :: JVMLong s -> JVMLong s
+lShiftMask i = App (BVAnd w64 i (lConst 63))
+
+-- Both positive and negative zeros
+posZerof :: JVMFloat s
+posZerof = App $ FloatLit 0.0
+
+negZerof :: JVMFloat s
+negZerof = App $ FloatLit (-0.0)
+
+posZerod :: JVMDouble s
+posZerod = App $ DoubleLit 0.0
+
+negZerod :: JVMDouble s
+negZerod = App $ DoubleLit (-0.0)
+
+iNeg :: JVMInt s -> JVMInt s
+iNeg e = App (BVSub w32 iZero e)
+
+lNeg :: JVMLong s -> JVMLong s
+lNeg e = App (BVSub w64 lZero e)
+
+-- TODO: doublecheck
+-- For float values, negation is not the same as subtraction from zero. If x is +0.0,
+-- then 0.0-x equals +0.0, but -x equals -0.0. Unary minus merely inverts the sign of a float.
+-- Special cases of interest:
+--    If the operand is NaN, the result is NaN (recall that NaN has no sign).
+--    If the operand is an infinity, the result is the infinity of opposite sign.
+--    If the operand is a zero, the result is the zero of opposite sign.
+fNeg :: JVMFloat s -> JVMGenerator h s ret (JVMFloat s)
+fNeg e = ifte (App $ FloatEq e posZerof)
+              (return negZerof)
+              (return $ App (FloatSub SingleFloatRepr RNE posZerof e))
+
+
+dAdd, dSub, dMul, dDiv, dRem :: JVMDouble s -> JVMDouble s -> JVMDouble s
+dAdd e1 e2 = App (FloatAdd DoubleFloatRepr RNE e1 e2)
+dSub e1 e2 = App (FloatSub DoubleFloatRepr RNE e1 e2)
+dMul e1 e2 = App (FloatMul DoubleFloatRepr RNE e1 e2)
+dDiv e1 e2 = App (FloatDiv DoubleFloatRepr RNE e1 e2)
+dRem e1 e2 = App (FloatRem DoubleFloatRepr e1 e2)
+
+
+--TODO: treatment of NaN
+--TODO: difference between dCmpg/dCmpl
+-- | If the two numbers are the same, the int 0 is pushed onto the
+-- stack. If value2 is greater than value1, the int 1 is pushed onto the
+-- stack. If value1 is greater than value2, -1 is pushed onto the
+-- stack. If either numbers is NaN, the int 1 is pushed onto the
+-- stack. +0.0 and -0.0 are treated as equal.
+dCmpg, dCmpl :: forall fi s h ret.
+                Expr JVM s (FloatType fi) -> Expr JVM s (FloatType fi) -> JVMGenerator h s ret (JVMInt s)
+dCmpg e1 e2 = ifte (App (FloatEq e1 e2)) (return $ App $ BVLit w32 0)
+                   (ifte (App (FloatGe e2 e1)) (return $ App $ BVLit w32 (-1))
+                         (return $ App $ BVLit w32 1))
+dCmpl = dCmpg
+
+dNeg :: JVMDouble s ->  JVMGenerator h s ret (JVMDouble s)
+dNeg e = ifte (App $ FloatEq e posZerod)
+              (return negZerod)
+              (return $ App (FloatSub DoubleFloatRepr RNE posZerod e))
+
+
+fAdd, fSub, fMul, fDiv, fRem :: JVMFloat s -> JVMFloat s -> JVMFloat s
+fAdd e1 e2 = App (FloatAdd SingleFloatRepr RNE e1 e2)
+fSub e1 e2 = App (FloatSub SingleFloatRepr RNE e1 e2)
+fMul e1 e2 = App (FloatMul SingleFloatRepr RNE e1 e2)
+fDiv e1 e2 = App (FloatDiv SingleFloatRepr RNE e1 e2)
+fRem e1 e2 = App (FloatRem SingleFloatRepr e1 e2)
+
+
+-- TODO: are these signed or unsigned integers?
+-- | Takes two two-word long integers off the stack and compares them. If
+-- the two integers are the same, the int 0 is pushed onto the stack. If
+-- value2 is greater than value1, the int 1 is pushed onto the stack. If
+-- value1 is greater than value2, the int -1 is pushed onto the stack.
+lCmp :: JVMLong s -> JVMLong s -> JVMGenerator h s ret (JVMInt s)
+lCmp e1 e2 = ifte (App (BVEq knownRepr e1 e2)) (return $ App $ BVLit w32 0)
+                  (ifte (App (BVSlt knownRepr e1 e2)) (return $ App $ BVLit w32 (-1))
+                        (return $ App $ BVLit w32 (1)))
+

--- a/crucible-jvm/src/Lang/Crucible/JVM/Numeric.hs
+++ b/crucible-jvm/src/Lang/Crucible/JVM/Numeric.hs
@@ -15,7 +15,6 @@ import Lang.Crucible.CFG.Generator
 import Lang.Crucible.Types
 
 import Lang.Crucible.JVM.Types
-import Lang.Crucible.JVM.Generator
 
 ----------------------------------------------------------------------
 -- * Type conversions
@@ -72,6 +71,9 @@ iShiftMask i = App (BVAnd w32 i (iConst 31))
 iNeg :: JVMInt s -> JVMInt s
 iNeg e = App (BVSub w32 iZero e)
 
+iIte :: JVMBool s -> JVMInt s -> JVMInt s -> JVMInt s
+iIte cond e1 e2 = App (BVIte cond w32 e1 e2)
+
 ----------------------------------------------------------------------
 -- * Long operations
 
@@ -88,16 +90,17 @@ lShiftMask i = App (BVAnd w64 i (lConst 63))
 lNeg :: JVMLong s -> JVMLong s
 lNeg e = App (BVSub w64 lZero e)
 
--- | Both value1 and value2 must be of type long. They are both popped
--- from the operand stack, and a signed integer comparison is
--- performed. If value1 is greater than value2, the int value 1 is
--- pushed onto the operand stack. If value1 is equal to value2, the
--- int value 0 is pushed onto the operand stack. If value1 is less
--- than value2, the int value -1 is pushed onto the operand stack.
+-- | Both @value1@ and @value2@ must be of type long. They are both
+-- popped from the operand stack, and a signed integer comparison is
+-- performed. If @value1@ is greater than @value2@, the @int@ value 1
+-- is pushed onto the operand stack. If @value1@ is equal to @value2@,
+-- the @int@ value 0 is pushed onto the operand stack. If @value1@ is
+-- less than @value2@, the @int@ value -1 is pushed onto the operand
+-- stack.
 lCmp :: JVMLong s -> JVMLong s -> JVMInt s
 lCmp e1 e2 =
-  App (BVIte (App (BVEq w64 e1 e2)) w32 (iConst 0)
-       (App (BVIte (App (BVSlt w64 e1 e2)) w32 (iConst (-1)) (iConst 1))))
+  iIte (App (BVEq w64 e1 e2)) (iConst 0) $
+  iIte (App (BVSlt w64 e1 e2)) (iConst (-1)) (iConst 1)
 
 ----------------------------------------------------------------------
 -- * Float operations
@@ -133,6 +136,26 @@ fMul e1 e2 = App (FloatMul SingleFloatRepr RNE e1 e2)
 fDiv e1 e2 = App (FloatDiv SingleFloatRepr RNE e1 e2)
 fRem e1 e2 = App (FloatRem SingleFloatRepr e1 e2)
 
+-- | A floating-point comparison is performed: If @value1@ is greater
+-- than @value2@, the @int@ value 1 is pushed onto the operand stack.
+-- Otherwise, if @value1@ is equal to @value2@, the @int@ value 0 is
+-- pushed onto the operand stack. Otherwise, if @value1@ is less than
+-- @value2@, the @int@ value -1 is pushed onto the operand stack.
+-- Otherwise, at least one of @value1@ or @value2@ is NaN. The @fcmpg@
+-- instruction pushes the @int@ value 1 onto the operand stack and the
+-- @fcmpl@ instruction pushes the @int@ value -1 onto the operand stack.
+fCmpg :: JVMFloat s -> JVMFloat s -> JVMInt s
+fCmpg e1 e2 =
+  iIte (App (FloatLt e1 e2)) (iConst (-1)) $
+  iIte (App (FloatFpEq e1 e2)) (iConst 0) $
+  iConst 1
+
+fCmpl :: JVMFloat s -> JVMFloat s -> JVMInt s
+fCmpl e1 e2 =
+  iIte (App (FloatGt e1 e2)) (iConst 1) $
+  iIte (App (FloatFpEq e1 e2)) (iConst 0) $
+  iConst (-1)
+
 ----------------------------------------------------------------------
 -- * Double operations
 
@@ -154,20 +177,25 @@ dMul e1 e2 = App (FloatMul DoubleFloatRepr RNE e1 e2)
 dDiv e1 e2 = App (FloatDiv DoubleFloatRepr RNE e1 e2)
 dRem e1 e2 = App (FloatRem DoubleFloatRepr e1 e2)
 
-
---TODO: treatment of NaN
---TODO: difference between dCmpg/dCmpl
--- | If the two numbers are the same, the int 0 is pushed onto the
--- stack. If value2 is greater than value1, the int 1 is pushed onto the
--- stack. If value1 is greater than value2, -1 is pushed onto the
--- stack. If either numbers is NaN, the int 1 is pushed onto the
--- stack. +0.0 and -0.0 are treated as equal.
-dCmpg, dCmpl :: forall fi s h ret.
-                Expr JVM s (FloatType fi) -> Expr JVM s (FloatType fi) -> JVMGenerator h s ret (JVMInt s)
-dCmpg e1 e2 = ifte (App (FloatEq e1 e2)) (return $ App $ BVLit w32 0)
-                   (ifte (App (FloatGe e2 e1)) (return $ App $ BVLit w32 (-1))
-                         (return $ App $ BVLit w32 1))
-dCmpl = dCmpg
-
 dNeg :: JVMDouble s -> JVMDouble s
 dNeg e = App (FloatNeg DoubleFloatRepr e)
+
+-- | A floating-point comparison is performed: If @value1@ is greater
+-- than @value2@, the @int@ value 1 is pushed onto the operand stack.
+-- Otherwise, if @value1@ is equal to @value2@, the @int@ value 0 is
+-- pushed onto the operand stack. Otherwise, if @value1@ is less than
+-- @value2@, the @int@ value -1 is pushed onto the operand stack.
+-- Otherwise, at least one of @value1@ or @value2@ is NaN. The @dcmpg@
+-- instruction pushes the @int@ value 1 onto the operand stack and the
+-- @dcmpl@ instruction pushes the @int@ value -1 onto the operand stack.
+dCmpg :: JVMDouble s -> JVMDouble s -> JVMInt s
+dCmpg e1 e2 =
+  iIte (App (FloatLt e1 e2)) (iConst (-1)) $
+  iIte (App (FloatFpEq e1 e2)) (iConst 0) $
+  iConst 1
+
+dCmpl :: JVMDouble s -> JVMDouble s -> JVMInt s
+dCmpl e1 e2 =
+  iIte (App (FloatGt e1 e2)) (iConst 1) $
+  iIte (App (FloatFpEq e1 e2)) (iConst 0) $
+  iConst (-1)

--- a/crucible-jvm/src/Lang/Crucible/JVM/Numeric.hs
+++ b/crucible-jvm/src/Lang/Crucible/JVM/Numeric.hs
@@ -113,17 +113,18 @@ fPosZero = fConst 0.0
 fNegZero :: JVMFloat s
 fNegZero = fConst (-0.0)
 
--- TODO: doublecheck
--- For float values, negation is not the same as subtraction from zero. If x is +0.0,
--- then 0.0-x equals +0.0, but -x equals -0.0. Unary minus merely inverts the sign of a float.
--- Special cases of interest:
---    If the operand is NaN, the result is NaN (recall that NaN has no sign).
---    If the operand is an infinity, the result is the infinity of opposite sign.
---    If the operand is a zero, the result is the zero of opposite sign.
-fNeg :: JVMFloat s -> JVMGenerator h s ret (JVMFloat s)
-fNeg e = ifte (App $ FloatEq e fPosZero)
-              (return fNegZero)
-              (return $ App (FloatSub SingleFloatRepr RNE fPosZero e))
+-- | For float values, negation is not the same as subtraction from
+-- zero. If @x@ is @+0.0,@ then @0.0-x@ equals @+0.0@, but @-x@ equals
+-- @-0.0@. Unary minus merely inverts the sign of a float. Special
+-- cases of interest:
+--
+--    * If the operand is NaN, the result is NaN (recall that NaN has no sign).
+--
+--    * If the operand is an infinity, the result is the infinity of opposite sign.
+--
+--    * If the operand is a zero, the result is the zero of opposite sign.
+fNeg :: JVMFloat s -> JVMFloat s
+fNeg e = App (FloatNeg SingleFloatRepr e)
 
 fAdd, fSub, fMul, fDiv, fRem :: JVMFloat s -> JVMFloat s -> JVMFloat s
 fAdd e1 e2 = App (FloatAdd SingleFloatRepr RNE e1 e2)
@@ -168,7 +169,5 @@ dCmpg e1 e2 = ifte (App (FloatEq e1 e2)) (return $ App $ BVLit w32 0)
                          (return $ App $ BVLit w32 1))
 dCmpl = dCmpg
 
-dNeg :: JVMDouble s ->  JVMGenerator h s ret (JVMDouble s)
-dNeg e = ifte (App $ FloatEq e dPosZero)
-              (return dNegZero)
-              (return $ App (FloatSub DoubleFloatRepr RNE dPosZero e))
+dNeg :: JVMDouble s -> JVMDouble s
+dNeg e = App (FloatNeg DoubleFloatRepr e)

--- a/crucible-jvm/src/Lang/Crucible/JVM/Translation.hs
+++ b/crucible-jvm/src/Lang/Crucible/JVM/Translation.hs
@@ -735,16 +735,16 @@ generateInstruction (pc, instr) =
     J.Dmul  -> binary dPop dPop dPush dMul
     J.Ddiv  -> binary dPop dPop dPush dDiv
     J.Drem  -> binary dPop dPop dPush dRem
-    J.Dcmpg -> binaryGen dPop dPop iPush dCmpg
-    J.Dcmpl -> binaryGen dPop dPop iPush dCmpl
+    J.Dcmpg -> binary dPop dPop iPush dCmpg
+    J.Dcmpl -> binary dPop dPop iPush dCmpl
     J.Fadd  -> binary fPop fPop fPush fAdd
     J.Fsub  -> binary fPop fPop fPush fSub
     J.Fneg  -> unary fPop fPush fNeg
     J.Fmul  -> binary fPop fPop fPush fMul
     J.Fdiv  -> binary fPop fPop fPush fDiv
     J.Frem  -> binary fPop fPop fPush fRem
-    J.Fcmpg -> binaryGen fPop fPop iPush dCmpg
-    J.Fcmpl -> binaryGen fPop fPop iPush dCmpl
+    J.Fcmpg -> binary fPop fPop iPush fCmpg
+    J.Fcmpl -> binary fPop fPop iPush fCmpl
     J.Iadd  -> binary iPop iPop iPush (\a b -> App (BVAdd w32 a b))
     J.Isub  -> binary iPop iPop iPush (\a b -> App (BVSub w32 a b))
     J.Imul  -> binary iPop iPop iPush (\a b -> App (BVMul w32 a b))
@@ -1120,18 +1120,6 @@ binary pop1 pop2 push op =
   do value2 <- pop2
      value1 <- pop1
      push (value1 `op` value2)
-
-binaryGen ::
-  JVMStmtGen h s ret a ->
-  JVMStmtGen h s ret b ->
-  (c -> JVMStmtGen h s ret ()) ->
-  (a -> b -> JVMGenerator h s ret c) ->
-  JVMStmtGen h s ret ()
-binaryGen pop1 pop2 push op =
-  do value2 <- pop2
-     value1 <- pop1
-     ret <- lift $ value1 `op` value2
-     push ret
 
 
 aloadInstr ::

--- a/crucible-jvm/src/Lang/Crucible/JVM/Translation.hs
+++ b/crucible-jvm/src/Lang/Crucible/JVM/Translation.hs
@@ -96,6 +96,7 @@ import           What4.Utils.MonadST (liftST)
 
 -- crucible-jvm
 import           Lang.Crucible.JVM.Types
+import           Lang.Crucible.JVM.Numeric
 import           Lang.Crucible.JVM.ClassRefs
 import           Lang.Crucible.JVM.Generator
 import           Lang.Crucible.JVM.Class
@@ -696,12 +697,6 @@ popArguments args =
 
 -- * Instruction generation
 
-iZero :: JVMInt s
-iZero = App (BVLit w32 0)
-
-lZero :: JVMLong s
-lZero = App (BVLit w64 0)
-
 bTrue :: JVMBool s
 bTrue = App (BoolLit True)
 
@@ -1237,147 +1232,6 @@ returnInstr pop =
      case testEquality retType (knownRepr :: TypeRepr tp) of
        Just Refl -> pop >>= (lift . returnFromFunction)
        Nothing -> sgFail "ireturn: type mismatch"
-
-----------------------------------------------------------------------
--- * Basic Value Operations
-
-floatFromDouble :: JVMDouble s -> JVMFloat s
-floatFromDouble d = App (FloatCast SingleFloatRepr RNE d)
-
-intFromDouble :: JVMDouble s -> JVMInt s
-intFromDouble d = App (FloatToSBV w32 RTZ d)
-
-longFromDouble :: JVMDouble s -> JVMLong s
-longFromDouble d = App (FloatToSBV w64 RTZ d)
-
-doubleFromFloat :: JVMFloat s -> JVMDouble s
-doubleFromFloat f = App (FloatCast DoubleFloatRepr RNE f)
-
-intFromFloat :: JVMFloat s -> JVMInt s
-intFromFloat f = App (FloatToSBV w32 RTZ f)
-
-longFromFloat :: JVMFloat s -> JVMLong s
-longFromFloat f = App (FloatToSBV w64 RTZ f)
-
-doubleFromInt :: JVMInt s -> JVMDouble s
-doubleFromInt i = App (FloatFromSBV DoubleFloatRepr RNE i)
-
-floatFromInt :: JVMInt s -> JVMFloat s
-floatFromInt i = App (FloatFromSBV SingleFloatRepr RNE i)
-
--- | TODO: double check this
-longFromInt :: JVMInt s -> JVMLong s
-longFromInt x = App (BVSext w64 w32 x)
-
-
-doubleFromLong :: JVMLong s -> JVMDouble s
-doubleFromLong l = App (FloatFromSBV DoubleFloatRepr RNE l)
-
-floatFromLong :: JVMLong s -> JVMFloat s
-floatFromLong l = App (FloatFromSBV SingleFloatRepr RNE l)
-
-intFromLong :: JVMLong s -> JVMInt s
-intFromLong l = App (BVTrunc w32 w64 l)
-
-iConst :: Integer -> JVMInt s
-iConst i = App (BVLit w32 i)
-
-lConst :: Integer -> JVMLong s
-lConst i = App (BVLit w64 i)
-
-dConst :: Double -> JVMDouble s
-dConst d = App (DoubleLit d)
-
-fConst :: Float -> JVMFloat s
-fConst f = App (FloatLit f)
-
--- | Mask the low 5 bits of a shift amount of type int.
-iShiftMask :: JVMInt s -> JVMInt s
-iShiftMask i = App (BVAnd w32 i (iConst 31))
-
--- | Mask the low 6 bits of a shift amount of type long.
-lShiftMask :: JVMLong s -> JVMLong s
-lShiftMask i = App (BVAnd w64 i (lConst 63))
-
--- Both positive and negative zeros
-posZerof :: JVMFloat s
-posZerof = App $ FloatLit 0.0
-
-negZerof :: JVMFloat s
-negZerof = App $ FloatLit (-0.0)
-
-posZerod :: JVMDouble s
-posZerod = App $ DoubleLit 0.0
-
-negZerod :: JVMDouble s
-negZerod = App $ DoubleLit (-0.0)
-
-iNeg :: JVMInt s -> JVMInt s
-iNeg e = App (BVSub w32 iZero e)
-
-lNeg :: JVMLong s -> JVMLong s
-lNeg e = App (BVSub w64 lZero e)
-
--- TODO: doublecheck
--- For float values, negation is not the same as subtraction from zero. If x is +0.0,
--- then 0.0-x equals +0.0, but -x equals -0.0. Unary minus merely inverts the sign of a float.
--- Special cases of interest:
---    If the operand is NaN, the result is NaN (recall that NaN has no sign).
---    If the operand is an infinity, the result is the infinity of opposite sign.
---    If the operand is a zero, the result is the zero of opposite sign.
-fNeg :: JVMFloat s -> JVMGenerator h s ret (JVMFloat s)
-fNeg e = ifte (App $ FloatEq e posZerof)
-              (return negZerof)
-              (return $ App (FloatSub SingleFloatRepr RNE posZerof e))
-
-
-dAdd, dSub, dMul, dDiv, dRem :: JVMDouble s -> JVMDouble s -> JVMDouble s
-dAdd e1 e2 = App (FloatAdd DoubleFloatRepr RNE e1 e2)
-dSub e1 e2 = App (FloatSub DoubleFloatRepr RNE e1 e2)
-dMul e1 e2 = App (FloatMul DoubleFloatRepr RNE e1 e2)
-dDiv e1 e2 = App (FloatDiv DoubleFloatRepr RNE e1 e2)
-dRem e1 e2 = App (FloatRem DoubleFloatRepr e1 e2)
-
-
---TODO: treatment of NaN
---TODO: difference between dCmpg/dCmpl
--- | If the two numbers are the same, the int 0 is pushed onto the
--- stack. If value2 is greater than value1, the int 1 is pushed onto the
--- stack. If value1 is greater than value2, -1 is pushed onto the
--- stack. If either numbers is NaN, the int 1 is pushed onto the
--- stack. +0.0 and -0.0 are treated as equal.
-dCmpg, dCmpl :: forall fi s h ret.
-                Expr JVM s (FloatType fi) -> Expr JVM s (FloatType fi) -> JVMGenerator h s ret (JVMInt s)
-dCmpg e1 e2 = ifte (App (FloatEq e1 e2)) (return $ App $ BVLit w32 0)
-                   (ifte (App (FloatGe e2 e1)) (return $ App $ BVLit w32 (-1))
-                         (return $ App $ BVLit w32 1))
-dCmpl = dCmpg
-
-dNeg :: JVMDouble s ->  JVMGenerator h s ret (JVMDouble s)
-dNeg e = ifte (App $ FloatEq e posZerod)
-              (return negZerod)
-              (return $ App (FloatSub DoubleFloatRepr RNE posZerod e))
-
-
-fAdd, fSub, fMul, fDiv, fRem :: JVMFloat s -> JVMFloat s -> JVMFloat s
-fAdd e1 e2 = App (FloatAdd SingleFloatRepr RNE e1 e2)
-fSub e1 e2 = App (FloatSub SingleFloatRepr RNE e1 e2)
-fMul e1 e2 = App (FloatMul SingleFloatRepr RNE e1 e2)
-fDiv e1 e2 = App (FloatDiv SingleFloatRepr RNE e1 e2)
-fRem e1 e2 = App (FloatRem SingleFloatRepr e1 e2)
-
-
--- TODO: are these signed or unsigned integers?
--- | Takes two two-word long integers off the stack and compares them. If
--- the two integers are the same, the int 0 is pushed onto the stack. If
--- value2 is greater than value1, the int 1 is pushed onto the stack. If
--- value1 is greater than value2, the int -1 is pushed onto the stack.
-lCmp :: JVMLong s -> JVMLong s -> JVMGenerator h s ret (JVMInt s)
-lCmp e1 e2 =  ifte (App (BVEq knownRepr e1 e2)) (return $ App $ BVLit w32 0)
-                   (ifte (App (BVSlt knownRepr e1 e2)) (return $ App $ BVLit w32 (-1))
-                         (return $ App $ BVLit w32 (1)))
-
-
 
 ----------------------------------------------------------------------
 

--- a/crucible-jvm/src/Lang/Crucible/JVM/Translation.hs
+++ b/crucible-jvm/src/Lang/Crucible/JVM/Translation.hs
@@ -731,7 +731,7 @@ generateInstruction (pc, instr) =
     -- Arithmetic instructions
     J.Dadd  -> binary dPop dPop dPush dAdd
     J.Dsub  -> binary dPop dPop dPush dSub
-    J.Dneg  -> unaryGen dPop dPush dNeg
+    J.Dneg  -> unary dPop dPush dNeg
     J.Dmul  -> binary dPop dPop dPush dMul
     J.Ddiv  -> binary dPop dPop dPush dDiv
     J.Drem  -> binary dPop dPop dPush dRem
@@ -739,7 +739,7 @@ generateInstruction (pc, instr) =
     J.Dcmpl -> binaryGen dPop dPop iPush dCmpl
     J.Fadd  -> binary fPop fPop fPush fAdd
     J.Fsub  -> binary fPop fPop fPush fSub
-    J.Fneg  -> unaryGen fPop fPush fNeg
+    J.Fneg  -> unary fPop fPush fNeg
     J.Fmul  -> binary fPop fPop fPush fMul
     J.Fdiv  -> binary fPop fPop fPush fDiv
     J.Frem  -> binary fPop fPop fPush fRem
@@ -1109,17 +1109,6 @@ unary ::
 unary pop push op =
   do value <- pop
      push (op value)
-
-
-unaryGen ::
-  JVMStmtGen h s ret a ->
-  (b -> JVMStmtGen h s ret ()) ->
-  (a -> JVMGenerator h s ret b) ->
-  JVMStmtGen h s ret ()
-unaryGen pop push op =
-  do value <- pop
-     ret <- lift $ op value
-     push ret
 
 binary ::
   JVMStmtGen h s ret a ->

--- a/crucible-jvm/src/Lang/Crucible/JVM/Translation.hs
+++ b/crucible-jvm/src/Lang/Crucible/JVM/Translation.hs
@@ -769,7 +769,7 @@ generateInstruction (pc, instr) =
     J.Land  -> binary lPop lPop lPush (\a b -> App (BVAnd w64 a b))
     J.Lor   -> binary lPop lPop lPush (\a b -> App (BVOr  w64 a b))
     J.Lxor  -> binary lPop lPop lPush (\a b -> App (BVXor w64 a b))
-    J.Lcmp  -> binaryGen lPop lPop iPush lCmp
+    J.Lcmp  -> binary lPop lPop iPush lCmp
     J.Lshl  -> binary lPop (longFromInt <$> iPop) lPush (\a b -> App (BVShl w64 a (lShiftMask b)))
     J.Lshr  -> binary lPop (longFromInt <$> iPop) lPush (\a b -> App (BVAshr w64 a (lShiftMask b)))
     J.Lushr -> binary lPop (longFromInt <$> iPop) lPush (\a b -> App (BVLshr w64 a (lShiftMask b)))


### PR DESCRIPTION
These patches clean up some definitions of JVM primitives on numeric types, fix a few bugs in them, and move the definitions to a separate module. 