### PR TITLE
Add option for per-goal timeout with Yices

### DIFF
--- a/crux/src/Crux.hs
+++ b/crux/src/Crux.hs
@@ -37,7 +37,7 @@ import What4.Interface (IsExprBuilder, getConfiguration)
 import What4.FunctionName (FunctionName)
 import What4.Protocol.Online (OnlineSolver)
 import What4.Solver.Z3 (z3Timeout)
-import What4.Solver.Yices (yicesEnableMCSat)
+import What4.Solver.Yices (yicesEnableMCSat, yicesEnableInteractive)
 
 import Crux.Log
 import Crux.Types
@@ -125,6 +125,7 @@ withBackend cruxOpts nonceGen f =
     "yices" ->
       withYicesOnlineBackend @(Flags FloatReal) nonceGen unsatCores $ \sym ->
         do symCfg sym yicesEnableMCSat (yicesMCSat cruxOpts)
+           symCfg sym yicesEnableInteractive (goalTimeout cruxOpts /= 0)
            f sym
 
     "z3" ->

--- a/crux/src/Crux.hs
+++ b/crux/src/Crux.hs
@@ -14,7 +14,6 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.IORef
 import Data.List(intercalate)
-import Data.Maybe (isJust)
 import qualified Data.Sequence as Seq
 import Control.Exception(catch, displayException)
 import Control.Monad(when)
@@ -38,7 +37,7 @@ import What4.Interface (IsExprBuilder, getConfiguration)
 import What4.FunctionName (FunctionName)
 import What4.Protocol.Online (OnlineSolver)
 import What4.Solver.Z3 (z3Timeout)
-import What4.Solver.Yices (yicesEnableMCSat, yicesEnableInteractive)
+import What4.Solver.Yices (yicesEnableMCSat, yicesGoalTimeout)
 
 import Crux.Log
 import Crux.Types
@@ -126,7 +125,9 @@ withBackend cruxOpts nonceGen f =
     "yices" ->
       withYicesOnlineBackend @(Flags FloatReal) nonceGen unsatCores $ \sym ->
         do symCfg sym yicesEnableMCSat (yicesMCSat cruxOpts)
-           symCfg sym yicesEnableInteractive (isJust (goalTimeout cruxOpts))
+           case goalTimeout cruxOpts of
+             Just s -> symCfg sym yicesGoalTimeout (floor s)
+             Nothing -> return ()
            f sym
 
     "z3" ->

--- a/crux/src/Crux.hs
+++ b/crux/src/Crux.hs
@@ -14,6 +14,7 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.IORef
 import Data.List(intercalate)
+import Data.Maybe (isJust)
 import qualified Data.Sequence as Seq
 import Control.Exception(catch, displayException)
 import Control.Monad(when)
@@ -125,12 +126,14 @@ withBackend cruxOpts nonceGen f =
     "yices" ->
       withYicesOnlineBackend @(Flags FloatReal) nonceGen unsatCores $ \sym ->
         do symCfg sym yicesEnableMCSat (yicesMCSat cruxOpts)
-           symCfg sym yicesEnableInteractive (goalTimeout cruxOpts /= 0)
+           symCfg sym yicesEnableInteractive (isJust (goalTimeout cruxOpts))
            f sym
 
     "z3" ->
       withZ3OnlineBackend @(Flags FloatIEEE) nonceGen ProduceUnsatCores $ \sym->
-        do symCfg sym z3Timeout (goalTimeout cruxOpts * 1000)
+        do case goalTimeout cruxOpts of
+             Just s -> symCfg sym z3Timeout (floor s * 1000)
+             Nothing -> return ()
            f sym
 
 

--- a/crux/src/Crux/Goal.hs
+++ b/crux/src/Crux/Goal.hs
@@ -19,8 +19,9 @@ import What4.SatResult(SatResult(..))
 import What4.Expr.Builder (ExprBuilder)
 import What4.Protocol.Online( OnlineSolver, inNewFrame, solverEvalFuns
                             , solverConn, check, getUnsatCore )
