### PR TITLE
Use Map-based data structure for LLVM allocation histories.

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/MemLog.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/MemLog.hs
@@ -33,7 +33,6 @@ module Lang.Crucible.LLVM.MemModel.MemLog
   , AllocInfo(..)
   , MemAllocs
   , sizeMemAllocs
-  -- , singleMemAlloc
   , allocMemAllocs
   , freeMemAllocs
   , muxMemAllocs

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/MemLog.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/MemLog.hs
@@ -117,7 +117,9 @@ data MemAlloc sym
     -- | The merger of two allocations.
   | AllocMerge (Pred sym) (MemAllocs sym) (MemAllocs sym)
 
--- | Memory allocations are represented as a list with the invariant
+-- | A record of which memory regions have been allocated or freed.
+
+-- Memory allocations are represented as a list with the invariant
 -- that any two adjacent 'Allocations' constructors must be merged
 -- together, and that no 'Allocations' constructor has an empty map.
 newtype MemAllocs sym = MemAllocs [MemAlloc sym]

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/MemLog.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/MemLog.hs
@@ -112,7 +112,7 @@ data MemAlloc sym
 
 -- | Memory allocations are represented as a list with the invariant
 -- that any two adjacent 'Allocations' constructors must be merged
--- together.
+-- together, and that no 'Allocations' constructor has an empty map.
 newtype MemAllocs sym = MemAllocs [MemAlloc sym]
 
 instance Semigroup (MemAllocs sym) where


### PR DESCRIPTION
Instead of recording allocations sequentially, we now store
collections of allocations together in a map indexed by block
ID. This makes lookups much faster in the common case where
the block ID we are checking is concrete.

Fixes #549.