### PR TITLE
Extend MemImpl with new field to support new faster `isGlobalPointer`.

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Value.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Value.hs
@@ -224,11 +224,13 @@ ppLLVMValWithGlobals :: forall sym.
   sym ->
   Map Natural L.Symbol {- ^ c.f. 'memImplSymbolMap' -} ->
   LLVMVal sym ->
-  IO Doc
-ppLLVMValWithGlobals _sym symbolMap = ppLLVMVal $ \allocNum offset ->
-  pure (isGlobalPointer' @sym symbolMap (LLVMPointer allocNum offset)) <&&>
-    \(L.Symbol symb) -> text ('@':symb)
-  where x <&&> f = (fmap . fmap) f x -- map under IO and Maybe
+  Doc
+ppLLVMValWithGlobals _sym symbolMap = runIdentity . ppLLVMVal ppInt
+  where
+    ppInt :: forall w. SymNat sym -> SymBV sym w -> Identity (Maybe Doc)
+    ppInt allocNum offset =
+      pure (ppSymbol <$> isGlobalPointer' @sym symbolMap (LLVMPointer allocNum offset))
+    ppSymbol (L.Symbol symb) = text ('@' : symb)
 
 -- | This instance tries to make things as concrete as possible.
 instance IsExpr (SymExpr sym) => Pretty (LLVMVal sym) where

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Value.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Value.hs
@@ -48,6 +48,7 @@ import           Data.Foldable (toList)
 import           Data.Functor.Identity (Identity(..))
 import           Data.Maybe (fromMaybe, mapMaybe)
 import           Data.List (intersperse)
+import           Numeric.Natural
 import           Text.PrettyPrint.ANSI.Leijen hiding ((<$>))
 
 import qualified Data.BitVector.Sized as BV
@@ -221,11 +222,11 @@ ppLLVMVal ppInt =
 ppLLVMValWithGlobals :: forall sym.
   (IsSymInterface sym) =>
   sym ->
-  Map L.Symbol (SomePointer sym) {-^ c.f. 'memImplGlobalMap' -} ->
+  Map Natural L.Symbol {- ^ c.f. 'memImplSymbolMap' -} ->
   LLVMVal sym ->
   IO Doc
-ppLLVMValWithGlobals sym globalMap = ppLLVMVal $ \allocNum offset ->
-  isGlobalPointer' sym globalMap (LLVMPointer allocNum offset) <&&>
+ppLLVMValWithGlobals _sym symbolMap = ppLLVMVal $ \allocNum offset ->
+  pure (isGlobalPointer' @sym symbolMap (LLVMPointer allocNum offset)) <&&>
     \(L.Symbol symb) -> text ('@':symb)
   where x <&&> f = (fmap . fmap) f x -- map under IO and Maybe
 


### PR DESCRIPTION
Fixes #545.

NOTE: This change will require some minor changes to saw-script, due to the changed type of `ppLLVMValWithGlobals`.

Another question: We could actually change the return type of `ppLLVMValWithGlobals` now from `IO Doc` to just `Doc`, because `isGlobalPointer` (which it calls) no longer needs `IO`. Should we do that as well?