### PR TITLE
Generalize asMemAllocationArrayStore to symbolic size allocations.

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
@@ -154,6 +154,7 @@ module Lang.Crucible.LLVM.MemModel
   , llvmStatementExec
   , G.pushStackFrameMem
   , G.popStackFrameMem
+  , G.asMemAllocationArrayStore
   , SomeFnHandle(..)
   , G.SomeAlloc(..)
   , G.possibleAllocs


### PR DESCRIPTION
This change enables `asMemAllocationArrayStore` to work on symbolic size allocations and writes in the simple case when the allocation size and the write size are determined equal by `bvEq`. This is sufficient to handle the combination of `crucible_symbolic_alloc` (GaloisInc/saw-script#760) and `crucible_array_prefix_points_to` (GaloisInc/saw-script#762) when the size of the allocation and the size of the points-to are the same SAWCore term. Deciding at What4 level that the array write covers the entire allocation prevents a possible ite explosion when reading. Supporting array writes that partially cover the allocation is more complicated, and may be addressed in the future as needed. 