### PR TITLE
Tr/crux separate online solver

### DIFF
--- a/crux/crux.cabal
+++ b/crux/crux.cabal
@@ -55,7 +55,8 @@ library
     Crux.Config,
     Crux.Config.Load,
     Crux.Config.Doc,
-    Crux.Config.Common
+    Crux.Config.Common,
+    Crux.Config.Solver,
     Crux.Extension,
     Crux.Version
 

--- a/crux/src/Crux.hs
+++ b/crux/src/Crux.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE NoMonoLocalBinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# Language RankNTypes, ImplicitParams, TypeApplications, MultiWayIf #-}
 {-# Language OverloadedStrings, FlexibleContexts, ScopedTypeVariables #-}
 module Crux
@@ -11,33 +14,42 @@ module Crux
   ) where
 
 import Control.Lens
+import Control.Monad ( unless )
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Foldable
 import Data.IORef
 import Data.List(intercalate)
+import Data.Maybe ( fromMaybe )
+import Data.Proxy ( Proxy(..) )
 import qualified Data.Sequence as Seq
+import qualified Data.Text as T
 import Control.Exception(catch, displayException)
 import Control.Monad(when)
 import System.Exit(exitSuccess, ExitCode(..))
 import System.Directory(createDirectoryIfMissing)
 import System.FilePath((</>))
 
-import Data.Parameterized.Nonce(withIONonceGenerator, NonceGenerator)
+import Data.Parameterized.Classes
+import Data.Parameterized.Nonce(newIONonceGenerator, NonceGenerator)
+import Data.Parameterized.Some ( Some(..) )
 
 import Lang.Crucible.Backend
 import Lang.Crucible.Backend.Online
+import qualified Lang.Crucible.Backend.Simple as CBS
 import Lang.Crucible.Simulator
 import Lang.Crucible.Simulator.BoundedExec
 import Lang.Crucible.Simulator.BoundedRecursion
 import Lang.Crucible.Simulator.Profiling
 import Lang.Crucible.Simulator.PathSatisfiability
 
-import What4.Config (Opt, ConfigOption, setOpt, getOptionSetting, verbosity)
+import What4.Config (Opt, ConfigOption, setOpt, getOptionSetting, verbosity, extendConfig)
 import What4.InterpretedFloatingPoint (IsInterpretedFloatExprBuilder)
 import What4.Interface (IsExprBuilder, getConfiguration)
+import qualified What4.Expr.Builder as WEB
 import What4.FunctionName (FunctionName)
 import What4.Protocol.Online (OnlineSolver)
+import qualified What4.Solver as WS
 import What4.Solver.CVC4 (cvc4Timeout)
 import What4.Solver.Z3 (z3Timeout)
 import What4.Solver.Yices (yicesEnableMCSat, yicesGoalTimeout)
@@ -49,6 +61,7 @@ import Crux.Goal
 import Crux.Model
 import Crux.Report
 import qualified Crux.Config.Load as Cfg
+import qualified Crux.Config.Solver as CCS
 import Crux.Config.Common
 import Crux.Config.Doc
 import Crux.Extension
