### PR TITLE
Support memory invalidation in LLVM memory model

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Partial.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Partial.hs
@@ -100,6 +100,7 @@ data MemoryLoadError sym =
   | PreviousErrors Text [MemoryLoadError sym]
   | ApplyViewFail ValueView
   | Invalid StorageType
+  | Invalidated Text
   | Other (Maybe String)
     -- ^ TODO: eliminate this constructor, replace with more specific messages
   deriving (Generic)
@@ -132,6 +133,8 @@ ppMemoryLoadError =
       "Failure when applying value view" <+> text (show vw)
     Invalid ty ->
       "Load from invalid memory at type " <+> text (show ty)
+    Invalidated msg ->
+      "Load from explicitly invalidated memory:" <+> text (unpack msg)
     Other msg -> vcat $ [ text "Generic memory load error." ] ++
                    case msg of
                      Just msg' -> [text "Details:", text msg']

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Run.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Run.hs
@@ -45,7 +45,7 @@ import Lang.Crucible.LLVM.Intrinsics
 import Lang.Crucible.LLVM(llvmExtensionImpl, llvmGlobals)
 import Lang.Crucible.LLVM.Translation
         (globalInitMap,transContext,translateModule,ModuleTranslation,cfgMap)
-import Lang.Crucible.LLVM.Globals(populateAllGlobals,initializeMemory)
+import Lang.Crucible.LLVM.Globals(populateAllGlobals,initializeAllMemory)
 
 import Lang.Crucible.LLVM.MemModel(withPtrWidth,HasPtrWidth,MemOptions)
 
@@ -95,7 +95,7 @@ runCruxLLVM llvm_mod memOpts (CruxLLVM setup) =
          withPtrWidthOf trans (
            do let llvmCtxt = trans ^. transContext
               mem <-
-                do mem0 <- initializeMemory cruxBackend llvmCtxt llvm_mod
+                do mem0 <- initializeAllMemory cruxBackend llvmCtxt llvm_mod
                    let ?lc = llvmCtxt ^. llvmTypeCtx
                    populateAllGlobals cruxBackend (globalInitMap trans) mem0
 

--- a/crux-llvm/src/CruxLLVMMain.hs
+++ b/crux-llvm/src/CruxLLVMMain.hs
@@ -59,7 +59,7 @@ import Lang.Crucible.Simulator.Profiling ( Metric(Metric) )
 -- crucible-llvm
 import Lang.Crucible.LLVM(llvmExtensionImpl, llvmGlobals, registerModuleFn)
 import Lang.Crucible.LLVM.Globals
-        ( initializeMemory, populateAllGlobals )
+        ( initializeAllMemory, populateAllGlobals )
 import Lang.Crucible.LLVM.MemModel
         ( MemImpl, withPtrWidth, memAllocCount, memWriteCount, MemOptions(..), laxPointerMemOptions )
 import Lang.Crucible.LLVM.Translation
@@ -178,7 +178,7 @@ simulateLLVM fs (cruxOpts,llvmOpts) sym _p cont = do
           let ?lc = llvmCtxt^.llvmTypeCtx
           let simctx = (setupSimCtxt halloc sym (memOpts llvmOpts) llvmCtxt) { printHandle = view outputHandle ?outputConfig }
           mem <- populateAllGlobals sym (globalInitMap trans)
-                    =<< initializeMemory sym llvmCtxt llvm_mod
+                    =<< initializeAllMemory sym llvmCtxt llvm_mod
           let globSt = llvmGlobals llvmCtxt mem
 
           let initSt = InitialState simctx globSt defaultAbortHandler UnitRepr $


### PR DESCRIPTION
Adds a new `WriteSource` called `MemInvalidate`. Reading from invalidated memory yields an error with a user-specified message.

This facilitates a `saw-script` change that should fix the compositional verification soundness bug described in GaloisInc/saw-script#30.