### PR TITLE
Pretty-printing of LLVMVals with names of global variables

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
@@ -75,6 +75,7 @@ module Lang.Crucible.LLVM.MemModel
 
     -- * \"Raw\" operations with LLVMVal
   , LLVMVal(..)
+  , ppLLVMValWithGlobals
   , FloatSize(..)
   , unpackMemValue
   , packMemValue
@@ -137,6 +138,7 @@ module Lang.Crucible.LLVM.MemModel
   , allocGlobal
   , functionAliases
   , reverseAliases
+  , isGlobalPointer
 
     -- * Misc
   , llvmStatementExec
@@ -166,7 +168,7 @@ import           Data.IORef
 import qualified Data.List as List
 import           Data.Map (Map)
 import qualified Data.Map as Map
-import           Data.Maybe (mapMaybe)
+import           Data.Maybe (mapMaybe, listToMaybe)
 import           Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
 import           Data.Set (Set)
@@ -175,6 +177,7 @@ import           Data.Word
 import           GHC.TypeNats
 import           System.IO (Handle, hPutStrLn)
 import           Text.PrettyPrint.ANSI.Leijen hiding ((<$>))
+import qualified Text.PrettyPrint.ANSI.Leijen as PP
 
 import           Data.Parameterized.Classes
 import qualified Data.Parameterized.Context as Ctx
@@ -1501,3 +1504,55 @@ allocGlobal sym mem (g, aliases, sz, alignment) = do
   -- TODO: Aliases are not propagated to doMalloc for error messages
   (ptr, mem') <- doMalloc sym G.GlobalAlloc mut sym_str mem sz' alignment
   return (registerGlobal mem' (symbol:aliases) ptr)
+
+-- | Look up a pointer in the 'memImplGlobalMap' to see if it's a global.
+--
+-- This is best-effort and will only work if the pointer is fully concrete
+-- and matches the address of the global on the nose. It is used in SAWscript
+-- for friendly error messages.
+isGlobalPointer :: forall sym w. (IsSymInterface sym, 1 <= w)
+                => sym
+                -> GlobalMap sym
+                -> LLVMPtr sym w
+                -> IO (Maybe L.Symbol)
+isGlobalPointer sym globalMap needle =
+  let fun :: L.Symbol -> SomePointer sym -> IO (Maybe L.Symbol)
+      fun symb (SomePointer ptr)
+        | Just Refl <- testEquality ptr needle -- do they have the same width?
+        = ptrEq sym (ptrWidth ptr) ptr needle <&> \equalityPredicate ->
+            case asConstantPred equalityPredicate of
+              Just True  -> Just symb
+              Just False -> Nothing
+              Nothing    -> Nothing
+      fun _ _ = pure Nothing
+  in listToMaybe . fmap fst . Map.toList <$>
+       Map.traverseMaybeWithKey fun globalMap
+
+-- | For when you don't know @1 <= w@
+isGlobalPointer' :: forall sym w. (IsSymInterface sym)
+                 => sym
+                 -> GlobalMap sym
+                 -> LLVMPtr sym w
+                 -> IO (Maybe L.Symbol)
+isGlobalPointer' sym globalMap needle =
+  case testLeq (knownNat :: NatRepr 1) (ptrWidth needle) of
+    Nothing       -> pure Nothing
+    Just LeqProof -> isGlobalPointer sym globalMap needle
+
+-- | Pretty-print an 'LLVMVal', but replace pointers to globals with the name of
+--   the global when possible. Probably pretty slow on big structures.
+--
+-- TODO(lb): This is in this module instead of "MemModel.Value" because
+-- 'SomePointer' is here, and I can't move 'SomePointer' to "MemModel.Pointer"
+-- because I get type errors? What's going on?
+ppLLVMValWithGlobals :: forall sym.
+  (IsSymInterface sym) =>
+  sym ->
+  GlobalMap sym {-^ c.f. 'memImplGlobalMap' -} ->
+  LLVMVal sym ->
+  IO PP.Doc
+ppLLVMValWithGlobals sym globalMap = ppLLVMVal $ \allocNum offset ->
+  isGlobalPointer' sym globalMap (LLVMPointer allocNum offset) <&&>
+    \(L.Symbol symb) -> PP.text ('@':symb)
+  where x <&&> f = (fmap . fmap) f x -- map under IO and Maybe
+

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Pointer.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Pointer.hs
@@ -117,6 +117,9 @@ llvmPointerView (LLVMPointer blk off) = (blk, off)
 ptrWidth :: IsExprBuilder sym => LLVMPtr sym w -> NatRepr w
 ptrWidth (LLVMPointer _blk bv) = bvWidth bv
 
+instance IsExprBuilder sym => TestEquality (LLVMPointer sym) where
+  testEquality ptr1 ptr2 = testEquality (ptrWidth ptr1) (ptrWidth ptr2)
+
 -- | Assert that the given LLVM pointer value is actually a raw bitvector and extract its value.
 projectLLVM_bv ::
   IsSymInterface sym => sym -> LLVMPtr sym w -> IO (SymBV sym w)

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Value.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Value.hs
@@ -160,7 +160,7 @@ ppLLVMVal ppInt =
                               ]
                     , "width = " ++ show (bvWidth w)
                     ]
-                  (Nothing) -> PP.text $ unwords $
+                  Nothing -> PP.text $ unwords $
                     [ "symbolic integer: "
                     , "width = " ++ show (bvWidth w)
                     ]

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Value.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Value.hs
@@ -139,6 +139,7 @@ ppLLVMVal ::
   f PP.Doc
 ppLLVMVal ppInt =
   let typed doc tp = PP.text doc PP.<+> PP.text ":" PP.<+> PP.text (show tp)
+      pp = ppLLVMVal ppInt
   in
     \case
       (LLVMValZero tp) -> pure $ PP.angles (typed "zero" tp)
@@ -182,8 +183,8 @@ ppLLVMVal ppInt =
       (LLVMValFloat SingleSize _) -> pure $ PP.text "symbolic float"
       (LLVMValFloat DoubleSize _) -> pure $ PP.text "symbolic double"
       (LLVMValFloat X86_FP80Size _) -> pure $ PP.text "symbolic long double"
-      (LLVMValStruct xs) -> pure $ PP.semiBraces (map (PP.pretty . snd) $ V.toList xs)
-      (LLVMValArray _ xs) -> pure $ PP.list (map PP.pretty $ V.toList xs)
+      (LLVMValStruct xs) -> PP.semiBraces <$> traverse (pp . snd) (V.toList xs)
+      (LLVMValArray _ xs) -> PP.list <$> traverse pp (V.toList xs)
 
 -- | This instance tries to make things as concrete as possible.
 instance IsExpr (SymExpr sym) => PP.Pretty (LLVMVal sym) where


### PR DESCRIPTION
This allows us to have error messages like this in SAWscript, which give users feedback in terms of the source language (C/LLVM) (note the presence of `@update256`):
```
could not match specified value with actual value:
  actual (simulator) value: @update256
  specified value: concrete pointer: allocation = 646, offset = 40
  type of actual value: i32(%struct.env_md_ctx_st*, i8*)**
  type of specified value: i32(%struct.env_md_ctx_st*, i8*)**
```
(c.f. https://github.com/GaloisInc/saw-script/pull/450). [This paste](https://clbin.com/jzjvI) has another example.

We should probably also consider using this in `readMem'`, so that if the memory model failed to load through a pointer to a global, the user doesn't have to look through the memory dump to find out which one it was.