### PR TITLE
fixpoint: Export additional types and functions to make the modified …

### DIFF
--- a/crucible/src/Lang/Crucible/Analysis/Fixpoint.hs
+++ b/crucible/src/Lang/Crucible/Analysis/Fixpoint.hs
@@ -37,6 +37,8 @@ module Lang.Crucible.Analysis.Fixpoint (
   IterationStrategy(..),
   Interpretation(..),
   PointAbstraction(..),
+  RefSet,
+  emptyRefSet,
   paGlobals,
   paRegisters,
   lookupAbstractRegValue,


### PR DESCRIPTION
…interface usable

These are needed to write type signatures and actually create ref sets.  There
needs to be more work done to expose primitives to manipulate ref sets, but I'm
not sure what they are supposed to be for.