### PR TITLE
An an option to CruxOptions for supplying additional problemFeatures

### DIFF
--- a/crucible/src/Lang/Crucible/Backend/Online.hs
+++ b/crucible/src/Lang/Crucible/Backend/Online.hs
@@ -164,10 +164,11 @@ withYicesOnlineBackend :: forall fm scope m a . (MonadIO m, MonadMask m) =>
                        (B.FloatModeRepr fm)
                        -> NonceGenerator IO scope
                        -> UnsatFeatures
+                       -> ProblemFeatures
                        -> (YicesOnlineBackend scope (B.Flags fm) -> m a)
                        -> m a
-withYicesOnlineBackend fm gen unsatFeat action =
-  let feat = Yices.yicesDefaultFeatures .|. unsatFeaturesToProblemFeatures unsatFeat in
+withYicesOnlineBackend fm gen unsatFeat extraFeatures action =
+  let feat = Yices.yicesDefaultFeatures .|. unsatFeaturesToProblemFeatures unsatFeat  .|. extraFeatures in
   withOnlineBackend fm gen feat $ \sym ->
     do liftIO $ extendConfig Yices.yicesOptions (getConfiguration sym)
        action sym
@@ -189,10 +190,11 @@ withZ3OnlineBackend :: forall fm scope m a . (MonadIO m, MonadMask m) =>
                     (B.FloatModeRepr fm)
                     -> NonceGenerator IO scope
                     -> UnsatFeatures
+                    -> ProblemFeatures
                     -> (Z3OnlineBackend scope (B.Flags fm) -> m a)
                     -> m a
-withZ3OnlineBackend fm gen unsatFeat action =
-  let feat = (SMT2.defaultFeatures Z3.Z3 .|. unsatFeaturesToProblemFeatures unsatFeat) in
+withZ3OnlineBackend fm gen unsatFeat extraFeatures action =
+  let feat = (SMT2.defaultFeatures Z3.Z3 .|. unsatFeaturesToProblemFeatures unsatFeat .|. extraFeatures) in
   withOnlineBackend fm gen feat $ \sym ->
     do liftIO $ extendConfig Z3.z3Options (getConfiguration sym)
        action sym
@@ -235,10 +237,11 @@ withCVC4OnlineBackend :: forall fm scope m a . (MonadIO m, MonadMask m) =>
                       (B.FloatModeRepr fm)
                       -> NonceGenerator IO scope
                       -> UnsatFeatures
+                      -> ProblemFeatures
                       -> (CVC4OnlineBackend scope (B.Flags fm) -> m a)
                       -> m a
-withCVC4OnlineBackend fm gen unsatFeat action =
-  let feat = (SMT2.defaultFeatures CVC4.CVC4 .|. unsatFeaturesToProblemFeatures unsatFeat) in
+withCVC4OnlineBackend fm gen unsatFeat extraFeatures action =
+  let feat = (SMT2.defaultFeatures CVC4.CVC4 .|. unsatFeaturesToProblemFeatures unsatFeat .|. extraFeatures) in
   withOnlineBackend fm gen feat $ \sym -> do
     liftIO $ extendConfig CVC4.cvc4Options (getConfiguration sym)
     action sym

--- a/crux/src/Crux.hs
+++ b/crux/src/Crux.hs
@@ -244,12 +244,12 @@ withSelectedOnlineBackend cruxOpts nonceGen selectedSolver maybeExplicitFloatMod
             Just s -> symCfg sym yicesGoalTimeout (floor s)
             Nothing -> return ()
           k floatRepr sym
-        CCS.CVC4 -> withCVC4OnlineBackend floatRepr nonceGen ProduceUnsatCores extraFeatures $ \sym -> do
+        CCS.CVC4 -> withCVC4OnlineBackend floatRepr nonceGen unsatCoreFeat extraFeatures $ \sym -> do
           case goalTimeout cruxOpts of
             Just s -> symCfg sym cvc4Timeout (floor (s * 1000))
             Nothing -> return ()
           k floatRepr sym
