### PR TITLE
Remove parameterized-utils as a git submodule: use hackage.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,9 +25,6 @@
 [submodule "dependencies/hpb"]
 	path = dependencies/hpb
 	url = https://github.com/GaloisInc/hpb.git
-[submodule "dependencies/parameterized-utils"]
-	path = dependencies/parameterized-utils
-	url = https://github.com/GaloisInc/parameterized-utils.git
 [submodule "dependencies/saw-core"]
 	path = dependencies/saw-core
 	url = https://github.com/GaloisInc/saw-core.git

--- a/cabal.project
+++ b/cabal.project
@@ -23,7 +23,6 @@ optional-packages:
   dependencies/hpb/
   dependencies/llvm-pretty/
   dependencies/llvm-pretty-bc-parser/
-  dependencies/parameterized-utils/
   dependencies/saw-core/
   dependencies/saw-core-aig/
   dependencies/saw-core-sbv/

--- a/stack-ghc-8.2.yaml
+++ b/stack-ghc-8.2.yaml
@@ -18,7 +18,6 @@ packages:
   - dependencies/jvm-parser/
   - dependencies/llvm-pretty/
   - dependencies/llvm-pretty-bc-parser/
-  - dependencies/parameterized-utils/
   - dependencies/saw-core/
   - dependencies/saw-core-aig/
   - dependencies/saw-core-sbv/

--- a/stack-ghc-8.4.yaml
+++ b/stack-ghc-8.4.yaml
@@ -18,7 +18,6 @@ packages:
   - dependencies/jvm-parser/
   - dependencies/llvm-pretty/
   - dependencies/llvm-pretty-bc-parser/
-  - dependencies/parameterized-utils/
   - dependencies/saw-core/
   - dependencies/saw-core-aig/
   - dependencies/saw-core-sbv/

--- a/stack-ghc-8.6.5.yaml
+++ b/stack-ghc-8.6.5.yaml
@@ -18,7 +18,6 @@ packages:
   - dependencies/jvm-parser/
   - dependencies/llvm-pretty/
   - dependencies/llvm-pretty-bc-parser/
-  - dependencies/parameterized-utils/
   - dependencies/saw-core/
   - dependencies/saw-core-aig/
   - dependencies/saw-core-sbv/

--- a/stack-travis.yaml
+++ b/stack-travis.yaml
@@ -12,7 +12,6 @@ packages:
 - crucible-server
 - dependencies/abcBridge
 - dependencies/aig
-- dependencies/parameterized-utils
 - dependencies/hpb
 - dependencies/saw-core
 - dependencies/llvm-pretty


### PR DESCRIPTION
Switches from getting parameterized-utils as a git submodule to getting it from hackage.

For updating local clones: https://stackoverflow.com/questions/1260748/how-do-i-remove-a-submodule