### PR TITLE
Implement “durable assertions”

### DIFF
--- a/crucible-saw/src/Lang/Crucible/Backend/SAWCore.hs
+++ b/crucible-saw/src/Lang/Crucible/Backend/SAWCore.hs
@@ -1253,7 +1253,10 @@ instance IsBoolSolver (SAWCoreBackend n solver fs) where
   addProofObligation sym a =
     case asConstantPred (a^.labeledPred) of
       Just True  -> return ()
-      _          -> AS.addProofObligation a =<< getAssumptionStack sym
+      _          -> addDurableProofObligation sym a
+
+  addDurableProofObligation sym a =
+     AS.addProofObligation a =<< getAssumptionStack sym
 
   addAssumption sym a = do
     case asConstantPred (a^.labeledPred) of

--- a/crucible-saw/src/Lang/Crucible/Backend/SAWCore.hs
+++ b/crucible-saw/src/Lang/Crucible/Backend/SAWCore.hs
@@ -1250,10 +1250,6 @@ getAssumptionStack sym =
   (assumptionStack . saw_online_state) <$> readIORef (B.sbStateManager sym)
 
 instance IsBoolSolver (SAWCoreBackend n solver fs) where
-  addProofObligation sym a =
-    case asConstantPred (a^.labeledPred) of
-      Just True  -> return ()
-      _          -> addDurableProofObligation sym a
 
   addDurableProofObligation sym a =
      AS.addProofObligation a =<< getAssumptionStack sym

--- a/crucible/src/Lang/Crucible/Backend.hs
+++ b/crucible/src/Lang/Crucible/Backend.hs
@@ -48,6 +48,7 @@ module Lang.Crucible.Backend
 
     -- * Utilities
   , addAssertion
+  , addDurableAssertion
   , addAssertionM
   , addFailedAssertion
   , assertIsInteger
@@ -208,6 +209,13 @@ class IsBoolSolver sym where
   -- See also 'addAssertion'.
   addProofObligation :: sym -> Assertion sym -> IO ()
 
+  -- | Add a new proof obligation to the system which will persist
+  -- throughout symbolic execution even if it is concretely valid.
+  -- The proof may use the current path condition and assumptions. Note
+  -- that this *DOES NOT* add the goal as an assumption. See also
+  -- 'addAssertion'.
+  addDurableProofObligation :: sym -> Assertion sym -> IO ()
+
   -- | Get the collection of proof obligations.
   getProofObligations :: sym -> IO (ProofObligations sym)
 
@@ -238,6 +246,16 @@ addAssertion sym a@(AS.LabeledPred p msg) =
   do addProofObligation sym a
      addAssumption sym (AS.LabeledPred p (AssumingNoError msg))
 
+-- | Add a durable proof obligation for the given predicate, and then
+-- assume it.
+-- Note that assuming the prediate might cause the current execution
+-- path to abort, if we happened to assume something that is obviously false.
+addDurableAssertion ::
+  (IsExprBuilder sym, IsBoolSolver sym) =>
+  sym -> Assertion sym -> IO ()
+addDurableAssertion sym a@(AS.LabeledPred p msg) =
+  do addDurableProofObligation sym a
+     addAssumption sym (AS.LabeledPred p (AssumingNoError msg))
 
 -- | Throw an exception, thus aborting the current execution path.
 abortExecBecause :: AbortExecReason -> IO a

--- a/crucible/src/Lang/Crucible/Backend.hs
+++ b/crucible/src/Lang/Crucible/Backend.hs
@@ -204,10 +204,18 @@ class IsBoolSolver sym where
   collectAssumptions :: sym -> IO (Seq (Assumption sym))
 
   -- | Add a new proof obligation to the system.
-  -- The proof may use the current path condition and assumptions.
-  -- Note that this *DOES NOT* add the goal as an assumption.
-  -- See also 'addAssertion'.
-  addProofObligation :: sym -> Assertion sym -> IO ()
+  -- The proof may use the current path condition and assumptions. Note
+  -- that this *DOES NOT* add the goal as an assumption. See also
+  -- 'addAssertion'. Also note that predicates that concretely evaluate
+  -- to True will be silently discarded. See 'addDurableProofObligation'
+  -- to avoid discarding goals.
+  addProofObligation ::
+    (IsExprBuilder sym) =>
+    sym -> Assertion sym -> IO ()
+  addProofObligation sym a =
+    case asConstantPred (a ^. AS.labeledPred) of
+      Just True -> return ()
+      _ -> addDurableProofObligation sym a
 
   -- | Add a new proof obligation to the system which will persist
   -- throughout symbolic execution even if it is concretely valid.

