### PR TITLE
What4 process tweaks

### DIFF
--- a/crux-llvm/crux-llvm.cabal
+++ b/crux-llvm/crux-llvm.cabal
@@ -48,12 +48,11 @@ library
 
   default-language: Haskell2010
 
-  
+
 
 executable crux-llvm
 
   hs-source-dirs: exe
-  main-is: Main.hs
 
   build-depends:
     ansi-terminal,
@@ -77,6 +76,12 @@ executable crux-llvm
     template-haskell,
     text,
     what4
+
+  if os(windows)
+    main-is: WinMain.hs
+  else
+    build-depends: unix
+    main-is: Main.hs
 
   ghc-options: -Wall
   ghc-prof-options: -O2 -fprof-auto-top
@@ -113,4 +118,3 @@ test-suite crux-llvm-test
                 what4
 
   default-language: Haskell2010
-

--- a/crux-llvm/exe/Main.hs
+++ b/crux-llvm/exe/Main.hs
@@ -7,7 +7,9 @@ import System.Posix.Process
 
 import CruxLLVMMain (mainWithOutputConfig, defaultOutputConfig)
 
--- Convert a SIGTERM signal into a SIGINT signal for the entire process group
+-- Rebroadcast SIGTERM to the entire process group.  The CatchOnce
+-- handler keeps this from handling and retransmitting SIGTERM to
+-- itself over and over.
 installSIGTERMHandler :: IO ()
 installSIGTERMHandler =
   do gid <- getProcessGroupID

--- a/crux-llvm/exe/Main.hs
+++ b/crux-llvm/exe/Main.hs
@@ -13,7 +13,7 @@ installSIGTERMHandler =
   do gid <- getProcessGroupID
      void $ installHandler sigTERM (CatchOnce (handler gid)) Nothing
  where
- handler gid = signalProcessGroup sigINT gid
+ handler gid = signalProcessGroup sigTERM gid
 
 
 main :: IO ()

--- a/crux-llvm/exe/Main.hs
+++ b/crux-llvm/exe/Main.hs
@@ -1,3 +1,23 @@
 module Main (main) where
 
-import CruxLLVMMain (main)
+import Control.Monad
+import System.Exit
+import System.Posix.Signals
+import System.Posix.Process
+
+import CruxLLVMMain (mainWithOutputConfig, defaultOutputConfig)
+
+-- Convert a SIGTERM signal into a SIGINT signal for the entire process group
+installSIGTERMHandler :: IO ()
+installSIGTERMHandler =
+  do gid <- getProcessGroupID
+     void $ installHandler sigTERM (CatchOnce (handler gid)) Nothing
+ where
+ handler gid = signalProcessGroup sigINT gid
+
+
+main :: IO ()
+main =
+  do installSIGTERMHandler
+     ec <- mainWithOutputConfig defaultOutputConfig
+     exitWith ec

--- a/crux-llvm/exe/WinMain.hs
+++ b/crux-llvm/exe/WinMain.hs
@@ -1,0 +1,7 @@
+module Main (main) where
+
+import System.Exit
+import CruxLLVMMain (mainWithOutputConfig, defaultOutputConfig)
+
+main :: IO ()
+main = mainWithOutputConfig defaultOutputConfig >>= exitWith

