### PR TITLE
Export function `isAligned` from LLVM memory model.

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
@@ -136,6 +136,7 @@ module Lang.Crucible.LLVM.MemModel
   , doPtrSubtract
   , isValidPointer
   , muxLLVMPtr
+  , G.isAligned
 
     -- * Disjointness
   , assertDisjointRegions


### PR DESCRIPTION
This lets us assert that a pointer satisfies a given alignment constraint.