### PR TITLE
WIP: have assert not assume by default

### DIFF
--- a/crucible/src/Lang/Crucible/Backend.hs
+++ b/crucible/src/Lang/Crucible/Backend.hs
@@ -224,15 +224,11 @@ class IsBoolSolver sym where
   restoreAssumptionState :: sym -> AssumptionState sym -> IO ()
 
 
--- | Add a proof obligation for the given predicate, and then assume it.
--- Note that assuming the prediate might cause the current execution
--- path to abort, if we happened to assume something that is obviously false.
+-- | Add a proof obligation for the given predicate.
 addAssertion ::
   (IsExprBuilder sym, IsBoolSolver sym) =>
   sym -> Assertion sym -> IO ()
-addAssertion sym a@(AS.LabeledPred p msg) =
-  do addProofObligation sym a
-     addAssumption sym (AS.LabeledPred p (AssumingNoError msg))
+addAssertion sym a@(AS.LabeledPred p msg) = addProofObligation sym a
 
 
 -- | Throw an exception, thus aborting the current execution path.
@@ -240,7 +236,6 @@ abortExecBecause :: AbortExecReason -> IO a
 abortExecBecause err = throwIO err
 
 -- | Add a proof obligation using the current program location.
---   Afterwards, assume the given fact.
 assert ::
   (IsExprBuilder sym, IsBoolSolver sym) =>
   sym ->


### PR DESCRIPTION
Chatting with @robdockins and @brianhuffman about the pros/cons of not having `assert` also insert an `assume` by default -- Rob suggested just making the change and seeing how it fairs against the CI, so here it is.

This commit makes that tweak within Crucible's backend... although we'd probably want to tweak/remove/cleanup a few more minor things _if_ we wanted this change, e.g., perhaps just use `addProofObligation` instead of the now redundant `addAssumption`?

For the particular domain I'm working in (float/bitvector cast heavy DSL) the default inclusion of assumes seemed to be helpful (i.e., some previously provable asserts were no longer proved by Z3 with these changes). Perhaps some of the other problems/domains that were brought up during our discussion (slow SAW proofs if I remember?) do not suffer in this way however... 