### PR TITLE
Update to use safe nonces

### DIFF
--- a/crucible-jvm/src/Lang/Crucible/JVM/Overrides.hs
+++ b/crucible-jvm/src/Lang/Crucible/JVM/Overrides.hs
@@ -260,7 +260,7 @@ register_jvm_override (JVMOverride { jvmOverride_className=cn
         do
            ctx <- lift $ use C.stateContext
            let ha = C.simHandleAllocator ctx
-           h <- lift $ liftST $ mkHandle' ha fnm derivedArgs derivedRet
+           h <- lift $ liftIO $ mkHandle' ha fnm derivedArgs derivedRet
            lift $ C.bindFnHandle h (C.UseOverride o)
            put (jvmctx { methodHandles = Map.insert (cn,mk) (JVMHandleInfo mk h) (methodHandles jvmctx) })
 

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
@@ -162,7 +162,6 @@ import           Prelude hiding (seq)
 import           Control.Lens hiding (Empty, (:>))
 import           Control.Monad
 import           Control.Monad.IO.Class
-import           Control.Monad.ST
 import           Control.Monad.Trans (lift)
 import           Control.Monad.Trans.State
 import           Data.Dynamic
@@ -455,8 +454,8 @@ evalStmt sym = eval
     do mem <- getMem mvar
        liftIO $ doPtrSubtract sym mem x y
 
-mkMemVar :: HandleAllocator s
-         -> ST s (GlobalVar Mem)
+mkMemVar :: HandleAllocator
+         -> IO (GlobalVar Mem)
 mkMemVar halloc = freshGlobalVar halloc "llvm_memory" knownRepr
 
 

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Run.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Run.hs
@@ -19,7 +19,6 @@ module Lang.Crucible.LLVM.Run
   ) where
 
 import Control.Lens((^.))
-import Control.Monad.ST(stToIO)
 import System.IO(Handle)
 import Data.String(fromString)
 import qualified Data.Map as Map
@@ -89,7 +88,7 @@ data Setup ext res =
 runCruxLLVM :: Module -> CruxLLVM res -> IO res
 runCruxLLVM llvm_mod (CruxLLVM setup) =
   do halloc <- newHandleAllocator
-     Some trans <- stToIO $ translateModule halloc llvm_mod
+     Some trans <- translateModule halloc llvm_mod
      res <- setup trans
      case res of
        Setup { .. } ->

--- a/crucible-llvm/test/Tests.hs
+++ b/crucible-llvm/test/Tests.hs
@@ -130,7 +130,7 @@ main = do
   putStrLn "Translating LLVM modules"
   halloc     <- newHandleAllocator
   -- translated :: [ModuleTranslation]
-  translated <- stToIO $ traverse (translateModule halloc) parsed
+  translated <- traverse (translateModule halloc) parsed
 
   -- Run tests on the results
   case translated of
@@ -318,10 +318,10 @@ withLLVMCtx :: forall a. L.Module
 withLLVMCtx mod action =
   let -- This is a separate function because we need to use the scoped type variable
       -- @s@ in the binding of @sym@, which is difficult to do inline.
-      with :: forall s. NonceGenerator IO s -> HandleAllocator RealWorld -> IO a
+      with :: forall s. NonceGenerator IO s -> HandleAllocator -> IO a
       with nonceGen halloc = do
         sym <- Crucible.newSimpleBackend @_ @(Crucible.Flags Crucible.FloatReal) nonceGen
-        Some (ModuleTranslation _ ctx _ _) <- stToIO $ translateModule halloc mod
+        Some (ModuleTranslation _ ctx _ _) <- translateModule halloc mod
         case llvmArch ctx                   of { X86Repr width ->
         case assertLeq (knownNat @1)  width of { LeqProof      ->
         case assertLeq (knownNat @16) width of { LeqProof      -> do

--- a/crucible-server/src/Lang/Crucible/Server/Simulator.hs
+++ b/crucible-server/src/Lang/Crucible/Server/Simulator.hs
@@ -27,7 +27,6 @@ import           Control.Applicative
 import           Control.Exception
 import           Control.Lens
 import           Control.Monad.IO.Class
-import           Control.Monad.ST (RealWorld, stToIO)
 import           Data.Hashable
 import qualified Data.HashTable.IO as HIO
 import           Data.IORef
@@ -44,7 +43,7 @@ import           GHC.IO.Handle
 
 import           Data.HPB
 import qualified Data.Parameterized.Map as MapF
-import           Data.Parameterized.Nonce.Unsafe (indexValue)
+import           Data.Parameterized.Nonce (indexValue)
 import           Data.Parameterized.Some
 
 import           What4.Config
@@ -99,7 +98,7 @@ data Simulator p sym
 getSimContext :: Simulator p sym -> IO (SimContext p sym ())
 getSimContext sim = readIORef (simContext sim)
 
-getHandleAllocator :: Simulator p sym -> IO (HandleAllocator RealWorld)
+getHandleAllocator :: Simulator p sym -> IO HandleAllocator
 getHandleAllocator sim = simHandleAllocator <$> getSimContext sim
 
 getInterface :: Simulator p sym -> IO sym
@@ -185,7 +184,7 @@ simMkHandle :: Simulator p sim
             -> IO (FnHandle args tp)
 simMkHandle sim nm args tp = do
   halloc <- getHandleAllocator sim
-  h <- stToIO $ mkHandle' halloc nm args tp
+  h <- mkHandle' halloc nm args tp
   modifyIORef' (handleCache sim) $ Map.insert (handleRef h) (SomeHandle h)
   return h
 

--- a/crucible-syntax/crucible-syntax/Main.hs
+++ b/crucible-syntax/crucible-syntax/Main.hs
@@ -1,31 +1,18 @@
 {-# LANGUAGE LambdaCase #-}
 module Main where
 
---import Control.Monad.Except
---import Control.Monad.ST
 import System.IO
 import Data.Monoid
---import Data.Text (Text)
---import qualified Data.Text as T
 import qualified Data.Text.IO as T
 
-
---import Lang.Crucible.Syntax.Concrete
---import Lang.Crucible.Syntax.SExpr
---import Lang.Crucible.Syntax.Atoms
 import Lang.Crucible.Syntax.Prog
 import Lang.Crucible.Syntax.Overrides (setupOverrides)
---import Lang.Crucible.CFG.SSAConversion
 
 import What4.Config
 import What4.Solver.Z3 ( z3Options )
 
 import qualified Options.Applicative as Opt
 import           Options.Applicative ( (<**>) )
-
---import System.Exit
-
-import Text.Megaparsec as MP
 
 data Check = Check { chkInFile :: TheFile
                    , chkOutFile :: Maybe TheFile

--- a/crucible-syntax/src/Lang/Crucible/Syntax/ExprParse.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/ExprParse.hs
@@ -671,7 +671,8 @@ printSyntaxError (SyntaxError rs) =
       , ", expected ", T.intercalate " or " (nub $ sort [ wanted | Reason _ wanted <- r:more ])
       , " but got ", toText mempty found]
 
-
+-- | Attempt to parse the given piece of syntax, returning the first success found,
+--   or the error(s) with the greatest progress otherwise.
 syntaxParseIO :: IsAtom atom => SyntaxParse atom a -> Syntax atom -> IO (Either (SyntaxError atom) a)
 syntaxParseIO p stx = do
   (P yes no) <-

--- a/crucible-syntax/src/Lang/Crucible/Syntax/ExprParse.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/ExprParse.hs
@@ -17,8 +17,7 @@
 module Lang.Crucible.Syntax.ExprParse
   ( MonadSyntax(..)
   , SyntaxParse
-  , syntaxParse
-  , syntaxParseST
+  , syntaxParseIO
 
   -- * Describing syntax
   , describe
@@ -69,7 +68,6 @@ import Control.Applicative
 import Control.Lens hiding (List, cons, backwards)
 import Control.Monad (ap)
 import Control.Monad.Reader
-import Control.Monad.ST ( ST, runST, stToIO, RealWorld )
 import qualified Control.Monad.State.Strict as Strict
 import qualified Control.Monad.State.Lazy as Lazy
 import Control.Monad.State.Class
@@ -94,7 +92,6 @@ import Lang.Crucible.Syntax.SExpr
 import qualified Text.Megaparsec as MP
 
 import What4.ProgramLoc (Posd(..), Position)
-import What4.Utils.MonadST (MonadST(liftST))
 
 data Search a = Try a (Search a) | Fail | Cut
   deriving Functor
@@ -240,23 +237,23 @@ instance MonadPlus (P atom) where
   mzero = empty
   mplus = (<|>)
 
-newtype STP atom h a = STP { runSTP :: ST h (P atom a) }
+newtype STP atom a = STP { runSTP :: IO (P atom a) }
   deriving (Semigroup, Monoid)
 
-instance Functor (STP atom h) where
+instance Functor (STP atom) where
   fmap f (STP x) = STP $ fmap (fmap f) x
 
-instance Applicative (STP atom h) where
+instance Applicative (STP atom) where
   pure = STP . pure . pure
   (<*>) = ap
 
-instance Monad (STP atom h) where
+instance Monad (STP atom) where
   STP m >>= f = STP $ do
     P xs e <- m
     mappend (runSTP (foldMap f xs)) (return $ P empty e)
 
-instance MonadST h (STP atom h) where
-  liftST m = STP $ return <$> m
+instance MonadIO (STP atom) where
+  liftIO m = STP $ return <$> m
 
 data SyntaxParseCtx atom =
   SyntaxParseCtx { _parseProgress :: Progress
@@ -275,15 +272,15 @@ parseFocus :: Simple Lens (SyntaxParseCtx atom) (Syntax atom)
 parseFocus = lens _parseFocus (\s v -> s { _parseFocus = v })
 
 -- | The default parsing monad. Use its 'MonadSyntax' instance to write parsers.
-newtype SyntaxParse atom h a =
+newtype SyntaxParse atom a =
   SyntaxParse { runSyntaxParse :: ReaderT (SyntaxParseCtx atom)
-                                          (STP atom h)
+                                          (STP atom)
                                           a }
   deriving ( Functor, Applicative, Monad
-           , MonadReader (SyntaxParseCtx atom), MonadST h
+           , MonadReader (SyntaxParseCtx atom), MonadIO
            )
 
-instance Alternative (SyntaxParse atom h) where
+instance Alternative (SyntaxParse atom) where
   empty =
     SyntaxParse $ ReaderT $ \(SyntaxParseCtx p r _) ->
       STP $ return $ P empty (Oops p (pure r))
@@ -293,7 +290,7 @@ instance Alternative (SyntaxParse atom h) where
       b <- runSTP $ y ctx
       return $ a <|> b
 
-instance MonadPlus (SyntaxParse atom h) where
+instance MonadPlus (SyntaxParse atom) where
   mzero = empty
   mplus = (<|>)
 
@@ -326,7 +323,7 @@ class (Alternative m, Monad m) => MonadSyntax atom m | m -> atom where
   -- expander. Use when solutions are expected to be unique.
   call :: m a -> m a
 
-instance MonadSyntax atom (SyntaxParse atom h) where
+instance MonadSyntax atom (SyntaxParse atom) where
   anything = view parseFocus
   progress = view parseProgress
   withFocus stx = local $ set parseFocus stx
@@ -674,14 +671,9 @@ printSyntaxError (SyntaxError rs) =
       , ", expected ", T.intercalate " or " (nub $ sort [ wanted | Reason _ wanted <- r:more ])
       , " but got ", toText mempty found]
 
--- | Invoke the default parsing monad on a piece of syntax, returning
--- the first success found, or the error(s) with the greatest progress
--- otherwise.
-syntaxParse :: IsAtom atom => (forall h. SyntaxParse atom h a) -> Syntax atom -> Either (SyntaxError atom) a
-syntaxParse p stx = runST $ syntaxParseST p stx
 
-syntaxParseST :: IsAtom atom => SyntaxParse atom h a -> Syntax atom -> ST h (Either (SyntaxError atom) a)
-syntaxParseST p stx = do
+syntaxParseIO :: IsAtom atom => SyntaxParse atom a -> Syntax atom -> IO (Either (SyntaxError atom) a)
+syntaxParseIO p stx = do
   (P yes no) <-
         runSTP $ runReaderT (runSyntaxParse p) $
           SyntaxParseCtx (Progress []) (Reason stx (T.pack "bad syntax")) stx
@@ -716,11 +708,11 @@ instance IsString TrivialAtom where
   fromString x = TrivialAtom (fromString x)
 
 -- | Test a parser on some input, displaying the result.
-test :: (HasCallStack, Show a) => Text -> SyntaxParse TrivialAtom RealWorld a -> IO ()
+test :: (HasCallStack, Show a) => Text -> SyntaxParse TrivialAtom a -> IO ()
 test txt p =
   case MP.parse (skipWhitespace *> sexp (TrivialAtom <$> identifier) <* MP.eof) "input" txt of
      Left err -> putStrLn "Reader error: " >> putStrLn (MP.errorBundlePretty err)
      Right sexpr ->
-       stToIO (syntaxParseST p sexpr) >>= \case
+       syntaxParseIO p sexpr >>= \case
          Left e -> T.putStrLn (printSyntaxError e)
          Right ok -> print ok

--- a/crucible-syntax/src/Lang/Crucible/Syntax/Overrides.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Overrides.hs
@@ -12,7 +12,6 @@ module Lang.Crucible.Syntax.Overrides
 import Control.Lens hiding ((:>), Empty)
 import Control.Monad (forM_)
 import Control.Monad.IO.Class
-import Control.Monad.ST
 import Data.Foldable(toList)
 import System.IO
 
@@ -34,9 +33,9 @@ import Lang.Crucible.Simulator.SimError (ppSimError)
 
 setupOverrides ::
   (IsSymInterface sym, sym ~ (ExprBuilder t st fs)) =>
-  sym -> HandleAllocator RealWorld -> IO [(FnBinding p sym ext, Position)]
+  sym -> HandleAllocator -> IO [(FnBinding p sym ext, Position)]
 setupOverrides _ ha =
-  do f1 <- FnBinding <$> stToIO (mkHandle ha "proveObligations")
+  do f1 <- FnBinding <$> mkHandle ha "proveObligations"
                      <*> pure (UseOverride (mkOverride "proveObligations" proveObligations))
 
      return [(f1, InternalPos)]

--- a/crucible-syntax/test/Overrides.hs
+++ b/crucible-syntax/test/Overrides.hs
@@ -33,11 +33,11 @@ import Lang.Crucible.Simulator.SimError (ppSimError)
 -- Some overrides for testing purposes.
 setupOverrides ::
   (IsSymInterface sym, sym ~ (ExprBuilder t st fs)) =>
-  sym -> HandleAllocator RealWorld -> IO [(FnBinding p sym ext, Position)]
+  sym -> HandleAllocator -> IO [(FnBinding p sym ext, Position)]
 setupOverrides _ ha =
-  do f1 <- FnBinding <$> stToIO (mkHandle ha "symbolicBranchTest")
+  do f1 <- FnBinding <$> mkHandle ha "symbolicBranchTest"
                      <*> pure (UseOverride (mkOverride "symbolicBranchTest" symbolicBranchTest))
-     f2 <- FnBinding <$> stToIO (mkHandle ha "symbolicBranchesTest")
+     f2 <- FnBinding <$> mkHandle ha "symbolicBranchesTest"
                      <*> pure (UseOverride (mkOverride "symbolicBranchesTest" symbolicBranchesTest))
      return [(f1, InternalPos),(f2,InternalPos)]
 

--- a/crucible-syntax/test/Tests.hs
+++ b/crucible-syntax/test/Tests.hs
@@ -92,11 +92,11 @@ data Lam = Lam [Text] (Datum TrivialAtom) deriving (Eq, Show)
 syntaxParsing :: TestTree
 syntaxParsing =
   let
-    anyUnit :: SyntaxParse TrivialAtom h ()
+    anyUnit :: SyntaxParse TrivialAtom ()
     anyUnit = anything *> pure ()
-    vars :: SyntaxParse TrivialAtom h [TrivialAtom]
+    vars :: SyntaxParse TrivialAtom [TrivialAtom]
     vars = describe "sequence of variable bindings" $ rep atomic
-    distinctVars :: SyntaxParse TrivialAtom h [TrivialAtom]
+    distinctVars :: SyntaxParse TrivialAtom [TrivialAtom]
     distinctVars = sideCondition' "sequence of distinct variable bindings" (\xs -> nub xs == xs) vars
     lambda =
       fmap (\(_, (xs, (body, ()))) -> Lam [x | TrivialAtom x <- xs] (syntaxToDatum body))
@@ -105,108 +105,110 @@ syntaxParsing =
        cons anything $ emptyList)
   in testGroup "Syntax parsing lib"
        [ testCase "Empty list is empty list" $
-         syntaxTest "()" emptyList @?= Right ()
+         do x <- syntaxTest "()" emptyList
+            x @?= Right ()
        , testCase "Empty list is not atom" $
-         syntaxTest "()" (atom ("foo" :: TrivialAtom)) @?=
-           Left
+         do x <- syntaxTest "()" (atom ("foo" :: TrivialAtom))
+            x @?= Left
              (SyntaxError $ pure $
                Reason { expr = Syntax {unSyntax = Posd {pos = fakeFilePos 1 1, pos_val = List []}}
                         , message = "foo"
                         })
        , testCase "Atom is not empty list" $
-         syntaxTest "foo" emptyList @?=
-           Left
-             (SyntaxError $ pure $
-               Reason { expr = Syntax {unSyntax = Posd {pos = fakeFilePos 1 1, pos_val = Atom (TrivialAtom "foo")}}
-                        , message = "empty expression ()"
-                        })
+          do x <- syntaxTest "foo" emptyList
+             x @?= Left
+               (SyntaxError $ pure $
+                 Reason { expr = Syntax {unSyntax = Posd {pos = fakeFilePos 1 1, pos_val = Atom (TrivialAtom "foo")}}
+                          , message = "empty expression ()"
+                          })
        , testCase "Three element list of whatever" $
-         syntaxTest "(delicious avocado toast)" (list [anyUnit, anyUnit, anyUnit]) @?=
-           Right [(), (), ()]
+         do x <- syntaxTest "(delicious avocado toast)" (list [anyUnit, anyUnit, anyUnit])
+            x @?= Right [(), (), ()]
        , testCase "Three element list of whatever, again" $
-         syntaxTest "(delicious (avocado and tomato) toast)" (list [anyUnit, anyUnit, anyUnit]) @?=
-           Right [(), (), ()]
+         do x <- syntaxTest "(delicious (avocado and tomato) toast)" (list [anyUnit, anyUnit, anyUnit])
+            x @?= Right [(), (), ()]
        , testCase "Three element list of atoms" $
-         syntaxTest "(delicious avocado toast)" (list [atomic, atomic, atomic]) @?=
-           Right [TrivialAtom "delicious", TrivialAtom "avocado", TrivialAtom "toast"]
+         do x <- syntaxTest "(delicious avocado toast)" (list [atomic, atomic, atomic])
+            x @?= Right [TrivialAtom "delicious", TrivialAtom "avocado", TrivialAtom "toast"]
        , testCase "Three element list of non-atoms isn't atoms" $
-         syntaxTest "((delicious) avocado toast)" (list [atomic, atomic, atomic]) @?=
-           Left
-             (SyntaxError $ pure $
-               Reason { expr =
-                          Syntax $
-                          Posd { pos = fakeFilePos 1 2
-                               , pos_val =
-                                   List [ Syntax (Posd (fakeFilePos 1 3)
-                                                   (Atom (TrivialAtom "delicious")))
-                                        ]
-                               }
-                      , message = "an atom"
-                      })
-       , testCase "Three element list of non-atoms still isn't atoms" $
-         syntaxTest "(delicious (avocado) toast)" (list [atomic, atomic, atomic]) @?=
-           Left
-             (SyntaxError $ pure $
-               Reason { expr =
-                          Syntax $
-                            Posd { pos = fakeFilePos 1 12
+         do x <- syntaxTest "((delicious) avocado toast)" (list [atomic, atomic, atomic])
+            x @?= Left
+               (SyntaxError $ pure $
+                 Reason { expr =
+                            Syntax $
+                            Posd { pos = fakeFilePos 1 2
                                  , pos_val =
-                                     List [ Syntax (Posd (fakeFilePos 1 13)
-                                                      (Atom (TrivialAtom "avocado")))
+                                     List [ Syntax (Posd (fakeFilePos 1 3)
+                                                     (Atom (TrivialAtom "delicious")))
                                           ]
                                  }
                         , message = "an atom"
                         })
+       , testCase "Three element list of non-atoms still isn't atoms" $
+         do x <- syntaxTest "(delicious (avocado) toast)" (list [atomic, atomic, atomic])
+            x @?= Left
+               (SyntaxError $ pure $
+                 Reason { expr =
+                            Syntax $
+                              Posd { pos = fakeFilePos 1 12
+                                   , pos_val =
+                                       List [ Syntax (Posd (fakeFilePos 1 13)
+                                                        (Atom (TrivialAtom "avocado")))
+                                            ]
+                                   }
+                          , message = "an atom"
+                          })
        , testCase "Many three-element lists of whatever (1)" $
-         syntaxTest "((delicious avocado toast))" (rep $ list [anything, anything, anything] *> pure ()) @?=
-           Right [()]
+         do x <- syntaxTest "((delicious avocado toast))" (rep $ list [anything, anything, anything] *> pure ())
+            x @?= Right [()]
        , testCase "Many three-element lists of whatever (0)" $
-         syntaxTest "()" (rep $ list [anything, anything, anything] *> pure ()) @?=
-           Right []
+         do x <- syntaxTest "()" (rep $ list [anything, anything, anything] *> pure ())
+            x @?= Right []
        , testCase "Many three-element lists of whatever (4)" $
-         syntaxTest "((programming is fun) (a b c) (x y z) (hello (more stuff) fits))" (rep $ list [anything, anything, anything] *> pure ()) @?=
-           Right [(), (), (), ()]
+         do x <- syntaxTest "((programming is fun) (a b c) (x y z) (hello (more stuff) fits))" (rep $ list [anything, anything, anything] *> pure ())
+            x @?= Right [(), (), (), ()]
        , testCase "Many three-element lists of whatever failing on third sublist" $
-         syntaxTest "((programming is fun) (a b c) (x y) (hello (more stuff) fits))" (rep $ list [anything, anything, anything] *> pure ()) @?=
-           Left
-             (SyntaxError $ pure $
-              Reason { expr = Syntax (Posd (fakeFilePos 1 31)
-                                       (List [ Syntax (Posd (fakeFilePos 1 32)
-                                                        (Atom (TrivialAtom "x")))
-                                             , Syntax (Posd (fakeFilePos 1 34)
-                                                        (Atom (TrivialAtom "y")))]))
-                     , message = "3 expressions"
-                     })
+         do x <- syntaxTest "((programming is fun) (a b c) (x y) (hello (more stuff) fits))" (rep $ list [anything, anything, anything] *> pure ())
+            x @?= Left
+               (SyntaxError $ pure $
+                Reason { expr = Syntax (Posd (fakeFilePos 1 31)
+                                         (List [ Syntax (Posd (fakeFilePos 1 32)
+                                                          (Atom (TrivialAtom "x")))
+                                               , Syntax (Posd (fakeFilePos 1 34)
+                                                          (Atom (TrivialAtom "y")))]))
+                       , message = "3 expressions"
+                       })
        , testCase "Realistic example 1" $
-         syntaxTest "(lambda (x y z) y)" lambda @?= Right (Lam ["x", "y", "z"] (Datum (Atom "y")))
+         do x <- syntaxTest "(lambda (x y z) y)" lambda
+            x @?= Right (Lam ["x", "y", "z"] (Datum (Atom "y")))
        , testCase "Realistic example 2" $
-         syntaxTest "(lambda (x y (z)) y)" lambda @?=
-           Left
-             (SyntaxError $ pure $
-              Reason { expr = Syntax (Posd (fakeFilePos 1 14)
-                                         (List [Syntax {unSyntax = Posd {pos = fakeFilePos 1 15, pos_val = Atom (TrivialAtom "z")}}]))
-                       , message = "an atom"
-                       })
+         do x <- syntaxTest "(lambda (x y (z)) y)" lambda
+            x @?= Left
+                (SyntaxError $ pure $
+                 Reason { expr = Syntax (Posd (fakeFilePos 1 14)
+                                            (List [Syntax {unSyntax = Posd {pos = fakeFilePos 1 15, pos_val = Atom (TrivialAtom "z")}}]))
+                          , message = "an atom"
+                          })
        , testCase "Realistic example 3" $
-         syntaxTest "(lambda x x)" lambda @?=
-           Left
-             (SyntaxError $ pure $
-              Reason { expr = Syntax (Posd (fakeFilePos 1 9)
-                                         (Atom "x"))
-                       , message = "sequence of variable bindings"
-                       })
+         do x <- syntaxTest "(lambda x x)" lambda
+            x @?= Left
+                (SyntaxError $ pure $
+                 Reason { expr = Syntax (Posd (fakeFilePos 1 9)
+                                            (Atom "x"))
+                          , message = "sequence of variable bindings"
+                          })
        , testCase "Realistic example 4" $
-         syntaxTest "(lambda (x y x) y)" lambda @?=
-           Left
-             (SyntaxError $ pure $
-              Reason { expr =
-                         Syntax (Posd (fakeFilePos 1 9)
-                                  (List [ Syntax {unSyntax = Posd {pos = fakeFilePos 1 10, pos_val = Atom (TrivialAtom "x")}}
-                                        , Syntax {unSyntax = Posd {pos = fakeFilePos 1 12, pos_val = Atom (TrivialAtom "y")}}
-                                        , Syntax {unSyntax = Posd {pos = fakeFilePos 1 14, pos_val = Atom (TrivialAtom "x")}}
-                                        ]))
-                       , message = "sequence of distinct variable bindings"
-                       })
+         do x <- syntaxTest "(lambda (x y x) y)" lambda
+            x @?= Left
+                (SyntaxError $ pure $
+                 Reason { expr =
+                            Syntax (Posd (fakeFilePos 1 9)
+                                     (List [ Syntax {unSyntax = Posd {pos = fakeFilePos 1 10, pos_val = Atom (TrivialAtom "x")}}
+                                           , Syntax {unSyntax = Posd {pos = fakeFilePos 1 12, pos_val = Atom (TrivialAtom "y")}}
+                                           , Syntax {unSyntax = Posd {pos = fakeFilePos 1 14, pos_val = Atom (TrivialAtom "x")}}
+                                           ]))
+                          , message = "sequence of distinct variable bindings"
+                          })
        ]
 
 fakeFile :: Text
@@ -215,8 +217,8 @@ fakeFile = "test input"
 fakeFilePos :: Int -> Int -> Position
 fakeFilePos = SourcePos fakeFile
 
-syntaxTest :: Text -> (forall h. SyntaxParse TrivialAtom h a) -> Either (SyntaxError TrivialAtom) a
+syntaxTest :: Text -> SyntaxParse TrivialAtom a -> IO (Either (SyntaxError TrivialAtom) a)
 syntaxTest txt p =
   case MP.parse (skipWhitespace *> sexp (TrivialAtom <$> identifier) <* MP.eof) (T.unpack fakeFile) txt of
      Left err -> error $ "Reader error: " ++ MP.errorBundlePretty err
-     Right sexpr -> syntaxParse p sexpr
+     Right sexpr -> syntaxParseIO p sexpr

--- a/crucible/src/Lang/Crucible/CFG/Common.hs
+++ b/crucible/src/Lang/Crucible/CFG/Common.hs
@@ -18,13 +18,12 @@ module Lang.Crucible.CFG.Common
   , BreakpointName(..)
   ) where
 
-import           Control.Monad.ST
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Text.PrettyPrint.ANSI.Leijen hiding ((<$>))
 
 import           Data.Parameterized.Classes
-import           Data.Parameterized.Nonce.Unsafe
+import           Data.Parameterized.Nonce
 
 import           Lang.Crucible.FunctionHandle
 import           Lang.Crucible.Types
@@ -34,7 +33,7 @@ import           Lang.Crucible.Types
 
 -- | A global variable.
 data GlobalVar (tp :: CrucibleType)
-   = GlobalVar { globalNonce :: {-# UNPACK #-} !(Nonce tp)
+   = GlobalVar { globalNonce :: {-# UNPACK #-} !(Nonce GlobalNonceGenerator tp)
                , globalName  :: !Text
                , globalType  :: !(TypeRepr tp)
                }
@@ -54,10 +53,10 @@ instance Pretty (GlobalVar tp) where
   pretty  = text . show
 
 
-freshGlobalVar :: HandleAllocator s
+freshGlobalVar :: HandleAllocator
                -> Text
                -> TypeRepr tp
-               -> ST s (GlobalVar tp)
+               -> IO (GlobalVar tp)
 freshGlobalVar halloc nm tp = do
   nonce <- freshNonce (haCounter halloc)
   return GlobalVar

--- a/crucible/src/Lang/Crucible/CFG/ExtractSubgraph.hs
+++ b/crucible/src/Lang/Crucible/CFG/ExtractSubgraph.hs
@@ -18,7 +18,6 @@ module Lang.Crucible.CFG.ExtractSubgraph
   ) where
 
 import           Control.Lens
-import           Control.Monad.ST
 import qualified Data.Bimap as Bimap
 import           Data.Parameterized.Context as Ctx
 import           Data.Parameterized.Map as MapF
@@ -42,8 +41,8 @@ extractSubgraph :: (KnownCtx TypeRepr init, KnownRepr TypeRepr ret)
                 => CFG ext blocks init ret
                 -> Set (BlockID blocks (EmptyCtx ::> ret))
                 -> BlockID blocks init
-                -> HandleAllocator s
-                -> ST s (Maybe (SomeCFG ext init ret))
+                -> HandleAllocator
+                -> IO (Maybe (SomeCFG ext init ret))
 extractSubgraph (CFG{cfgBlockMap = orig, cfgBreakpoints = breakpoints}) cuts bi halloc =
   extractSubgraphFirst orig cuts MapF.empty zeroSize bi $
     \(SubgraphIntermediate finalMap finalInitMap _sz entryID cb) -> do

--- a/crucible/src/Lang/Crucible/Simulator/BoundedExec.hs
+++ b/crucible/src/Lang/Crucible/Simulator/BoundedExec.hs
@@ -32,7 +32,6 @@ module Lang.Crucible.Simulator.BoundedExec
 
 import           Control.Lens ( (^.), to, (&), (%~), (.~) )
 import           Control.Monad ( when )
-import           Control.Monad.ST ( stToIO )
 import           Data.IORef
 import           Data.Map (Map)
 import qualified Data.Map as Map
@@ -271,7 +270,7 @@ boundedExecFeature getLoopBounds generateSideConditions =
  onStep gvRef = \case
    InitialState simctx globals ah cont ->
      do let halloc = simHandleAllocator simctx
-        gv <- stToIO (freshGlobalVar halloc (Text.pack "BoundedExecFrameData") knownRepr)
+        gv <- freshGlobalVar halloc (Text.pack "BoundedExecFrameData") knownRepr
         writeIORef gvRef gv
         let globals' = insertGlobal gv [Left "_init"] globals
         let simctx' = simctx{ ctxIntrinsicTypes = MapF.insert (knownSymbol @"BoundedExecFrameData") IntrinsicMuxFn (ctxIntrinsicTypes simctx) }

--- a/crucible/src/Lang/Crucible/Simulator/EvalStmt.hs
+++ b/crucible/src/Lang/Crucible/Simulator/EvalStmt.hs
@@ -62,7 +62,6 @@ import           What4.InterpretedFloatingPoint (freshFloatConstant)
 import           What4.Partial
 import           What4.ProgramLoc
 import           What4.Symbol (emptySymbol)
-import           What4.Utils.MonadST
 
 import           Lang.Crucible.Backend
 import           Lang.Crucible.CFG.Core
@@ -220,14 +219,14 @@ stepStmt verb stmt rest =
        NewRefCell tpr x ->
          do let halloc = simHandleAllocator ctx
             v <- evalReg x
-            r <- liftST (freshRefCell halloc tpr)
+            r <- liftIO $ freshRefCell halloc tpr
             continueWith $
                (stateTree . actFrame . gpGlobals %~ insertRef sym r v) .
                (stateCrucibleFrame %~ extendFrame (ReferenceRepr tpr) (toMuxTree sym r) rest)
 
        NewEmptyRefCell tpr ->
          do let halloc = simHandleAllocator ctx
-            r <- liftST (freshRefCell halloc tpr)
+            r <- liftIO $ freshRefCell halloc tpr
             continueWith $
               stateCrucibleFrame %~ extendFrame (ReferenceRepr tpr) (toMuxTree sym r) rest
 

--- a/crucible/src/Lang/Crucible/Simulator/ExecutionTree.hs
+++ b/crucible/src/Lang/Crucible/Simulator/ExecutionTree.hs
@@ -139,7 +139,6 @@ module Lang.Crucible.Simulator.ExecutionTree
 
 import           Control.Lens
 import           Control.Monad.Reader
-import           Control.Monad.ST (RealWorld)
 import           Data.Kind
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -1002,7 +1001,7 @@ data SimContext (personality :: Type) (sym :: Type) (ext :: Type)
                 , ctxSolverProof         :: !(forall a . IsSymInterfaceProof sym a)
                 , ctxIntrinsicTypes      :: !(IntrinsicTypes sym)
                   -- | Allocator for function handles
-                , simHandleAllocator     :: !(HandleAllocator RealWorld)
+                , simHandleAllocator     :: !(HandleAllocator)
                   -- | Handle to write messages to.
                 , printHandle            :: !Handle
                 , extensionImpl          :: ExtensionImpl personality sym ext
@@ -1016,7 +1015,7 @@ initSimContext ::
   IsSymInterface sym =>
   sym {- ^ Symbolic backend -} ->
   IntrinsicTypes sym {- ^ Implementations of intrinsic types -} ->
-  HandleAllocator RealWorld {- ^ Handle allocator for creating new function handles -} ->
+  HandleAllocator {- ^ Handle allocator for creating new function handles -} ->
   Handle {- ^ Handle to write output to -} ->
   FunctionBindings personality sym ext {- ^ Initial bindings for function handles -} ->
   ExtensionImpl personality sym ext {- ^ Semantics for extension syntax -} ->

--- a/crucible/src/Lang/Crucible/Simulator/OverrideSim.hs
+++ b/crucible/src/Lang/Crucible/Simulator/OverrideSim.hs
@@ -287,7 +287,7 @@ newEmptyRef ::
   OverrideSim p sym ext rtp args ret (RefCell tp)
 newEmptyRef tpr =
   do halloc <- use (stateContext . to simHandleAllocator)
-     liftST (freshRefCell halloc tpr)
+     liftIO $ freshRefCell halloc tpr
 
 -- | Read the current value of a reference cell.
 readRef ::

--- a/crux-llvm/src/CruxLLVMMain.hs
+++ b/crux-llvm/src/CruxLLVMMain.hs
@@ -13,7 +13,6 @@ import Data.String (fromString)
 import qualified Data.Map as Map
 import Control.Lens ((&), (%~), (^.), view)
 import Control.Monad(forM_,unless)
-import Control.Monad.ST(RealWorld, stToIO)
 import Control.Monad.State(liftIO, MonadIO)
 import Control.Exception
 import qualified Data.Foldable as Fold
@@ -128,7 +127,7 @@ makeCounterExamplesLLVM opts = mapM_ go . Fold.toList
 -- | Create a simulator context for the given architecture.
 setupSimCtxt ::
   (ArchOk arch, IsSymInterface sym) =>
-  HandleAllocator RealWorld ->
+  HandleAllocator ->
   sym ->
   LLVMContext arch ->
   SimCtxt sym (LLVM arch)
@@ -170,7 +169,7 @@ simulateLLVM :: Crux.SimulateCallback LLVMOptions
 simulateLLVM fs (cruxOpts,_) sym _p cont = do
     llvm_mod   <- parseLLVM (Crux.outDir cruxOpts </> "combined.bc")
     halloc     <- newHandleAllocator
-    Some trans <- stToIO (translateModule halloc llvm_mod)
+    Some trans <- translateModule halloc llvm_mod
     let llvmCtxt = trans ^. transContext
 
     llvmPtrWidth llvmCtxt $ \ptrW ->


### PR DESCRIPTION
This update changes the `HandleAllocator` to use the global nonce generator from `Data.Parameterized.Nonce`, instead of creating a fresh nonce counter from `Data.Parameterized.Nonce.Unsafe`.

This changes requires the handle allocation to occur in `IO`, which is fine since we are already basically in IO everywhere we needed to be anyway, and this simplifies quite a few things.

This PR will require downstream fixes, but they are very straightforward.

Will fix #284 