### PR TITLE
Fix/vectorized llvm comparisons

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/Arch.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Arch.hs
@@ -4,6 +4,8 @@ module Lang.Crucible.LLVM.Arch
   ( llvmExtensionEval
   ) where
 
+import           What4.Interface
+
 import           Lang.Crucible.Backend
 import           Lang.Crucible.Simulator.Intrinsics
 import           Lang.Crucible.Simulator.Evaluation
@@ -33,3 +35,11 @@ llvmExtensionEval sym _iTypes _logFn eval e =
 
     LLVM_PointerOffset _w ptr ->
       llvmPointerOffset <$> eval ptr
+
+    LLVM_PointerIte _w c x y ->
+      do cond <- eval c
+         LLVMPointer xblk xoff <- eval x
+         LLVMPointer yblk yoff <- eval y
+         blk <- natIte sym cond xblk yblk
+         off <- bvIte sym cond xoff yoff
+         return (LLVMPointer blk off)

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Extension/Syntax.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Extension/Syntax.hs
@@ -56,6 +56,11 @@ data LLVMExtensionExpr (arch :: LLVMArch) :: (CrucibleType -> Type) -> (Crucible
     (1 <= w) => !(NatRepr w) -> !(f (LLVMPointerType w)) ->
     LLVMExtensionExpr arch f (BVType w)
 
+  LLVM_PointerIte ::
+    (1 <= w) => !(NatRepr w) ->
+    !(f BoolType) -> !(f (LLVMPointerType w)) -> !(f (LLVMPointerType w)) ->
+    LLVMExtensionExpr arch f (LLVMPointerType w)
+
 
 -- | Extension statements for LLVM.  These statements represent the operations
 --   necessary to interact with the LLVM memory model.
@@ -185,6 +190,7 @@ instance TypeApp (LLVMExtensionExpr arch) where
       LLVM_PointerExpr w _ _ -> LLVMPointerRepr w
       LLVM_PointerBlock _ _  -> NatRepr
       LLVM_PointerOffset w _ -> BVRepr w
+      LLVM_PointerIte w _ _ _ -> LLVMPointerRepr w
 
 instance PrettyApp (LLVMExtensionExpr arch) where
   ppApp pp e =
@@ -196,6 +202,8 @@ instance PrettyApp (LLVMExtensionExpr arch) where
         text "pointerBlock" <+> pp ptr
       LLVM_PointerOffset _ ptr ->
         text "pointerOffset" <+> pp ptr
+      LLVM_PointerIte _ cond x y ->
+        text "pointerIte" <+> pp cond <+> pp x <+> pp y
 
 instance TestEqualityFC (LLVMExtensionExpr arch) where
   testEqualityFC testSubterm =

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Instruction.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Instruction.hs
@@ -154,8 +154,16 @@ instrResultType instr =
     L.Load x _ _ -> case L.typedType x of
                    L.PtrTo ty -> liftMemType ty
                    _ -> fail $ unwords ["load through non-pointer type", show (L.typedType x)]
-    L.ICmp{} -> liftMemType (L.PrimType (L.Integer 1))
-    L.FCmp{} -> liftMemType (L.PrimType (L.Integer 1))
+    L.ICmp _op tv _ -> do
+      inpType <- liftMemType (L.typedType tv)
+      case inpType of
+        VecType len _ -> return (VecType len (IntType 1))
+        _ -> return (IntType 1)
+    L.FCmp _op tv _ -> do
+      inpType <- liftMemType (L.typedType tv)
+      case inpType of
+        VecType len _ -> return (VecType len (IntType 1))
+        _ -> return (IntType 1)
     L.Phi tp _   -> liftMemType tp
 
     L.GEP inbounds base elts ->

--- a/crux-llvm/test-data/golden/vector-cmp.good
+++ b/crux-llvm/test-data/golden/vector-cmp.good
@@ -1,0 +1,11 @@
+[Crux] Simulating function "main"
+let -- internal
+    v2 = floatFromBinary 0x40a00000:[32]
+    -- internal
+    v3 = floatFromBinary 0x42280000:[32]
+    -- internal
+    v10 = ite (floatLe v3 v2) 0x0:[1] 0x1:[1]
+    -- internal
+    v12 = bvZext 32 (bvAnd (ite (floatLe v2 v3) 0x1:[1] 0x0:[1]) v10)
+ in bvOr 0x1:[32] (bvShl v12 0x1:[32])
+[Crux] No goals to prove.

--- a/crux-llvm/test-data/golden/vector-cmp.ll
+++ b/crux-llvm/test-data/golden/vector-cmp.ll
@@ -1,0 +1,62 @@
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
+
+declare void @crucible_print_uint32( i32 )
+
+
+define i1 @f( i32, i32 ) {
+  %v1.0 = insertelement <2 x i32> undef, i32 %0, i32 0
+  %v1   = insertelement <2 x i32> %v1.0, i32 %1, i32 1
+
+  %v2.0 = insertelement <2 x i32> undef, i32 %0, i32 1
+  %v2   = insertelement <2 x i32> %v2.0, i32 %1, i32 0
+
+  %vres = icmp ule <2 x i32> %v1, %v2
+
+  %res0 = extractelement <2 x i1> %vres, i32 0
+  %res1 = extractelement <2 x i1> %vres, i32 1
+
+  %x    = icmp eq i1 %res0, 1
+  %y    = icmp eq i1 %res1, 0
+  %z    = and i1 %x, %y
+  ret i1 %z
+}
+
+define i1 @g( float, float ) {
+  %p = alloca <2 x float>
+  %p0 = bitcast <2 x float>* %p to float*
+  %p1 = getelementptr float, float* %p0, i32 1
+
+  store float %0, float* %p0
+  store float %1, float* %p1
+  %v1 = load <2 x float>, <2 x float>* %p
+
+  store float %1, float* %p0
+  store float %0, float* %p1
+  %v2 = load <2 x float>, <2 x float>* %p
+
+  %vres = fcmp ole <2 x float> %v1, %v2
+
+  %res0 = extractelement <2 x i1> %vres, i32 0
+  %res1 = extractelement <2 x i1> %vres, i32 1
+
+  %x    = icmp eq i1 %res0, 1
+  %y    = icmp eq i1 %res1, 0
+  %z    = and i1 %x, %y
+  ret i1 %z
+}
+
+define i32 @main() {
+   %fres = call i1 @f( i32 5, i32 42 )
+   %fres32 = zext i1 %fres to i32
+
+   %gres = call i1 @g( float 5.0, float 42.0 )
+   %gres32 = zext i1 %gres to i32
+
+   %x = shl i32 %gres32, 1
+   %r = or i32 %fres32, %x
+
+   call void @crucible_print_uint32( i32 %r )
+
+   ret i32 %r
+}

--- a/crux-llvm/test-data/golden/vector-select.good
+++ b/crux-llvm/test-data/golden/vector-select.good
@@ -1,0 +1,3 @@
+[Crux] Simulating function "main"
+0x1:[32]
+[Crux] No goals to prove.

--- a/crux-llvm/test-data/golden/vector-select.ll
+++ b/crux-llvm/test-data/golden/vector-select.ll
@@ -1,0 +1,35 @@
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
+
+declare void @crucible_print_uint32( i32 )
+
+
+define i1 @f( i1, i1 ) {
+  %v1.0 = insertelement <2 x i32> undef, i32 42, i32 0
+  %v1   = insertelement <2 x i32> %v1.0, i32 43, i32 1
+
+  %v2.0 = insertelement <2 x i32> undef, i32 44, i32 0
+  %v2   = insertelement <2 x i32> %v2.0, i32 45, i32 1
+
+  %c.0  = insertelement <2 x i1> undef, i1 %0, i32 0
+  %c    = insertelement <2 x i1> %c.0,  i1 %1, i32 1
+
+  %vres = select <2 x i1> %c, <2 x i32> %v1, <2 x i32> %v2
+
+  %res0 = extractelement <2 x i32> %vres, i32 0
+  %res1 = extractelement <2 x i32> %vres, i32 1
+
+  %x    = icmp eq i32 %res0, 44
+  %y    = icmp eq i32 %res1, 43
+  %z    = and i1 %x, %y
+  ret i1 %z
+}
+
+define i32 @main() {
+   %res = call i1 @f( i1 0, i1 1 )
+   %res32 = zext i1 %res to i32
+
+   call void @crucible_print_uint32( i32 %res32 )
+
+   ret i32 %res32
+}

--- a/crux-llvm/test/Test.hs
+++ b/crux-llvm/test/Test.hs
@@ -24,7 +24,7 @@ suite =
 
 goldenTests :: FilePath -> IO TestTree
 goldenTests dir =
-  do cFiles <- findByExtension [".c"] dir
+  do cFiles <- findByExtension [".c",".ll"] dir
      return $
        testGroup "Golden testing of crux-llvm"
          [ goldenVsFile (takeBaseName cFile) goodFile outFile $


### PR DESCRIPTION
Allows the LLVM instructions `icmp` and `select` to be vectorized. `fcmp` should probably be vectorized as well before we merge.