### PR TITLE
Replace deprecated GitHub Actions functions

### DIFF
--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -137,7 +137,7 @@ install_system_deps() {
   install_llvm &
   wait
   export PATH=$PWD/$BIN:$PATH
-  echo "::add-path::$PWD/$BIN"
+  echo "$PWD/$BIN" >> $GITHUB_PATH
   is_exe "$BIN" z3 && is_exe "$BIN" yices
 }
 


### PR DESCRIPTION
`add-path` and `set-env` have been deprecated as of 10/1/2020 and will be removed, this patch replaces them with environment files to keep the existing workflows running.