### PR TITLE
Update CFG.Expr pretty printer to show partial expressions.

### DIFF
--- a/crucible/src/Lang/Crucible/CFG/Expr.hs
+++ b/crucible/src/Lang/Crucible/CFG/Expr.hs
@@ -58,6 +58,7 @@ module Lang.Crucible.CFG.Expr
   , RoundingMode(..)
   ) where
 
+import           Control.Lens ((^.))
 import           Control.Monad.Identity
 import           Control.Monad.State.Strict
 import           Data.Kind (Type)
@@ -1284,10 +1285,10 @@ instance PrettyApp (ExprExtension ext) => PrettyApp (App ext) where
           , ( U.ConType [t|Vector|] `U.TypeApp` U.AnyType
             , [| \pp v -> brackets (commas (fmap pp v)) |]
             )
-          , ( U.ConType [t|PartialExpr|] `U.TypeApp` U.AnyType
+          , ( U.ConType [t|PartialExpr|] `U.TypeApp` U.DataArg 0
+                                         `U.TypeApp` U.DataArg 1
                                          `U.TypeApp` U.AnyType
-                                         `U.TypeApp` U.AnyType
-            , [| \_ _ -> text "<some assertion>" |]
+            , [| \pp pe -> text "partial" <> parens (pp (pe ^. value)) |]
             )
           ])
 


### PR DESCRIPTION
The predicate part is still omitted, however.

Fixes #337.

The previous behavior would print `WithAssertion` expressions as
```
$17 = withAssertion(BVRepr 64, <some assertion>)
```
while the new version prints them as
```
$17 = withAssertion(BVRepr 64, partial($16))
```
Other than the inclusion of the value expression, I don't have any strong preferences about the syntax. Further bike-shedding would be welcome.