### PR TITLE
Add GitHub Action for crux-llvm

### DIFF
--- a/.github/package-crux-llvm.sh
+++ b/.github/package-crux-llvm.sh
@@ -1,0 +1,14 @@
+DATE=`date "+%Y-%m-%d"`
+PKG=crux-llvm-$DATE
+rm -rf $PKG
+cabal v2-build exe:crux-llvm
+cabal v2-build exe:crux-llvm-svcomp
+mkdir $PKG
+mkdir $PKG/bin
+mkdir $PKG/doc
+cp `cabal v2-exec which crux-llvm` $PKG/bin
+cp `cabal v2-exec which crux-llvm-svcomp` $PKG/bin
+cp crux-llvm/README.md $PKG/doc
+cp -r crux-llvm/c-src $PKG
+tar cf $PKG.tar.gz $PKG
+rm -rf $PKG

--- a/.github/package-crux-llvm.sh
+++ b/.github/package-crux-llvm.sh
@@ -4,7 +4,7 @@ set -Eeuo pipefail
 DATE=`date "+%Y-%m-%d"`
 PKG=crux-llvm-$DATE
 EXE=`cabal v2-exec which crux-llvm`
-EXE_SVCOMP=`cabal v2-exec which crux-llvm-svcomp`
+EXE_SVCOMP=`cabal v2-exec which crux-llvm-svcomp || true`
 
 rm -rf $PKG
 
@@ -13,7 +13,7 @@ mkdir $PKG/bin
 mkdir $PKG/doc
 
 cp $EXE $PKG/bin
-if [ -e $EXE_SVCOMP ] ; then
+if [ -e "$EXE_SVCOMP" ] ; then
   cp $EXE_SVCOMP $PKG/bin
 fi
 cp crux-llvm/README.md $PKG/doc

--- a/.github/package-crux-llvm.sh
+++ b/.github/package-crux-llvm.sh
@@ -1,8 +1,10 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
 DATE=`date "+%Y-%m-%d"`
 PKG=crux-llvm-$DATE
 rm -rf $PKG
-cabal v2-build exe:crux-llvm
-cabal v2-build exe:crux-llvm-svcomp
+cabal v2-build exe:crux-llvm exe:crux-llvm-svcomp
 mkdir $PKG
 mkdir $PKG/bin
 mkdir $PKG/doc

--- a/.github/package-crux-llvm.sh
+++ b/.github/package-crux-llvm.sh
@@ -5,7 +5,7 @@ set -Eeuo pipefail
 
 DATE=`date "+%Y-%m-%d"`
 PKG=crux-llvm-$DATE
-EXE=`cabal v2-exec which crux-llvm`
+EXE=`cabal v2-exec which crux-llvm | tail -1`
 
 rm -rf $PKG
 
@@ -13,9 +13,11 @@ mkdir $PKG
 mkdir $PKG/bin
 mkdir $PKG/doc
 
+cabal v2-build exe:crux-llvm
 cp $EXE $PKG/bin
 if ! $IS_WIN ; then
-  EXE_SVCOMP=`cabal v2-exec which crux-llvm-svcomp`
+  cabal v2-build exe:crux-llvm-svcomp
+  EXE_SVCOMP=`cabal v2-exec which crux-llvm-svcomp | tail -1`
   cp $EXE_SVCOMP $PKG/bin
 fi
 cp crux-llvm/README.md $PKG/doc

--- a/.github/package-crux-llvm.sh
+++ b/.github/package-crux-llvm.sh
@@ -3,14 +3,22 @@ set -Eeuo pipefail
 
 DATE=`date "+%Y-%m-%d"`
 PKG=crux-llvm-$DATE
+EXE=`cabal v2-exec which crux-llvm`
+EXE_SVCOMP=`cabal v2-exec which crux-llvm-svcomp`
+
 rm -rf $PKG
-cabal v2-build exe:crux-llvm exe:crux-llvm-svcomp
+
 mkdir $PKG
 mkdir $PKG/bin
 mkdir $PKG/doc
-cp `cabal v2-exec which crux-llvm` $PKG/bin
-cp `cabal v2-exec which crux-llvm-svcomp` $PKG/bin
+
+cp $EXE $PKG/bin
+if [ -e $EXE_SVCOMP ] ; then
+  cp $EXE_SVCOMP $PKG/bin
+fi
 cp crux-llvm/README.md $PKG/doc
 cp -r crux-llvm/c-src $PKG
+
 tar cf $PKG.tar.gz $PKG
+
 rm -rf $PKG

