### PR TITLE
fix cmd line arg for yices mcsat

### DIFF
--- a/what4/src/What4/Solver/Yices.hs
+++ b/what4/src/What4/Solver/Yices.hs
@@ -608,7 +608,7 @@ yicesStartSolver features auxOutput sym = do -- FIXME
   yices_path <- findSolverPath yicesPath cfg
   enableMCSat <- getOpt =<< getOptionSetting yicesEnableMCSat cfg
   let args = ["--mode=push-pop", "--print-success"] ++
-             if enableMCSat then ["--mcsat"] else []
+             if enableMCSat then ["--logic=QF_NRA"] else []
       hasNamedAssumptions = features `hasProblemFeature` useUnsatCores ||
                             features `hasProblemFeature` useUnsatAssumptions
   when (enableMCSat && hasNamedAssumptions) $


### PR DESCRIPTION
After tinkering a bit and checking the docs (http://yices.csl.sri.com/doc/context-operations.html#creation-and-configuration), it appears `--mcsat` is not a valid flag for the `yices` cmd line executable. Instead, setting the logic flag appropriately  enables MCSAT usage in Yices.

E.g., on my machine:
```
$ yices --mode=push-pop --print-success --mcsat
yices: invalid option: --mcsat
Try 'yices --help' for more information
```

whereas:
```
$ yices --mode=push-pop --print-success --logic=QF_NRA
yices> 
```