@@ -117,53 +130,97 @@ showVersion l = outputLn ("crux version: " ++ Crux.version ++ ", " ++
 
 --------------------------------------------------------------------------------
 
+-- | For a given configuration, compute the 'FloatModeRepr'
+--
+-- Note that this needs to be CPS-ed because of the type parameter to the float
+-- mode.  Also note that we can't use this function in
+-- 'withSelectedOnlineBackend', unfortunately, because that function requires a
+-- 'IsInterpretedFloatExprBuilder' constraint that we don't seem to have a way
+-- to capture in this CPS-ed style.
+withFloatRepr :: (CCS.HasDefaultFloatRepr solver)
+              => proxy s
+              -> CruxOptions
+              -> solver
+              -> (forall fm . (IsInterpretedFloatExprBuilder (WEB.ExprBuilder s CBS.SimpleBackendState (Flags fm))) => FloatModeRepr fm -> IO a)
+              -> IO a
+withFloatRepr proxy cruxOpts selectedSolver k =
+  case floatMode cruxOpts of
+    "real" -> k FloatRealRepr
+    "ieee" -> k FloatIEEERepr
+    "uninterpreted" -> k FloatUninterpretedRepr
+    "default" -> CCS.withDefaultFloatRepr proxy selectedSolver k
+    fm -> fail ("Unknown floating point mode: " ++ fm ++ "; expected one of [real|ieee|uninterpreted|default]")
 
--- Run a computation in the context of a given online solver
--- with a particular floating-point interpretation mode.
-withBackend ::
+floatReprString :: FloatModeRepr fm -> String
+floatReprString floatRepr =
+  case floatRepr of
+    FloatRealRepr -> "real"
+    FloatIEEERepr -> "ieee"
+    FloatUninterpretedRepr -> "uninterpreted"
+
+-- | Parse through the options structure to determine which online backend to
+-- instantiate (including the chosen floating point mode).
+--
+-- The choice of solver is provided as a separate argument (the
+-- 'CCS.SolverOnline').  This function dispatches primarily on floating point
+-- mode.  An explicit floating point mode can be provided if it has to match
+-- another solver that has already started.  This code is slightly complicated
+-- and duplicated because it is very hard to quantify over 'FloatModeRepr's in
+-- such a way that captures the necessary 'IsInterpretedFloatExprBuilder'
+-- constraints.
+withSelectedOnlineBackend ::
+  (?outputConfig :: OutputConfig) =>
   CruxOptions ->
   NonceGenerator IO scope ->
-  (forall solver fs.
+  CCS.SolverOnline ->
+  Maybe String ->
+  -- ^ An optional explicitly-requested float mode that supersedes the choice in
+  -- the configuration (probably due to using two different online connections)
+  (forall solver fm .
     ( OnlineSolver scope solver
-    , IsInterpretedFloatExprBuilder (OnlineBackend scope solver fs)
+    , IsInterpretedFloatExprBuilder (OnlineBackend scope solver (Flags fm))
     ) =>
-    OnlineBackend scope solver fs -> IO a) -> IO a
-withBackend cruxOpts nonceGen f =
-  case floatMode cruxOpts of
-    "real" -> withSolver FloatRealRepr (solver cruxOpts)
-    "ieee" -> withSolver FloatIEEERepr (solver cruxOpts)
-    "uninterpreted" -> withSolver FloatUninterpretedRepr (solver cruxOpts)
+    FloatModeRepr fm -> OnlineBackend scope solver (Flags fm) -> IO a) -> IO a
+withSelectedOnlineBackend cruxOpts nonceGen selectedSolver maybeExplicitFloatMode k =
+  case fromMaybe (floatMode cruxOpts) maybeExplicitFloatMode of
+    "real" -> withOnlineBackendFM FloatRealRepr
+    "ieee" -> withOnlineBackendFM FloatIEEERepr
+    "uninterpreted" -> withOnlineBackendFM FloatUninterpretedRepr
     "default" ->
-      case (solver cruxOpts) of
-        s@"cvc4" -> withSolver FloatRealRepr s
-        s@"yices" -> withSolver FloatRealRepr s
-        s@"z3" -> withSolver FloatIEEERepr s
-        s -> fail $ "unknown solver: " ++ s ++ "; expepected of one [cvc4|yices|z3]."
-    fm -> fail $ "unknown floating-point mode: " ++ fm ++ "; expepected of one [real|ieee|uninterpreted|default]."
+      case selectedSolver of
+        CCS.Yices -> withOnlineBackendFM FloatRealRepr
+        CCS.CVC4 -> withOnlineBackendFM FloatRealRepr
+        CCS.STP -> withOnlineBackendFM FloatRealRepr
+        CCS.Z3 -> withOnlineBackendFM FloatIEEERepr
+    fm -> fail ("Unknown floating point mode: " ++ fm ++ "; expected one of [real|ieee|uninterpreted|default]")
   where
-  unsatCores | yicesMCSat cruxOpts = NoUnsatFeatures
-             | otherwise           = ProduceUnsatCores
-  withSolver fpMode "cvc4" =
-    withCVC4OnlineBackend fpMode nonceGen ProduceUnsatCores $ \sym->
-      do case goalTimeout cruxOpts of
-           Just s -> symCfg sym cvc4Timeout (floor (s * 1000))
-           Nothing -> return ()
-         f sym
-  withSolver fpMode "yices" =
-    withYicesOnlineBackend fpMode nonceGen unsatCores $ \sym ->
-      do symCfg sym yicesEnableMCSat (yicesMCSat cruxOpts)
-         case goalTimeout cruxOpts of
-           Just s -> symCfg sym yicesGoalTimeout (floor s)
-           Nothing -> return ()
-         f sym
-  withSolver fpMode "z3" =
-    withZ3OnlineBackend fpMode nonceGen ProduceUnsatCores $ \sym->
-      do case goalTimeout cruxOpts of
-           Just s -> symCfg sym z3Timeout (floor (s * 1000))
-           Nothing -> return ()
-         f sym
-  withSolver _fpMode other =
-    fail $ "unknown solver: " ++ other ++ "; expepected of one [cvc4|yices|z3]."
+    unsatCores | yicesMCSat cruxOpts = NoUnsatFeatures
+               | otherwise           = ProduceUnsatCores
+
+    withOnlineBackendFM floatRepr =
+      case selectedSolver of
+        CCS.Yices -> withYicesOnlineBackend floatRepr nonceGen unsatCores $ \sym -> do
+          symCfg sym yicesEnableMCSat (yicesMCSat cruxOpts)
+          case goalTimeout cruxOpts of
+            Just s -> symCfg sym yicesGoalTimeout (floor s)
+            Nothing -> return ()
+          k floatRepr sym
+        CCS.CVC4 -> withCVC4OnlineBackend floatRepr nonceGen ProduceUnsatCores $ \sym -> do
+          case goalTimeout cruxOpts of
+            Just s -> symCfg sym cvc4Timeout (floor (s * 1000))
+            Nothing -> return ()
+          k floatRepr sym
+        CCS.Z3 -> withZ3OnlineBackend floatRepr nonceGen ProduceUnsatCores $ \sym -> do
+          case goalTimeout cruxOpts of
+            Just s -> symCfg sym z3Timeout (floor (s * 1000))
+            Nothing -> return ()
+          k floatRepr sym
+        CCS.STP -> do
+          -- We don't have a timeout option for STP
+          case goalTimeout cruxOpts of
+            Just _ -> sayWarn "Crux" "Goal timeout requested but not supported by STP"
+            Nothing -> return ()
+          withSTPOnlineBackend floatRepr nonceGen (k floatRepr)
 
 symCfg :: (IsExprBuilder sym, Opt t a) => sym -> ConfigOption t -> a -> IO ()
 symCfg sym x y =
@@ -233,83 +290,188 @@ data ProgramCompleteness
  | ProgramIncomplete
  deriving (Eq,Ord,Show)
 
-runSimulator ::
-  Logs =>
-  Language opts ->
-  Options opts  ->
-  IO (ProgramCompleteness, Seq.Seq (ProvedGoals (Either AssumptionReason SimError)))
-runSimulator lang opts@(cruxOpts,_) =
-  withIONonceGenerator $ \nonceGen ->
-  withBackend cruxOpts nonceGen $ \sym ->
+-- | Common setup for all solver connections
+setupSolver :: (IsExprBuilder sym) => CruxOptions -> Maybe FilePath -> sym -> IO ()
+setupSolver cruxOpts mInteractionFile sym = do
+  mapM_ (symCfg sym solverInteractionFile) (fmap T.pack mInteractionFile)
 
-  do -- The simulator verbosity is one less than our verbosity.
-     -- In this way, we can say things, without the simulator also
-     -- being verbose
-     symCfg sym verbosity $ toInteger $ if simVerbose cruxOpts > 1
-                                          then simVerbose cruxOpts - 1
-                                          else 0
+  -- The simulator verbosity is one less than our verbosity.
+  -- In this way, we can say things, without the simulator also
+  -- being verbose
+  symCfg sym verbosity $ toInteger $ if simVerbose cruxOpts > 1
+                                       then simVerbose cruxOpts - 1
+                                       else 0
 
-     -- XXX: add an option for this
-     symCfg sym solverInteractionFile "crux-solver.out"
+-- | A GADT to capture the online solver constraints when we need them
+data SomeOnlineSolver sym where
+  SomeOnlineSolver :: (sym ~ OnlineBackend scope solver fs
+                      , OnlineSolver scope solver
+                      ) => SomeOnlineSolver sym
 
-     frm <- pushAssumptionFrame sym
+-- | Common code for initializing all of the requested execution features
+--
+-- This function is a bit funny because one feature, path satisfiability
+-- checking, requires on online solver while the others do not.  In order to
+-- maximally reuse code, we pass in the necessary online constraints as an extra
+-- argument when we have them available (i.e., when we build an online solver)
+-- and elide them otherwise.
+setupExecutionFeatures :: (IsSymInterface sym)
+                       => CruxOptions
+                       -> sym
+                       -> Maybe (SomeOnlineSolver sym)
+                       -> IO
+                       ([GenericExecutionFeature sym], ProfData sym)
+setupExecutionFeatures cruxOpts sym maybeOnline = do
+  -- Setup profiling
+  let profiling = isProfiling cruxOpts
+  profInfo <- if profiling then setupProfiling sym cruxOpts
+                           else pure noProfiling
 
-     createDirectoryIfMissing True (outDir cruxOpts)
+  -- Global timeout
+  tfs <- execFeatureMaybe (globalTimeout cruxOpts) timeoutFeature
 
-     compRef <- newIORef ProgramComplete
+  -- Loop bound
+  bfs <- execFeatureMaybe (loopBound cruxOpts) $ \i ->
+          boundedExecFeature (\_ -> return (Just i)) True {- side cond: yes -}
 
-     -- Setup profiling
-     let profiling = profileCrucibleFunctions cruxOpts || profileSolver cruxOpts
-     profInfo <- if profiling then setupProfiling sym cruxOpts
-                              else pure noProfiling
+  -- Recursion bound
+  rfs <- execFeatureMaybe (recursionBound cruxOpts) $ \i ->
+          boundedRecursionFeature (\_ -> return (Just i)) True {- side cond: yes -}
 
-     -- Global timeout
-     tfs <- execFeatureMaybe (globalTimeout cruxOpts) timeoutFeature
+  -- Check path satisfiability
+  psat_fs <- case maybeOnline of
+    Just SomeOnlineSolver -> execFeatureIf (checkPathSat cruxOpts)
+           $ pathSatisfiabilityFeature sym (considerSatisfiability sym)
+    Nothing -> return []
 
-     -- Loop bound
-     bfs <- execFeatureMaybe (loopBound cruxOpts) $ \i ->
-             boundedExecFeature (\_ -> return (Just i)) True {- side cond: yes -}
+  return (concat [tfs, profExecFeatures profInfo, bfs, rfs, psat_fs], profInfo)
 
-     -- Recursion bound
-     rfs <- execFeatureMaybe (recursionBound cruxOpts) $ \i ->
-             boundedRecursionFeature (\_ -> return (Just i)) True {- side cond: yes -}
+-- | Select the What4 solver adapter for the user's solver choice (used for
+-- offline solvers)
+withSolverAdapter :: CCS.SolverOffline -> (WS.SolverAdapter st -> a) -> a
+withSolverAdapter solverOff k =
+  case solverOff of
+    CCS.Boolector -> k WS.boolectorAdapter
+    CCS.DReal -> k WS.drealAdapter
+    CCS.SolverOnline CCS.CVC4 -> k WS.cvc4Adapter
+    CCS.SolverOnline CCS.STP -> k WS.stpAdapter
+    CCS.SolverOnline CCS.Yices -> k WS.yicesAdapter
+    CCS.SolverOnline CCS.Z3 -> k WS.z3Adapter
 
