### PR TITLE
Add a `ub-sanitizer` configuration option to crux-llvm.

### DIFF
--- a/crux-llvm/src/Crux/LLVM/Compile.hs
+++ b/crux-llvm/src/Crux/LLVM/Compile.hs
@@ -113,6 +113,7 @@ genBitCode cruxOpts llvmOpts =
            | otherwise =
               [ "-c", "-g", "-emit-llvm", "-O1" ] ++
               concat [ [ "-I", dir ] | dir <- incs src ] ++
+              concat [ [ "-fsanitize="++san, "-fsanitize-trap="++san ] | san <- ubSanitizers llvmOpts ] ++
               [ "-o", srcBC, src ]
 
      finalBCExists <- doesFileExist finalBCFile

--- a/crux-llvm/src/Crux/LLVM/Config.hs
+++ b/crux-llvm/src/Crux/LLVM/Config.hs
@@ -13,7 +13,6 @@ import Lang.Crucible.LLVM.MemModel ( MemOptions(..), laxPointerMemOptions )
 
 import qualified Crux
 
-
 --
 -- LLVM specific errors
 --
@@ -56,6 +55,7 @@ data LLVMOptions = LLVMOptions
   , clangOpts  :: [String]
   , libDir     :: FilePath
   , incDirs    :: [FilePath]
+  , ubSanitizers :: [String]
   , memOpts    :: MemOptions
   , laxArithmetic :: Bool
   , entryPoint :: String
@@ -99,6 +99,9 @@ llvmCruxConfig =
 
          lazyCompile <- Crux.section "lazy-compile" Crux.yesOrNoSpec False
                            "Avoid compiling bitcode from source if intermediate files already exist"
+
+         ubSanitizers <- Crux.section "ub-sanitizers" (Crux.listSpec Crux.stringSpec) []
+                           "Undefined Behavior sanitizers to enable in Clang"
 
          return LLVMOptions { .. }
 

--- a/crux-llvm/svcomp/Main.hs
+++ b/crux-llvm/svcomp/Main.hs
@@ -106,8 +106,9 @@ genSVCOMPBitCode cruxOpts llvmOpts svOpts tm = concat <$> mapM goTask (zip [0::I
                      , libDir llvmOpts </> "includes"
                      ] ++ incDirs llvmOpts
           params (src, srcBC) =
-            [ "-c", "-g", "-emit-llvm", "-O1", "-fsanitize=shift", "-fsanitize-trap=shift", "--target=" ++ tgt ] ++
+            [ "-c", "-g", "-emit-llvm", "-O1", "--target=" ++ tgt ] ++
             concat [ ["-I", dir] | dir <- incs src ] ++
+            concat [ [ "-fsanitize="++san, "-fsanitize-trap="++san ] | san <- ubSanitizers llvmOpts ] ++
             [ "-o", srcBC, src ]
 
       createDirectoryIfMissing True outputPath

--- a/crux/src/Crux/Config.hs
+++ b/crux/src/Crux/Config.hs
@@ -7,7 +7,7 @@ module Crux.Config
     -- ** Configuration files
   , SectionsSpec, section, sectionMaybe
   , yesOrNoSpec, stringSpec, numSpec, fractionalSpec
-  , oneOrList, fileSpec, dirSpec
+  , oneOrList, fileSpec, dirSpec, listSpec
 
     -- ** Environment variables
   , EnvDescr(..), mapEnvDescr


### PR DESCRIPTION
This allows users to enable undefined behavior sanitizers in Clang,
which can catch some cases of undefined behavior that may otherwise
be compiled away.