### PR TITLE
Remove DisjPred constructor

### DIFF
--- a/crucible-saw/src/Lang/Crucible/Backend/SAWCore.hs
+++ b/crucible-saw/src/Lang/Crucible/Backend/SAWCore.hs
@@ -871,7 +871,7 @@ evaluateExpr sym sc cache = f []
             BM.BoolMapDualUnit -> SAWExpr <$> SC.scBool sc False
             BM.BoolMapTerms (t:|ts) ->
               let pol (x,BM.Positive) = f env x
-                  pol (x,BM.Negative) = SC.scNot sc =<< f env x
+                  pol (x,BM.Negative) = termOfSAWExpr sym sc =<< goNeg env x
               in SAWExpr <$> join (foldM (SC.scAnd sc) <$> pol t <*> mapM pol ts)
 
         B.SemiRingProd pd ->

--- a/crucible-saw/src/Lang/Crucible/Backend/SAWCore.hs
+++ b/crucible-saw/src/Lang/Crucible/Backend/SAWCore.hs
@@ -867,15 +867,6 @@ evaluateExpr sym sc cache = f []
                   pol (x,BM.Negative) = SC.scNot sc =<< f env x
               in SAWExpr <$> join (foldM (SC.scAnd sc) <$> pol t <*> mapM pol ts)
 
-        B.DisjPred xs ->
-          case BM.viewBoolMap xs of
-            BM.BoolMapUnit -> SAWExpr <$> SC.scBool sc False
-            BM.BoolMapDualUnit -> SAWExpr <$> SC.scBool sc True
-            BM.BoolMapTerms (t:|ts) ->
-              let pol (x,BM.Positive) = f env x
-                  pol (x,BM.Negative) = SC.scNot sc =<< f env x
-              in SAWExpr <$> join (foldM (SC.scOr sc) <$> pol t <*> mapM pol ts)
-
         B.SemiRingProd pd ->
            case WSum.prodRepr pd of
              B.SemiRingRealRepr ->

--- a/crucible-syntax/test-data/simulator-tests/assume-merge2.out.good
+++ b/crucible-syntax/test-data/simulator-tests/assume-merge2.out.good
@@ -4,9 +4,9 @@
 ==== Proof obligations ====
 Assuming:
 * in main test-data/simulator-tests/assume-merge2.cbl:9:5: odd
-    or (intLe 0 cx@0:i) (eq 1 (intMod cx@0:i 2))
+    not (and (not (intLe 0 cx@0:i)) (not (eq 1 (intMod cx@0:i 2))))
 * in main test-data/simulator-tests/assume-merge2.cbl:6:5: even
-    or (not (intLe 0 cx@0:i)) (eq 0 (intMod cx@0:i 2))
+    not (and (intLe 0 cx@0:i) (not (eq 0 (intMod cx@0:i 2))))
 Prove:
   oopsie!
   in main at test-data/simulator-tests/assume-merge2.cbl:12:5

--- a/crucible-syntax/test-data/simulator-tests/bool-expr.out.good
+++ b/crucible-syntax/test-data/simulator-tests/bool-expr.out.good
@@ -4,7 +4,7 @@ and cx@0:b cy@1:b cz@2:b
 === (or q1 y) ===
 cy@1:b
 === (or q1 (or y z)) ===
-or cy@1:b cz@2:b
+not (and (not cy@1:b) (not cz@2:b))
 === (and q1 y) ===
 and cx@0:b cy@1:b cz@2:b
 === (and q1 (not y)) ===
@@ -12,14 +12,14 @@ false
 === (or (not q1) y) ===
 true
 === (or q1 (not y)) ===
-or (and cx@0:b cy@1:b cz@2:b) (not cy@1:b)
+not (and (not (and cx@0:b cy@1:b cz@2:b)) cy@1:b)
 ====== expect single n-ary connective
-not (or cx@0:b cy@1:b cz@2:b cw@3:b)
+and (not cx@0:b) (not cy@1:b) (not cz@2:b) (not cw@3:b)
 not (and cx@0:b cy@1:b cz@2:b cw@3:b)
-or (not cx@0:b) (not cy@1:b) cz@2:b cw@3:b
-or (not cx@0:b) (not cy@1:b) cz@2:b cw@3:b
+not (and cx@0:b cy@1:b (not cz@2:b) (not cw@3:b))
+not (and cx@0:b cy@1:b (not cz@2:b) (not cw@3:b))
 ====== expect absorption to (or z w)
-or cz@2:b cw@3:b
+not (and (not cz@2:b) (not cw@3:b))
 
 ==== Finish Simulation ====
 ==== No proof obligations ====

--- a/crucible-syntax/test-data/simulator-tests/override-test2.out.good
+++ b/crucible-syntax/test-data/simulator-tests/override-test2.out.good
@@ -16,11 +16,13 @@ Prove:
 COUNTEREXAMPLE
 Assuming:
 * The branch in symbolicBranchesTest from after branch 1 to third branch
-    or (eq 1 cx@0:i) (eq 2 cx@0:i) (eq 3 cx@0:i)
+    let -- default branch
+        v26 = and (not (eq 1 cx@0:i)) (not (eq 2 cx@0:i)) (not (eq 3 cx@0:i))
+     in not v26
 Prove:
   bogus!
   in main at test-data/simulator-tests/override-test2.cbl:6:5
   let -- default branch
-      v18 = intSum (intMul 2 cx@0:i) (ite (eq 2 cx@0:i) 0 cy@1:i)
-   in eq (ite (eq 1 cx@0:i) cy@1:i v18) cx@0:i
+      v19 = intSum (intMul 2 cx@0:i) (ite (eq 2 cx@0:i) 0 cy@1:i)
+   in eq (ite (eq 1 cx@0:i) cy@1:i v19) cx@0:i
 COUNTEREXAMPLE