-     -- Check path satisfiability
-     psat_fs <- execFeatureIf (checkPathSat cruxOpts)
-              $ pathSatisfiabilityFeature sym (considerSatisfiability sym)
+-- | Parse through all of the user-provided options and start up the verification process
+--
+-- This figures out which solvers need to be run, and in which modes.  It takes
+-- as arguments some of the results of common setup code.  It also tries to
+-- minimize code duplication between the different verification paths (e.g.,
+-- online vs offline solving).
+runSimulator :: forall opts
+              . (Logs)
+             => Language opts
+             -> Options opts
+             -> IO (ProgramCompleteness, Seq.Seq (ProvedGoals (Either AssumptionReason SimError)))
+runSimulator lang opts@(cruxOpts, _) = do
+  createDirectoryIfMissing True (outDir cruxOpts)
+  compRef <- newIORef ProgramComplete
+  glsRef <- newIORef Seq.empty
+  Some (nonceGen :: NonceGenerator IO s) <- newIONonceGenerator
+  case CCS.parseSolverConfig cruxOpts of
+    Right (CCS.SingleOnlineSolver onSolver) ->
+      withSelectedOnlineBackend cruxOpts nonceGen onSolver Nothing $ \_ sym -> do
+        setupSolver cruxOpts (onlineSolverOutput cruxOpts) sym
+        (execFeatures, profInfo) <- setupExecutionFeatures cruxOpts sym (Just SomeOnlineSolver)
+        doSimWithResults lang opts compRef glsRef sym execFeatures profInfo (proveGoalsOnline sym)
+    Right (CCS.OnlineSolverWithOfflineGoals onSolver offSolver) ->
+      withSelectedOnlineBackend cruxOpts nonceGen onSolver Nothing $ \_ sym -> do
+        setupSolver cruxOpts (pathSatSolverOutput cruxOpts) sym
+        (execFeatures, profInfo) <- setupExecutionFeatures cruxOpts sym (Just SomeOnlineSolver)
+        withSolverAdapter offSolver $ \adapter -> do
+          -- We have to add the configuration options from the solver adapter,
+          -- since they weren't included in the symbolic backend configuration
+          -- with the initial setup of the online solver (since it could have
+          -- been a different solver)
+          unless (CCS.sameSolver onSolver offSolver) $ do
+            -- In this case we don't add the extra configuration options because
+            -- the online solver setup already added them.  What4 raises an
+            -- error if the same option is added more than once.
+            extendConfig (WS.solver_adapter_config_options adapter) (getConfiguration sym)
+          doSimWithResults lang opts compRef glsRef sym execFeatures profInfo (proveGoalsOffline adapter)
+    Right (CCS.OnlyOfflineSolver offSolver) -> do
+      withFloatRepr (Proxy @s) cruxOpts offSolver $ \floatRepr -> do
+        withSolverAdapter offSolver $ \adapter -> do
+          sym <- CBS.newSimpleBackend floatRepr nonceGen
+          setupSolver cruxOpts Nothing sym
+          -- Since we have a bare SimpleBackend here, we have to initialize it
+          -- with the options taken from the solver adapter (e.g., solver path)
+          extendConfig (WS.solver_adapter_config_options adapter) (getConfiguration sym)
+          (execFeatures, profInfo) <- setupExecutionFeatures cruxOpts sym Nothing
+          doSimWithResults lang opts compRef glsRef sym execFeatures profInfo (proveGoalsOffline adapter)
+    Right (CCS.OnlineSolverWithSeparateOnlineGoals pathSolver goalSolver) -> do
+      -- This case is probably the most complicated because it needs two
+      -- separate online solvers.  The two must agree on the floating point
+      -- mode.
+      withSelectedOnlineBackend cruxOpts nonceGen pathSolver Nothing $ \floatRepr1 pathSatSym -> do
+        setupSolver cruxOpts (pathSatSolverOutput cruxOpts) pathSatSym
+        (execFeatures, profInfo) <- setupExecutionFeatures cruxOpts pathSatSym (Just SomeOnlineSolver)
+        withSelectedOnlineBackend cruxOpts nonceGen goalSolver (Just (floatReprString floatRepr1)) $ \floatRepr2 goalSym -> do
+          setupSolver cruxOpts (onlineSolverOutput cruxOpts) goalSym
+          -- NOTE: We pass in an explicit requested float mode in our second
+          -- online solver connection instantiation to ensure that both solvers
+          -- use the same float mode, so no mismatch here should be possible.
+          case testEquality floatRepr1 floatRepr2 of
+            Just Refl ->
+              doSimWithResults lang opts compRef glsRef pathSatSym execFeatures profInfo (proveGoalsOnline goalSym)
+            Nothing -> fail "Impossible: the argument interpretation produced two different float modes"
 
