### PR TITLE
Add a new method for creating solver symbols that should always succeed

### DIFF
--- a/what4/src/What4/Interface.hs
+++ b/what4/src/What4/Interface.hs
@@ -144,6 +144,7 @@ module What4.Interface
   , What4.Symbol.SolverSymbol
   , What4.Symbol.emptySymbol
   , What4.Symbol.userSymbol
+  , What4.Symbol.safeSymbol
   , NatValueRange(..)
   , ValueRange(..)
   ) where

--- a/what4/src/What4/Symbol.hs
+++ b/what4/src/What4/Symbol.hs
@@ -16,6 +16,7 @@ module What4.Symbol
   , emptySymbol
   , userSymbol
   , systemSymbol
+  , safeSymbol
   , ppSolverSymbolError
   ) where
 
@@ -26,6 +27,8 @@ import qualified Data.Set as Set
 import           Data.String
 import           Data.Text (Text)
 import qualified Data.Text as Text
+
+import qualified Text.Encoding.Z as Z
 
 isAsciiLetter :: Char -> Bool
 isAsciiLetter c
@@ -104,6 +107,16 @@ systemSymbol s
     case parseAnySymbol s of
       Left e -> error ("Error parsing system symbol " ++ show s ++ ": " ++ ppSolverSymbolError e)
       Right r -> r
+
+
+-- | Attempts to create a user symbol from the given string.  If this fails
+--   for some reason, the string is Z-encoded into a system symbol instead
+--   with the prefix \"zenc!\".
+safeSymbol :: String -> SolverSymbol
+safeSymbol str =
+  case userSymbol str of
+    Right s -> s
+    Left _err -> systemSymbol ("zenc!" ++ Z.zEncodeString str)
 
 instance Show SolverSymbol where
   show s = Text.unpack (solverSymbolAsText s)

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -48,6 +48,7 @@ library
     utf8-string,
     vector,
     versions,
+    zenc >= 0.1.0 && < 0.2.0,
     ghc-prim
 
   default-language: Haskell2010


### PR DESCRIPTION
It first attempts to create a user symbol (using the exact
given string), but if that fails it uses Z-encoding to remove any
special characters and produces a system symbol instead.