--- a/crux-llvm/src/CruxLLVMMain.hs
+++ b/crux-llvm/src/CruxLLVMMain.hs
@@ -7,7 +7,7 @@
 {-# Language RecordWildCards #-}
 {-# Language ScopedTypeVariables #-}
 
-module CruxLLVMMain (main, mainWithOutputTo, mainWithOutputConfig, registerFunctions) where
+module CruxLLVMMain (mainWithOutputTo, mainWithOutputConfig, defaultOutputConfig, registerFunctions) where
 
 import Data.String (fromString)
 import qualified Data.Map as Map
@@ -18,7 +18,6 @@ import Control.Exception
 import qualified Data.Foldable as Fold
 import Data.Text (Text)
 import Data.List(intercalate)
-
 
 import Data.Binary.IEEE754 as IEEE754
 import qualified Data.Parameterized.Map as MapF
@@ -88,9 +87,6 @@ import Crux.Config.Common
 -- local
 import Crux.LLVM.Overrides
 
-
-main :: IO ()
-main = mainWithOutputConfig defaultOutputConfig >>= exitWith
 
 mainWithOutputTo :: Handle -> IO ExitCode
 mainWithOutputTo h = mainWithOutputConfig (OutputConfig False h h False)

--- a/what4/src/What4/Panic.hs
+++ b/what4/src/What4/Panic.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE Trustworthy, TemplateHaskell #-}
+module What4.Panic
+  (HasCallStack, What4, Panic, panic) where
+
+import Panic hiding (panic)
+import qualified Panic
+
+data What4 = What4
+
+panic :: HasCallStack => String -> [String] -> a
+panic = Panic.panic What4
+
+instance PanicComponent What4 where
+  panicComponentName _ = "What4"
+  panicComponentIssues _ = "https://github.com/GaloisInc/crucible/issues"
+
+  {-# Noinline panicComponentRevision #-}
+  panicComponentRevision = $useGitRevision

--- a/what4/src/What4/Protocol/Online.hs
+++ b/what4/src/What4/Protocol/Online.hs
@@ -85,6 +85,10 @@ data SolverProcess scope solver = SolverProcess
   { solverConn  :: !(WriterConn scope solver)
     -- ^ Writer for sending commands to the solver
 
+  , solverCleanupCallback :: IO ExitCode
+    -- ^ Callback for regular code paths to gracefully close associated pipes
+    --   and wait for the process to shutdown
+
   , solverHandle :: !ProcessHandle
     -- ^ Handle to the solver process
 

--- a/what4/src/What4/Protocol/SMTLib2.hs
+++ b/what4/src/What4/Protocol/SMTLib2.hs
@@ -1039,7 +1039,8 @@ startSolver solver ack setup feats auxOutput sym = do
       { Process.std_in       = Process.CreatePipe
       , Process.std_out      = Process.CreatePipe
       , Process.std_err      = Process.CreatePipe
-      , Process.create_group = True
+      , Process.create_group = False
+      , Process.delegate_ctlc = True
       , Process.cwd          = Nothing
       }
   (in_h, out_h, err_h, ph) <- case solver_process of

--- a/what4/src/What4/Utils/Process.hs
+++ b/what4/src/What4/Utils/Process.hs
@@ -59,7 +59,8 @@ withProcessHandles path args mcwd action = do
           { std_in  = CreatePipe
           , std_out = CreatePipe
           , std_err = CreatePipe
-          , create_group = True
+          , create_group = False
+          , delegate_ctlc = True
           , cwd = mcwd
           }
   let startProcess = do

--- a/what4/src/What4/Utils/Process.hs
+++ b/what4/src/What4/Utils/Process.hs
@@ -92,7 +92,6 @@ startProcess path args mcwd =
               , std_out = CreatePipe
               , std_err = CreatePipe
               , create_group = False
-              , delegate_ctlc = True
               , cwd = mcwd
               }
      createProcess create_proc >>= \case

--- a/what4/what4.cabal
+++ b/what4/what4.cabal
@@ -37,6 +37,7 @@ library
     io-streams,
     lens,
     mtl,
+    panic >= 0.3,
     parameterized-utils >= 1.0.8 && < 2.1,
     process,
     scientific,
@@ -67,6 +68,7 @@ library
     What4.Interface
     What4.InterpretedFloatingPoint
     What4.LabeledPred
+    What4.Panic
     What4.Partial
     What4.Partial.AssertionTree
     What4.ProblemFeatures


### PR DESCRIPTION
Fiddle with the process handling code in what4 to more reliably clean up when processes are killed.

Because GHC signal/process/thread handling is a pretty complicated beast, this doesn't completely guarantee good behavior, but seems to do a better job in common cases.