### PR TITLE
Add function to check validity and alignment of LLVM pointers

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Generic.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Generic.hs
@@ -1764,9 +1764,18 @@ ppMerge vpp c x y =
   where ppAllocList [] = (<+> text "<none>")
         ppAllocList xs = (<$$> indent 2 (vcat $ map vpp xs))
 
+ppAlignment :: Alignment -> Doc
+ppAlignment a =
+  text $ show (fromAlignment a) ++ "-byte-aligned"
+
 ppAlloc :: IsExprBuilder sym => MemAlloc sym -> Doc
-ppAlloc (Alloc atp base sz mut _alignment loc) =
-  text (show atp) <+> text (show base) <+> (pretty $ printSymExpr <$> sz) <+> text (show mut) <+> text loc
+ppAlloc (Alloc atp base sz mut alignment loc) =
+  text (show atp)
+  <+> text (show base)
+  <+> (pretty $ printSymExpr <$> sz)
+  <+> text (show mut)
+  <+> ppAlignment alignment
+  <+> text loc
 ppAlloc (MemFree base) =
   text "Free" <+> printSymExpr base
 ppAlloc (AllocMerge c x y) = do


### PR DESCRIPTION
New function `isAllocatedAlignedPointer` is used to to check that an LLVM pointer is valid, points to an allocated region of sufficient size and mutability, and that the pointer meets the required minimum alignment.