### PR TITLE
Cxx/lax memory

### DIFF
--- a/crucible-llvm/crucible-llvm.cabal
+++ b/crucible-llvm/crucible-llvm.cabal
@@ -72,6 +72,7 @@ library
     Lang.Crucible.LLVM.MemModel.Generic
     Lang.Crucible.LLVM.MemModel.Partial
     Lang.Crucible.LLVM.MemModel.Pointer
+    Lang.Crucible.LLVM.MemModel.Options
     Lang.Crucible.LLVM.MemModel.Type
     Lang.Crucible.LLVM.MemModel.Value
     Lang.Crucible.LLVM.Translation.Constant

--- a/crucible-llvm/src/Lang/Crucible/LLVM.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM.hs
@@ -8,6 +8,7 @@
 -- Stability        : provisional
 ------------------------------------------------------------------------
 
+{-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Lang.Crucible.LLVM
@@ -53,8 +54,9 @@ llvmGlobals
 llvmGlobals ctx mem = emptyGlobals & insertGlobal var mem
   where var = llvmMemVar $ ctx
 
-llvmExtensionImpl :: HasPtrWidth (ArchWidth arch) => ExtensionImpl p sym (LLVM arch)
-llvmExtensionImpl =
+llvmExtensionImpl :: (HasPtrWidth (ArchWidth arch)) => MemOptions -> ExtensionImpl p sym (LLVM arch)
+llvmExtensionImpl mo =
+  let ?memOpts = mo in
   ExtensionImpl
   { extensionEval = llvmExtensionEval
   , extensionExec = llvmStatementExec

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Options.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Options.hs
@@ -1,0 +1,56 @@
+------------------------------------------------------------------------
+-- |
+-- Module           : Lang.Crucible.LLVM.MemModel.Options
+-- Description      : Definition of options that can be tweaked in the memory model
+-- Copyright        : (c) Galois, Inc 2019
+-- License          : BSD3
+-- Maintainer       : Rob Dockins <rdockins@galois.com>
+-- Stability        : provisional
+------------------------------------------------------------------------
+
+module Lang.Crucible.LLVM.MemModel.Options
+  ( MemOptions(..)
+  , defaultMemOptions
+  , laxPointerMemOptions
+  ) where
+
+-- | This datatype encodes a variety of tweakable settings supported
+--   by the LLVM memory model.  They generally involve some weakening
+--   of the strict rules of the language standard to allow common
+--   idioms, at the cost that reasoning using the resulting memory model
+--   is less generalizable (i.e., makes more assumptions about the
+--   runtime behavior of the system).
+data MemOptions
+  = MemOptions
+    { laxPointerOrdering :: !Bool
+      -- ^ Should we allow ordering comparisons on pointers that are
+      --   not from the same allocation unit?  This is not allowed
+      --   by the C standard, but is nonetheless commonly done.
+
+    , laxConstantEquality :: !Bool
+      -- ^ Should we allow equality comparisons on pointers to constant
+      --   data? Different symbols with the same data are allowed to
+      --   be consolidated, so pointer apparently-distinct pointers
+      --   will sometimes compare equal if the compiler decides to
+      --   consolidate their storage.
+    }
+
+
+-- | The default memory model options require strict adherence to
+--   the language standard regarding pointer equality and ordering.
+defaultMemOptions :: MemOptions
+defaultMemOptions =
+  MemOptions
+  { laxPointerOrdering = False
+  , laxConstantEquality = False
+  }
+
+
+-- | The lax pointer memory options allow pointer ordering comparisons
+--   and equality comparisons of pointers to constant data.
+laxPointerMemOptions :: MemOptions
+laxPointerMemOptions =
+  MemOptions
+  { laxPointerOrdering = True
+  , laxConstantEquality = True
+  }

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Run.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Run.hs
@@ -47,7 +47,7 @@ import Lang.Crucible.LLVM.Translation
         (globalInitMap,transContext,translateModule,ModuleTranslation,cfgMap)
 import Lang.Crucible.LLVM.Globals(populateAllGlobals,initializeMemory)
 
-import Lang.Crucible.LLVM.MemModel(withPtrWidth,HasPtrWidth)
+import Lang.Crucible.LLVM.MemModel(withPtrWidth,HasPtrWidth,MemOptions)
 
 import Lang.Crucible.LLVM.Extension(ArchWidth)
 
@@ -85,8 +85,8 @@ data Setup ext res =
   }
 
 -- | Run Crucible with the given initialization, on the given LLVM module.
-runCruxLLVM :: Module -> CruxLLVM res -> IO res
-runCruxLLVM llvm_mod (CruxLLVM setup) =
+runCruxLLVM :: Module -> MemOptions -> CruxLLVM res -> IO res
+runCruxLLVM llvm_mod memOpts (CruxLLVM setup) =
   do halloc <- newHandleAllocator
      Some trans <- translateModule halloc llvm_mod
      res <- setup trans
@@ -106,7 +106,7 @@ runCruxLLVM llvm_mod (CruxLLVM setup) =
                               halloc
                               cruxOutput
                               (fnBindingsFromList [])
-                              llvmExtensionImpl
+                              (llvmExtensionImpl memOpts)
                               cruxUserState
 
               cruxGo $ InitialState simctx globSt defaultAbortHandler cruxInitCodeReturns

--- a/crucible-mc/exe/Main.hs
+++ b/crucible-mc/exe/Main.hs
@@ -20,6 +20,7 @@ import Lang.Crucible.Backend(IsSymInterface)
 import Lang.Crucible.CFG.Core(AnyCFG(..),cfgArgTypes,cfgReturnType)
 import Lang.Crucible.Simulator
 
+import Lang.Crucible.LLVM.MemModel(defaultMemOptions)
 import Lang.Crucible.LLVM.Translation
 import Lang.Crucible.LLVM.Run
 
@@ -38,7 +39,7 @@ main :: IO ()
 main =
   parseLLVM test_file                       >>= \llvm_mod ->
   withZ3                                    $ \sym ->
-  runCruxLLVM llvm_mod                      $
+  runCruxLLVM llvm_mod defaultMemOptions    $
   CruxLLVM                                  $ \mt ->
   withPtrWidthOf mt                         $
   case findCFG mt test_fun of

--- a/crux-llvm/crux-llvm.cabal
+++ b/crux-llvm/crux-llvm.cabal
@@ -22,27 +22,27 @@ library
     Crux.LLVM.Overrides
 
   build-depends:
-    base >= 4.8 && < 4.13,
+    ansi-terminal,
     ansi-wl-pprint,
-    containers,
-    data-binary-ieee754,
-    lens,
-    mtl,
     bytestring,
+    base >= 4.8 && < 4.13,
+    config-schema,
+    containers,
     crucible,
     crucible-llvm,
-    what4,
+    crux,
+    data-binary-ieee754,
+    directory,
+    filepath,
+    lens,
     llvm-pretty,
     llvm-pretty-bc-parser,
+    mtl,
     parameterized-utils,
-    filepath,
     process,
-    directory,
     template-haskell,
     text,
-    ansi-terminal,
-    crux
-
+    what4
   ghc-options: -Wall
   ghc-prof-options: -O2 -fprof-auto-top
 
@@ -56,27 +56,27 @@ executable crux-llvm
   main-is: Main.hs
 
   build-depends:
-    base >= 4.8 && < 4.13,
+    ansi-terminal,
     ansi-wl-pprint,
-    containers,
-    crux-llvm,
-    data-binary-ieee754,
-    lens,
-    mtl,
+    base >= 4.8 && < 4.13,
     bytestring,
+    containers,
     crucible,
     crucible-llvm,
-    what4,
+    crux,
+    crux-llvm,
+    data-binary-ieee754,
+    directory,
+    filepath,
+    lens,
     llvm-pretty,
     llvm-pretty-bc-parser,
+    mtl,
     parameterized-utils,
-    filepath,
     process,
-    directory,
     template-haskell,
     text,
-    ansi-terminal,
-    crux
+    what4
 
   ghc-options: -Wall
   ghc-prof-options: -O2 -fprof-auto-top


### PR DESCRIPTION
This PR relaxes some of the rules regarding when pointers can be compared in ways that are disallowed by the C standard, but are nonetheless common and appear in `libcxx`.

This PR exists as a reminder to

1. Setup up configuration knobs for being able to selectively enable this, and similar, relaxations.
2. Investigate if we can/should equip pointers with a more principled total order by e.g., abstracting over all possible allocation block orderings using an arbitrary permutation.