-     let execFeatures = tfs ++ profExecFeatures profInfo ++ bfs ++ rfs ++ psat_fs
+    Left rsns -> fail ("Invalid solver configuration:\n" ++ unlines rsns)
 
-     -- Ready to go!
-     gls <- newIORef Seq.empty
-     inFrame profInfo "<Crux>" $
-       simulate lang execFeatures opts sym emptyModel $ \(Result res) ->
-        do case res of
-             TimeoutResult _ ->
-               do sayWarn "Crux" "Simulation timed out! Program might not be fully verified!"
-                  writeIORef compRef ProgramIncomplete
-             _ -> return ()
+-- | Core invocation of the symbolic execution engine
+--
+-- This is separated out so that we don't have to duplicate the code sequence in
+-- 'runSimulator'.  The strategy used to ultimately discharge proof obligations
+-- is a parameter to allow this code to use either an online or offline solver
+-- connection.
+--
+-- The main work in this function is setting up appropriate solver frames and
+-- traversing the goals tree, as well as handling some reporting.
+doSimWithResults :: (Logs, IsSymInterface sym)
+                 => Language opts
+                 -> Options opts
+                 -> IORef ProgramCompleteness
+                 -> IORef (Seq.Seq (ProvedGoals (Either AssumptionReason SimError)))
+                 -> sym
+                 -> [GenericExecutionFeature sym]
+                 -> ProfData sym
+                 -> (forall ext . CruxOptions -> SimCtxt sym ext -> Maybe (Goals (LPred sym AssumptionReason) (LPred sym SimError)) -> IO (Maybe (Goals (LPred sym AssumptionReason) (LPred sym SimError, ProofResult (Either (LPred sym AssumptionReason) (LPred sym SimError))))))
+                 -- ^ The function to use to prove goals; this is intended to be
+                 -- one of 'proveGoalsOffline' or 'proveGoalsOnline'
+                 -> IO ( ProgramCompleteness
+                       , Seq.Seq (ProvedGoals (Either AssumptionReason SimError))
+                       )
+doSimWithResults lang opts@(cruxOpts, _) compRef glsRef sym execFeatures profInfo goalProver = do
+  frm <- pushAssumptionFrame sym
+  inFrame profInfo "<Crux>" $ do
+    simulate lang execFeatures opts sym emptyModel $ \(Result res) -> do
+      case res of
+        TimeoutResult {} -> do
+          sayWarn "Crux" "Simulation timed out! Program might not be fully verified!"
+          writeIORef compRef ProgramIncomplete
+        _ -> return ()
+      popUntilAssumptionFrame sym frm
+      let ctx' = execResultContext res
+      inFrame profInfo "<Prove Goals>" $ do
+        todo <- getProofObligations sym
+        proved <- goalProver cruxOpts ctx' todo
+        mgt <- provedGoalsTree ctx' proved
+        case mgt of
+          Nothing -> return ()
+          Just gt -> modifyIORef glsRef (Seq.|> gt)
+  when (simVerbose cruxOpts > 1) $ do
+    say "Crux" "Simulation complete."
+  when (isProfiling cruxOpts) $ writeProf profInfo
+  (,) <$> readIORef compRef <*> readIORef glsRef
 