-import What4.Protocol.SMTWriter(mkFormula,assumeFormulaWithFreshName,assumeFormula,smtExprGroundEvalFn)
-
+import What4.Protocol.SMTWriter( mkFormula, assumeFormulaWithFreshName
+                               , assumeFormula, smtExprGroundEvalFn
+                               , addCommand, setGoalTimeoutCommand )
 import Lang.Crucible.Backend
 import Lang.Crucible.Backend.Online
         ( OnlineBackendState, getSolverProcess )
@@ -153,6 +154,10 @@ proveGoals opts ctxt (Just gs0) =
            nm <- doAssume =<< mkFormula conn =<< notPred sym (p ^. labeledPred)
            bindName nm (Right p) nameMap
 
+           case setGoalTimeoutCommand sp (goalTimeout opts) of
+             Just c -> addCommand (solverConn sp) c
+             -- If there's no command, we would have set it already.
+             Nothing -> return ()
            res <- check sp "proof"
            ret <- case res of
                       Unsat () ->

--- a/crux/src/Crux/Goal.hs
+++ b/crux/src/Crux/Goal.hs
@@ -5,7 +5,7 @@
 module Crux.Goal where
 
 import Control.Lens ((^.), view)
-import Control.Monad (forM_, unless)
+import Control.Monad (forM_, unless, join)
 import Data.Either (partitionEithers)
 import Data.IORef
 import Data.Maybe (fromMaybe)
@@ -154,7 +154,7 @@ proveGoals opts ctxt (Just gs0) =
            nm <- doAssume =<< mkFormula conn =<< notPred sym (p ^. labeledPred)
            bindName nm (Right p) nameMap
 
-           case setGoalTimeoutCommand sp (goalTimeout opts) of
+           case join (setGoalTimeoutCommand sp <$> goalTimeout opts) of
              Just c -> addCommand (solverConn sp) c
              -- If there's no command, we would have set it already.
              Nothing -> return ()

--- a/crux/src/Crux/Goal.hs
+++ b/crux/src/Crux/Goal.hs
@@ -5,7 +5,7 @@
 module Crux.Goal where
 
 import Control.Lens ((^.), view)
-import Control.Monad (forM_, unless, join)
+import Control.Monad (forM_, unless)
 import Data.Either (partitionEithers)
 import Data.IORef
 import Data.Maybe (fromMaybe)
@@ -20,8 +20,7 @@ import What4.Expr.Builder (ExprBuilder)
 import What4.Protocol.Online( OnlineSolver, inNewFrame, solverEvalFuns
                             , solverConn, check, getUnsatCore )
 import What4.Protocol.SMTWriter( mkFormula, assumeFormulaWithFreshName
-                               , assumeFormula, smtExprGroundEvalFn
-                               , addCommand, setGoalTimeoutCommand )
+                               , assumeFormula, smtExprGroundEvalFn )
 import Lang.Crucible.Backend
 import Lang.Crucible.Backend.Online
         ( OnlineBackendState, getSolverProcess )
@@ -154,10 +153,6 @@ proveGoals opts ctxt (Just gs0) =
            nm <- doAssume =<< mkFormula conn =<< notPred sym (p ^. labeledPred)
            bindName nm (Right p) nameMap
 
-           case join (setGoalTimeoutCommand sp <$> goalTimeout opts) of
-             Just c -> addCommand (solverConn sp) c
-             -- If there's no command, we would have set it already.
-             Nothing -> return ()
            res <- check sp "proof"
            ret <- case res of
                       Unsat () ->

--- a/what4/src/What4/Protocol/Online.hs
+++ b/what4/src/What4/Protocol/Online.hs
@@ -203,7 +203,7 @@ checkWithAssumptions proc rsn ps =
               { satQuerySolverName = solverName proc
               , satQueryReason = rsn
               }
-            addCommandNoAck conn (checkWithAssumptionsCommand conn nms)
+            addCommands conn (checkWithAssumptionsCommands conn nms)
             sat_result <- getSatResult proc
             solverLogFn proc
               SolverEndSATQuery
