### PR TITLE
Line up Crux version numbers

### DIFF
--- a/crux-llvm/crux-llvm.cabal
+++ b/crux-llvm/crux-llvm.cabal
@@ -1,5 +1,5 @@
 Name:          crux-llvm
-Version:       0.3.2
+Version:       0.4
 Author:        Galois Inc.
 Maintainer:    iavor.diatchki@gmail.com
 Copyright:     (c) Galois, Inc 2014-2017

--- a/crux-mir/crux-mir.cabal
+++ b/crux-mir/crux-mir.cabal
@@ -1,5 +1,5 @@
 name:                crux-mir
-version:             0.1.0.0
+version:             0.4
 -- synopsis:
 -- description:
 homepage:            https://github.com/GaloisInc/crucible/blob/master/crux-mir/README.md

--- a/crux/crux.cabal
+++ b/crux/crux.cabal
@@ -1,5 +1,5 @@
 Name:          crux
-Version:       0.1
+Version:       0.4
 Author:        Galois Inc.
 Copyright:     (c) Galois, Inc. 2018
 Maintainer:    sweirich@galois.com


### PR DESCRIPTION
This commit bumps the version numbers for `crux`, `crux-llvm`, and
`crux-mir` with the goal of presenting "Crux" as a unified entity.