-           popUntilAssumptionFrame sym frm
-
-           let ctx' = execResultContext res
-
-           inFrame profInfo "<Prove Goals>" $
-             do todo <- getProofObligations sym
-                proved <- proveGoals cruxOpts ctx' todo
-                mgt <- provedGoalsTree ctx' proved
-                case mgt of
-                  Nothing -> return ()
-                  Just gt ->
-                    modifyIORef gls (Seq.|> gt)
-
-     when (simVerbose cruxOpts > 1) $
-       say "Crux" "Simulation complete."
-
-     when profiling $
-       writeProf profInfo
-
-     (,) <$> readIORef compRef <*> readIORef gls
+isProfiling :: CruxOptions -> Bool
+isProfiling cruxOpts = profileCrucibleFunctions cruxOpts || profileSolver cruxOpts
 
 computeExitCode :: ProgramCompleteness -> Seq.Seq (ProvedGoals a) -> ExitCode
 computeExitCode cmpl = maximum . (base:) . fmap f . toList

--- a/crux/src/Crux/Config/Solver.hs
+++ b/crux/src/Crux/Config/Solver.hs
@@ -1,0 +1,196 @@
+{-# LANGUAGE DeriveFoldable #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+module Crux.Config.Solver (
+  parseSolverConfig,
+  SolverConfig(..),
+  SolverOnline(..),
+  SolverOffline(..),
+  HasDefaultFloatRepr(..),
+  sameSolver
+  ) where
+
+import           Control.Applicative ( (<|>), empty, Alternative )
+import qualified Data.Foldable as F
+import qualified Data.Traversable as T
+import qualified Lang.Crucible.Backend.Simple as CBS
+import           Text.Printf ( printf )
+import qualified What4.Expr.Builder as WEB
+import qualified What4.InterpretedFloatingPoint as WIF
+
+import qualified Crux.Config.Common as CCC
+
+data SolverOnline = Yices | Z3 | CVC4 | STP
+  deriving (Eq, Ord, Show)
+data SolverOffline = SolverOnline SolverOnline | Boolector | DReal
+  deriving (Eq, Ord, Show)
+
+class HasDefaultFloatRepr solver where
+  withDefaultFloatRepr :: proxy s -> solver -> (forall fm . (WIF.IsInterpretedFloatExprBuilder (WEB.ExprBuilder s CBS.SimpleBackendState (WEB.Flags fm))) => WEB.FloatModeRepr fm -> a) -> a
+
+instance HasDefaultFloatRepr SolverOnline where
+  withDefaultFloatRepr _ s k =
+    case s of
+      CVC4 -> k WEB.FloatRealRepr
+      STP -> k WEB.FloatRealRepr
+      Yices -> k WEB.FloatRealRepr
+      Z3 -> k WEB.FloatIEEERepr
+
+instance HasDefaultFloatRepr SolverOffline where
+  withDefaultFloatRepr proxy s k =
+    case s of
+      SolverOnline s' -> withDefaultFloatRepr proxy s' k
+      Boolector -> k WEB.FloatUninterpretedRepr
+      DReal -> k WEB.FloatRealRepr
+
+-- | Test to see if an online and offline solver are actually the same
+sameSolver :: SolverOnline -> SolverOffline -> Bool
+sameSolver o f =
+  case f of
+    SolverOnline s' -> o == s'
+    _ -> False
+
+data SolverConfig = SingleOnlineSolver SolverOnline
+                  -- ^ Use a single online solver for both path satisfiability
+                  -- checking and goal discharge
+                  | OnlineSolverWithOfflineGoals SolverOnline SolverOffline
+                  -- ^ Use an online solver for path satisfiability checking and
+                  -- use an offline solver for goal discharge
+                  | OnlineSolverWithSeparateOnlineGoals SolverOnline SolverOnline
+                  -- ^ Use one online solver connection for path satisfiability
+                  -- checking and a separate online solver connection for goal
+                  -- discharge
+                  | OnlyOfflineSolver SolverOffline
+                  -- ^ Use only an offline solver with no support for path
+                  -- satisfiability checking
+
+-- | A type that contains a validated instance of a value or a list of messages
+-- describing why it was not valid
+--
+-- This is basically `Either [String] a` but with instances that accumulate
+-- error messages across alternatives unless there is a success.
+data Validated a = Invalid [String] | Validated a
+  deriving (Show, Functor, F.Foldable, T.Traversable)
+
+validatedToEither :: Validated a -> Either [String] a
+validatedToEither v =
+  case v of
+    Invalid rsns -> Left rsns
+    Validated a -> Right a
+
+instance Applicative Validated where
+  pure = Validated
+  Validated f <*> Validated a = Validated (f a)
+  Validated _f <*> Invalid rsns = Invalid rsns
+  Invalid rsns1 <*> Invalid rsns2 = Invalid (rsns1 <> rsns2)
+  Invalid rsns <*> Validated _ = Invalid rsns
+
+instance Alternative Validated where
+  empty = Invalid []
+  Validated a <|> _ = Validated a
+  Invalid rsns1 <|> Invalid rsns2 = Invalid (rsns1 <> rsns2)
+  Invalid _ <|> Validated a = Validated a
+
+invalid :: String -> Validated a
+invalid rsn = Invalid [rsn]
+
+-- | Boolector and DReal only support offline solving (for our purposes), so
+-- attempt to parse them from the given string
+asOnlyOfflineSolver :: String -> Validated SolverOffline
+asOnlyOfflineSolver s =
+  case s of
+    "dreal" -> pure DReal
+    "boolector" -> pure Boolector
+    _ -> invalid (printf "%s is not an offline-only solver (expected dreal or boolector)" s)
+
+-- | Solvers that can be used in offline mode
+asAnyOfflineSolver :: String -> Validated SolverOffline
+asAnyOfflineSolver s =
+  case s of
+    "dreal" -> pure DReal
+    "boolector" -> pure Boolector
+    "z3" -> pure (SolverOnline Z3)
+    "yices" -> pure (SolverOnline Yices)
+    "cvc4" -> pure (SolverOnline CVC4)
+    "stp" -> pure (SolverOnline STP)
+    _ -> invalid (printf "%s is not a valid solver (expected dreal, boolector, z3, yices, cvc4, or stp)" s)
+
+-- | Attempt to parse the string as one of our solvers that supports online mode
+asOnlineSolver :: String -> Validated SolverOnline
+asOnlineSolver s =
+  case s of
+    "yices" -> pure Yices
+    "cvc4" -> pure CVC4
+    "z3" -> pure Z3
+    "stp" -> pure STP
+    _ -> invalid (printf "%s is not a valid online solver (expected yices, cvc4, z3, or stp)" s)
+
+-- | Examine a 'CCC.CruxOptions' and determine what solver configuration to use for
+-- symbolic execution.  This can fail if an invalid solver configuration is
+-- requested by the user.
+--
+-- The high level logic is that:
+--
+--  * If a user specifies only a single solver with the --solver option, that is
+--    used as an online solver if possible for path sat checking (if requested)
+--    and goal discharge.
+--  * If the user specifies an explicit --path-sat-solver, that solver is used
+--    for path satisfiability checking (if requested) while the solver specified
+--    with --solver is used for goal discharge.
+--  * The goal solver can be entirely offline (if it doesn't support online
+--    mode) or if the user requests that it be used in offline mode with the
+--    --force-offline-goal-solving option.
+parseSolverConfig :: CCC.CruxOptions -> Either [String] SolverConfig
+parseSolverConfig cruxOpts = validatedToEither $
+  case (CCC.pathSatSolver cruxOpts, CCC.checkPathSat cruxOpts, CCC.forceOfflineGoalSolving cruxOpts) of
+    (Nothing, True, False) ->
+      -- No separate path sat checker was requested, but we do have to check
+      -- path satisfiability.  That means that we have to use the one solver
+      -- specified and it must be one that supports online solving
+      trySingleOnline
+    (Nothing, True, True) ->
+      -- The user requested path satisfiability checking (using an online
+      -- solver), but also wants to force goals to be discharged using the same
+      -- solver in offline mode.
+      OnlineSolverWithOfflineGoals <$> asOnlineSolver (CCC.solver cruxOpts) <*> asAnyOfflineSolver (CCC.solver cruxOpts)
+    (Just _, False, False) ->
+      -- The user specified a separate path sat checking solver, but did not
+      -- request path satisfiability checking; we'll treat that as not asking
+      -- for path satisfiability checking and just use a single online solver
+      tryOnlyOffline <|> trySingleOnline
+    (Just _, False, True) ->
+      -- The user requested a separate path sat checking solver, but did not
+      -- request path satisfiability checking.  They also requested that a
+      -- separate solver be used for each goal (offline mode).  We'll use the
+      -- specified solver as the only solver purely in offline mode.
+      tryAnyOffline
+    (Nothing, False, False) ->
+      -- This is currently the same as the previous case, but the user
+      -- explicitly selected no path sat checking
+      tryOnlyOffline <|> trySingleOnline
+    (Nothing, False, True) ->
+      -- This is the same as the `(Just _, False, True)` case since we were just
+      -- ignoring the unused path sat solver option.
+      tryAnyOffline
+    (Just onSolver, True, False) ->
+      -- The user requested path sat checking and specified a solver
+      --
+      -- NOTE: We can still use the goal solver in online mode if it is supported
+
+      -- In this case, the user requested a goal solver that is only usable as
+      -- an offline solver
+      (OnlineSolverWithOfflineGoals <$> asOnlineSolver onSolver <*> asOnlyOfflineSolver (CCC.solver cruxOpts)) <|>
+        -- In this case, the requested solver can be used in online mode so we
+        -- use it as such
+       (OnlineSolverWithSeparateOnlineGoals <$> asOnlineSolver onSolver <*> asOnlineSolver (CCC.solver cruxOpts))
+    (Just onSolver, True, True) ->
+      -- In this case, the user requested separate solvers for path sat checking
+      -- and goal discharge, but further requested that we force goals to be
+      -- discharged with an offline solver.
+      OnlineSolverWithOfflineGoals <$> asOnlineSolver onSolver <*> asAnyOfflineSolver (CCC.solver cruxOpts)
+  where
+    tryAnyOffline = OnlyOfflineSolver <$> asAnyOfflineSolver (CCC.solver cruxOpts)
+    tryOnlyOffline = OnlyOfflineSolver <$> asOnlyOfflineSolver (CCC.solver cruxOpts)
+    trySingleOnline = SingleOnlineSolver <$> asOnlineSolver (CCC.solver cruxOpts)