@@ -238,7 +238,7 @@ check p rsn =
            { satQuerySolverName = solverName p
            , satQueryReason = rsn
            }
-         addCommandNoAck c (checkCommand c)
+         addCommands c (checkCommands c)
          sat_result <- getSatResult p
          solverLogFn p
            SolverEndSATQuery

--- a/what4/src/What4/Protocol/SMTLib2.hs
+++ b/what4/src/What4/Protocol/SMTLib2.hs
@@ -482,6 +482,7 @@ instance SMTLib2Tweaks a => SMTWriter (Writer a) where
   popCommand _   = SMT2.pop 1
   resetCommand _ = SMT2.resetAssertions
 
+  setGoalTimeoutCommand _ _ = Nothing
   checkCommand _ = SMT2.checkSat
   checkWithAssumptionsCommand _ = SMT2.checkSatWithAssumptions
 

--- a/what4/src/What4/Protocol/SMTWriter.hs
+++ b/what4/src/What4/Protocol/SMTWriter.hs
@@ -786,6 +786,10 @@ class (SupportTermOps (Term h)) => SMTWriter h where
   -- | Reset the solver state, forgetting all pushed frames and assertions
   resetCommand  :: f h -> Command h
 
+  -- | Set the timeout for the next goal. Returns @Nothing@ if setting
+  -- per-goal timeouts is not supported.
+  setGoalTimeoutCommand  :: f h -> Integer -> Maybe (Command h)
+
   -- | Check if the current set of assumption is satisfiable
   checkCommand  :: f h -> Command h
 

--- a/what4/src/What4/Protocol/SMTWriter.hs
+++ b/what4/src/What4/Protocol/SMTWriter.hs
@@ -67,6 +67,7 @@ module What4.Protocol.SMTWriter
   , Command
   , addCommand
   , addCommandNoAck
+  , addCommands
   , mkFreeVar
   , TypeMap(..)
   , freshBoundVarName
@@ -115,7 +116,6 @@ import           Data.Text.Lazy.Builder (Builder)
 import qualified Data.Text.Lazy.Builder as Builder
 import qualified Data.Text.Lazy.Builder.Int as Builder (decimal)
 import qualified Data.Text.Lazy as Lazy
-import           Data.Time.Clock
 import           Data.Word
 import           Numeric.Natural
 import           Text.PrettyPrint.ANSI.Leijen hiding ((<$>), (<>))
@@ -787,16 +787,14 @@ class (SupportTermOps (Term h)) => SMTWriter h where
   -- | Reset the solver state, forgetting all pushed frames and assertions
   resetCommand  :: f h -> Command h
 
-  -- | Set the timeout for the next goal. Returns @Nothing@ if setting
-  -- per-goal timeouts is not supported.
-  setGoalTimeoutCommand  :: f h -> DiffTime -> Maybe (Command h)
-
-  -- | Check if the current set of assumption is satisfiable
-  checkCommand  :: f h -> Command h
+  -- | Check if the current set of assumption is satisfiable. May
+  -- require multiple commands. The intial commands require an ack. The
+  -- last one does not.
+  checkCommands  :: f h -> [Command h]
 
   -- | Check if a collection of assumptions is satisfiable in the current context.
   --   The assumptions must be given as the names of literals already in scope.
-  checkWithAssumptionsCommand :: f h -> [Text] -> Command h
+  checkWithAssumptionsCommands :: f h -> [Text] -> [Command h]
 
   -- | Ask the solver to return an unsatisfiable core from among the assumptions
   --   passed into the previous "check with assumptions" command.
@@ -854,6 +852,14 @@ addCommandNoAck conn cmd = do
     withWriterState conn $ lastPosition .= cur
 
   writeCommand conn cmd
+
+-- | Write a sequence of commands. All but the last should have
+-- acknowledgement.
+addCommands :: SMTWriter h => WriterConn t h -> [Command h] -> IO ()
+addCommands _ [] = fail "internal: empty list in addCommands"
+addCommands conn cmds = do
+  mapM_ (addCommand conn) (init cmds)
+  addCommandNoAck conn (last cmds)
 
 -- | Create a new variable with the given name.
 mkFreeVar :: SMTWriter h

