### PR TITLE
let Crux extensions use the online solver backend

### DIFF
--- a/crux/crux.cabal
+++ b/crux/crux.cabal
@@ -58,6 +58,7 @@ library
     Crux.Config.Common,
     Crux.Config.Solver,
     Crux.Extension,
+    Crux.Online,
     Crux.Version
 
   other-modules:

--- a/crux/src/Crux/Extension.hs
+++ b/crux/src/Crux/Extension.hs
@@ -10,6 +10,7 @@ import Crux.Types(Model,Result,ProvedGoals)
 import Crux.Log(Logs)
 import Crux.Config(Config(..))
 import Crux.Config.Common
+import Crux.Online
 
 data Language opts = Language
   { name :: String
@@ -36,7 +37,7 @@ type Options opts = (CruxOptions, opts)
 
 -- | Type of the 'simulate' method.
 type SimulateCallback opts =
-    forall sym.  (IsSymInterface sym, Logs) =>
+    forall sym.  (IsSymInterface sym, MaybeOnlineSolver sym, Logs) =>
     [GenericExecutionFeature sym] {- ^ Execution features -} ->
     Options opts {- ^ Configuration -} ->
     sym          {- ^ The backend -} ->
@@ -51,5 +52,3 @@ type CounterExampleCallback opts =
   Seq (ProvedGoals (Either AssumptionReason SimError))
   {- ^ The goals we looked at, and if they were proved. -} ->
   IO ()
-
-

--- a/crux/src/Crux/Online.hs
+++ b/crux/src/Crux/Online.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE FlexibleInstances #-}
+module Crux.Online where
+
+import Lang.Crucible.Backend.Online
+import What4.Protocol.Online (OnlineSolver)
+import qualified Lang.Crucible.Backend.Simple as CBS
+
+-- | A GADT to capture the online solver constraints when we need them
+data SomeOnlineSolver sym where
+  SomeOnlineSolver :: (sym ~ OnlineBackend scope solver fs
+                      , OnlineSolver scope solver
+                      ) => SomeOnlineSolver sym
+
+-- | Allows checking whether `sym` is an online solver.  Produces a
+-- `SomeOnlineSolver` proof if it is, allowing the caller to use functions that
+-- are specific to online solvers.
+class MaybeOnlineSolver sym where
+  maybeOnlineSolver :: Maybe (SomeOnlineSolver sym)
+
+instance OnlineSolver scope solver => MaybeOnlineSolver (OnlineBackend scope solver fs) where
+  maybeOnlineSolver = Just SomeOnlineSolver
+
+instance MaybeOnlineSolver (CBS.SimpleBackend t fs) where
+  maybeOnlineSolver = Nothing


### PR DESCRIPTION
This branch provides Crux extensions with the ability to use the online solver backend, if one exists.  The extension's `SimulateCallback` can now include a new `MaybeOnlineSolver sym` constraint and use it to obtain a `Maybe (SomeOnlineSolver sym)` value - either `Just` a proof that `sym` is an online backend, or `Nothing`.  After matching on the proof, the extension can call functions like `withSolverProcess` that require an online backend.

The Rust frontend needs this functionality to support [custom printing of counterexamples](https://github.com/GaloisInc/mir-verifier/pull/10).