### PR TITLE
Update CFG.Expr pretty printer to indicate omitted AssertionTree.

### DIFF
--- a/crucible/src/Lang/Crucible/CFG/Expr.hs
+++ b/crucible/src/Lang/Crucible/CFG/Expr.hs
@@ -1288,7 +1288,8 @@ instance PrettyApp (ExprExtension ext) => PrettyApp (App ext) where
           , ( U.ConType [t|PartialExpr|] `U.TypeApp` U.DataArg 0
                                          `U.TypeApp` U.DataArg 1
                                          `U.TypeApp` U.AnyType
-            , [| \pp pe -> text "partial" <> parens (pp (pe ^. value)) |]
+            , [| \pp pe -> text "partialExpr" <>
+                parens (commas [pp (pe ^. value), text "<some assertion>"]) |]
             )
           ])
 


### PR DESCRIPTION
Note: This PR is a continuation of #339, which was already merged and couldn't be reopened.