### PR TITLE
WIP commit for adding more realistic symbolic string support.

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Instruction.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Instruction.hs
@@ -40,6 +40,7 @@ import           Control.Lens hiding (op, (:>) )
 import           Control.Monad.Except
 import           Control.Monad.State.Strict
 import           Control.Monad.Trans.Maybe
+import qualified Data.ByteString.Char8 as BSChar
 import           Data.Functor.Identity (runIdentity)
 import           Data.Foldable (toList)
 import           Data.Int
@@ -1141,7 +1142,7 @@ pointerCmp op x y =
     case op of
       L.Ieq  -> callIsNull PtrWidth ptr
       L.Ine  -> App . Not <$> callIsNull PtrWidth ptr
-      _ -> reportError $ litExpr $ Text.pack $ unlines $
+      _ -> reportError $ litExpr $ BSChar.pack $ unlines $
             [ "Arithmetic comparison on incompatible values"
             , "Comparison operation: " ++ show op
             , "Value 1: " ++ show x
@@ -1169,7 +1170,7 @@ pointerCmp op x y =
          L.Iugt -> do
            isLe <- extensionStmt (LLVM_PtrLe memVar x y)
            return $ App (Not isLe)
-         _ -> reportError $ litExpr $ Text.pack $ unlines $
+         _ -> reportError $ litExpr $ BSChar.pack $ unlines $
                 [ "Signed comparison on pointer values"
                 , "Comparison operation: " ++ show op
                 , "Value 1:" ++ show x
@@ -1216,7 +1217,7 @@ pointerOp op x y =
       L.Sub _ _ -> BitvectorAsPointerExpr PtrWidth <$> callPtrSubtract x y
       _ -> err
 
-  err = reportError $ litExpr $ Text.pack $ unlines $
+  err = reportError $ litExpr $ BSChar.pack $ unlines $
           [ "Invalid pointer operation"
           , "Operation: " ++ show op
           , "Value 1: " ++ show x
@@ -1594,7 +1595,7 @@ generateInstr retType lab instr assign_f k =
     L.VaArg{} -> unsupported
 
  where
- unsupported = reportError $ App $ TextLit $ Text.pack $ unwords ["unsupported instruction", showInstr instr]
+ unsupported = reportError $ App $ StringLit $ BSChar.pack $ unwords ["unsupported instruction", showInstr instr]
 
 
 arithOp ::
@@ -1693,7 +1694,7 @@ callFunction _tailCall fnTy@(L.FunTy lretTy largTys varargs) fn args assign_f = 
         _ -> fail $ unwords ["unsupported function value", show fn]
 
 callFunction _tailCall fnTy _fn _args _assign_f =
-  reportError $ App $ TextLit $ Text.pack $ unwords $
+  reportError $ App $ StringLit $ BSChar.pack $ unwords $
     [ "[callFunction] Unsupported function type"
     , show fnTy
     ]

--- a/crucible/src/Lang/Crucible/Backend/Online.hs
+++ b/crucible/src/Lang/Crucible/Backend/Online.hs
@@ -72,6 +72,8 @@ import           Control.Monad
 import           Control.Monad.Catch
 import           Control.Monad.IO.Class
 import           Data.Bits
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BSChar
 import           Data.Data (Data)
 import           Data.Foldable
 import           Data.IORef
@@ -79,7 +81,6 @@ import           Data.Parameterized.Nonce
 import           Data.Typeable (Typeable)
 import           GHC.Generics (Generic)
 import           System.IO
-import qualified Data.Text as Text
 import qualified Text.PrettyPrint.ANSI.Leijen as PP
 
 import           What4.Config
@@ -310,8 +311,8 @@ getSolverProcess' getSolver sym = do
            getMaybeOpt auxOutSetting >>= \case
              Nothing -> return Nothing
              Just fn
-               | Text.null fn -> return Nothing
-               | otherwise    -> Just <$> openFile (Text.unpack fn) WriteMode
+               | BS.null fn -> return Nothing
+               | otherwise  -> Just <$> openFile (BSChar.unpack fn) WriteMode
          p <- startSolverProcess feats auxh sym
          push p
          writeIORef (solverProc st) (SolverStarted p auxh)

--- a/crucible/src/Lang/Crucible/CFG/Core.hs
+++ b/crucible/src/Lang/Crucible/CFG/Core.hs
@@ -165,7 +165,7 @@ newtype Expr ext (ctx :: Ctx CrucibleType) (tp :: CrucibleType)
       = App (App ext (Reg ctx) tp)
 
 instance IsString (Expr ext ctx StringType) where
-  fromString  = App . TextLit . fromString
+  fromString  = App . StringLit . fromString
 
 instance PrettyApp (ExprExtension ext) => Pretty (Expr ext ctx tp) where
   pretty (App a) = ppApp pretty a

--- a/crucible/src/Lang/Crucible/CFG/Expr.hs
+++ b/crucible/src/Lang/Crucible/CFG/Expr.hs
@@ -60,8 +60,8 @@ module Lang.Crucible.CFG.Expr
 
 import           Control.Monad.Identity
 import           Control.Monad.State.Strict
+import           Data.ByteString (ByteString)
 import           Data.Kind (Type)
-import           Data.Text (Text)
 import           Data.Vector (Vector)
 import           Numeric.Natural
 import           Text.PrettyPrint.ANSI.Leijen hiding ((<$>))
@@ -915,7 +915,7 @@ data App (ext :: Type) (f :: CrucibleType -> Type) (tp :: CrucibleType) where
   ----------------------------------------------------------------------
   -- String
 
-  TextLit :: !Text
+  StringLit :: !ByteString
           -> App ext f StringType
 
   ShowValue :: !(BaseTypeRepr bt)
@@ -930,6 +930,8 @@ data App (ext :: Type) (f :: CrucibleType -> Type) (tp :: CrucibleType) where
                -> !(f StringType)
                -> App ext f StringType
 
+  StringLength :: !(f StringType)
+               -> App ext f NatType
 
   ----------------------------------------------------------------------
   -- Arrays (supporting symbolic operations)
@@ -1204,9 +1206,10 @@ instance TypeApp (ExprExtension ext) => TypeApp (App ext) where
     ----------------------------------------------------------------------
     -- String
 
-    TextLit{} -> knownRepr
+    StringLit{} -> knownRepr
     ShowValue{} -> knownRepr
     ShowFloat{} -> knownRepr
+    StringLength{} -> knownRepr
     AppendString{} -> knownRepr
 
     ------------------------------------------------------------------------

--- a/crucible/src/Lang/Crucible/CFG/Reg.hs
+++ b/crucible/src/Lang/Crucible/CFG/Reg.hs
@@ -421,7 +421,7 @@ instance TypeApp (ExprExtension ext) => IsExpr (Expr ext s) where
   exprType (AtomExpr a)     = typeOfAtom a
 
 instance IsString (Expr ext s StringType) where
-  fromString s = App (TextLit (fromString s))
+  fromString s = App (StringLit (fromString s))
 
 substExpr :: ( Applicative m, TraverseExt ext )
           => (forall (x :: CrucibleType). Nonce s x -> m (Nonce s' x))

--- a/crucible/src/Lang/Crucible/Simulator/EvalStmt.hs
+++ b/crucible/src/Lang/Crucible/Simulator/EvalStmt.hs
@@ -47,10 +47,10 @@ module Lang.Crucible.Simulator.EvalStmt
 import qualified Control.Exception as Ex
 import           Control.Lens
 import           Control.Monad.Reader
+import qualified Data.ByteString.Char8 as BSChar
 import           Data.Maybe (fromMaybe)
 import qualified Data.Parameterized.Context as Ctx
 import           Data.Parameterized.TraversableFC
-import qualified Data.Text as Text
 import           Data.Time.Clock
 import           System.IO
 import           System.IO.Error as Ex
@@ -298,7 +298,7 @@ stepStmt verb stmt rest =
        Print e ->
          do msg <- evalReg e
             let msg' = case asString msg of
-                         Just txt -> Text.unpack txt
+                         Just txt -> BSChar.unpack txt
                          _ -> show (printSymExpr msg)
             liftIO $ do
               let h = printHandle ctx
@@ -310,7 +310,7 @@ stepStmt verb stmt rest =
          do c <- evalReg c_expr
             msg <- evalReg msg_expr
             let msg' = case asString msg of
-                         Just txt -> Text.unpack txt
+                         Just txt -> BSChar.unpack txt
                          _ -> show (printSymExpr msg)
             liftIO $ assert sym c (AssertFailureSimError msg')
             continueWith (stateCrucibleFrame  . frameStmts .~ rest)
@@ -319,7 +319,7 @@ stepStmt verb stmt rest =
          do c <- evalReg c_expr
             msg <- evalReg msg_expr
             let msg' = case asString msg of
-                         Just txt -> Text.unpack txt
+                         Just txt -> BSChar.unpack txt
                          _ -> show (printSymExpr msg)
             liftIO $
               do loc <- getCurrentProgramLoc sym
@@ -396,7 +396,7 @@ stepTerm _ (ErrorStmt msg) =
      sym <- view stateSymInterface
      liftIO $ case asString msg' of
        Just txt -> addFailedAssertion sym
-                      $ GenericSimError $ Text.unpack txt
+                      $ GenericSimError $ BSChar.unpack txt
        Nothing  -> addFailedAssertion sym
                       $ GenericSimError $ show (printSymExpr msg')
 

--- a/crucible/src/Lang/Crucible/Simulator/Evaluation.hs
+++ b/crucible/src/Lang/Crucible/Simulator/Evaluation.hs
@@ -38,10 +38,10 @@ import qualified Control.Exception as Ex
 import           Control.Lens
 import           Control.Monad
 import           Data.Bitraversable (bitraverse)
+import qualified Data.ByteString.Char8 as BSChar
 import qualified Data.Map.Strict as Map
 import           Data.Maybe
 import           Data.Proxy (Proxy(..))
-import qualified Data.Text as Text
 import qualified Data.Vector as V
 import           Data.Word
 import           Numeric ( showHex )
@@ -417,7 +417,7 @@ evalApp sym itefns _logFn evalExt (evalSub :: forall tp. f tp -> IO (RegValue sy
         _ -> do
           msg <- evalSub msg_expr
           case asString msg of
-            Just msg' -> readPartExpr sym maybe_val (GenericSimError (Text.unpack msg'))
+            Just msg' -> readPartExpr sym maybe_val (GenericSimError (BSChar.unpack msg'))
             Nothing ->
               addFailedAssertion sym $
                 Unsupported "Symbolic string in fromJustValue"
@@ -917,13 +917,16 @@ evalApp sym itefns _logFn evalExt (evalSub :: forall tp. f tp -> IO (RegValue sy
     --------------------------------------------------------------------
     -- Text
 
-    TextLit txt -> stringLit sym txt
+    StringLit txt -> stringLit sym txt
     ShowValue _bt x_expr -> do
       x <- evalSub x_expr
-      stringLit sym (Text.pack (show (printSymExpr x)))
+      stringLit sym (BSChar.pack (show (printSymExpr x)))
     ShowFloat _fi x_expr -> do
       x <- evalSub x_expr
-      stringLit sym (Text.pack (show (printSymExpr x)))
+      stringLit sym (BSChar.pack (show (printSymExpr x)))
+    StringLength x -> do
+      x' <- evalSub x
+      stringLength sym x'
     AppendString x y -> do
       x' <- evalSub x
       y' <- evalSub y

--- a/crucible/src/Lang/Crucible/Simulator/RegValue.hs
+++ b/crucible/src/Lang/Crucible/Simulator/RegValue.hs
@@ -49,12 +49,12 @@ module Lang.Crucible.Simulator.RegValue
 
 import           Control.Monad
 import           Control.Monad.Trans.Class
+import           Data.ByteString (ByteString)
 import           Data.Kind
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Proxy
 import qualified Data.Set as Set
-import           Data.Text (Text)
 import qualified Data.Vector as V
 import           Data.Word
 import           GHC.TypeNats (KnownNat)
@@ -92,7 +92,7 @@ type family RegValue (sym :: Type) (tp :: CrucibleType) :: Type where
   RegValue sym (WordMapType w tp) = WordMap sym w tp
   RegValue sym (RecursiveType nm ctx) = RolledType sym nm ctx
   RegValue sym (IntrinsicType nm ctx) = Intrinsic sym nm ctx
-  RegValue sym (StringMapType tp) = Map Text (PartExpr (Pred sym) (RegValue sym tp))
+  RegValue sym (StringMapType tp) = Map ByteString (PartExpr (Pred sym) (RegValue sym tp))
 
 -- | A newtype wrapper around RegValue.  This is wrapper necessary because
 --   RegValue is a type family and, as such, cannot be partially applied.
@@ -273,7 +273,7 @@ instance IsExprBuilder sym => CanMux sym (FunctionHandleType a r) where
 muxStringMap :: IsExprBuilder sym
              => sym
              -> MuxFn (Pred sym) e
-             -> MuxFn (Pred sym) (Map Text (PartExpr (Pred sym) e))
+             -> MuxFn (Pred sym) (Map ByteString (PartExpr (Pred sym) e))
 muxStringMap sym = \f c x y -> do
   let keys = Set.toList $ Set.union (Map.keysSet x) (Map.keysSet y)
   fmap Map.fromList $ forM keys $ \k -> do

--- a/crucible/src/Lang/Crucible/Syntax.hs
+++ b/crucible/src/Lang/Crucible/Syntax.hs
@@ -86,11 +86,11 @@ module Lang.Crucible.Syntax
   ) where
 
 import           Control.Lens
+import           Data.ByteString (ByteString)
 import           Data.Kind
 import           Data.Parameterized.Classes
 import qualified Data.Parameterized.Context as Ctx
 import           Data.Parameterized.Some
-import           Data.Text (Text)
 import qualified Data.Vector as V
 import           Numeric.Natural
 
@@ -278,8 +278,8 @@ instance ConvertableToNat e ComplexRealType where
 ------------------------------------------------------------------------
 -- String
 
-instance LitExpr e StringType Text where
-  litExpr t = app (TextLit t)
+instance LitExpr e StringType ByteString where
+  litExpr t = app (StringLit t)
 
 ------------------------------------------------------------------------
 -- Maybe
@@ -343,7 +343,7 @@ emptyIdentValueMap = app (EmptyStringMap knownRepr)
 -- Update the value of the ident value map with the given value.
 setIdentValue :: (IsExpr e, KnownRepr TypeRepr tp)
               => e (StringMapType tp)
-              -> Text
+              -> ByteString
               -> e (MaybeType tp)
               -> e (StringMapType tp)
 setIdentValue m i v = app (InsertStringMapEntry knownRepr m (litExpr i) v)

--- a/what4-abc/src/What4/Solver/ABC.hs
+++ b/what4-abc/src/What4/Solver/ABC.hs
@@ -48,6 +48,8 @@ import qualified Data.ABC.GIA as GIA
 import qualified Data.AIG.Operations as AIG
 import qualified Data.AIG.Interface as AIG
 
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString.Char8 as BSChar
 import qualified Data.ByteString.UTF8 as UTF8
 import qualified Data.Foldable as Fold
 import qualified Data.HashSet as HSet
@@ -61,7 +63,6 @@ import           Data.Parameterized.Nonce (Nonce)
 import           Data.Parameterized.Some
 import           Data.Set (Set)
 import qualified Data.Set as Set
-import qualified Data.Text as T
 import           Foreign.C.Types
 import           Numeric.Natural
 import           System.Directory
@@ -132,7 +133,7 @@ genericSatAdapter =
    , solver_adapter_config_options = genericSatOptions
    , solver_adapter_check_sat = \sym logData ps cont -> do
        let cfg = getConfiguration sym
-       cmd <- T.unpack <$> (getOpt =<< getOptionSetting satCommand cfg)
+       cmd <- BSChar.unpack <$> (getOpt =<< getOptionSetting satCommand cfg)
        let mkCommand path = do
              let var_map = Map.fromList [("1",path)]
              Env.expandEnvironmentPath var_map cmd
@@ -152,7 +153,7 @@ type family LitValue s (tp :: BaseType) where
   LitValue s BaseNatType      = Natural
   LitValue s BaseIntegerType  = Integer
   LitValue s BaseRealType     = Rational
-  LitValue s BaseStringType   = T.Text
+  LitValue s BaseStringType   = ByteString
   LitValue s BaseComplexType  = Complex Rational
 
 -- | Newtype wrapper around names.
@@ -162,7 +163,7 @@ data NameType s (tp :: BaseType) where
   GroundNat :: Natural -> NameType s BaseNatType
   GroundInt :: Integer -> NameType s BaseIntegerType
   GroundRat :: Rational -> NameType s BaseRealType
-  GroundString :: T.Text -> NameType s BaseStringType
+  GroundString :: ByteString -> NameType s BaseStringType
   GroundComplex :: Complex Rational -> NameType s BaseComplexType
 
 -- | A variable binding in ABC.
@@ -533,6 +534,12 @@ bitblastExpr h ae = do
 
     IntegerToNat{} -> natFail
     IntegerToBV{}  -> intFail
+
+    ------------------------------------------------------------------------
+    -- String operations
+
+    StringLength{} -> stringFail
+    StringAppend{} -> stringFail
 
     ------------------------------------------------------------------------
     -- Complex operations

--- a/what4-abc/what4-abc.cabal
+++ b/what4-abc/what4-abc.cabal
@@ -21,6 +21,7 @@ library
     aig,
     abcBridge >= 0.11,
     ansi-wl-pprint,
+    bytestring,
     containers,
     what4 >= 0.4,
     directory,

--- a/what4-blt/src/What4/Solver/BLT.hs
+++ b/what4-blt/src/What4/Solver/BLT.hs
@@ -67,13 +67,13 @@ import qualified Control.Exception as Ex
 import           Control.Lens
 import           Control.Monad (foldM, forM_, when, liftM2)
 import           Control.Monad.ST
+import qualified Data.ByteString.Char8 as BSChar
 import           Data.IORef
 import           Data.Int (Int64)
 import           Data.List.NonEmpty (NonEmpty(..))
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe, isJust)
-import qualified Data.Text as T
 import           Data.Traversable
 import           Data.Typeable
 import           System.IO (hPutStrLn, stderr)
@@ -129,7 +129,7 @@ runBLTInOverride :: IsExprBuilder sym
                  -> IO a
 runBLTInOverride sym logData ps contFn = do
   let cfg = getConfiguration sym
-  epar <- parseBLTParams . T.unpack <$> (getOpt =<< getOptionSetting bltParams cfg)
+  epar <- parseBLTParams . BSChar.unpack <$> (getOpt =<< getOptionSetting bltParams cfg)
   par  <- either fail return epar
   logSolverEvent sym
     SolverStartSATQuery

--- a/what4-blt/what4-blt.cabal
+++ b/what4-blt/what4-blt.cabal
@@ -19,6 +19,7 @@ library
     base >= 4.7 && < 4.13,
     ansi-wl-pprint,
     blt >= 0.12.1,
+    bytestring,
     containers,
     what4 >= 0.4,
     lens >= 1.2,

--- a/what4/src/What4/Concrete.hs
+++ b/what4/src/What4/Concrete.hs
@@ -46,10 +46,10 @@ module What4.Concrete
   , fromConcreteComplex
   ) where
 
+import           Data.ByteString (ByteString)
 import           Data.List
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Text (Text)
 import qualified Numeric as N
 import           Numeric.Natural
 import qualified Text.PrettyPrint.ANSI.Leijen as PP
@@ -69,7 +69,7 @@ data ConcreteVal tp where
   ConcreteNat     :: Natural -> ConcreteVal BaseNatType
   ConcreteInteger :: Integer -> ConcreteVal BaseIntegerType
   ConcreteReal    :: Rational -> ConcreteVal BaseRealType
-  ConcreteString  :: Text -> ConcreteVal BaseStringType
+  ConcreteString  :: ByteString -> ConcreteVal BaseStringType
   ConcreteComplex :: Complex Rational -> ConcreteVal BaseComplexType
   ConcreteBV      ::
     (1 <= w) =>
@@ -98,7 +98,7 @@ fromConcreteReal (ConcreteReal x) = x
 fromConcreteComplex :: ConcreteVal BaseComplexType -> Complex Rational
 fromConcreteComplex (ConcreteComplex x) = x
 
-fromConcreteString :: ConcreteVal BaseStringType -> Text
+fromConcreteString :: ConcreteVal BaseStringType -> ByteString
 fromConcreteString (ConcreteString x) = x
 
 fromConcreteUnsignedBV :: ConcreteVal (BaseBVType w) -> Integer

--- a/what4/src/What4/Expr/AppTheory.hs
+++ b/what4/src/What4/Expr/AppTheory.hs
@@ -223,6 +223,12 @@ appTheory a0 =
     SelectArray{} -> ArrayTheory
     UpdateArray{} -> ArrayTheory
 
+    ---------------------------
+    -- String operations
+
+    StringLength{} -> StringTheory
+    StringAppend{} -> StringTheory
+
     ---------------------
     -- Complex operations
 

--- a/what4/src/What4/Expr/GroundEval.hs
+++ b/what4/src/What4/Expr/GroundEval.hs
@@ -41,6 +41,9 @@ import           Control.Monad
 import           Control.Monad.Trans.Class
 import           Control.Monad.Trans.Maybe
 import           Data.Bits
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import           Data.Foldable (toList)
 import           Data.List (foldl')
 import           Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.Map.Strict as Map
@@ -49,7 +52,6 @@ import qualified Data.Parameterized.Context as Ctx
 import           Data.Parameterized.NatRepr
 import           Data.Parameterized.TraversableFC
 import           Data.Ratio
-import           Data.Text (Text)
 import           Numeric.Natural
 
 import           What4.BaseTypes
@@ -72,7 +74,7 @@ type family GroundValue (tp :: BaseType) where
   GroundValue (BaseBVType w)        = Integer
   GroundValue (BaseFloatType fpp)   = Integer
   GroundValue BaseComplexType       = Complex Rational
-  GroundValue BaseStringType        = Text
+  GroundValue BaseStringType        = ByteString
   GroundValue (BaseArrayType idx b) = GroundArray idx b
   GroundValue (BaseStructType ctx)  = Ctx.Assignment GroundValueWrapper ctx
 
@@ -514,6 +516,9 @@ evalGroundApp f0 a0 = do
 
     IntegerToNat x -> fromInteger . max 0 <$> f x
     IntegerToBV x w -> toUnsigned w <$> f x
+
+    StringLength x -> fromIntegral . BS.length <$> f x
+    StringAppend ss -> BS.concat <$> mapM f (toList (stringSeq ss))
 
     ------------------------------------------------------------------------
     -- Complex operations.

--- a/what4/src/What4/Interface.hs
+++ b/what4/src/What4/Interface.hs
@@ -151,8 +151,9 @@ module What4.Interface
 import           Control.Exception (assert)
 import           Control.Lens
 import           Control.Monad
-import           Data.Bits
 import           Control.Monad.IO.Class
+import           Data.Bits
+import           Data.ByteString
 import           Data.Coerce (coerce)
 import           Data.Foldable
 import           Data.Hashable
@@ -167,7 +168,6 @@ import           Data.Parameterized.TraversableFC
 import qualified Data.Parameterized.Vector as Vector
 import           Data.Ratio
 import           Data.Scientific (Scientific)
-import           Data.Text (Text)
 import           GHC.Generics (Generic)
 import           Numeric.Natural
 import           Text.PrettyPrint.ANSI.Leijen (Doc)
@@ -300,7 +300,7 @@ class IsExpr e where
   asAffineVar :: e tp -> Maybe (ConcreteVal tp, e tp, ConcreteVal tp)
 
   -- | Return the string value if this is a constant string
-  asString :: e BaseStringType -> Maybe Text
+  asString :: e BaseStringType -> Maybe ByteString
   asString _ = Nothing
 
   -- | Return the unique element value if this is a constant array,
@@ -1534,7 +1534,7 @@ class (IsExpr (SymExpr sym), HashableF (SymExpr sym)) => IsExprBuilder sym where
   -- String operations
 
   -- | Create a concrete string literal
-  stringLit :: sym -> Text -> IO (SymString sym)
+  stringLit :: sym -> ByteString -> IO (SymString sym)
 
   -- | Check the equality of two strings
   stringEq :: sym -> SymString sym -> SymString sym -> IO (Pred sym)

--- a/what4/src/What4/Protocol/SMTWriter.hs
+++ b/what4/src/What4/Protocol/SMTWriter.hs
@@ -2483,6 +2483,12 @@ appSMTExpr ae = do
           freshBoundTerm RealTypeMap $ arrayComplexImagPart @h (asBase c)
 
     --------------------------------------------------------------------
+    -- Strings
+
+    StringLength _ -> error "FIXME!!"
+    StringAppend _ -> error "FIXME!!"
+
+    --------------------------------------------------------------------
     -- Structures
 
     StructCtor _ vals -> do

--- a/what4/src/What4/Solver/Adapter.hs
+++ b/what4/src/What4/Solver/Adapter.hs
@@ -23,8 +23,8 @@ module What4.Solver.Adapter
 
 import           Data.Bits
 import           Data.IORef
+import qualified Data.ByteString.Char8 as BSChar
 import qualified Data.Map as Map
-import qualified Data.Text as T
 import           System.IO
 import qualified Text.PrettyPrint.ANSI.Leijen as PP
 
@@ -113,9 +113,9 @@ solverAdapterOptions xs@(def:_) =
      return (opts, readIORef ref)
 
  where
- f ref x = (T.pack (solver_adapter_name x), writeIORef ref x >> return optOK)
+ f ref x = (BSChar.pack (solver_adapter_name x), writeIORef ref x >> return optOK)
  vals ref = Map.fromList (map (f ref) xs)
  sty ref = mkOpt defaultSolverAdapter
                  (listOptSty (vals ref))
                  (Just (PP.text "Indicates which solver to use for check-sat queries"))
-                 (Just (ConcreteString (T.pack (solver_adapter_name def))))
+                 (Just (ConcreteString (BSChar.pack (solver_adapter_name def))))

--- a/what4/src/What4/Solver/Yices.hs
+++ b/what4/src/What4/Solver/Yices.hs
@@ -68,6 +68,8 @@ import           Control.Monad
 import           Control.Monad.Identity
 import qualified Data.Attoparsec.Text as Atto
 import           Data.Bits
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString.Lazy as BSL
 
 import           Data.IORef
 import           Data.Foldable (toList)
@@ -86,6 +88,7 @@ import qualified Data.Text.Lazy as Lazy
 import           Data.Text.Lazy.Builder (Builder)
 import qualified Data.Text.Lazy.Builder as Builder
 import           Data.Text.Lazy.Builder.Int (decimal)
+import           Data.Text.Lazy.Encoding (decodeLatin1)
 import           System.Exit
 import           System.IO
 import qualified System.IO.Streams as Streams
@@ -130,7 +133,7 @@ asYicesConfigValue v = case v of
   ConcreteInteger x ->
       return $ decimal x
   ConcreteString x ->
-      return $ Builder.fromText x
+      return $ Builder.fromLazyText $ decodeLatin1 $ BSL.fromStrict x
   _ ->
       Nothing
 
@@ -842,7 +845,7 @@ yicesOptions =
   ]
   ++ yicesInternalOptions
 
-yicesBranchingChoices :: Set Text
+yicesBranchingChoices :: Set ByteString
 yicesBranchingChoices = Set.fromList
   [ "default"
   , "negative"
@@ -852,7 +855,7 @@ yicesBranchingChoices = Set.fromList
   , "th-neg"
   ]
 
-yicesEFGenModes :: Set Text
+yicesEFGenModes :: Set ByteString
 yicesEFGenModes = Set.fromList
   [ "auto"
   , "none"
@@ -891,7 +894,7 @@ intWithRangeOpt nm lo hi =
         Nothing
         Nothing
 
-enumOpt :: String -> Set Text -> ConfigDesc
+enumOpt :: String -> Set ByteString -> ConfigDesc
 enumOpt nm xs =
   mkOpt (configOption BaseStringRepr $ "yices."++nm)
         (enumOptSty xs)

--- a/what4/src/What4/Utils/Process.hs
+++ b/what4/src/What4/Utils/Process.hs
@@ -21,7 +21,7 @@ module What4.Utils.Process
 
 import           Control.Exception
 import qualified Data.Map as Map
-import qualified Data.Text as T
+import qualified Data.ByteString.Char8 as BSChar
 import           System.IO
 import           System.Process
 
@@ -40,7 +40,7 @@ resolveSolverPath path = do
 findSolverPath :: ConfigOption BaseStringType -> Config -> IO FilePath
 findSolverPath o cfg =
   do v <- getOpt =<< getOptionSetting o cfg
-     resolveSolverPath (T.unpack v)
+     resolveSolverPath (BSChar.unpack v)
 
 -- | This runs a given external binary, providing the process handle and handles to
 -- input and output to the action.  It takes care to terminate the process if any


### PR DESCRIPTION
As I am doing this refactoring, I've (re)discovered that string handling
is stupid and complicated. The avaliable SMT theories for strings treat
strings as a sequence of bytes (as does raw C), but Java wants strings
to be sequences of 16-byte codepoints, and Haskell's `Text` datatype
assumes UTF-8 encoding, etc.

Doing this correctly will requre a lot of care *sigh*.  We'll probably
need to implement a family of string representations to actually
get the semantics right...