### PR TITLE
More concise and explicit pretty-printing of allocation/write merges

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Generic.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Generic.hs
@@ -1379,18 +1379,18 @@ ppMerge vpp c x y =
   indent 2 $
     text "Condition:" <$$>
     indent 2 (printSymExpr c) <$$>
-    text "True Branch:"  <$$>
-    indent 2 (vcat $ map vpp x) <$$>
-    text "False Branch:" <$$>
-    indent 2 (vcat $ map vpp y)
+    ppAllocList x (text "True Branch:") <$$>
+    ppAllocList y (text "False Branch:")
+  where ppAllocList [] = (<+> text "<none>")
+        ppAllocList xs = (<$$> indent 2 (vcat $ map vpp xs))
 
 ppAlloc :: IsExprBuilder sym => MemAlloc sym -> Doc
 ppAlloc (Alloc atp base sz mut _alignment loc) =
   text (show atp) <+> text (show base) <+> (pretty $ printSymExpr <$> sz) <+> text (show mut) <+> text loc
 ppAlloc (MemFree base) =
-  text "free" <+> printSymExpr base
+  text "Free" <+> printSymExpr base
 ppAlloc (AllocMerge c x y) = do
-  text "merge" <$$> ppMerge ppAlloc c x y
+  text "Merge" <$$> ppMerge ppAlloc c x y
 
 ppAllocs :: IsExprBuilder sym => [MemAlloc sym] -> Doc
 ppAllocs xs = vcat $ map ppAlloc xs


### PR DESCRIPTION
Here's what it looks like in a SAW error message:
```diff
> git diff /tmp/diff2.txt /tmp/diff1.txt
diff --git a/tmp/diff2.txt b/tmp/diff1.txt
index 70c42b1..711aede 100644
--- a/tmp/diff2.txt
+++ b/tmp/diff1.txt
@@ -4,16 +4,12 @@
         Merge
           Condition:
             eq 0x0:[64] c@2434:bv
-          True Branch:
-
-          False Branch:
-
+          True Branch: <none>
+          False Branch: <none>
         Merge
           Condition:
             eq 0x0:[64] c@2437:bv
-          True Branch:
-
-          False Branch:
-
+          True Branch: <none>
+          False Branch: <none>
         StackAlloc 671 0x4:[64] Mutable "/build/openssl-1.0.2r/crypto/evp/digest.c:300:5"
         StackAlloc 670 0x8:[64] Mutable "/build/openssl-1.0.2r/crypto/evp/digest.c:300:5"
```