### PR TITLE
Simplify predicates generated by `isAllocated`.

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Generic.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Generic.hs
@@ -1129,28 +1129,29 @@ isAllocatedMut ::
   Maybe (SymBV sym w)  ->
   Mem sym              ->
   IO (Pred sym)
-isAllocatedMut mutOk sym w minAlign ptr@(llvmPointerView -> (blk, _off)) sz m =
-  do overflowPred <- ptrRangeNoOF sym ptr sz
-     andPred sym overflowPred =<< go (pure (falsePred sym)) (memAllocs m)
+isAllocatedMut mutOk sym w minAlign (llvmPointerView -> (blk, off)) sz m =
+  go (pure (falsePred sym)) (memAllocs m)
   where
-    -- @inThisAllocation a allocatedSz@ produces the predicate that records
-    -- whether the pointer @ptr@ of size @sz@ falls within the allocation of block @a@ of size @allocatedSz@
+    -- @inThisAllocation a allocatedSz@ produces the predicate that
+    -- records whether the pointer @ptr@ of size @sz@ falls within the
+    -- allocation of block @a@ of size @allocatedSz@.
     inThisAllocation :: forall w'. Natural -> Maybe (SymBV sym w') -> IO (Pred sym)
-    inThisAllocation a Nothing = isSameBlock sym ptr a
+    inThisAllocation a Nothing = isSameBlock sym blk a
       -- If the allocation is unbounded, we just have to check we are in the right block
-    inThisAllocation a (Just allocatedSize)
+    inThisAllocation a (Just allocSize)
       -- If the allocation is done at pointer width is equal to @w@, check
       -- if this allocation covers the required range
-      | Just Refl <- testEquality w (bvWidth allocatedSize)
+      | Just Refl <- testEquality w (bvWidth allocSize)
       , Just currSize <- sz =
-        do sameBlock <- isSameBlock sym ptr a           -- a == blockname(ptr)
-           end       <- ptrRangeEnd sym ptr currSize    -- ptr+currSize
-           inRange   <- bvUle sym end allocatedSize     -- offset(ptr)+currSize <= allocatedSize
-           andPred sym sameBlock inRange
-    inThisAllocation a (Just _allocatedSize)
+        do sameBlock <- isSameBlock sym blk a           -- a == blockname(ptr)
+           smallSize <- bvUle sym currSize allocSize    -- currSize <= allocSize
+           maxOffset <- bvSub sym allocSize currSize    -- maxOffset = allocSize - currSize
+           inRange   <- bvUle sym off maxOffset         -- offset(ptr) <= maxOffset
+           andPred sym sameBlock =<< andPred sym smallSize inRange
+    inThisAllocation a (Just _allocSize)
       -- If the allocation is done at pointer width not equal to @w@,
       -- check that this allocation is distinct from the base pointer.
-      | otherwise = notPred sym =<< isSameBlock sym ptr a
+      | otherwise = notPred sym =<< isSameBlock sym blk a
 
     go :: IO (Pred sym) -> [MemAlloc sym] -> IO (Pred sym)
     go fallback [] = fallback
@@ -1173,40 +1174,9 @@ isAllocatedMut mutOk sym w minAlign ptr@(llvmPointerView -> (blk, _off)) sz m =
 
 -- | Checks if the block ID given as a natural number is the same as the block
 -- in which the pointer is located
-isSameBlock :: (IsSymInterface sym)
-            => sym
-            -> LLVMPtr sym w
-            -> Natural
-            -> IO (Pred sym)
-isSameBlock sym (llvmPointerView -> (blk,_off)) n = do
+isSameBlock :: (IsSymInterface sym) => sym -> SymNat sym -> Natural -> IO (Pred sym)
+isSameBlock sym blk n =
   natEq sym blk =<< natLit sym n
-
--- | Adds the offset of the given pointer to the bitvector, which represents the
--- number of bytes to read. Produces a bitvector corresponding to the upper
--- bound of the range.
-ptrRangeEnd :: (1 <= w, IsSymInterface sym)
-           => sym
-           -> LLVMPtr sym w
-           -> SymBV sym w
-           -> IO (SymBV sym w)
-ptrRangeEnd sym (llvmPointerView -> (_blk,off)) x = do
-    (_ov,v) <- addUnsignedOF sym off x
-    return v
-
--- | Produces an overflow bit that is false if the range overflows the address
--- space. That is, the overflow bit will be false iff @0 < off + sz < min(off,sz)@
-ptrRangeNoOF ::  (1 <= w, IsSymInterface sym)
-             => sym
-             -> LLVMPtr sym w
-             -> Maybe (SymBV sym w)
-             -> IO (Pred sym)
-ptrRangeNoOF sym _ptr Nothing   = return (truePred sym)
-ptrRangeNoOF sym (llvmPointerView -> (_blk,off)) (Just sz) = do
-    (litOF,v) <- addUnsignedOF sym off sz
-    vEq0      <- bvEq sym v =<< bvLit sym (bvWidth sz) 0
-    -- there is no overflow if @litOF --> v=0@
-    impliesPred sym litOF vEq0
-
 
 -- | @isAllocated sym w p sz m@ returns the condition required to prove
 -- range @[p..p+sz)@ lies within a single allocation in @m@.


### PR DESCRIPTION
Instead of
```
      ((off <= sz + off) && (sz <= sz + off) || (0 == sz + off))
      && (sz + off <= allocSize)
```
it now produces
```
(sz <= allocSize) && (off <= allocSize - sz)
```
Fixes GaloisInc/saw-script#587.