### PR TITLE
Add a special case to the memory model to load 0 at pointer types

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Expr.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Expr.hs
@@ -363,6 +363,9 @@ transValue ty L.ValZeroInit =
 transValue ty@(PtrType _) L.ValNull =
   return $ ZeroExpr ty
 
+transValue ty@(PtrType _) (L.ValInteger 0) =
+  return $ ZeroExpr ty
+
 transValue ty@(IntType _) L.ValNull =
   return $ ZeroExpr ty
 


### PR DESCRIPTION
This is a seemingly-missing special case where the memory model is allowed to
load a 0 integer value as a value of pointer type.