### PR TITLE
[crucible-llvm] fix type for atomicrw operation

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Expr.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Expr.hs
@@ -366,6 +366,9 @@ transValue ty@(PtrType _) L.ValNull =
 transValue ty@(PtrType _) (L.ValInteger 0) =
   return $ ZeroExpr ty
 
+transValue ty@(PtrType _) v@(L.ValInteger _) =
+  reportError $ fromString $ unwords ["Attempted to use integer ", show v, " as pointer: ", show ty]
+
 transValue ty@(IntType _) L.ValNull =
   return $ ZeroExpr ty
 

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Instruction.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Instruction.hs
@@ -1570,7 +1570,7 @@ generateInstr retType lab instr assign_f k =
          case tp' of
            PtrType (MemType valTy@(IntType _)) ->
              llvmTypeAsRepr valTy $ \expectTy ->
-               do val' <- transValue tp' (L.typedValue val)
+               do val' <- transValue valTy $ L.typedValue val
                   let a0 = memTypeAlign (llvmDataLayout ?lc) valTy
                   oldVal <- callLoad valTy expectTy ptr' a0
                   newVal <- atomicRWOp op oldVal val'


### PR DESCRIPTION
The atomicrw operation takes a pointer, an op, and a value.  The
pointer must point to a type that is the same as value.  The original
code used the pointer type for the value interpretation, not the
pointed-to type.  This fix uses the pointed-to type (and also provides
an enhanced message for attempts to use an integer value as a
pointer), which fixes errors of the type:

   Branch aborted: AssumedFalse (AssumingNoError Attempted to use integer
   ValInteger NNNN as pointer: i64* in LOC)