### PR TITLE
[what4] fix BVashr to treat shift amount as unsigned always

### DIFF
--- a/what4/src/What4/Expr/Builder.hs
+++ b/what4/src/What4/Expr/Builder.hs
@@ -4871,7 +4871,7 @@ instance IsExprBuilder (ExprBuilder t st fs) where
      sbMakeExpr sym $ BVLshr (bvWidth x) x y
 
   bvAshr sym x y
-   | Just i <- asSignedBV x, Just n <- asSignedBV y = do
+   | Just i <- asSignedBV x, Just n <- asUnsignedBV y = do
      bvLit sym (bvWidth x) $ Bits.shiftR i (fromIntegral n)
    | Just 0 <- asUnsignedBV y = do
      pure x

--- a/what4/src/What4/Interface.hs
+++ b/what4/src/What4/Interface.hs
@@ -795,8 +795,8 @@ class (IsExpr (SymExpr sym), HashableF (SymExpr sym)) => IsExprBuilder sym where
                         SymBV sym w {- ^ Amount to shift by -} ->
                         IO (SymBV sym w)
 
-  -- | Arithmetic right shift.  The shift amount is treated as a
-  -- signed value, and a negative shift value indicates a left shift.
+  -- | Arithmetic right shift.  The shift amount is treated as an
+  -- unsigned value.
   bvAshr :: (1 <= w) => sym ->
                         SymBV sym w {- ^ Shift this -} ->
                         SymBV sym w {- ^ Amount to shift by -} ->

--- a/what4/test/GenWhat4Expr.hs
+++ b/what4/test/GenWhat4Expr.hs
@@ -1015,10 +1015,8 @@ bvExprs bvTerm conTE projTE teSubCon expr width toWord =
 
     , subBVTerms2
       (\x y -> teSubCon (unwords [pdesc x, pfx "asr", pdesc y])
-               (let s = fromEnum $ sBV $ testval y
-                in mask (if s >= 0
-                          then sBV (testval x) `shiftR` s
-                          else testval x `shiftL` (-s)))
+               (let s = fromEnum $ uBV $ testval y
+                in mask (sBV (testval x) `shiftR` s))
                (\sym -> do x' <- expr x sym
                            y' <- expr y sym
                            bvAshr sym x' y'))


### PR DESCRIPTION
The shift amount was unsigned if this was not a concrete value, but it
was being treated as signed if both arguments were concrete, which
resulted in a shift left if the amount was negative.