--- a/crux/src/Crux/Goal.hs
+++ b/crux/src/Crux/Goal.hs
@@ -166,8 +166,6 @@ proveGoalsOffline :: forall st sym p asmp ast t fs
 proveGoalsOffline _adapter _opts _ctx Nothing = return Nothing
 proveGoalsOffline adapter opts ctx (Just gs0) = do
   goalNum <- newIORef (ProcessedGoals 0 0 0)
-  unless hasUnsatCores $ do
-    sayWarn "Crux" "Warning: Skipping unsat cores because MC-SAT is enabled."
   Just <$> go goalNum [] gs0
   where
     (start,end)
@@ -178,7 +176,6 @@ proveGoalsOffline adapter opts ctx (Just gs0) = do
       | Just seconds <- goalTimeout opts = ST.timeout (round seconds * 1000000) action
       | otherwise = Just <$> action
 
-    hasUnsatCores = not (yicesMCSat opts)
     failfast = proofGoalsFailFast opts
 
     go :: IORef ProcessedGoals

--- a/what4/src/What4/Utils/Process.hs
+++ b/what4/src/What4/Utils/Process.hs
@@ -75,6 +75,6 @@ withProcessHandles path args mcwd action = do
               (\(_ :: SomeException) -> return ())
   let onError (_,_,_,ph) = do
         -- Interrupt process; suppress any exceptions that occur.
-        catch (interruptProcessGroupOf ph) (\(_ :: SomeException) -> return ())
+        catch (terminateProcess ph) (\(_ :: SomeException) -> return ())
 
   bracket startProcess cleanup (\hs -> onException (action hs) (onError hs))


### PR DESCRIPTION
This set of commits adds options to crux to let the user choose different solvers for path satisfiability checking and proving goals.  Changes:

- Users can select a separate solver for path satisfiability checking (`--path-sat-solver`)
- Goals can be proved using solvers that do not have an online mode (e.g., boolector and dreal)
- The goal solver can be forced into offline mode even if it supports online solving (useful for eventually solving in parallel)
- The default behavior (if only `--solver` is specified) should be the same as before
- Adds support for the STP solver in both online and offline modes