### PR TITLE
Tr/crux extended runnable state

### DIFF
--- a/crux-llvm/c-src/includes/crucible.h
+++ b/crux-llvm/c-src/includes/crucible.h
@@ -9,7 +9,6 @@ extern "C" {
 #include <stdint.h>
 #include <stddef.h>
 
-void crucible_breakpoint(void);
 void crucible_assume(uint8_t x, const char *file, int line);
 void crucible_assert(uint8_t x, const char *file, int line);
 

--- a/crux-llvm/c-src/includes/crucible.h
+++ b/crux-llvm/c-src/includes/crucible.h
@@ -9,6 +9,7 @@ extern "C" {
 #include <stdint.h>
 #include <stddef.h>
 
+void crucible_breakpoint(void);
 void crucible_assume(uint8_t x, const char *file, int line);
 void crucible_assert(uint8_t x, const char *file, int line);
 

--- a/crux/src/Crux.hs
+++ b/crux/src/Crux.hs
@@ -1,6 +1,6 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE NoMonoLocalBinds #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# Language RankNTypes, ImplicitParams, TypeApplications, MultiWayIf #-}


### PR DESCRIPTION
This change extends the `RunnableState` type in crux to allow client code to pass in additional execution features.  It uses a pattern synonym to preserve backwards-compatibility.