### PR TITLE
SVCOMP improvements

### DIFF
--- a/crux-llvm/crux-llvm.cabal
+++ b/crux-llvm/crux-llvm.cabal
@@ -97,6 +97,9 @@ executable crux-llvm-svcomp
   main-is: Main.hs
 
   build-depends:
+    aeson >= 1.4.7,
+    attoparsec >= 0.13,
+    async >= 2.2,
     ansi-terminal,
     ansi-wl-pprint,
     base >= 4.8 && < 4.14,

--- a/crux/src/Crux/SVCOMP.hs
+++ b/crux/src/Crux/SVCOMP.hs
@@ -36,6 +36,9 @@ data SVCOMPOptions = SVCOMPOptions
 
   , svcompCPUlimit :: Maybe Integer
       -- ^ CPU time limit (in seconds) per verification task
+
+  , svcompOutputFile :: FilePath
+      -- ^ file path for JSON verification results output
   }
 
 svcompOptions :: Config SVCOMPOptions
@@ -52,6 +55,10 @@ svcompOptions = Config
          svcompCPUlimit <-
            sectionMaybe "svcomp-cpulimit" numSpec
            "total CPU time limit (in seconds) per verification task"
+
+         svcompOutputFile <-
+           section "svcomp-output" fileSpec "svcomp.json"
+           "output file path for JSON verification results output"
 
          return SVCOMPOptions{ .. }
 


### PR DESCRIPTION
Produce JSON objects describing the output of verification tasks in SVCOMP mode.

We now output a JSON object for each verification task into a configurable
output file.  This should be more reliable than scraping the stdout
output of the SV-COMP driver.