--- a/.github/package-crux-llvm.sh
+++ b/.github/package-crux-llvm.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
+[[ "$RUNNER_OS" == 'Windows' ]] && IS_WIN=true || IS_WIN=false
+
 DATE=`date "+%Y-%m-%d"`
 PKG=crux-llvm-$DATE
 EXE=`cabal v2-exec which crux-llvm`
@@ -13,9 +15,7 @@ mkdir $PKG/bin
 mkdir $PKG/doc
 
 cp $EXE $PKG/bin
-if [ -e "$EXE_SVCOMP" ] ; then
-  cp $EXE_SVCOMP $PKG/bin
-fi
+$IS_WIN || cp $EXE_SVCOMP $PKG/bin
 cp crux-llvm/README.md $PKG/doc
 cp -r crux-llvm/c-src $PKG
 

--- a/.github/package-crux-llvm.sh
+++ b/.github/package-crux-llvm.sh
@@ -6,7 +6,6 @@ set -Eeuo pipefail
 DATE=`date "+%Y-%m-%d"`
 PKG=crux-llvm-$DATE
 EXE=`cabal v2-exec which crux-llvm`
-EXE_SVCOMP=`cabal v2-exec which crux-llvm-svcomp || true`
 
 rm -rf $PKG
 
@@ -15,7 +14,10 @@ mkdir $PKG/bin
 mkdir $PKG/doc
 
 cp $EXE $PKG/bin
-$IS_WIN || cp $EXE_SVCOMP $PKG/bin
+if ! $IS_WIN ; then
+  EXE_SVCOMP=`cabal v2-exec which crux-llvm-svcomp`
+  cp $EXE_SVCOMP $PKG/bin
+fi
 cp crux-llvm/README.md $PKG/doc
 cp -r crux-llvm/c-src $PKG
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,3 +72,11 @@ jobs:
 
       - shell: bash
         run: cabal v2-build --allow-newer crux-llvm
+
+      - shell: bash
+        run: .github/package-crux-llvm.sh
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: crux-llvm-*.tar.gz
+          name: crux-llvm-${{ runner.os }}-${{ matrix.ghc }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Let's support Windows eventually, but we don't need to now.
         os: [ubuntu-latest, macos-latest, windows-latest]
         ghc: ["8.6.5", "8.8.4", "8.10.2"]
+        # Windows only seems to work on 8.6.5. Others result in
+        # segfaults or other internal errors.
+        exclude:
+          - os: windows-latest
+            ghc: 8.10.2
+          - os: windows-latest
+            ghc: 8.8.4
     name: crux-llvm - GHC v${{ matrix.ghc }} - ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches: [master, "release-**"]
   pull_request:
+  workflow_dispatch:
 
 jobs:
   outputs:
@@ -24,17 +25,7 @@ jobs:
       matrix:
         # Let's support Windows eventually, but we don't need to now.
         os: [ubuntu-latest, macos-latest] # , windows-latest]
-        ghc: ["8.6.5", "8.8.3", "8.10.1"]
-        exclude:
-          # The process-1.6.8 library contains a memory leak on windows,
-          # causing RAM constrained builds to sometimes fail.
-          # Technically, windows+GHC 8.10.1 should also likely be excluded, but
-          # we use GHC 8.10.1 for releases currently.
-          #
-          # https://gitlab.haskell.org/ghc/ghc/-/issues/17926
-          # TODO: remove when 8.8.4 and 8.10.2 are released
-          - os: windows-latest
-            ghc: 8.8.3
+        ghc: ["8.6.5", "8.8.4", "8.10.2"]
     name: crux-llvm - GHC v${{ matrix.ghc }} - ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -71,7 +62,7 @@ jobs:
         run: cabal v2-update
 
       - shell: bash
-        run: cabal v2-build --allow-newer crux-llvm
+        run: cabal v2-build exe:crux-llvm exe:crux-llvm-svcomp
 
       - shell: bash
         run: .github/package-crux-llvm.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
         run: cabal v2-update
 
       - shell: bash
-        run: cabal v2-build exe:crux-llvm exe:crux-llvm-svcomp
+        run: cabal v2-build exe:crux-llvm
 
       - shell: bash
         run: cabal v2-build exe:crux-llvm-svcomp

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # Let's support Windows eventually, but we don't need to now.
+        os: [ubuntu-latest, macos-latest] # , windows-latest]
         ghc: ["8.6.5", "8.8.3", "8.10.1"]
         exclude:
           # The process-1.6.8 library contains a memory leak on windows,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,73 @@
+name: crux-llvm
+on:
+  push:
+    branches: [master, "release-**"]
+  pull_request:
+
+jobs:
+  outputs:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.outputs.outputs.changed-files }}
+      name: ${{ steps.outputs.outputs.name }}
+      release: ${{ steps.env.outputs.release }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+  build:
+    runs-on: ${{ matrix.os }}
+    needs: [outputs]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        ghc: ["8.6.5", "8.8.3", "8.10.1"]
+        exclude:
+          # The process-1.6.8 library contains a memory leak on windows,
+          # causing RAM constrained builds to sometimes fail.
+          # Technically, windows+GHC 8.10.1 should also likely be excluded, but
+          # we use GHC 8.10.1 for releases currently.
+          #
+          # https://gitlab.haskell.org/ghc/ghc/-/issues/17926
+          # TODO: remove when 8.8.4 and 8.10.2 are released
+          - os: windows-latest
+            ghc: 8.8.3
+    name: crux-llvm - GHC v${{ matrix.ghc }} - ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - uses: actions/setup-haskell@v1
+        id: setup-haskell
+        with:
+          ghc-version: ${{ matrix.ghc }}
+
+      - uses: actions/cache@v1
+        name: Cache cabal store
+        with:
+          path: ${{ steps.setup-haskell.outputs.cabal-store }}
+          # https://github.com/actions/cache/issues/109 "Enable always writing cache to support hermetic build systems"
+          # https://github.com/actions/cache/issues/239#issuecomment-606950711 Investigate this workaround if cache starts filling up
+          key: store-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('**/cabal.GHC-*') }}-${{ github.sha }}
+          restore-keys: |
+            store-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('**/cabal.GHC-*') }}-
+            store-${{ runner.os }}-${{ matrix.ghc }}-
+            store-${{ runner.os }}-
+
+      - uses: actions/cache@v1
+        name: Cache dist-newstyle
+        with:
+          path: dist-newstyle
+          key: dist-newstyle-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('**/cabal.GHC-*') }}-${{ github.sha }}
+          restore-keys: |
+            dist-newstyle-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('**/cabal.GHC-*') }}-
+            dist-newstyle-${{ runner.os }}-${{ matrix.ghc }}-
+
+      - shell: bash
+        run: cabal v2-update
+
+      - shell: bash
+        run: cabal v2-build --allow-newer

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,10 @@ jobs:
         run: cabal v2-build exe:crux-llvm exe:crux-llvm-svcomp
 
       - shell: bash
