### PR TITLE
Fix(?) online solver process termination

### DIFF
--- a/what4/src/What4/Protocol/Online.hs
+++ b/what4/src/What4/Protocol/Online.hs
@@ -47,7 +47,7 @@ import           System.Exit
 import           System.IO
 import qualified System.IO.Streams as Streams
 import           System.Process
-                   (ProcessHandle, interruptProcessGroupOf, waitForProcess)
+                   (ProcessHandle, terminateProcess, waitForProcess)
 import           Text.PrettyPrint.ANSI.Leijen hiding ((<$>), (<>))
 
 import           What4.Expr
@@ -109,7 +109,7 @@ data SolverProcess scope solver = SolverProcess
 --   or in some unrecoverable error state.
 killSolver :: SolverProcess t solver -> IO ()
 killSolver p =
-  do catch (interruptProcessGroupOf (solverHandle p)) (\(_ :: SomeException) -> return ())
+  do catch (terminateProcess (solverHandle p)) (\(_ :: SomeException) -> return ())
      void $ waitForProcess (solverHandle p)
 
 -- | Check if the given formula is satisfiable in the current
@@ -317,7 +317,7 @@ getSatResult yp = do
     Left (SomeException e) ->
        do txt <- readAllLines err_reader
           -- Interrupt process; suppress any exceptions that occur.
-          catch (interruptProcessGroupOf ph) (\(_ :: IOError) -> return ())
+          catch (terminateProcess ph) (\(_ :: IOError) -> return ())
           -- Wait for process to end
           ec <- waitForProcess ph
           let ec_code = case ec of


### PR DESCRIPTION
The `interruptProcessGroupOf` function from System.Process sends SIGINT, which
is the equivalent of Ctrl+C.  I'm not sure if Ctrl+C behavior is quite the right
notion we want to capture; I think SIGTERM (signal 15 on x86/Linux and most
other platforms) is the "soft kill" that is still handleable.

Selfishly, I want to make this change because yices (in native non-SMT mode) has
special handling for SIGINT that doesn't work when MCSAT is enabled.  yices-smt2
has the correct behavior.

Switching to SIGTERM (via `terminateProcess`) has the expected behavior on
yices, z3, and cvc4.

Note that this is not the uncatchable SIGKILL (usually signal 9).