### PR TITLE
crux: emit JSON version of the report

### DIFF
--- a/crux/src/Crux/Report.hs
+++ b/crux/src/Crux/Report.hs
@@ -38,8 +38,12 @@ generateReport opts res
        createDirectoryIfMissing True (outDir opts)
        maybeGenerateSource opts (inputFiles opts)
        cwd <- getCurrentDirectory
-       writeFile (outDir opts </> "report.js")
-          $ "var goals = " ++ renderJS (jsList (renderSideConds opts cwd xs))
+       let contents = renderJS (jsList (renderSideConds opts cwd xs))
+       -- Due to CORS restrictions, the only current way of statically loading local data
+       -- is by including a <script> with the contents we want. 
+       writeFile (outDir opts </> "report.js") $ "var goals = " ++ contents
+       -- However, for some purposes, having a JSON file is more practical.
+       writeFile (outDir opts </> "report.json") contents
        T.writeFile (outDir opts </> "index.html") indexHtml
        T.writeFile (outDir opts </> "jquery.min.js") jquery
 


### PR DESCRIPTION
For some purposes (e.g. VSCode extension), having the report be a
Javascript file registering a global variable is awful.

This commit makes the script also emit a JSON copy.  Due to CORS, the
redundancy seems unavoidable: one cannot load the JSON from the
Javascript file without using a server, which I assume we are trying to
avoid.