### PR TITLE
what4: Fix SMT generation for z3 in the presence of exists/forall pro…

### DIFF
--- a/what4/src/What4/Protocol/SMTLib2.hs
+++ b/what4/src/What4/Protocol/SMTLib2.hs
@@ -287,7 +287,11 @@ instance SupportTermOps Term where
   x .== y = SMT2.eq [x,y]
   x ./= y = SMT2.distinct [x,y]
 
-  letExpr = SMT2.letBinder
+  -- NB: SMT2.letBinder defines a "parallel" let, and
+  -- we want the semantics of a "sequential" let, so expand
+  -- to a series of nested lets.
+  letExpr [] t = t
+  letExpr (v:vs) = SMT2.letBinder [v] (letExpr vs t)
 
   ite = SMT2.ite
 

--- a/what4/src/What4/Protocol/SMTLib2.hs
+++ b/what4/src/What4/Protocol/SMTLib2.hs
@@ -290,8 +290,7 @@ instance SupportTermOps Term where
   -- NB: SMT2.letBinder defines a "parallel" let, and
   -- we want the semantics of a "sequential" let, so expand
   -- to a series of nested lets.
-  letExpr [] t = t
-  letExpr (v:vs) t = SMT2.letBinder [v] (letExpr vs t)
+  letExpr vs t = foldr (\v -> SMT2.letBinder [v]) t vs
 
   ite = SMT2.ite
 

--- a/what4/src/What4/Protocol/SMTLib2.hs
+++ b/what4/src/What4/Protocol/SMTLib2.hs
@@ -291,7 +291,7 @@ instance SupportTermOps Term where
   -- we want the semantics of a "sequential" let, so expand
   -- to a series of nested lets.
   letExpr [] t = t
-  letExpr (v:vs) = SMT2.letBinder [v] (letExpr vs t)
+  letExpr (v:vs) t = SMT2.letBinder [v] (letExpr vs t)
 
   ite = SMT2.ite
 

--- a/what4/src/What4/Protocol/SMTLib2/Syntax.hs
+++ b/what4/src/What4/Protocol/SMTLib2/Syntax.hs
@@ -320,8 +320,8 @@ letBinding (nm, t) = app_list (Builder.fromText nm) [renderTerm t]
 -- | Create a let binding
 letBinder :: [(Text, Term)] -> Term -> Term
 letBinder [] r = r
-letBinder (var:vars) r =
-  T (app "let" [builder_list [letBinding var], renderTerm (letBinder vars r)])
+letBinder vars r =
+  T (app "let" [builder_list (letBinding <$> vars), renderTerm r])
 
 ------------------------------------------------------------------------
 -- Reals/Int/Real_Ints theories

--- a/what4/src/What4/Protocol/SMTLib2/Syntax.hs
+++ b/what4/src/What4/Protocol/SMTLib2/Syntax.hs
@@ -320,8 +320,8 @@ letBinding (nm, t) = app_list (Builder.fromText nm) [renderTerm t]
 -- | Create a let binding
 letBinder :: [(Text, Term)] -> Term -> Term
 letBinder [] r = r
-letBinder vars r =
-  T (app "let" [builder_list (letBinding <$> vars), renderTerm r])
+letBinder (var:vars) r =
+  T (app "let" [builder_list [letBinding var], renderTerm (letBinder vars r)])
 
 ------------------------------------------------------------------------
 -- Reals/Int/Real_Ints theories

--- a/what4/src/What4/Protocol/SMTLib2/Syntax.hs
+++ b/what4/src/What4/Protocol/SMTLib2/Syntax.hs
@@ -317,7 +317,10 @@ exists vars r =
 letBinding :: (Text, Term) -> Builder
 letBinding (nm, t) = app_list (Builder.fromText nm) [renderTerm t]
 
--- | Create a let binding
+-- | Create a let binding.  NOTE: SMTLib2 defines this to be
+--   a \"parallel\" let, which means that the bound variables
+--   are NOT in scope in the right-hand sides of other
+--   bindings, even syntactically-later ones.
 letBinder :: [(Text, Term)] -> Term -> Term
 letBinder [] r = r
 letBinder vars r =

--- a/what4/src/What4/Protocol/SMTWriter.hs
+++ b/what4/src/What4/Protocol/SMTWriter.hs
@@ -265,7 +265,10 @@ class Num v => SupportTermOps v where
   impliesExpr :: v -> v -> v
   impliesExpr x y = notExpr x .|| y
 
-  -- | Create a let expression.
+  -- | Create a let expression.  This is a "sequential" let,
+  --   which is syntactic sugar for a nested series of single
+  --   let bindings.  As a consequence, bound variables are in
+  --   scope for the right-hand-sides of subsequent bindings.
   letExpr :: [(Text, v)] -> v -> v
 
   -- | Create an if-then-else expression.

--- a/what4/src/What4/Solver/Yices.hs
+++ b/what4/src/What4/Solver/Yices.hs
@@ -187,7 +187,9 @@ instance SupportTermOps (YicesTerm s) where
   (./=) = bin_app "/="
   ite c x y = term_app "if" [c, x, y]
 
-  letExpr    vars t = binder_app "let"    (uncurry letBinding <$> vars) t
+  -- NB: Yices "let" has the semantics of a sequential let, so no
+  -- transformations need to be done
+  letExpr vars t = binder_app "let" (uncurry letBinding <$> vars) t
 
   sumExpr [] = 0
   sumExpr [e] = e


### PR DESCRIPTION
…blems

The previous translation used a more compact notation with multiple values bound
in each let binding:

(let ((a foo)
      (b (bar a))
      ...)

Unfortunately, z3 doesn't scope variables as we might like in this case: the
reference to `a` in the definition of `b` above is not in scope.  This change
uses a single let per value defined instead, which has the expected scoping
behavior.

It seems like this wasn't observed before because the exists/forall backend is
not used very often, and let bindings are only used (by what4) in exists/forall
problems.

It isn't clear if this is a problem for other SMT solvers besides z3 - it could
be that this change belongs in a quirks instance for z3 instead of applying to
all smtlib2-based solver backends.