### PR TITLE
Add a `quiet` mode to crux that suppresses informational output.

### DIFF
--- a/crux-llvm/crux-llvm.cabal
+++ b/crux-llvm/crux-llvm.cabal
@@ -97,6 +97,7 @@ test-suite crux-llvm-test
                 base             >= 4.7,
                 containers,
                 crucible,
+                crux,
                 crux-llvm,
                 deepseq,
                 directory,

--- a/crux-llvm/src/CruxLLVMMain.hs
+++ b/crux-llvm/src/CruxLLVMMain.hs
@@ -7,7 +7,7 @@
 {-# Language RecordWildCards #-}
 {-# Language ScopedTypeVariables #-}
 
-module CruxLLVMMain (main, mainWithOutputTo, registerFunctions) where
+module CruxLLVMMain (main, mainWithOutputTo, mainWithOutputConfig, registerFunctions) where
 
 import Data.String (fromString)
 import qualified Data.Map as Map
@@ -96,7 +96,7 @@ main :: IO ()
 main = mainWithOutputConfig defaultOutputConfig >>= exitWith
 
 mainWithOutputTo :: Handle -> IO ExitCode
-mainWithOutputTo h = mainWithOutputConfig (OutputConfig False h h)
+mainWithOutputTo h = mainWithOutputConfig (OutputConfig False h h False)
 
 mainWithOutputConfig :: OutputConfig -> IO ExitCode
 mainWithOutputConfig cfg =

--- a/crux-llvm/test-data/golden/float-cast.good
+++ b/crux-llvm/test-data/golden/float-cast.good
@@ -1,7 +1,5 @@
-[Crux] Simulating function "main"
 bvZext 32 (bvSelect 0 8 (floatToBinary cX@1:f))
 bvZext 32 (bvSelect 8 8 (floatToBinary cX@1:f))
 bvZext 32 (bvSelect 16 8 (floatToBinary cX@1:f))
 bvZext 32 (bvSelect 24 8 (floatToBinary cX@1:f))
-[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-llvm/test-data/golden/float-cast2.good
+++ b/crux-llvm/test-data/golden/float-cast2.good
@@ -1,4 +1,2 @@
-[Crux] Simulating function "main"
 bvZext 32 (ite (floatIsNaN cX@1:f) 0x0:[1] 0x1:[1])
-[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-llvm/test-data/golden/hello.good
+++ b/crux-llvm/test-data/golden/hello.good
@@ -1,4 +1,2 @@
-[Crux] Simulating function "main"
 Hello, world
-[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-llvm/test-data/golden/hello2.good
+++ b/crux-llvm/test-data/golden/hello2.good
@@ -1,4 +1,2 @@
-[Crux] Simulating function "main"
 Hello again, world
-[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-llvm/test-data/golden/printing.good
+++ b/crux-llvm/test-data/golden/printing.good
@@ -1,8 +1,6 @@
-[Crux] Simulating function "main"
 44
 4294967252
 2c
 2C
 --------------------------
-[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-llvm/test-data/golden/string.good
+++ b/crux-llvm/test-data/golden/string.good
@@ -1,8 +1,1 @@
-[Crux] Simulating function "main"
-[Crux] Goal status:
-[Crux]   Total: 2
-[Crux]   Proved: 2
-[Crux]   Disproved: 0
-[Crux]   Incomplete: 0
-[Crux]   Unknown: 0
 [Crux] Overall status: Valid.

--- a/crux-llvm/test-data/golden/string2.good
+++ b/crux-llvm/test-data/golden/string2.good
@@ -1,8 +1,1 @@
-[Crux] Simulating function "main"
-[Crux] Goal status:
-[Crux]   Total: 3
-[Crux]   Proved: 3
-[Crux]   Disproved: 0
-[Crux]   Incomplete: 0
-[Crux]   Unknown: 0
 [Crux] Overall status: Valid.

--- a/crux-llvm/test-data/golden/uint-cast.good
+++ b/crux-llvm/test-data/golden/uint-cast.good
@@ -1,7 +1,5 @@
-[Crux] Simulating function "main"
 bvZext 32 (bvSelect 0 8 cX@1:bv)
 bvZext 32 (bvSelect 8 8 cX@1:bv)
 bvZext 32 (bvSelect 16 8 cX@1:bv)
 bvZext 32 (bvSelect 24 8 cX@1:bv)
-[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-llvm/test-data/golden/vector-cmp.good
+++ b/crux-llvm/test-data/golden/vector-cmp.good
@@ -1,4 +1,3 @@
-[Crux] Simulating function "main"
 let -- internal
     v2 = floatFromBinary 0x40a00000:[32]
     -- internal
@@ -8,5 +7,4 @@ let -- internal
     -- internal
     v12 = bvZext 32 (bvAnd (ite (floatLe v2 v3) 0x1:[1] 0x0:[1]) v10)
  in bvOr 0x1:[32] (bvShl v12 0x1:[32])
-[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-llvm/test-data/golden/vector-gep.good
+++ b/crux-llvm/test-data/golden/vector-gep.good
@@ -1,3 +1,1 @@
-[Crux] Simulating function "main"
-[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-llvm/test-data/golden/vector-select.good
+++ b/crux-llvm/test-data/golden/vector-select.good
@@ -1,4 +1,2 @@
-[Crux] Simulating function "main"
 0x1:[32]
-[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-llvm/test/Test.hs
+++ b/crux-llvm/test/Test.hs
@@ -15,6 +15,7 @@ import System.Process ( readProcess )
 import Test.Tasty (defaultMain, testGroup, TestTree)
 import Test.Tasty.Golden (goldenVsFile, findByExtension)
 
+import qualified Crux.Log as C
 import qualified CruxLLVMMain as C
 
 main :: IO ()
@@ -46,7 +47,9 @@ goldenTests dir =
          [ goldenVsFile (takeBaseName cFile) goodFile outFile $
            withArgs ["--solver=z3",cFile] $
            withFile outFile WriteMode $ \h ->
-           void $ C.mainWithOutputTo h
+             let cfg = C.OutputConfig False h h True in -- Quiet mode, don't print colors
+             void $ C.mainWithOutputConfig cfg
+
          | cFile <- cFiles
          , notHidden cFile
          , let goodFile = replaceExtension cFile ".good"

--- a/crux/src/Crux/Config/Common.hs
+++ b/crux/src/Crux/Config/Common.hs
@@ -78,6 +78,9 @@ data CruxOptions = CruxOptions
   , floatMode                :: String
     -- ^ Tells the solver which representation to use for floating point values.
 
+  , quietMode                :: Bool
+    -- ^ If true, produce minimal output
+
   , proofGoalsFailFast       :: Bool
     -- ^ If true, stop attempting to prove goals as soon as one is disproved
   }
@@ -136,7 +139,6 @@ cruxOptions = Config
             section "make-executables" yesOrNoSpec True
             "Should we generate counter-example executables. (default: yes)"
 
-
           solver <-
             section "solver" stringSpec "yices"
             "Select solver to use. (default: \"yices\")"
@@ -155,12 +157,15 @@ cruxOptions = Config
              ++ " i.e. one of [real|ieee|uninterpreted|default].\n"
              ++ "Default representation is solver specific: [cvc4|yices]=>real, z3=>ieee.")
 
+          quietMode <-
+            section "quiet-mode" yesOrNoSpec False
+            "If true, produce minimal output"
+
           proofGoalsFailFast <-
             section "proof-goals-fail-fast" yesOrNoSpec False
             "If true, stop attempting to prove goals as soon as one of them is disproved"
 
           pure CruxOptions { .. }
-
 
 
   , cfgEnv = []
@@ -241,6 +246,10 @@ cruxOptions = Config
       , Option [] ["fail-fast"]
         "Stop attempting to prove goals as soon as one of them is disproved"
         $ NoArg $ \opts -> Right opts { proofGoalsFailFast = True }
+
+      , Option "q" ["quiet"]
+        "Quiet mode; produce minimal output"
+        $ NoArg $ \opts -> Right opts{ quietMode = True }
 
       , Option "f" ["floating-point"]
         ("Select floating point representation,"

--- a/crux/src/Crux/Goal.hs
+++ b/crux/src/Crux/Goal.hs
@@ -151,11 +151,13 @@ proveGoals opts ctxt (Just gs0) =
      goalNum <- newIORef (zero,zero,zero) -- total, proved, disproved
      nameMap <- newIORef Map.empty
      unless hasUnsatCores $
-      sayWarn "Crux" "Warning: skipping unsat cores because MC-SAT is enabled."
+       sayWarn "Crux" "Warning: skipping unsat cores because MC-SAT is enabled."
      res <- inNewFrame sp (go sp goalNum gs0 nameMap)
      return (Just res)
   where
-  (start,end) = prepStatus "Checking: " (countGoals gs0)
+  (start,end)
+    | view quiet ?outputConfig = (\_ -> return (), return ())
+    | otherwise = prepStatus "Checking: " (countGoals gs0)
 
   bindName nm p nameMap = modifyIORef nameMap (Map.insert nm p)
 


### PR DESCRIPTION
Applying the quiet mode to the crux-llvm test suite prevents it from
printing proof goal summaries, which should help address some problems
with test suite fragility.