### PR TITLE
Remove duplicate line from crucible-llvm.cabal.

### DIFF
--- a/crucible-llvm/crucible-llvm.cabal
+++ b/crucible-llvm/crucible-llvm.cabal
@@ -105,7 +105,6 @@ test-suite crucible-llvm-tests
   hs-source-dirs: test
   default-language: Haskell2010
   ghc-options: -Wall -Wcompat
-  default-language: Haskell2010
   -- other-modules:
   build-depends:
     base,


### PR DESCRIPTION
The extra line was causing a warning message from cabal
about "default-language" specified more than once.