### PR TITLE
Add what4 option to pass `--mcsat` to Yices

### DIFF
--- a/crux/src/Crux/CruxMain.hs
+++ b/crux/src/Crux/CruxMain.hs
@@ -39,6 +39,7 @@ import What4.InterpretedFloatingPoint (IsInterpretedFloatExprBuilder)
 import What4.Interface (getConfiguration)
 import What4.FunctionName (FunctionName)
 import What4.Protocol.Online (OnlineSolver)
+import What4.Solver.Yices (yicesEnableMCSat)
 import What4.Solver.Z3 (z3Timeout)
 
 -- crux
@@ -123,7 +124,14 @@ simulate opts  =
 
      void $ join (setOpt <$> getOptionSetting solverInteractionFile (getConfiguration sym)
                          <*> pure ("crux-solver.out"))
-     
+
+     case solver cruxOpts of
+       "yices" -> void $ join $
+         setOpt <$> getOptionSetting yicesEnableMCSat (getConfiguration sym)
+                <*> pure (yicesMCSat cruxOpts)
+       _ -> when (yicesMCSat cruxOpts) $
+            fail "The `--mcsat` option is only valid with `--solver=yices`."
+
      when (solver cruxOpts == "z3") $
        void $ join (setOpt <$> getOptionSetting z3Timeout (getConfiguration sym)
                            <*> pure (goalTimeout cruxOpts * 1000))

--- a/crux/src/Crux/CruxMain.hs
+++ b/crux/src/Crux/CruxMain.hs
@@ -90,20 +90,25 @@ parseNominalDiffTime xs =
 -- moment, each solver is associated with a fixed floating-point
 -- interpretation. Ultimately, this should be an option, too.
 withBackend ::
-  String ->
+  (Language l) =>
+  Options l ->
   NonceGenerator IO scope ->
   (forall solver fs.
     (OnlineSolver scope solver
     , IsInterpretedFloatExprBuilder (OnlineBackend scope solver fs)) =>
       OnlineBackend scope solver fs -> IO a) ->
   IO a
-withBackend "cvc4" nonceGen f =
-  withCVC4OnlineBackend @(Flags FloatReal) nonceGen ProduceUnsatCores f
-withBackend "yices" nonceGen f =
-  withYicesOnlineBackend @(Flags FloatReal) nonceGen ProduceUnsatCores f
-withBackend "z3" nonceGen f =
-  withZ3OnlineBackend @(Flags FloatIEEE) nonceGen ProduceUnsatCores f
-withBackend s _ _ = fail $ "unknown solver: " ++ s
+withBackend (cruxOpts, _) nonceGen f = do
+  let unsatCores | yicesMCSat cruxOpts = NoUnsatFeatures
+                 | otherwise = ProduceUnsatCores
+  case solver cruxOpts of
+    "cvc4" ->
+      withCVC4OnlineBackend @(Flags FloatReal) nonceGen ProduceUnsatCores f
+    "yices" ->
+      withYicesOnlineBackend @(Flags FloatReal) nonceGen unsatCores f
+    "z3" ->
+      withZ3OnlineBackend @(Flags FloatIEEE) nonceGen ProduceUnsatCores f
+    s -> fail $ "unknown solver: " ++ s
 
 -- Returns only non-trivial goals
 simulate :: (Language a, ?outputConfig :: OutputConfig) => Options a ->
@@ -113,7 +118,7 @@ simulate opts  =
   in
   liftIO $
   withIONonceGenerator $ \nonceGen ->
-  withBackend (solver cruxOpts) nonceGen $ \sym -> do
+  withBackend opts nonceGen $ \sym -> do
      -- The simulator verbosity is one less than our verbosity.
      -- In this way, we can say things, without the simulator also being verbose
      let simulatorVerb = toInteger
@@ -216,7 +221,7 @@ simulate opts  =
           let ctx' = execResultContext res
 
           inFrame "<Prove Goals>" $
-            do pg <- proveGoals ctx' =<< (getProofObligations sym)
+            do pg <- proveGoals cruxOpts ctx' =<< (getProofObligations sym)
                provedGoalsTree ctx' pg
 
      when (simVerbose cruxOpts > 1) $

