### PR TITLE
what4: Explicitly shut down the solver connection for yices

### DIFF
--- a/what4/src/What4/Solver/Yices.hs
+++ b/what4/src/What4/Solver/Yices.hs
@@ -374,6 +374,9 @@ efSolveCommand = Cmd "(ef-solve)"
 evalCommand :: Term (Connection s)-> Command (Connection s)
 evalCommand v = Cmd $ app "eval" [renderTerm v]
 
+exitCommand :: Command (Connection s)
+exitCommand = Cmd "(exit)"
+
 -- | Tell yices to show a model
 showModelCommand :: Command (Connection s)
 showModelCommand = Cmd "(show-model)"
@@ -535,7 +538,8 @@ instance OnlineSolver s (Connection s) where
 
 yicesShutdownSolver :: SolverProcess s (Connection s) -> IO (ExitCode, Lazy.Text)
 yicesShutdownSolver p =
-   do Streams.write Nothing (solverStdin p)
+   do addCommandNoAck (solverConn p) exitCommand
+      Streams.write Nothing (solverStdin p)
 
       --logLn 2 "Waiting for yices to terminate"
       txt <- readAllLines (solverStderr p)


### PR DESCRIPTION
Previously, we shut down the solver connection by closing stdin.  It turns out
that this is not sufficient to shut the connection down when yices is run in
ef (exists-forall) mode.  Without an explicit (exit) command, the process using
yices via what4 just hangs.