### PR TITLE
have Solver.Yices respect the requested features

### DIFF
--- a/what4/src/What4/Solver/Yices.hs
+++ b/what4/src/What4/Solver/Yices.hs
@@ -436,7 +436,7 @@ newConnection stream ack reqFeatures timeout bindings = do
   let nlSolver = reqFeatures `hasProblemFeature` useNonlinearArithmetic
   let features | efSolver  = useLinearArithmetic
                | nlSolver  = useNonlinearArithmetic .|. useIntegerArithmetic
-               | otherwise = yicesDefaultFeatures
+               | otherwise = reqFeatures
   let nm | efSolver  = "Yices ef-solver"
          | nlSolver  = "Yices nl-solver"
          | otherwise = "Yices"
@@ -906,7 +906,7 @@ yicesSMT2Features
 
 yicesDefaultFeatures :: ProblemFeatures
 yicesDefaultFeatures
-    = useLinearArithmetic
+    = useIntegerArithmetic
   .|. useBitvectors
   .|. useStructs
 


### PR DESCRIPTION
add useIntegerArithmetic to the default features for Yices

Fixes #367.