--- a/crux/src/Crux/Goal.hs
+++ b/crux/src/Crux/Goal.hs
@@ -11,6 +11,7 @@ import Data.IORef
 import Data.Maybe (fromMaybe)
 import qualified Data.Map as Map
 import qualified Data.Sequence as Seq
+import qualified Data.Text as Text
 
 
 import What4.Interface (notPred, printSymExpr,asConstantPred)
@@ -18,7 +19,7 @@ import What4.SatResult(SatResult(..))
 import What4.Expr.Builder (ExprBuilder)
 import What4.Protocol.Online( OnlineSolver, inNewFrame, solverEvalFuns
                             , solverConn, check, getUnsatCore )
-import What4.Protocol.SMTWriter(mkFormula,assumeFormulaWithFreshName,smtExprGroundEvalFn)
+import What4.Protocol.SMTWriter(mkFormula,assumeFormulaWithFreshName,assumeFormula,smtExprGroundEvalFn)
 
 import Lang.Crucible.Backend
 import Lang.Crucible.Backend.Online
@@ -31,6 +32,7 @@ import Lang.Crucible.Simulator.ExecutionTree
 import Crux.Types
 import Crux.Model
 import Crux.Log
+import Crux.Options
 import Crux.ProgressBar
 
 
@@ -93,15 +95,16 @@ proveGoals ::
   , OnlineSolver s solver
   , ?outputConfig :: OutputConfig
   ) =>
+  CruxOptions ->
   SimCtxt sym p ->
   Maybe (Goals (LPred sym asmp) (LPred sym ast)) ->
   IO (Maybe (Goals (LPred sym asmp) (LPred sym ast, ProofResult (Either (LPred sym asmp) (LPred sym ast)))))
 
-proveGoals _ctxt Nothing =
+proveGoals _opts _ctxt Nothing =
   do -- sayOK "Crux" $ unwords [ "No goals to prove." ]
      return Nothing
 
-proveGoals ctxt (Just gs0) =
+proveGoals opts ctxt (Just gs0) =
   do let sym = ctxt ^. ctxSymInterface
      sp <- getSolverProcess sym
      goalNum <- newIORef (0,0) -- total, proved
@@ -119,13 +122,15 @@ proveGoals ctxt (Just gs0) =
 
   bindName nm p nameMap = modifyIORef nameMap (Map.insert nm p)
 
-  go sp gn gs nameMap =
+  hasUnsatCores = not (yicesMCSat opts)
+
+  go sp gn gs nameMap = do
     case gs of
 
       Assuming ps gs1 ->
         do forM_ ps $ \p ->
              unless (asConstantPred (p^.labeledPred) == Just True) $
-              do nm <- assumeFormulaWithFreshName conn =<< mkFormula conn (p ^. labeledPred)
+              do nm <- doAssume =<< mkFormula conn (p ^. labeledPred)
                  bindName nm (Left p) nameMap
            res <- go sp gn gs1 nameMap
            return (Assuming ps res)
@@ -134,18 +139,23 @@ proveGoals ctxt (Just gs0) =
         do num <- atomicModifyIORef' gn (\(val,y) -> ((val + 1,y), val))
            start num
            let sym  = ctxt ^. ctxSymInterface
-           nm <- assumeFormulaWithFreshName conn
-                    =<< mkFormula conn =<< notPred sym (p ^. labeledPred)
+           nm <- doAssume =<< mkFormula conn =<< notPred sym (p ^. labeledPred)
            bindName nm (Right p) nameMap
 
            res <- check sp "proof"
            ret <- case res of
                       Unsat () ->
                         do modifyIORef' gn (\(x,f) -> (x,f+1))
-                           core <- getUnsatCore sp
                            namemap <- readIORef nameMap
