### PR TITLE
Separate Travis build+test jobs from lint jobs

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -12,6 +12,11 @@
 # Will suggest replacing "wibbleMany [myvar]" with "wibbleOne myvar"
 # - error: {lhs: "wibbleMany [x]", rhs: wibbleOne x}
 
+# We should use "panic", not "error".
+# - error:
+#     lhs: "error x"
+#     rhs: 'panic "nameOfFunction" [x, "more lines of details"]'
+
 # TODO: specialize these to the modules they are needed
 - ignore: {name: 'Use :'}
 - ignore: {name: Avoid lambda using `infix`}
@@ -48,7 +53,7 @@
 - ignore: {name: Use fewer imports}
 - ignore: {name: Use fmap}
 - ignore: {name: Use forM_}
-- ignore: {name: Use fromMaybe, within: [Lang.Crucible.Analysis.Shape, Lang.Crucible.JVM.Class]}
+- ignore: {name: Use fromMaybe, within: [Lang.Crucible.Analysis.Shape, Lang.Crucible.JVM.Class, Lang.Crucible.JVM.Translation.Class]}
 - ignore: {name: Use record patterns, within: [Lang.Crucible.Simulator.EvalStmt, Lang.Crucible.Simulator.Profiling, Lang.Crucible.CFG.Core]}
 - ignore: {name: Use guards}
 - ignore: {name: Use hPrint}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 script:
-- '[[ $DO_LINT != True ]] && cabal new-update'
-- '[[ $DO_LINT == True ]] && curl -sSL https://raw.github.com/ndmitchell/neil/master/misc/travis.sh
-  | sh -s -- hlint crucible{,-jvm,-llvm,-saw,-server,-syntax} crux{,-llvm} what4{,-abc,-blt}'
-- '[[ $DO_LINT != True ]] && cabal new-build crucible{,-jvm,-llvm,-saw,-syntax}
-  crux{,-llvm} what4{,-abc,-blt} -j --disable-optimization $BUILD_ARG'
+- if [[ $DO_LINT != True ]]; cabal new-update; fi
+- if [[ $DO_LINT == True ]]; curl -sSL https://raw.github.com/ndmitchell/neil/master/misc/travis.sh
+  | sh -s -- hlint crucible{,-jvm,-llvm,-saw,-server,-syntax} crux{,-llvm} what4{,-abc,-blt};
+  fi
+- if [[ $DO_LINT != True ]]; cabal new-build crucible{,-jvm,-llvm,-saw,-syntax} crux{,-llvm}
+  what4{,-abc,-blt} -j --disable-optimization $BUILD_ARG; fi
 before_cache:
 - rm -fv $HOME/.cabal/packages/hackage.haskell.org/build-reports.log
 - rm -fv $HOME/.cabal/packages/hackage.haskell.org/00-index.tar

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 script:
-- if [[ $DO_LINT != True ]]; cabal new-update; fi
-- if [[ $DO_LINT == True ]]; curl -sSL https://raw.github.com/ndmitchell/neil/master/misc/travis.sh
-  | sh -s -- hlint crucible{,-jvm,-llvm,-saw,-server,-syntax} crux{,-llvm} what4{,-abc,-blt};
-  fi
-- if [[ $DO_LINT != True ]]; cabal new-build crucible{,-jvm,-llvm,-saw,-syntax} crux{,-llvm}
-  what4{,-abc,-blt} -j --disable-optimization $BUILD_ARG; fi
+- if [[ $DO_LINT != True ]]; then cabal new-update ; fi
+- if [[ $DO_LINT == True ]]; then curl -sSL https://raw.github.com/ndmitchell/neil/master/misc/travis.sh
+  | sh -s -- hlint crucible{,-jvm,-llvm,-saw,-server,-syntax} crux{,-llvm} what4{,-abc,-blt}
+  ; fi
+- if [[ $DO_LINT != True ]]; then cabal new-build crucible{,-jvm,-llvm,-saw,-syntax}
+  crux{,-llvm} what4{,-abc,-blt} -j --disable-optimization $BUILD_ARG ; fi
 before_cache:
 - rm -fv $HOME/.cabal/packages/hackage.haskell.org/build-reports.log
 - rm -fv $HOME/.cabal/packages/hackage.haskell.org/00-index.tar

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
 script:
-- cabal new-update
-- curl -sSL https://raw.github.com/ndmitchell/neil/master/misc/travis.sh | sh -s --
-  hlint crucible{,-jvm,-llvm,-saw,-server,-syntax} crux{,-llvm} what4{,-abc,-blt}
-- cabal new-build crucible{,-jvm,-llvm,-saw,-syntax} crux{,-llvm} what4{,-abc,-blt}
-  -j --disable-optimization $BUILD_ARG
+- '[[ $DO_LINT != True ]] && cabal new-update'
+- '[[ $DO_LINT == True ]] && curl -sSL https://raw.github.com/ndmitchell/neil/master/misc/travis.sh
+  | sh -s -- hlint crucible{,-jvm,-llvm,-saw,-server,-syntax} crux{,-llvm} what4{,-abc,-blt}'
+- '[[ $DO_LINT != True ]] && cabal new-build crucible{,-jvm,-llvm,-saw,-syntax}
+  crux{,-llvm} what4{,-abc,-blt} -j --disable-optimization $BUILD_ARG'
 before_cache:
 - rm -fv $HOME/.cabal/packages/hackage.haskell.org/build-reports.log
 - rm -fv $HOME/.cabal/packages/hackage.haskell.org/00-index.tar
 matrix:
   fast_finish: true
   include:
-  - env: CABALVER=2.4 GHCVER=8.6.3 BUILD_ARG=
+  - env: CABALVER=2.4 GHCVER=8.6.3 BUILD_ARG= DO_LINT=False
     addons:
       apt:
         sources:
@@ -21,7 +21,7 @@ matrix:
         - libglpk-dev
         - libntl-dev
         - libboost-all-dev
-  - env: CABALVER=2.4 GHCVER=8.4.3 BUILD_ARG=
+  - env: CABALVER=2.4 GHCVER=8.4.3 BUILD_ARG= DO_LINT=False
     addons:
       apt:
         sources:
@@ -32,7 +32,7 @@ matrix:
         - libglpk-dev
         - libntl-dev
         - libboost-all-dev
-  - env: CABALVER=2.4 GHCVER=8.6.3 BUILD_ARG=
+  - env: CABALVER=2.4 GHCVER=8.6.3 BUILD_ARG= DO_LINT=False
     addons:
       homebrew:
         packages:
@@ -42,7 +42,8 @@ matrix:
         - cabal-install
         update: true
     os: osx
-  - env: CABALVER=2.4 GHCVER=8.6.3 BUILD_ARG=--allow-newer
+  - env: CABALVER=2.4 GHCVER=8.6.3 BUILD_ARG= DO_LINT=True
+  - env: CABALVER=2.4 GHCVER=8.6.3 BUILD_ARG=--allow-newer DO_LINT=False
     addons:
       apt:
         sources:
@@ -54,7 +55,7 @@ matrix:
         - libntl-dev
         - libboost-all-dev
   allow_failures:
-  - env: CABALVER=2.4 GHCVER=8.6.3 BUILD_ARG=--allow-newer
+  - env: CABALVER=2.4 GHCVER=8.6.3 BUILD_ARG=--allow-newer DO_LINT=False
 cache:
   directories:
   - $HOME/.cabsnap