--- a/what4-abc/src/What4/Solver/ABC.hs
+++ b/what4-abc/src/What4/Solver/ABC.hs
@@ -391,16 +391,6 @@ bitblastExpr h ae = do
         BM.BoolMapTerms (t:|ts) ->
           B <$> join (foldM (AIG.lAnd' g) <$> pol t <*> mapM pol ts)
 
-    DisjPred xs ->
-      let pol (x,BM.Positive) = eval' h x
-          pol (x,BM.Negative) = AIG.not <$> eval' h x
-      in
-      case BM.viewBoolMap xs of
-        BM.BoolMapUnit -> return (B GIA.false)
-        BM.BoolMapDualUnit -> return (B GIA.true)
-        BM.BoolMapTerms (t:|ts) ->
-          B <$> join (foldM (AIG.lOr' g) <$> pol t <*> mapM pol ts)
-
     SemiRingSum s ->
       case WSum.sumRepr s of
         SemiRingBVRepr BVArithRepr w -> BV <$> WSum.evalM (AIG.add g) smul cnst s

--- a/what4-blt/src/What4/Solver/BLT.hs
+++ b/what4-blt/src/What4/Solver/BLT.hs
@@ -425,15 +425,6 @@ assume h (BoolExpr b l)
 assume h b@(AppExpr ba) =
   let a = appExprApp ba in
     case a of
-      NotPred (asApp -> Just (DisjPred xs)) ->
-        case BM.viewBoolMap xs of
-          BM.BoolMapUnit -> return ()
-          BM.BoolMapDualUnit ->
-               do when (isVerb h) $ warnAt l "problem assumes False"
-                  setUNSAT h
-          BM.BoolMapTerms (t:|ts) -> mapM_ f (t:ts)
-            where f (x,BM.Negative) = assume h x
-                  f (_,BM.Positive) = unsupported
       ConjPred xs ->
         case BM.viewBoolMap xs of
           BM.BoolMapUnit -> return ()

--- a/what4/src/What4/Expr/AppTheory.hs
+++ b/what4/src/What4/Expr/AppTheory.hs
@@ -72,7 +72,6 @@ appTheory a0 =
 
     NotPred{} -> BoolTheory
     ConjPred{} -> BoolTheory
-    DisjPred{} -> BoolTheory
 
     RealIsInteger{} -> LinearArithTheory
 

--- a/what4/src/What4/Expr/GroundEval.hs
+++ b/what4/src/What4/Expr/GroundEval.hs
@@ -261,16 +261,6 @@ evalGroundApp f0 a0 = do
         BM.BoolMapTerms (t:|ts) ->
           foldl' (&&) <$> pol t <*> mapM pol ts
 
-    DisjPred xs ->
-      let pol (x,Positive) = f x
-          pol (x,Negative) = not <$> f x
-      in
-      case BM.viewBoolMap xs of
-        BM.BoolMapUnit -> return False
-        BM.BoolMapDualUnit -> return True
-        BM.BoolMapTerms (t:|ts) ->
-          foldl' (||) <$> pol t <*> mapM pol ts
-
     RealIsInteger x -> (\xv -> denominator xv == 1) <$> f x
     BVTestBit i x -> assert (i <= fromIntegral (maxBound :: Int)) $
         (`testBit` (fromIntegral i)) <$> f x

--- a/what4/src/What4/Expr/VarIdentification.hs
+++ b/what4/src/What4/Expr/VarIdentification.hs
@@ -314,15 +314,6 @@ recurseAssertedAppExprVars scope p e = go e
      BM.BoolMapDualUnit -> return ()
      BM.BoolMapTerms (t:|ts) -> mapM_ pol (t:ts)
 
- go (asApp -> Just (DisjPred xs)) =
-   let pol (x,Positive) = recordAssertionVars scope p x
-       pol (x,Negative) = recordAssertionVars scope (negatePolarity p) x
-   in
-   case BM.viewBoolMap xs of
-     BM.BoolMapUnit -> return ()
-     BM.BoolMapDualUnit -> return ()
-     BM.BoolMapTerms (t:|ts) -> mapM_ pol (t:ts)
-
  go (asApp -> Just (BaseIte BaseBoolRepr _ c x y)) =
    do recordExprVars scope c
       recordAssertionVars scope p x

--- a/what4/src/What4/Protocol/SMTWriter.hs
+++ b/what4/src/What4/Protocol/SMTWriter.hs
@@ -1948,21 +1948,6 @@ appSMTExpr ae = do
 
     NotPred x -> freshBoundTerm BoolTypeMap . notExpr =<< mkBaseExpr x
 
-    DisjPred xs ->
-      let pol (x,Positive) = mkBaseExpr x
-          pol (x,Negative) = notExpr <$> mkBaseExpr x
-      in
-      case BM.viewBoolMap xs of
-        BM.BoolMapUnit ->
-          return $ SMTExpr BoolTypeMap $ boolExpr False
-        BM.BoolMapDualUnit ->
-          return $ SMTExpr BoolTypeMap $ boolExpr True
-        BM.BoolMapTerms (t:|[]) ->
-          SMTExpr BoolTypeMap <$> pol t
-        BM.BoolMapTerms (t:|ts) ->
-          do cnj <- orAll <$> mapM pol (t:ts)
-             freshBoundTerm BoolTypeMap cnj
-
     ConjPred xs ->
       let pol (x,Positive) = mkBaseExpr x
           pol (x,Negative) = notExpr <$> mkBaseExpr x


### PR DESCRIPTION
We now represent disjunctions as negated conjunctions with opposite-polarity elements. This change makes it possible to significantly simplify the definitions of the `andPred` and `orPred` operations.