### PR TITLE
Try many solvers

### DIFF
--- a/crux/crux.cabal
+++ b/crux/crux.cabal
@@ -17,6 +17,7 @@ library
     aig,
     ansi-wl-pprint,
     array,
+    async,
     attoparsec,
     bv-sized >= 1.0.0,
     containers,

--- a/crux/src/Crux.hs
+++ b/crux/src/Crux.hs
@@ -461,17 +461,6 @@ runSimulator cruxOpts simCallback = do
             -- error if the same option is added more than once.
             extendConfig (WS.solver_adapter_config_options adapter) (getConfiguration sym)
           doSimWithResults cruxOpts simCallback compRef glsRef sym execFeatures profInfo monline (proveGoalsOffline [adapter])
-    -- Right (CCS.OnlyOfflineSolvers [offSolver]) -> do
-    --   -- When there's only one solver, we can specialize the float mode to that solver
-    --   withFloatRepr (Proxy @s) cruxOpts offSolver $ \floatRepr -> do
-    --     withSolverAdapter offSolver $ \adapter -> do
-    --       sym <- CBS.newSimpleBackend floatRepr nonceGen
-    --       setupSolver cruxOpts Nothing sym
-    --       -- Since we have a bare SimpleBackend here, we have to initialize it
-    --       -- with the options taken from the solver adapter (e.g., solver path)
-    --       extendConfig (WS.solver_adapter_config_options adapter) (getConfiguration sym)
-    --       (execFeatures, profInfo) <- setupExecutionFeatures cruxOpts sym Nothing
-    --       doSimWithResults cruxOpts simCallback compRef glsRef sym execFeatures profInfo Nothing (proveGoalsOffline [adapter])
     Right (CCS.OnlyOfflineSolvers offSolvers) -> do
       withFloatRepr (Proxy @s) cruxOpts offSolvers $ \floatRepr -> do
         withSolverAdapters offSolvers $ \adapters -> do

--- a/crux/src/Crux/Config/Common.hs
+++ b/crux/src/Crux/Config/Common.hs
@@ -183,7 +183,10 @@ cruxOptions = Config
 
           solver <-
             section "solver" stringSpec "yices"
-            "Select the solver to use to discharge proof obligations. (default: \"yices\")"
+            ("Select the solver to use to discharge proof obligations." <>
+             "May be a single solver, a comma-separated list of solvers, or the string \"all\"." <>
+             "Specifying multiple solvers requires the --force-offline-goal-solving option" <>
+             "(default: \"yices\")")
 
           pathSatSolver <-
             sectionMaybe "path-sat-solver" stringSpec

--- a/crux/src/Crux/Config/Common.hs
+++ b/crux/src/Crux/Config/Common.hs
@@ -183,9 +183,9 @@ cruxOptions = Config
 
           solver <-
             section "solver" stringSpec "yices"