--- a/travis/travis.dhall
+++ b/travis/travis.dhall
@@ -218,7 +218,8 @@ in    { language =
           [     let cond =
                         λ(cond : Text)
                       → λ(step : Text)
-                      → concatSep "; " [ "if ${cond}", step, "fi" ] : Text
+                      →   concatSep " " [ "if ${cond}; then", step, ";", "fi" ]
+                        : Text
             
             in  let doLint = cond "[[ \$DO_LINT == True ]]"
             

--- a/travis/travis.dhall
+++ b/travis/travis.dhall
@@ -6,6 +6,9 @@ in  let map =
 in  let concatSep =
           https://raw.githubusercontent.com/dhall-lang/dhall-lang/v5.0.0/Prelude/Text/concatSep
 
+in  let bShow =
+          https://raw.githubusercontent.com/dhall-lang/dhall-lang/v5.0.0/Prelude/Bool/show
+
 in  let OperatingSystem = < Linux : {} | OSX : {} >
 
 in  let operatingSystem = constructors OperatingSystem
@@ -22,7 +25,17 @@ in  let Include =
           }
 
 in  let MakeIncludeArgs =
-          { ghc : Text, cabal : Text, os : OperatingSystem, buildArg : Text }
+          { ghc :
+              Text
+          , cabal :
+              Text
+          , os :
+              OperatingSystem
+          , buildArg :
+              Text
+          , doLint :
+              Bool
+          }
 
 in  let makeEnv =
             λ(args : MakeIncludeArgs)
@@ -31,6 +44,7 @@ in  let makeEnv =
               [ "CABALVER=${args.cabal}"
               , "GHCVER=${args.ghc}"
               , "BUILD_ARG=${args.buildArg}"
+              , "DO_LINT=${bShow args.doLint}"
               ]
             : Text
 
@@ -41,40 +55,48 @@ in  let makeInclude =
               , compiler =
                   [] : Optional Text
               , addons =
-                  merge
-                  { Linux =
-                        λ(_ : {})
-                      → [ { apt =
-                              [ { packages =
-                                    [ "cabal-install-${args.cabal}"
-                                    , "ghc-${args.ghc}"
-                                    , "libglpk-dev"
-                                    , "libntl-dev"
-                                    , "libboost-all-dev"
-                                    ]
-                                , sources =
-                                    [ "hvr-ghc" ]
+                        if args.doLint
+                  
+                  then  [] : Optional schema.Addon
+                  
+                  else  merge
+                        { Linux =
+                              λ(_ : {})
+                            → [ { apt =
+                                    [ { packages =
+                                          [ "cabal-install-${args.cabal}"
+                                          , "ghc-${args.ghc}"
+                                          , "libglpk-dev"
+                                          , "libntl-dev"
+                                          , "libboost-all-dev"
+                                          ]
+                                      , sources =
+                                          [ "hvr-ghc" ]
+                                      }
+                                    ] : Optional schema.AddonApt
+                                , homebrew =
+                                    [] : Optional schema.AddonBrew
                                 }
-                              ] : Optional schema.AddonApt
-                          , homebrew =
-                              [] : Optional schema.AddonBrew
-                          }
-                        ] : Optional schema.Addon
-                  , OSX =
-                        λ(_ : {})
-                      → [ { apt =
-                              [] : Optional schema.AddonApt
-                          , homebrew =
-                              [ { packages =
-                                    [ "ghc", "ntl", "glpk", "cabal-install" ]
-                                , update =
-                                    True
+                              ] : Optional schema.Addon
+                        , OSX =
+                              λ(_ : {})
+                            → [ { apt =
+                                    [] : Optional schema.AddonApt
+                                , homebrew =
+                                    [ { packages =
+                                          [ "ghc"
+                                          , "ntl"
+                                          , "glpk"
+                                          , "cabal-install"
+                                          ]
+                                      , update =
+                                          True
+                                      }
+                                    ] : Optional schema.AddonBrew
                                 }
-                              ] : Optional schema.AddonBrew
-                          }
-                        ] : Optional schema.Addon
-                  }
-                  args.os
+                              ] : Optional schema.Addon
+                        }
+                        args.os
               , os =
                   merge
                   { Linux =
@@ -95,6 +117,8 @@ in  let allowNewer =
                 operatingSystem.Linux {=}
             , buildArg =
                 "--allow-newer"
+            , doLint =
+                False
             }
           : MakeIncludeArgs
 
@@ -130,6 +154,8 @@ in    { language =
                         operatingSystem.Linux {=}
                     , buildArg =
                         ""
+                    , doLint =
+                        False
                     }
                   , { ghc =
                         "8.4.3"
@@ -139,6 +165,8 @@ in    { language =
                         operatingSystem.Linux {=}
                     , buildArg =
                         ""
+                    , doLint =
+                        False
                     }
                   , { ghc =
                         "8.6.3"
@@ -148,6 +176,19 @@ in    { language =
                         operatingSystem.OSX {=}
                     , buildArg =
                         ""
+                    , doLint =
+                        False
+                    }
+                  , { ghc =
+                        "8.6.3"
+                    , cabal =
+                        "2.4"
+                    , os =
+                        operatingSystem.Linux {=}
+                    , buildArg =
+                        ""
+                    , doLint =
+                        True
                     }
                   , allowNewer
                   ]
@@ -174,15 +215,15 @@ in    { language =
             ]
           ] : Optional (List Text)
       , script =
-          [ [ "cabal new-update"
+          [ [ "[[ \$DO_LINT != True ]] && cabal new-update"
             ,     let hlintURL =
                         "https://raw.github.com/ndmitchell/neil/master/misc/travis.sh"
               
               in  let pkgs =
                         "crucible{,-jvm,-llvm,-saw,-server,-syntax} crux{,-llvm} what4{,-abc,-blt}"
               
-              in  "curl -sSL ${hlintURL} | sh -s -- hlint ${pkgs}"
-            , "cabal new-build crucible{,-jvm,-llvm,-saw,-syntax} crux{,-llvm} what4{,-abc,-blt} -j --disable-optimization \$BUILD_ARG"
+              in  "[[ \$DO_LINT == True ]] && curl -sSL ${hlintURL} | sh -s -- hlint ${pkgs}"
+            , "[[ \$DO_LINT != True ]] && cabal new-build crucible{,-jvm,-llvm,-saw,-syntax} crux{,-llvm} what4{,-abc,-blt} -j --disable-optimization \$BUILD_ARG"
             ]
           ] : Optional (List Text)
       }


### PR DESCRIPTION
This makes it easier to tell if a build is failing or if linting is failing, and speeds up the build+test jobs by about 2 minutes. Fixes #244. 

These commits should be squashed when merged. 