--- a/what4/src/What4/Protocol/SMTWriter.hs
+++ b/what4/src/What4/Protocol/SMTWriter.hs
@@ -115,6 +115,7 @@ import           Data.Text.Lazy.Builder (Builder)
 import qualified Data.Text.Lazy.Builder as Builder
 import qualified Data.Text.Lazy.Builder.Int as Builder (decimal)
 import qualified Data.Text.Lazy as Lazy
+import           Data.Time.Clock
 import           Data.Word
 import           Numeric.Natural
 import           Text.PrettyPrint.ANSI.Leijen hiding ((<$>), (<>))
@@ -788,7 +789,7 @@ class (SupportTermOps (Term h)) => SMTWriter h where
 
   -- | Set the timeout for the next goal. Returns @Nothing@ if setting
   -- per-goal timeouts is not supported.
-  setGoalTimeoutCommand  :: f h -> Integer -> Maybe (Command h)
+  setGoalTimeoutCommand  :: f h -> DiffTime -> Maybe (Command h)
 
   -- | Check if the current set of assumption is satisfiable
   checkCommand  :: f h -> Command h

--- a/what4/src/What4/Solver/Yices.hs
+++ b/what4/src/What4/Solver/Yices.hs
@@ -859,7 +859,7 @@ yicesEnableMCSat = configOption knownRepr "yices_enable-mcsat"
 yicesEnableInteractive :: ConfigOption BaseBoolType
 yicesEnableInteractive = configOption knownRepr "yices_enable-interactive"
 
--- | Set a per-goal timeout.
+-- | Set a per-goal timeout in seconds.
 yicesGoalTimeout :: ConfigOption BaseIntegerType
 yicesGoalTimeout = configOption knownRepr "yices_goal-timeout"
 

--- a/what4/src/What4/Solver/Yices.hs
+++ b/what4/src/What4/Solver/Yices.hs
@@ -88,6 +88,7 @@ import qualified Data.Text.Lazy as Lazy
 import           Data.Text.Lazy.Builder (Builder)
 import qualified Data.Text.Lazy.Builder as Builder
 import           Data.Text.Lazy.Builder.Int (decimal)
+import           Data.Time.Clock
 import           System.Exit
 import           System.IO
 import qualified System.IO.Streams as Streams
@@ -397,8 +398,9 @@ checkExistsForallCommand = safeCmd "(ef-solve)"
 setParamCommand :: Text -> Builder -> Command (Connection s)
 setParamCommand nm v = safeCmd $ app "set-param" [ Builder.fromText nm, v ]
 
-setTimeoutCommand :: Integer -> Command (Connection s)
-setTimeoutCommand t = unsafeCmd $ app "set-timeout" [ Builder.fromString (show t) ]
+setTimeoutCommand :: DiffTime -> Command (Connection s)
+setTimeoutCommand t = unsafeCmd $
+  app "set-timeout" [ Builder.fromString (show (floor t :: Integer)) ]
 
 ------------------------------------------------------------------------
 -- Connection

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -43,6 +43,7 @@ library
     template-haskell,
     text,
     th-abstraction >=0.1 && <0.4,
+    time,
     transformers,
     unordered-containers,
     utf8-string,

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -43,7 +43,6 @@ library
     template-haskell,
     text,
     th-abstraction >=0.1 && <0.4,
-    time,
     transformers,
     unordered-containers,
     utf8-string,


### PR DESCRIPTION
This adds an option to the What4 Yices backend to support per-goal timeouts, and updates Crux to use that option.

It's slightly dissatisfying because in Yices it can't be set globally and it's necessary to emit a `(set-timout n)` command before every `(check)` command. Because of the current architecture of `SMTWriter`, we need to expose a separate command to set the timeout for the current goal. However, this command does not exist in standard SMTLib2. So the method in the `SMTWriter` class returns a `Maybe Command`. This isn't ideal, and I'd love thoughts on a better way to do it.