-            ("Select the solver to use to discharge proof obligations." <>
-             "May be a single solver, a comma-separated list of solvers, or the string \"all\"." <>
-             "Specifying multiple solvers requires the --force-offline-goal-solving option" <>
+            (pack $ "Select the solver to use to discharge proof obligations. " ++
+             "May be a single solver, a comma-separated list of solvers, or the string \"all\". " ++
+             "Specifying multiple solvers requires the --force-offline-goal-solving option. " ++
              "(default: \"yices\")")
 
           pathSatSolver <-
@@ -323,7 +323,10 @@ cruxOptions = Config
         $ NoArg $ \opts -> Right opts { unsatCores = False }
 
       , Option "s" ["solver"]
-        "Select the solver to use to discharge proof obligations"
+        ("Select the solver to use to discharge proof obligations. " ++
+         "May be a single solver, a comma-separated list of solvers, or the string \"all\". " ++
+         "Specifying multiple solvers requires the --force-offline-goal-solving option. " ++
+         "(default: \"yices\")")
         $ ReqArg "solver" $ \v opts -> Right opts { solver = map toLower v }
 
       , Option [] ["path-sat-solver"]

--- a/crux/src/Crux/Config/Solver.hs
+++ b/crux/src/Crux/Config/Solver.hs
@@ -63,9 +63,6 @@ data SolverConfig = SingleOnlineSolver SolverOnline
                   -- ^ Use one online solver connection for path satisfiability
                   -- checking and a separate online solver connection for goal
                   -- discharge
-                  | OnlyOfflineSolver SolverOffline
-                  -- ^ Use only an offline solver with no support for path
-                  -- satisfiability checking
                   | OnlyOfflineSolvers [SolverOffline]
                   -- ^ Try any of a number of offline solvers with no support
                   -- for path satisfiability checking
@@ -202,7 +199,7 @@ parseSolverConfig cruxOpts = validatedToEither $
       -- discharged with an offline solver.
       OnlineSolverWithOfflineGoals <$> asOnlineSolver onSolver <*> asAnyOfflineSolver (CCC.solver cruxOpts)
   where
-    tryAnyOffline = OnlyOfflineSolver <$> asAnyOfflineSolver (CCC.solver cruxOpts)
-    tryOnlyOffline = OnlyOfflineSolver <$> asOnlyOfflineSolver (CCC.solver cruxOpts)
+    tryAnyOffline = OnlyOfflineSolvers . pure <$> asAnyOfflineSolver (CCC.solver cruxOpts)
+    tryOnlyOffline = OnlyOfflineSolvers . pure <$> asOnlyOfflineSolver (CCC.solver cruxOpts)
     trySingleOnline = SingleOnlineSolver <$> asOnlineSolver (CCC.solver cruxOpts)
     tryManyOffline = OnlyOfflineSolvers <$> asManyOfflineSolvers (CCC.solver cruxOpts)

--- a/crux/src/Crux/Config/Solver.hs
+++ b/crux/src/Crux/Config/Solver.hs
@@ -176,7 +176,7 @@ parseSolverConfig cruxOpts = validatedToEither $
       -- request path satisfiability checking.  They also requested that a
       -- separate solver be used for each goal (offline mode).  We'll use the
       -- specified solver as the only solver purely in offline mode.
-      tryManyOffline
+      tryAnyOffline <|> tryManyOffline
     (Nothing, False, False) ->
       -- This is currently the same as the previous case, but the user
       -- explicitly selected no path sat checking

--- a/crux/src/Crux/Goal.hs
+++ b/crux/src/Crux/Goal.hs
@@ -8,7 +8,7 @@
 
 module Crux.Goal where
 
-import Control.Concurrent.Async (AsyncCancelled(..), async, asyncThreadId, waitAnyCatch)
+import Control.Concurrent.Async (async, asyncThreadId, waitAnyCatch)
 import Control.Exception (throwTo, SomeException, displayException)
 import Control.Lens ((^.), view)
 import qualified Control.Lens as L
@@ -20,6 +20,7 @@ import Data.Maybe (fromMaybe)
 import qualified Data.Map as Map
 import qualified Data.Sequence as Seq
 import qualified Data.Text as Text
+import           System.Exit (ExitCode(ExitSuccess))
 import qualified System.Timeout as ST
 import           Text.PrettyPrint.ANSI.Leijen hiding ((<$>))
 
@@ -299,7 +300,7 @@ dispatchSolversOnGoalAsync adapters withAdapter = do
           await as' es
 
     -- `cancel` from async blocks until the canceled thread has terminated.
-    kill a = throwTo (asyncThreadId a) AsyncCancelled
+    kill a = throwTo (asyncThreadId a) ExitSuccess
 
 
 -- | Prove a collection of goals.  The result is a goal tree, where

--- a/crux/src/Crux/Goal.hs
+++ b/crux/src/Crux/Goal.hs
@@ -27,7 +27,7 @@ import           Text.PrettyPrint.ANSI.Leijen hiding ((<$>))
 import What4.Interface (notPred, printSymExpr,asConstantPred)
 import qualified What4.Interface as WI
 import What4.SatResult(SatResult(..))
-import What4.Expr (ExprBuilder, GroundEvalFn(..))
+import What4.Expr (ExprBuilder, GroundEvalFn(..), BoolExpr)
 import What4.Protocol.Online( OnlineSolver, inNewFrame, solverEvalFuns
                             , solverConn, check, getUnsatCore )
 import What4.Protocol.SMTWriter( mkFormula, assumeFormulaWithFreshName
@@ -205,10 +205,6 @@ proveGoalsOffline adapters opts ctx explainFailure (Just gs0) = do
   return (nms, Just gs)
 
   where
-    withTimeout action
-      | Just seconds <- goalTimeout opts = ST.timeout (round seconds * 1000000) action
-      | otherwise = Just <$> action
-
     failfast = proofGoalsFailFast opts
 
     go :: (Integer -> IO (), IO ())
@@ -237,31 +233,8 @@ proveGoalsOffline adapters opts ctx explainFailure (Just gs0) = do
           let sym = ctx ^. ctxSymInterface
           assumptions <- WI.andAllOf sym (L.folded . id) (fmap (^. labeledPred) (mconcat assumptionsInScope))
           goal <- notPred sym (p ^. labeledPred)
-          -- NOTE: We don't currently provide a method for capturing the output
-          -- sent to offline solvers.  We would probably want a file per goal.
-          let logData = WS.defaultLogData
 
-          let runOneSolver adapter = do
-                mres <- withTimeout $ WS.solver_adapter_check_sat adapter sym logData [assumptions, goal] $ \satRes ->
-                  case satRes of
-                    Unsat _ -> do
-                      -- NOTE: We don't have an easy way to get an unsat core here
-                      -- because we don't have a solver connection.
-                      let core = fmap Left (F.toList (mconcat assumptionsInScope))
-                      return (Proved core)
-                    Sat (evalFn, _) -> do
-                      let model = ctx ^. cruciblePersonality . personalityModel
-                      vals <- evalModel evalFn model
-                      explain <- explainFailure (Just evalFn) p
-                      return (NotProved explain (Just (ModelView vals)))
-                    Unknown -> do
-                      explain <- explainfailure Nothing p
-                      return (NotProved explain Nothing)
-                case mres of
-                  Just res -> return res
-                  Nothing -> return (NotProved mempty Nothing)
-
-          res <- dispatchSolversOnGoalAsync adapters runOneSolver
+          res <- dispatchSolversOnGoalAsync (goalTimeout opts) adapters $ runOneSolver p assumptionsInScope assumptions goal
           end
           case res of
             Right details -> do
@@ -276,28 +249,67 @@ proveGoalsOffline adapters opts ctx explainFailure (Just gs0) = do
               modifyIORef' goalNum (updateProcessedGoals p (NotProved mempty Nothing))
               let allExceptions = unlines (displayException <$> es)
               fail allExceptions
-                          
-dispatchSolversOnGoalAsync :: forall a s. [WS.SolverAdapter s]
-                      -> (WS.SolverAdapter s -> IO (ProofResult a))
-                      -> IO (Either [SomeException] (ProofResult a))
-dispatchSolversOnGoalAsync adapters withAdapter = do
+
+    runOneSolver :: LPred sym SimError
+                 -> [Seq.Seq (LPred sym asmp)]
+                 -> BoolExpr t
+                 -> BoolExpr t
+                 -> WS.SolverAdapter st
+                 -> IO (ProofResult (Either (LPred sym asmp) a))
+    runOneSolver p assumptionsInScope assumptions goal adapter = do
+      -- NOTE: We don't currently provide a method for capturing the output
+      -- sent to offline solvers.  We would probably want a file per goal per adapter.
+      let logData = WS.defaultLogData
+      WS.solver_adapter_check_sat adapter (ctx ^. ctxSymInterface) logData [assumptions, goal] $ \satRes ->
+        case satRes of
+          Unsat _ -> do
+            -- NOTE: We don't have an easy way to get an unsat core here
+            -- because we don't have a solver connection.
+            let core = fmap Left (F.toList (mconcat assumptionsInScope))
+            return (Proved core)
+          Sat (evalFn, _) -> do
+            let model = ctx ^. cruciblePersonality . personalityModel
+            vals <- evalModel evalFn model
+            explain <- explainFailure (Just evalFn) p
+            return (NotProved explain (Just (ModelView vals)))
+          Unknown -> do
+            explain <- explainFailure Nothing p
+            return (NotProved explain Nothing)
+
+dispatchSolversOnGoalAsync :: forall a s time.
+                              (RealFrac time)
+                           => Maybe time
+                           -> [WS.SolverAdapter s]
+                           -> (WS.SolverAdapter s -> IO (ProofResult a))
+                           -> IO (Either [SomeException] (ProofResult a))
+dispatchSolversOnGoalAsync mtimeoutSeconds adapters withAdapter = do
   asyncs <- forM adapters (async . withAdapter)
   await asyncs []
   where
     await [] es = return $ Left es
     await as es = do
-      (a, result) <- waitAnyCatch as
-      let as' = filter (/= a) as
-      case result of
-        Left  exc          -> await as' (exc : es)
-        Right r@(Proved _) -> do
-          mapM_ kill as'
-          return $ Right r
-        Right r@(NotProved _ (Just _)) -> do
-          mapM_ kill as'
-          return $ Right r
-        Right _ ->
-          await as' es
+      mresult <- withTimeout $ waitAnyCatch as
+      case mresult of
+        Just (a, result) -> do
+          let as' = filter (/= a) as
+          case result of
+            Left  exc ->
+              await as' (exc : es)
+            Right r@(Proved _) -> do
+              mapM_ kill as'
+              return $ Right r
+            Right r@(NotProved _ (Just _)) -> do
+              mapM_ kill as'
+              return $ Right r
+            Right _ ->
+              await as' es
+        Nothing -> do
+          mapM_ kill as
+          return $ Right $ NotProved (text "(Timeout)") Nothing
+         
+    withTimeout action
+      | Just seconds <- mtimeoutSeconds = ST.timeout (round seconds * 1000000) action
+      | otherwise = Just <$> action
 
     -- `cancel` from async blocks until the canceled thread has terminated.
     kill a = throwTo (asyncThreadId a) ExitSuccess


### PR DESCRIPTION
This is a proposal for throwing multiple solvers at a problem in offline mode.

The changes are:

- Allow the user to specify a _list_ of solvers (or the string "all") to try for each goal
- For each goal, `forkIO` a thread for each solver. If a thread returns a definite result, then use that as the result for the goal. Otherwise, each thread has either timed out or thrown an exception, in which case we might want to report those exceptions, for example (this is what the PR does currently).

At this point I'm looking for comments/suggestions.