-        CCS.Z3 -> withZ3OnlineBackend floatRepr nonceGen ProduceUnsatCores extraFeatures $ \sym -> do
+        CCS.Z3 -> withZ3OnlineBackend floatRepr nonceGen unsatCoreFeat extraFeatures $ \sym -> do
           case goalTimeout cruxOpts of
             Just s -> symCfg sym z3Timeout (floor (s * 1000))
             Nothing -> return ()

--- a/crux/src/Crux.hs
+++ b/crux/src/Crux.hs
@@ -234,20 +234,22 @@ withSelectedOnlineBackend cruxOpts nonceGen selectedSolver maybeExplicitFloatMod
                   , not (yicesMCSat cruxOpts) = ProduceUnsatCores
                   | otherwise                 = NoUnsatFeatures
 
+    extraFeatures = onlineProblemFeatures cruxOpts
+
     withOnlineBackendFM floatRepr =
       case selectedSolver of
-        CCS.Yices -> withYicesOnlineBackend floatRepr nonceGen unsatCoreFeat $ \sym -> do
+        CCS.Yices -> withYicesOnlineBackend floatRepr nonceGen unsatCoreFeat extraFeatures $ \sym -> do
           symCfg sym yicesEnableMCSat (yicesMCSat cruxOpts)
           case goalTimeout cruxOpts of
             Just s -> symCfg sym yicesGoalTimeout (floor s)
             Nothing -> return ()
           k floatRepr sym
-        CCS.CVC4 -> withCVC4OnlineBackend floatRepr nonceGen unsatCoreFeat $ \sym -> do
+        CCS.CVC4 -> withCVC4OnlineBackend floatRepr nonceGen ProduceUnsatCores extraFeatures $ \sym -> do
           case goalTimeout cruxOpts of
             Just s -> symCfg sym cvc4Timeout (floor (s * 1000))
             Nothing -> return ()
           k floatRepr sym
-        CCS.Z3 -> withZ3OnlineBackend floatRepr nonceGen unsatCoreFeat $ \sym -> do
+        CCS.Z3 -> withZ3OnlineBackend floatRepr nonceGen ProduceUnsatCores extraFeatures $ \sym -> do
           case goalTimeout cruxOpts of
             Just s -> symCfg sym z3Timeout (floor (s * 1000))
             Nothing -> return ()

--- a/crux/src/Crux/Config/Common.hs
+++ b/crux/src/Crux/Config/Common.hs
@@ -13,6 +13,8 @@ import Crux.Config
 import Crux.Log
 import Config.Schema
 
+import What4.ProblemFeatures
+
 data PathStrategy
   = AlwaysMergePaths
   | SplitAndExploreDepthFirst
@@ -117,6 +119,8 @@ data CruxOptions = CruxOptions
   , hashConsing              :: Bool
     -- ^ Turn on hash-consing in the symbolic expression backend
 
+  , onlineProblemFeatures    :: ProblemFeatures
+    -- ^ Problem Features to force in online solvers
   }
 
 
@@ -232,6 +236,8 @@ cruxOptions = Config
           proofGoalsFailFast <-
             section "proof-goals-fail-fast" yesOrNoSpec False
             "If true, stop attempting to prove goals as soon as one of them is disproved"
+
+          onlineProblemFeatures <- pure noFeatures
 
           pure CruxOptions { .. }
 


### PR DESCRIPTION
This PR adds an option to supply a set of `problemFeatures` to be `OR`'d in with the default `problemFeatures` when configuring online solvers. This allows us to force the array theory to be enabled, for example.

- `crux/src/Crux/Config/Common.hs` modified to extend `CruxOptions` and set `problemFeatures` to the empty set of features by default
- `crucible/src/Lang/Crucible/Backend/Online.hs` modified to `OR` in the additional features
- `crux/src/Crux.hs` modified to pass in the additional features to the `with...OnlineBackend` functions