+        run: cabal v2-build exe:crux-llvm-svcomp
+        if: 'runner.os != Windows'
+
+      - shell: bash
         run: .github/package-crux-llvm.sh
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         # Let's support Windows eventually, but we don't need to now.
-        os: [ubuntu-latest, macos-latest] # , windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         ghc: ["8.6.5", "8.8.4", "8.10.2"]
     name: crux-llvm - GHC v${{ matrix.ghc }} - ${{ matrix.os }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
 
       - shell: bash
         run: cabal v2-build exe:crux-llvm-svcomp
-        if: 'runner.os != Windows'
+        if: runner.os != 'Windows'
 
       - shell: bash
         run: .github/package-crux-llvm.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,4 +70,4 @@ jobs:
         run: cabal v2-update
 
       - shell: bash
-        run: cabal v2-build --allow-newer
+        run: cabal v2-build --allow-newer crux-llvm

--- a/crux-llvm/crux-llvm.cabal
+++ b/crux-llvm/crux-llvm.cabal
@@ -143,7 +143,6 @@ test-suite crux-llvm-test
 
   main-is: Test.hs
 
-
   build-depends:
                 base             >= 4.7,
                 bytestring,

--- a/crux-llvm/crux-llvm.cabal
+++ b/crux-llvm/crux-llvm.cabal
@@ -97,6 +97,9 @@ executable crux-llvm-svcomp
   hs-source-dirs: svcomp
   main-is: Main.hs
 
+  if os(windows)
+    buildable: False
+
   build-depends:
     aeson >= 1.4.7,
     attoparsec >= 0.13,
@@ -139,6 +142,7 @@ test-suite crux-llvm-test
   ghc-prof-options: -fprof-auto -O2
 
   main-is: Test.hs
+
 
   build-depends:
                 base             >= 4.7,


### PR DESCRIPTION
This builds `crux-llvm` on Linux, macOS, and Windows. It also builds `crux-llvm-svcomp` on the former two, but omits Windows due to its `unix` dependency.