-                           let core' = map (lookupnm namemap) core
-                           return (Prove (p, (Proved core')))
+                           say "Crux" "About to compute unsat cores"
+                           core <- if hasUnsatCores
+                                   then do
+                                     core <- getUnsatCore sp
+                                     return (map (lookupnm namemap) core)
+                                   else do
+                                     say "Crux" "Warning: can't use UNSAT cores in MC-SAT mode."
+                                     return (Map.elems namemap)
+                           return (Prove (p, (Proved core)))
 
                       Sat ()  ->
                         do f <- smtExprGroundEvalFn conn (solverEvalFuns sp)
@@ -170,3 +180,10 @@ proveGoals ctxt (Just gs0) =
     lookupnm namemap x =
       fromMaybe (error $ "Named predicate " ++ show x ++ " not found!")
                 (Map.lookup x namemap)
+
+    doAssume formula = do
+      namemap <- readIORef nameMap
+      if hasUnsatCores
+      then assumeFormulaWithFreshName conn formula
+      else assumeFormula conn formula >> return (Text.pack ("x" ++ show (Map.size namemap)))
+

--- a/crux/src/Crux/Language.hs
+++ b/crux/src/Crux/Language.hs
@@ -52,6 +52,8 @@ data CruxOptions = CruxOptions
     -- ^ Should we construct counter-example executables
   , solver :: String
     -- ^ Solver to user for the online backend
+  , yicesMCSat :: Bool
+    -- ^ Whether to use the MC-SAT engine with Yices.
   }
 
 type Options a = (CruxOptions, LangOptions a)

--- a/crux/src/Crux/Options.hs
+++ b/crux/src/Crux/Options.hs
@@ -46,6 +46,7 @@ defaultCruxOptions = CruxOptions {
   , loopBound = Nothing
   , makeCexes = True
   , solver = "yices"
+  , yicesMCSat = False
   }
 
 -- | All possible options that could be set from the command line.
@@ -129,6 +130,11 @@ cmdLineCruxOptions =
      (\v opts -> opts { solver = map toLower v })
        "solver")
     "Select solver to use"
+
+  , Option [] ["mcsat"]
+    (NoArg
+     (\opts -> opts { yicesMCSat = True }))
+    "Enable the MC-SAT solver in Yices"
   ]
 
 promoteLang :: forall a. Language a => (CL.LangOptions a -> CL.LangOptions a)

--- a/crux/src/Crux/Options.hs
+++ b/crux/src/Crux/Options.hs
@@ -134,7 +134,7 @@ cmdLineCruxOptions =
   , Option [] ["mcsat"]
     (NoArg
      (\opts -> opts { yicesMCSat = True }))
-    "Enable the MC-SAT solver in Yices"
+    "Enable the MC-SAT solver in Yices (disables unsat cores)"
   ]
 
 promoteLang :: forall a. Language a => (CL.LangOptions a -> CL.LangOptions a)

--- a/what4/src/What4/Solver/Yices.hs
+++ b/what4/src/What4/Solver/Yices.hs
@@ -583,6 +583,10 @@ yicesStartSolver features auxOutput sym = do -- FIXME
   enableMCSat <- getOpt =<< getOptionSetting yicesEnableMCSat cfg
   let args = ["--mode=push-pop", "--print-success"] ++
              if enableMCSat then ["--mcsat"] else []
+      hasNamedAssumptions = features `hasProblemFeature` useUnsatCores ||
+                            features `hasProblemFeature` useUnsatAssumptions
+  when (enableMCSat && hasNamedAssumptions) $
+     fail "Unsat cores and named assumptions are incompatible with MC-SAT in Yices."
 
   let create_proc
         = (proc yices_path args)
@@ -988,6 +992,10 @@ runYicesInOverride sym logData conditions resultFn = do
             | nlSolver  = ["--logic=QF_NRA"] -- ,"--print-success"]
             | otherwise = ["--mode=one-shot"] -- ,"--print-success"]
   let args = args0 ++ if enableMCSat then ["--mcsat"] else []
+      hasNamedAssumptions = features `hasProblemFeature` useUnsatCores ||
+                            features `hasProblemFeature` useUnsatAssumptions
+  when (enableMCSat && hasNamedAssumptions) $
+     fail "Unsat cores and named assumptions are incompatible with MC-SAT in Yices."
 
   withProcessHandles yices_path args Nothing $ \(in_h, out_h, err_h, ph) -> do
 

--- a/what4/src/What4/Solver/Yices.hs
+++ b/what4/src/What4/Solver/Yices.hs
@@ -57,6 +57,7 @@ module What4.Solver.Yices
   , yicesPath
   , yicesOptions
   , yicesDefaultFeatures
+  , yicesEnableMCSat
   ) where
 
 import           Control.Exception


### PR DESCRIPTION
The development version of Yices supports a `--mcsat` flag to enable the use of MC-SAT instead of DPLL(T) as the guiding search strategy.