### PR TITLE
Add a crux primitive: crucible_string

### DIFF
--- a/crux-llvm/c-src/includes/crucible.h
+++ b/crux-llvm/c-src/includes/crucible.h
@@ -21,6 +21,15 @@ double   crucible_double   (const char *name);
 
 size_t   crucible_size_t   (const char *name);
 
+// Allocate a string of fixed length with symbolic contents
+//
+// The string has @max_len@ symbolic bytes plus a fixed NUL terminator.  Each
+// character is unconstrained and may also be NUL, allowing for verification of
+// algorithms over strings up to a certain length.
+//
+// The string contents are read-only.
+const char* crucible_string(const char *name, size_t max_len);
+
 #define crucible_uint8_t(n)  ((uint8_t)crucible_int8_t(n))
 #define crucible_uint16_t(n)  ((uint16_t)crucible_int16_t(n))
 #define crucible_uint32_t(n)  ((uint32_t)crucible_int32_t(n))

--- a/crux-llvm/src/Crux/LLVM/Overrides.hs
+++ b/crux-llvm/src/Crux/LLVM/Overrides.hs
@@ -1,12 +1,13 @@
-{-# Language ImplicitParams #-}
-{-# Language RankNTypes #-}
-{-# Language TypeFamilies #-}
-{-# Language TypeApplications #-}
-{-# Language TypeOperators #-}
-{-# Language DataKinds #-}
-{-# Language PatternSynonyms #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# Language ConstraintKinds #-}
+{-# Language DataKinds #-}
+{-# Language ImplicitParams #-}
 {-# Language LambdaCase #-}
+{-# Language PatternSynonyms #-}
+{-# Language RankNTypes #-}
+{-# Language TypeApplications #-}
+{-# Language TypeFamilies #-}
+{-# Language TypeOperators #-}
 module Crux.LLVM.Overrides where
 
 import Data.String(fromString)
@@ -25,8 +26,8 @@ import Data.Parameterized.Context(pattern Empty, pattern (:>))
 import What4.FunctionName(functionNameFromText)
 import What4.Symbol(userSymbol, emptySymbol)
 import What4.Interface
-          (freshConstant, bvLit, bvEq, asUnsignedBV,notPred
-          , getCurrentProgramLoc, printSymExpr)
+          (freshConstant, bvLit, bvEq, bvAdd, asUnsignedBV,notPred
+          , getCurrentProgramLoc, printSymExpr, natLit)
 import What4.InterpretedFloatingPoint (freshFloatConstant, iFloatBaseTypeRepr)
 
 import Lang.Crucible.Types
@@ -61,8 +62,8 @@ import Lang.Crucible.LLVM.Translation
 import Lang.Crucible.LLVM.DataLayout
   (noAlignment)
 import Lang.Crucible.LLVM.MemModel
-  (Mem, LLVMPointerType, pattern LLVMPointerRepr,loadString,HasPtrWidth,
-   llvmPointer_bv, projectLLVM_bv, doArrayStore)
+  (Mem, LLVMPointerType, pattern LLVMPointerRepr,loadString,HasPtrWidth,LLVMVal(..), ptrAdd, doMalloc, AllocType(HeapAlloc), Mutability(Immutable),
+   llvmPointer_bv, projectLLVM_bv, doArrayStore, bitvectorType, storeConstRaw, doArrayConstStore)
 
 import Lang.Crucible.LLVM.Extension(LLVM)
 import Lang.Crucible.LLVM.Extension(ArchWidth)
@@ -79,6 +80,9 @@ type TBits n        = LLVMPointerType n
 
 tPtr :: HasPtrWidth w => TypeRepr (LLVMPointerType w)
 tPtr = LLVMPointerRepr ?ptrWidth
+
+tBVPtrWidth :: (HasPtrWidth w) => TypeRepr (TBits w)
+tBVPtrWidth = LLVMPointerRepr ?ptrWidth
 
 setupOverrides ::
   (ArchOk arch, IsSymInterface b) =>
@@ -102,6 +106,9 @@ setupOverrides ctxt =
         (Empty :> tPtr) knownRepr (lib_fresh_i32 mvar)
      regOver ctxt "crucible_uint64_t"
         (Empty :> tPtr) knownRepr (lib_fresh_i64 mvar)
+
+     regOver ctxt "crucible_string"
+        (Empty :> tPtr :> tBVPtrWidth) tPtr (lib_fresh_str mvar)
 
      regOver ctxt "crucible_assume"
         (Empty :> knownRepr :> tPtr :> knownRepr) knownRepr lib_assume
@@ -270,6 +277,44 @@ lib_fresh_i64 ::
   GlobalVar Mem -> Fun sym (LLVM arch) (EmptyCtx ::> TPtr arch) (TBits 64)
 lib_fresh_i64 mem = lib_fresh_bits mem knownNat
 
+lib_fresh_str ::
+  (ArchOk arch, IsSymInterface sym) =>
+  GlobalVar Mem -> Fun sym (LLVM arch) (EmptyCtx ::> TPtr arch ::> TBits (ArchWidth arch)) (TPtr arch)
+lib_fresh_str mvar = do
+  RegMap args <- getOverrideArgs
+  case args of
+    Empty :> pName :> maxLen -> do
+      name <- lookupString mvar pName
+      sym <- getSymInterface
+
+      -- Compute the allocation length, which is the requested length plus one
+      -- to hold the NUL terminator
+      one <- liftIO $ bvLit sym ?ptrWidth 1
+      maxLenBV <- liftIO $ projectLLVM_bv sym (regValue maxLen)
+      len <- liftIO $ bvAdd sym maxLenBV one
+      mem0 <- readGlobal mvar
+
+      -- Allocate memory to hold the string
+      (ptr, mem1) <- liftIO $ doMalloc sym HeapAlloc Immutable name mem0 len noAlignment
+
+      -- Allocate contents for the string - we want to make each byte symbolic,
+      -- so we allocate a fresh array (which has unbounded length) with symbolic
+      -- contents and write it into our allocation.  This write does not cover
+      -- the NUL terminator.
+      contentsName <- case userSymbol (name ++ "_contents") of
+        Left err -> fail (show err)
+        Right nm -> return nm
+      let arrayRep = BaseArrayRepr (Empty :> BaseBVRepr ?ptrWidth) (BaseBVRepr (knownNat @8))
+      initContents <- liftIO $ freshConstant sym contentsName arrayRep
+      mem2 <- liftIO $ doArrayConstStore sym mem1 ptr noAlignment initContents maxLenBV
+
+      -- Write the NUL terminator to the last byte
+      zeroByte <- liftIO $ bvLit sym (knownNat @8) 0
+      n0 <- liftIO $ natLit sym 0
+      termPtr <- liftIO $ ptrAdd sym ?ptrWidth ptr maxLenBV
+      mem3 <- liftIO $ storeConstRaw sym mem2 termPtr (bitvectorType 1) noAlignment (LLVMValInt n0 zeroByte)
+      writeGlobal mvar mem3
+      return ptr
 
 lib_assume ::
   (ArchOk arch, IsSymInterface sym) =>

--- a/crux-llvm/src/Crux/LLVM/Overrides.hs
+++ b/crux-llvm/src/Crux/LLVM/Overrides.hs
@@ -62,7 +62,7 @@ import Lang.Crucible.LLVM.Translation
 import Lang.Crucible.LLVM.DataLayout
   (noAlignment)
 import Lang.Crucible.LLVM.MemModel
-  (Mem, LLVMPointerType, pattern LLVMPointerRepr,loadString,HasPtrWidth,LLVMVal(..), ptrAdd, doMalloc, AllocType(HeapAlloc), Mutability(Immutable),
+  (Mem, LLVMPointerType, pattern LLVMPointerRepr,loadString,HasPtrWidth,LLVMVal(..), ptrAdd, doMalloc, AllocType(HeapAlloc), Mutability(Mutable),
    llvmPointer_bv, projectLLVM_bv, doArrayStore, bitvectorType, storeConstRaw, doArrayConstStore)
 
 import Lang.Crucible.LLVM.Extension(LLVM)
@@ -295,7 +295,7 @@ lib_fresh_str mvar = do
       mem0 <- readGlobal mvar
 
       -- Allocate memory to hold the string
-      (ptr, mem1) <- liftIO $ doMalloc sym HeapAlloc Immutable name mem0 len noAlignment
+      (ptr, mem1) <- liftIO $ doMalloc sym HeapAlloc Mutable name mem0 len noAlignment
 
       -- Allocate contents for the string - we want to make each byte symbolic,
       -- so we allocate a fresh array (which has unbounded length) with symbolic

--- a/crux-llvm/test-data/golden/string.c
+++ b/crux-llvm/test-data/golden/string.c
@@ -1,0 +1,9 @@
+#include <crucible.h>
+
+int main() {
+  const char* str = crucible_string("x", 5);
+  assuming(str[0] > 5 && str[0] < 20);
+  assuming(str[1] > 5 && str[1] < 10);
+  check(str[0] + str[1] > 5);
+  return 0;
+}

--- a/crux-llvm/test-data/golden/string.c
+++ b/crux-llvm/test-data/golden/string.c
@@ -1,9 +1,21 @@
 #include <crucible.h>
 
+int string_length(const char* str) {
+  int len = 0;
+  int i = 0;
+  while(str[i] != '\0') {
+    i++;
+    len++;
+  }
+
+  return len;
+}
+
 int main() {
   const char* str = crucible_string("x", 5);
   assuming(str[0] > 5 && str[0] < 20);
   assuming(str[1] > 5 && str[1] < 10);
   check(str[0] + str[1] > 5);
+  check(string_length(str) <= 5);
   return 0;
 }

--- a/crux-llvm/test-data/golden/string.good
+++ b/crux-llvm/test-data/golden/string.good
@@ -1,0 +1,2 @@
+[Crux] Simulating function "main"
+[Crux] Proved all 2 goals.


### PR DESCRIPTION
This primitive allocates a fixed-length string with symbolic contents.  The
string has the user-specified number of symbolic bytes plus a concrete NUL
terminator.

Note that the symbolic bytes are unconstrained and could also be NUL.