### PR TITLE
Expose combinators for creating fresh values

### DIFF
--- a/crucible/src/Lang/Crucible/CFG/Generator.hs
+++ b/crucible/src/Lang/Crucible/CFG/Generator.hs
@@ -63,6 +63,8 @@ module Lang.Crucible.CFG.Generator
   , addBreakpointStmt
   , extensionStmt
   , mkAtom
+  , mkFresh
+  , mkFreshFloat
   , forceEvaluation
     -- * Labels
   , newLabel
@@ -334,6 +336,13 @@ freshAtom av =
                      }
      addStmt (DefineAtom atom av)
      return atom
+
+
+mkFresh :: (Monad m, IsSyntaxExtension ext) => BaseTypeRepr tp -> Generator ext s t ret m (Atom s (BaseToType tp))
+mkFresh tr = freshAtom (FreshConstant tr Nothing)
+
+mkFreshFloat :: (Monad m, IsSyntaxExtension ext) => FloatInfoRepr fi -> Generator ext s t ret m (Atom s (FloatType fi))
+mkFreshFloat fi = freshAtom (FreshFloat fi Nothing)
 
 -- | Create an atom equivalent to the given expression if it is
 -- not already an 'AtomExpr'.

--- a/crucible/src/Lang/Crucible/CFG/Generator.hs
+++ b/crucible/src/Lang/Crucible/CFG/Generator.hs
@@ -123,6 +123,7 @@ import           Data.Text (Text)
 import           Data.Void
 
 import           What4.ProgramLoc
+import           What4.Symbol
 
 import           Lang.Crucible.CFG.Core (AnyCFG(..))
 import           Lang.Crucible.CFG.Expr(App(..))
@@ -338,11 +339,17 @@ freshAtom av =
      return atom
 
 
-mkFresh :: (Monad m, IsSyntaxExtension ext) => BaseTypeRepr tp -> Generator ext s t ret m (Atom s (BaseToType tp))
-mkFresh tr = freshAtom (FreshConstant tr Nothing)
+mkFresh :: (Monad m, IsSyntaxExtension ext)
+        => BaseTypeRepr tp
+        -> Maybe SolverSymbol
+        -> Generator ext s t ret m (Atom s (BaseToType tp))
+mkFresh tr symb = freshAtom (FreshConstant tr symb)
 
-mkFreshFloat :: (Monad m, IsSyntaxExtension ext) => FloatInfoRepr fi -> Generator ext s t ret m (Atom s (FloatType fi))
-mkFreshFloat fi = freshAtom (FreshFloat fi Nothing)
+mkFreshFloat :: (Monad m, IsSyntaxExtension ext)
+             => FloatInfoRepr fi
+             -> Maybe SolverSymbol
+             -> Generator ext s t ret m (Atom s (FloatType fi))
+mkFreshFloat fi symb = freshAtom (FreshFloat fi symb)
 
 -- | Create an atom equivalent to the given expression if it is
 -- not already an 'AtomExpr'.


### PR DESCRIPTION
This PR exposes two combinators for creating fresh values in Crucible syntax: `mkFresh` and `mkFreshFloat`