### PR TITLE
Add special case to `bvSelect` for truncating a WeightedSum of bitvectors

### DIFF
--- a/what4/src/What4/Expr/Builder.hs
+++ b/what4/src/What4/Expr/Builder.hs
@@ -162,7 +162,7 @@ import           Control.Lens hiding (asIndex, (:>), Empty)
 import           Control.Monad
 import           Control.Monad.IO.Class
 import           Control.Monad.ST
-import           Control.Monad.Trans.Writer.CPS (writer, runWriter)
+import           Control.Monad.Trans.Writer.Strict (writer, runWriter)
 import           Data.Bimap (Bimap)
 import qualified Data.Bimap as Bimap
 import qualified Data.Binary.IEEE754 as IEEE754

--- a/what4/src/What4/Expr/Builder.hs
+++ b/what4/src/What4/Expr/Builder.hs
@@ -4601,43 +4601,43 @@ instance IsExprBuilder (ExprBuilder t st fs) where
       bvSelect sb idx n x'
 
       -- select is entirely within the less-significant bits of a concat
-   | Just (BVConcat _w _a b) <- asApp x
-   , Just LeqProof <- testLeq (addNat idx n) (bvWidth b) = do
-     bvSelect sb idx n b
+    | Just (BVConcat _w _a b) <- asApp x
+    , Just LeqProof <- testLeq (addNat idx n) (bvWidth b) = do
+      bvSelect sb idx n b
 
       -- select is entirely within the more-significant bits of a concat
-   | Just (BVConcat _w a b) <- asApp x
-   , Just LeqProof <- testLeq (bvWidth b) idx
-   , Just LeqProof <- isPosNat idx
-   , let diff = subNat idx (bvWidth b)
-   , Just LeqProof <- testLeq (addNat diff n) (bvWidth a) = do
-     bvSelect sb (subNat idx (bvWidth b)) n a
+    | Just (BVConcat _w a b) <- asApp x
+    , Just LeqProof <- testLeq (bvWidth b) idx
+    , Just LeqProof <- isPosNat idx
+    , let diff = subNat idx (bvWidth b)
+    , Just LeqProof <- testLeq (addNat diff n) (bvWidth a) = do
+      bvSelect sb (subNat idx (bvWidth b)) n a
 
-   -- when the selected region overlaps a concat boundary we have:
-   --  select idx n (concat a b) =
-   --      concat (select 0 n1 a) (select idx n2 b)
-   --   where n1 + n2 = n and idx + n2 = width b
-   --
-   -- NB: this case must appear after the two above that check for selects
-   --     entirely within the first or second arguments of a concat, otherwise
-   --     some of the arithmetic checks below may fail
-   | Just (BVConcat _w a b) <- asApp x = do
-     Just LeqProof <- return $ testLeq idx (bvWidth b)
-     let n2 = subNat (bvWidth b) idx
-     Just LeqProof <- return $ testLeq n2 n
-     let n1 = subNat n n2
-     let z  = knownNat :: NatRepr 0
+    -- when the selected region overlaps a concat boundary we have:
+    --  select idx n (concat a b) =
+    --      concat (select 0 n1 a) (select idx n2 b)
+    --   where n1 + n2 = n and idx + n2 = width b
+    --
+    -- NB: this case must appear after the two above that check for selects
+    --     entirely within the first or second arguments of a concat, otherwise
+    --     some of the arithmetic checks below may fail
+    | Just (BVConcat _w a b) <- asApp x = do
+      Just LeqProof <- return $ testLeq idx (bvWidth b)
+      let n2 = subNat (bvWidth b) idx
+      Just LeqProof <- return $ testLeq n2 n
+      let n1 = subNat n n2
+      let z  = knownNat :: NatRepr 0
 
-     Just LeqProof <- return $ isPosNat n1
-     Just LeqProof <- return $ testLeq (addNat z n1) (bvWidth a)
-     a' <- bvSelect sb z   n1 a
+      Just LeqProof <- return $ isPosNat n1
+      Just LeqProof <- return $ testLeq (addNat z n1) (bvWidth a)
+      a' <- bvSelect sb z   n1 a
 
-     Just LeqProof <- return $ isPosNat n2
-     Just LeqProof <- return $ testLeq (addNat idx n2) (bvWidth b)
-     b' <- bvSelect sb idx n2 b
+      Just LeqProof <- return $ isPosNat n2
+      Just LeqProof <- return $ testLeq (addNat idx n2) (bvWidth b)
+      b' <- bvSelect sb idx n2 b
 
-     Just Refl <- return $ testEquality (addNat n1 n2) n
-     bvConcat sb a' b'
+      Just Refl <- return $ testEquality (addNat n1 n2) n
+      bvConcat sb a' b'
 
 {-  Avoid doing work that may lose sharing...
 

--- a/what4/src/What4/Expr/WeightedSum.hs
+++ b/what4/src/What4/Expr/WeightedSum.hs
@@ -40,6 +40,7 @@ module What4.Expr.WeightedSum
   , asAffineVar
   , isZero
   , traverseVars
+  , traverseCoeffs
   , add
   , addVar
   , addVars
@@ -236,6 +237,17 @@ traverseVars f w =
     Map.filter (not . SR.eq sr (SR.zero sr)) .
     Map.fromListWith (SR.add sr) <$>
       traverse (_1 (traverseWrap f)) (Map.toList (_sumMap w))
+
+-- | Traverse the coefficients in a weighted sum.
+traverseCoeffs :: forall m f sr.
+  (Applicative m, HashableF f) =>
+  (SR.Coefficient sr -> m (SR.Coefficient sr)) ->
+  WeightedSum f sr ->
+  m (WeightedSum f sr)
+traverseCoeffs f w = mkSum <$> traverse f (_sumMap w) <*> f (_sumOffset w)
+  where
+    sr = sumRepr w
+    mkSum m = unfilteredSum sr (Map.filter (not . SR.eq sr (SR.zero sr)) m)
 
 -- | Traverse the expressions in a product.
 traverseProdVars :: forall k j m sr.

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -43,7 +43,7 @@ library
     template-haskell,
     text,
     th-abstraction >=0.1 && <0.4,
-    transformers,
+    transformers >= 0.5.6.0,
     unordered-containers,
     utf8-string,
     vector,

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -43,7 +43,7 @@ library
     template-haskell,
     text,
     th-abstraction >=0.1 && <0.4,
-    transformers >= 0.5.6.0,
+    transformers,
     unordered-containers,
     utf8-string,
     vector,


### PR DESCRIPTION
Truncating a WeightedSum of bitvectors now truncates all the integer coefficients in the weighted sum, removing those that reduce to 0. This is useful for simplifying e.g. alignment constraints.

Fixes GaloisInc/saw-script#586.