### PR TITLE
what4: Replace DisjPred constructor with NandPred.

### DIFF
--- a/crucible-saw/src/Lang/Crucible/Backend/SAWCore.hs
+++ b/crucible-saw/src/Lang/Crucible/Backend/SAWCore.hs
@@ -867,13 +867,13 @@ evaluateExpr sym sc cache = f []
                   pol (x,BM.Negative) = SC.scNot sc =<< f env x
               in SAWExpr <$> join (foldM (SC.scAnd sc) <$> pol t <*> mapM pol ts)
 
-        B.DisjPred xs ->
+        B.NandPred xs ->
           case BM.viewBoolMap xs of
             BM.BoolMapUnit -> SAWExpr <$> SC.scBool sc False
             BM.BoolMapDualUnit -> SAWExpr <$> SC.scBool sc True
             BM.BoolMapTerms (t:|ts) ->
-              let pol (x,BM.Positive) = f env x
-                  pol (x,BM.Negative) = SC.scNot sc =<< f env x
+              let pol (x, BM.Negative) = f env x
+                  pol (x, BM.Positive) = SC.scNot sc =<< f env x
               in SAWExpr <$> join (foldM (SC.scOr sc) <$> pol t <*> mapM pol ts)
 
         B.SemiRingProd pd ->

--- a/what4-abc/src/What4/Solver/ABC.hs
+++ b/what4-abc/src/What4/Solver/ABC.hs
@@ -386,9 +386,9 @@ bitblastExpr h ae = do
         BM.BoolMapTerms (t:|ts) ->
           B <$> join (foldM (AIG.lAnd' g) <$> pol t <*> mapM pol ts)
 
-    DisjPred xs ->
-      let pol (x,BM.Positive) = eval' h x
-          pol (x,BM.Negative) = AIG.not <$> eval' h x
+    NandPred xs ->
+      let pol (x, BM.Negative) = eval' h x
+          pol (x, BM.Positive) = AIG.not <$> eval' h x
       in
       case BM.viewBoolMap xs of
         BM.BoolMapUnit -> return (B GIA.false)

--- a/what4-blt/src/What4/Solver/BLT.hs
+++ b/what4-blt/src/What4/Solver/BLT.hs
@@ -423,15 +423,6 @@ assume h (BoolExpr b l)
 assume h b@(AppExpr ba) =
   let a = appExprApp ba in
     case a of
-      NotPred (asApp -> Just (DisjPred xs)) ->
-        case BM.viewBoolMap xs of
-          BM.BoolMapUnit -> return ()
-          BM.BoolMapDualUnit ->
-               do when (isVerb h) $ warnAt l "problem assumes False"
-                  setUNSAT h
-          BM.BoolMapTerms (t:|ts) -> mapM_ f (t:ts)
-            where f (x,BM.Negative) = assume h x
-                  f (_,BM.Positive) = unsupported
       ConjPred xs ->
         case BM.viewBoolMap xs of
           BM.BoolMapUnit -> return ()

--- a/what4/src/What4/Expr/AppTheory.hs
+++ b/what4/src/What4/Expr/AppTheory.hs
@@ -72,7 +72,7 @@ appTheory a0 =
 
     NotPred{} -> BoolTheory
     ConjPred{} -> BoolTheory
-    DisjPred{} -> BoolTheory
+    NandPred{} -> BoolTheory
 
     RealIsInteger{} -> LinearArithTheory
 

--- a/what4/src/What4/Expr/GroundEval.hs
+++ b/what4/src/What4/Expr/GroundEval.hs
@@ -256,9 +256,9 @@ evalGroundApp f0 a0 = do
         BM.BoolMapTerms (t:|ts) ->
           foldl' (&&) <$> pol t <*> mapM pol ts
 
-    DisjPred xs ->
-      let pol (x,Positive) = f x
-          pol (x,Negative) = not <$> f x
+    NandPred xs ->
+      let pol (x, Negative) = f x
+          pol (x, Positive) = not <$> f x
       in
       case BM.viewBoolMap xs of
         BM.BoolMapUnit -> return False

--- a/what4/src/What4/Expr/VarIdentification.hs
+++ b/what4/src/What4/Expr/VarIdentification.hs
@@ -309,9 +309,9 @@ recurseAssertedAppExprVars scope p e = go e
      BM.BoolMapDualUnit -> return ()
      BM.BoolMapTerms (t:|ts) -> mapM_ pol (t:ts)
 
- go (asApp -> Just (DisjPred xs)) =
-   let pol (x,Positive) = recordAssertionVars scope p x
-       pol (x,Negative) = recordAssertionVars scope (negatePolarity p) x
+ go (asApp -> Just (NandPred xs)) =
+   let pol (x, Negative) = recordAssertionVars scope p x
+       pol (x, Positive) = recordAssertionVars scope (negatePolarity p) x
    in
    case BM.viewBoolMap xs of
      BM.BoolMapUnit -> return ()

--- a/what4/src/What4/Protocol/SMTWriter.hs
+++ b/what4/src/What4/Protocol/SMTWriter.hs
@@ -1943,9 +1943,9 @@ appSMTExpr ae = do
 
     NotPred x -> freshBoundTerm BoolTypeMap . notExpr =<< mkBaseExpr x
 
-    DisjPred xs ->
-      let pol (x,Positive) = mkBaseExpr x
-          pol (x,Negative) = notExpr <$> mkBaseExpr x
+    NandPred xs ->
+      let pol (x, Negative) = mkBaseExpr x
+          pol (x, Positive) = notExpr <$> mkBaseExpr x
       in
       case BM.viewBoolMap xs of
         BM.BoolMapUnit ->


### PR DESCRIPTION
A NandPred contains a BoolMap just like the DisjPred did, but with
the reversed polarity convention on the terms inside. This change
makes it possible to significantly simplify the definitions of the
andPred and orPred operations.