--- a/crucible/src/Lang/Crucible/Backend.hs
+++ b/crucible/src/Lang/Crucible/Backend.hs
@@ -213,7 +213,7 @@ class IsBoolSolver sym where
   -- throughout symbolic execution even if it is concretely valid.
   -- The proof may use the current path condition and assumptions. Note
   -- that this *DOES NOT* add the goal as an assumption. See also
-  -- 'addAssertion'.
+  -- 'addDurableAssertion'.
   addDurableProofObligation :: sym -> Assertion sym -> IO ()
 
   -- | Get the collection of proof obligations.

--- a/crucible/src/Lang/Crucible/Backend/Online.hs
+++ b/crucible/src/Lang/Crucible/Backend/Online.hs
@@ -438,7 +438,10 @@ instance OnlineSolver scope solver => IsBoolSolver (OnlineBackend scope solver f
   addProofObligation sym a =
     case asConstantPred (a^.labeledPred) of
       Just True -> return ()
-      _ -> AS.addProofObligation a =<< getAssumptionStack sym
+      _ -> addDurableProofObligation sym a
+
+  addDurableProofObligation sym a =
+     AS.addProofObligation a =<< getAssumptionStack sym
 
   addAssumption sym a =
     let cond = asConstantPred (a^.labeledPred)

--- a/crucible/src/Lang/Crucible/Backend/Online.hs
+++ b/crucible/src/Lang/Crucible/Backend/Online.hs
@@ -435,10 +435,6 @@ withOnlineBackend floatMode gen feats action = do
 
 
 instance OnlineSolver scope solver => IsBoolSolver (OnlineBackend scope solver fs) where
-  addProofObligation sym a =
-    case asConstantPred (a^.labeledPred) of
-      Just True -> return ()
-      _ -> addDurableProofObligation sym a
 
   addDurableProofObligation sym a =
      AS.addProofObligation a =<< getAssumptionStack sym

--- a/crucible/src/Lang/Crucible/Backend/Simple.hs
+++ b/crucible/src/Lang/Crucible/Backend/Simple.hs
@@ -72,11 +72,6 @@ getAssumptionStack sym = sbAssumptionStack <$> readIORef (B.sbStateManager sym)
 
 instance IsBoolSolver (SimpleBackend t fs) where
 
-  addProofObligation sym a =
-    case asConstantPred (a^.labeledPred) of
-      Just True -> return ()    -- no trivialities
-      _         -> addDurableProofObligation sym a
-
   addDurableProofObligation sym a =
      AS.addProofObligation a =<< getAssumptionStack sym
 

--- a/crucible/src/Lang/Crucible/Backend/Simple.hs
+++ b/crucible/src/Lang/Crucible/Backend/Simple.hs
@@ -75,7 +75,10 @@ instance IsBoolSolver (SimpleBackend t fs) where
   addProofObligation sym a =
     case asConstantPred (a^.labeledPred) of
       Just True -> return ()    -- no trivialities
-      _         -> AS.addProofObligation a =<< getAssumptionStack sym
+      _         -> addDurableProofObligation sym a
+
+  addDurableProofObligation sym a =
+     AS.addProofObligation a =<< getAssumptionStack sym
 
   addAssumption sym a =
     case asConstantPred (a^.labeledPred) of

--- a/crux-llvm/README.md
+++ b/crux-llvm/README.md
@@ -3,8 +3,7 @@
 The `crux-llvm` tool (and corresponding C library) are intended for
 verifying C programs containing inline specifications (in the form of
 function calls to create non-deterministic values and assert
-properties). The API defined by SV-COMP is supported, as is an
-alternative, slightly more flexible API.
+properties).
 
 # Prerequisites
 
@@ -130,6 +129,13 @@ following alternative API is available.
 * The `__VERIFIER_nondet_*` functions create non-deterministic values of
   the corresponding type. These symbolic values all have the name `x`.
   To supply distinct names, use the `crucible_*_t` functions, instead.
+
+Note that support for the SV-COMP API exists primarily for backward
+compatibility, since a large number of benchmarks already exist in that
+form. The `crucible.h` API allows for better explanations by a) allowing
+user-specified names for non-deterministic variables, and b) ensuring
+that the conditions used in assertions are directly available and not
+obscured by a conditional wrapper around an error function.
 
 # Standard C and C++ Libraries
 

