### PR TITLE
Fix the semantics of `strlen` on symbolic strings.

### DIFF
--- a/crux-llvm/test-data/golden/strlen_test.c
+++ b/crux-llvm/test-data/golden/strlen_test.c
@@ -1,0 +1,23 @@
+#include <stdlib.h>
+#include <string.h>
+
+#include "crucible.h"
+
+#define MAX 10
+
+char* mkstr() {
+  char* x = malloc(MAX);
+  for( int i=0; i<MAX; i++ ) {
+    x[i] = crucible_int8_t( "x" );
+  }
+
+  assuming( x[MAX-1] == 0 );
+
+  return x;
+}
+
+int main() {
+  char *str = mkstr();
+  size_t sz = strlen(str);
+  check( sz < MAX );
+}

--- a/crux-llvm/test-data/golden/strlen_test.good
+++ b/crux-llvm/test-data/golden/strlen_test.good
@@ -1,0 +1,1 @@
+[Crux] Overall status: Valid.


### PR DESCRIPTION
Previously, `strlen` would recurse down a string until it
ran into a concrete zero.  This is fine, except that it would
assert that each load along the way would succeed, without taking
into account the previous zero tests that had to fail.  To correct
this we need to emulate a path condition such that to load
at position `n` each of the `n-1` previous locations must have
been non-zero, and the loads are only required to succeed under
that condition.  This allows one, for example, to assume that
some value in a string is 0 (but not specify which one).  Previously,
`strlen` would index off the end of the allocation of such a string
and fail.  Now it will succeed because the path condition required
to index out-of-bounds is inconsistent.

Fixes #468