### PR TITLE
Fix the extern "C" preprocessor guards in crucible.h for crux

### DIFF
--- a/crux-llvm/c-src/includes/crucible.h
+++ b/crux-llvm/c-src/includes/crucible.h
@@ -1,9 +1,9 @@
 #ifndef CRUCIBLE_H
 #define CRUCIBLE_H
 
-#ifdef __cplusplus__
+#ifdef __cplusplus
 extern "C" {
-#endif //__cplusplus__
+#endif //__cplusplus
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -29,8 +29,8 @@ size_t   crucible_size_t   (const char *name);
 #define assuming(e) crucible_assume(e, __FILE__, __LINE__)
 #define check(e) crucible_assert(e, __FILE__, __LINE__)
 
-#ifdef __cplusplus__
+#ifdef __cplusplus
 }
-#endif //__cplusplus__
+#endif //__cplusplus
 
 #endif


### PR DESCRIPTION
The header attempts to add extern "C" when compiled in C++ mode to avoid name
mangling when matching overrides.  This is good, but the preprocessor guards
were testing the `__cplusplus__` macro, which is not correct: it is actually
`__cplusplus` (no trailing underscores).  See
http://www.cplusplus.com/doc/tutorial/preprocessor/ for details.