--- a/crux-llvm/src/Crux/LLVM/Overrides.hs
+++ b/crux-llvm/src/Crux/LLVM/Overrides.hs
@@ -47,8 +47,8 @@ import Lang.Crucible.Simulator.OverrideSim
         )
 import Lang.Crucible.Simulator.SimError (SimErrorReason(..),SimError(..))
 import Lang.Crucible.Backend
-          ( IsSymInterface, addFailedAssertion, addDurableAssertion
-          , addAssumption , LabeledPred(..), AssumptionReason(..))
+          ( IsSymInterface, addDurableAssertion, addFailedAssertion
+          , addAssumption, LabeledPred(..), AssumptionReason(..))
 import Lang.Crucible.LLVM.QQ( llvmOvr )
 import Lang.Crucible.LLVM.DataLayout
   (noAlignment)

--- a/crux-llvm/src/Crux/LLVM/Overrides.hs
+++ b/crux-llvm/src/Crux/LLVM/Overrides.hs
@@ -47,8 +47,8 @@ import Lang.Crucible.Simulator.OverrideSim
         )
 import Lang.Crucible.Simulator.SimError (SimErrorReason(..),SimError(..))
 import Lang.Crucible.Backend
-          (IsSymInterface,addAssertion, addFailedAssertion
-          , addAssumption, LabeledPred(..), AssumptionReason(..))
+          ( IsSymInterface, addFailedAssertion, addDurableAssertion
+          , addAssumption , LabeledPred(..), AssumptionReason(..))
 import Lang.Crucible.LLVM.QQ( llvmOvr )
 import Lang.Crucible.LLVM.DataLayout
   (noAlignment)
@@ -438,7 +438,7 @@ do_assert mvar sym (Empty :> p :> pFile :> line) =
      loc <- liftIO $ getCurrentProgramLoc sym
      let loc' = loc{ plSourceLoc = pos }
      let msg = GenericSimError "crucible_assert"
-     liftIO $ addAssertion sym (LabeledPred cond (SimError loc' msg))
+     liftIO $ addDurableAssertion sym (LabeledPred cond (SimError loc' msg))
 
 do_print_uint32 ::
   (ArchOk arch, IsSymInterface sym) =>
@@ -487,7 +487,7 @@ cprover_assert mvar sym (Empty :> p :> pMsg) =
      str <- lookupString mvar pMsg
      loc <- liftIO $ getCurrentProgramLoc sym
      let msg = AssertFailureSimError "__CPROVER_assert" str
-     liftIO $ addAssertion sym (LabeledPred cond (SimError loc msg))
+     liftIO $ addDurableAssertion sym (LabeledPred cond (SimError loc msg))
 
 sv_comp_assume ::
   (ArchOk arch, IsSymInterface sym) =>
@@ -511,7 +511,7 @@ sv_comp_assert _mvar sym (Empty :> p) = liftIO $
   do cond <- bvIsNonzero sym (regValue p)
      loc  <- getCurrentProgramLoc sym
      let msg = AssertFailureSimError "__VERIFIER_assert" ""
-     addAssertion sym (LabeledPred cond (SimError loc msg))
+     addDurableAssertion sym (LabeledPred cond (SimError loc msg))
 
 sv_comp_error ::
   (ArchOk arch, IsSymInterface sym) =>

--- a/crux-llvm/test/Test.hs
+++ b/crux-llvm/test/Test.hs
@@ -6,7 +6,8 @@ import Control.Monad (void)
 
 import GHC.IO.Handle (hDuplicate, hDuplicateTo, hSetBuffering, Handle, BufferMode(..))
 
-import Data.List ( isPrefixOf )
+import Data.Char ( isLetter )
+import Data.List ( isInfixOf )
 import System.Environment ( withArgs, lookupEnv )
 import System.FilePath (takeBaseName, replaceExtension)
 import System.IO --(IOMode(..), hFlush, withFile, stdout, stderr)
@@ -28,8 +29,9 @@ main = do
   clangBin <- lookupEnv "CLANG" >>= \case
     Just x -> return x
     Nothing -> return "clang"
-  let isVerLine = isPrefixOf "clang version"
-      getVer = head . drop 2 . words . head . filter isVerLine . lines
+  let isVerLine = isInfixOf "clang version"
+      dropLetter = dropWhile (all isLetter)
+      getVer = head . dropLetter . words . head . filter isVerLine . lines
   ver <- getVer <$> readProcess clangBin [ "--version" ] ""
 
   defaultMain =<< suite ver


### PR DESCRIPTION
These will not be simplified away and will always show up in the final list of goals to prove. This commit modifies the overrides for the various assertion functions supported by `crux-llvm` to use durable assertions, so that users will always see a goal in the result for each assertion they explicitly specify in the input source code.