### PR TITLE
Fix some minor bugs regarding datalayout.

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/DataLayout.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/DataLayout.hs
@@ -236,7 +236,7 @@ setAt f sz a = f . at sz ?= a
 defaultDataLayout :: DataLayout
 defaultDataLayout = execState defaults dl
   where dl = DL { _intLayout = BigEndian
-                , _stackAlignment = Alignment 1
+                , _stackAlignment = noAlignment
                 , _ptrSize  = 8 -- 64 bit pointers = 8 bytes
                 , _ptrAlign = Alignment 3 -- 64 bit alignment: 2^3=8 byte boundaries
                 , _integerInfo = emptyAlignInfo

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Type.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Type.hs
@@ -134,6 +134,7 @@ typeEnd a tp = seq a $
     Float -> a + 4
     Double -> a + 8
     X86_FP80 -> a + 10
+    Array 0 _   -> a
     Array n etp -> typeEnd (a + (n-1) * (storageTypeSize etp)) etp
     Struct flds -> typeEnd (a + fieldOffset f) (f^.fieldVal)
       where f = V.last flds


### PR DESCRIPTION
First, the stack allocation field should have `noAlignment` not `Alignment 1` which indicates
alignment to `2^1` = `2`-byte boundaries.

Second, arrays of static size 0 should always be computed to have
0 bytes size.  The previous formula was not correct in the case
that the `typeSize` and `storateTypeSize` for a type were not the
same, which can happen because of alignment/padding.