### PR TITLE
Changes to crucible-jvm field operations

### DIFF
--- a/crucible-jvm/src/Lang/Crucible/JVM/Context.hs
+++ b/crucible-jvm/src/Lang/Crucible/JVM/Context.hs
@@ -30,7 +30,7 @@ import           Lang.Crucible.JVM.Types
 -- * JVMContext
 
 
-type StaticFieldTable = Map (J.ClassName, J.FieldId) (GlobalVar JVMValueType)
+type StaticFieldTable = Map J.FieldId (GlobalVar JVMValueType)
 type MethodHandleTable = Map (J.ClassName, J.MethodKey) JVMHandleInfo
 
 data JVMHandleInfo where
@@ -41,7 +41,7 @@ data JVMHandleInfo where
 data JVMContext = JVMContext
   { methodHandles :: Map (J.ClassName, J.MethodKey) JVMHandleInfo
       -- ^ Map from static and dynamic methods to Crucible function handles.
-  , staticFields :: Map (J.ClassName, J.FieldId) (GlobalVar JVMValueType)
+  , staticFields :: Map J.FieldId (GlobalVar JVMValueType)
       -- ^ Map from static field names to Crucible global variables.
       -- We know about these fields at translation time so we can allocate
       -- global variables to store them.

--- a/crucible-jvm/src/Lang/Crucible/JVM/Simulate.hs
+++ b/crucible-jvm/src/Lang/Crucible/JVM/Simulate.hs
@@ -456,7 +456,7 @@ jvmSimContext sym halloc handle ctx verbosity p =
 -- | Make the initial state for the simulator, binding the function handles so that
 -- they translate method bodies when they are accessed.
 mkSimSt ::
-  -- forall sym .
+  forall sym p ret.
   (IsSymInterface sym) =>
   sym ->
   p ->
@@ -470,7 +470,7 @@ mkSimSt sym p halloc ctx verbosity ret k =
   do globals <- Map.foldrWithKey initField (return globals0) (staticFields ctx)
      return $ C.InitialState simctx globals C.defaultAbortHandler ret k
   where
-    -- initField :: J.FieldId -> GlobalVar JVMValueType -> IO (C.SymGlobalState sym) -> IO (C.SymGlobalState sym)
+    initField :: J.FieldId -> GlobalVar JVMValueType -> IO (C.SymGlobalState sym) -> IO (C.SymGlobalState sym)
     initField fi var m =
       do gs <- m
          z <- zeroValue sym (J.fieldIdType fi)

--- a/crucible-jvm/src/Lang/Crucible/JVM/Simulate.hs
+++ b/crucible-jvm/src/Lang/Crucible/JVM/Simulate.hs
@@ -345,7 +345,7 @@ declareStaticField halloc c m f = do
   let fieldId = J.FieldId cn fn (J.fieldType f)
   let str = fn ++ show (J.fieldType f)
   gvar <- C.freshGlobalVar halloc (globalVarName cn str) (knownRepr :: TypeRepr JVMValueType)
-  return $ (Map.insert (cn,fieldId) gvar m)
+  return $ Map.insert fieldId gvar m
 
 
 -- | Create the initial 'JVMContext'.
@@ -471,8 +471,8 @@ mkSimSt sym p halloc ctx verbosity ret k =
   do globals <- Map.foldrWithKey initField (return globals0) (staticFields ctx)
      return $ C.InitialState simctx globals C.defaultAbortHandler ret k
   where
-    -- initField :: (J.ClassName, J.FieldId) -> GlobalVar JVMValueType -> IO (C.SymGlobalState sym) -> IO (C.SymGlobalState sym)
-    initField (_, fi) var m =
+    -- initField :: J.FieldId -> GlobalVar JVMValueType -> IO (C.SymGlobalState sym) -> IO (C.SymGlobalState sym)
+    initField fi var m =
       do gs <- m
          z <- zeroValue sym (J.fieldIdType fi)
          return (C.insertGlobal var z gs)

--- a/crucible-jvm/src/Lang/Crucible/JVM/Translation/Class.hs
+++ b/crucible-jvm/src/Lang/Crucible/JVM/Translation/Class.hs
@@ -362,7 +362,7 @@ getStaticFieldValue fieldId = do
       let cls = J.fieldIdClass fieldId
       ctx <- gets jsContext
       initializeClass cls
-      case Map.lookup (J.fieldIdClass fieldId, fieldId) (staticFields ctx) of
+      case Map.lookup fieldId (staticFields ctx) of
         Just glob -> do
           r <- readGlobal glob
           fromJVMDynamic (J.fieldIdType fieldId) r
@@ -374,7 +374,7 @@ setStaticFieldValue :: J.FieldId -> JVMValue s -> JVMGenerator s ret ()
 setStaticFieldValue  fieldId val = do
     ctx <- gets jsContext
     let cName = J.fieldIdClass fieldId
-    case Map.lookup (cName, fieldId) (staticFields ctx) of
+    case Map.lookup fieldId (staticFields ctx) of
          Just glob -> do
            writeGlobal glob (valueToExpr val)
          Nothing ->

--- a/crucible-jvm/src/Lang/Crucible/JVM/Translation/Class.hs
+++ b/crucible-jvm/src/Lang/Crucible/JVM/Translation/Class.hs
@@ -365,7 +365,7 @@ getStaticFieldValue fieldId = do
       case Map.lookup fieldId (staticFields ctx) of
         Just glob -> do
           r <- readGlobal glob
-          fromJVMDynamic (J.fieldIdType fieldId) r
+          fromJVMDynamic ("getstatic " <> fieldIdText fieldId) (J.fieldIdType fieldId) r
         Nothing ->
           jvmFail $ "getstatic: field " ++ J.fieldIdName fieldId ++ " not found"
 
@@ -834,12 +834,12 @@ resolveField fieldId =
 getInstanceFieldValue :: JVMObject s -> J.FieldId -> JVMGenerator s ret (JVMValue s)
 getInstanceFieldValue obj fieldId =
   do let uobj = App (UnrollRecursive knownRepr knownRepr obj)
-     inst <- projectVariant Ctx.i1of2 uobj
+     inst <- projectVariant "getfield: expected class instance" Ctx.i1of2 uobj
      let fields = App (GetStruct inst Ctx.i1of2 knownRepr)
      key <- resolveField fieldId
      let mval = App (LookupStringMapEntry knownRepr fields key)
      dyn <- assertedJustExpr mval "Field not present"
-     fromJVMDynamic (J.fieldIdType fieldId) dyn
+     fromJVMDynamic ("getfield " <> fieldIdText fieldId) (J.fieldIdType fieldId) dyn
 
 -- | Update a field of a JVM object (must be a class instance, not an array).
 setInstanceFieldValue :: JVMObject s -> J.FieldId -> JVMValue s -> JVMGenerator s ret (JVMObject s)
@@ -847,7 +847,7 @@ setInstanceFieldValue obj fieldId val =
   do let dyn  = valueToExpr val
      let mdyn = App (JustValue knownRepr dyn)
      let uobj = App (UnrollRecursive knownRepr knownRepr obj)
-     inst <- projectVariant Ctx.i1of2 uobj
+     inst <- projectVariant "setfield: expected class instance" Ctx.i1of2 uobj
      let fields = App (GetStruct inst Ctx.i1of2 knownRepr)
      key <- resolveField fieldId
      let fields' = App (InsertStringMapEntry knownRepr fields key mdyn)
@@ -859,7 +859,7 @@ setInstanceFieldValue obj fieldId val =
 getJVMInstanceClass :: JVMObject s -> JVMGenerator s ret (JVMClass s)
 getJVMInstanceClass obj = do
   let uobj = App (UnrollRecursive knownRepr knownRepr obj)
-  inst <- projectVariant Ctx.i1of2 uobj
+  inst <- projectVariant "invokeinterface: expected class instance" Ctx.i1of2 uobj
   return $ App (GetStruct inst Ctx.i2of2 knownRepr)
 
 


### PR DESCRIPTION
This PR includes a few changes to the APIs for loading and storing of instance fields and static fields:
- Simplify key type on `staticFields` map of `JVMContext`.
- `doFieldLoad` and `doFieldStore` now take a `FieldId` instead of a string
- Add functions `doStaticFieldStore` and `doStaticFieldLoad`
- Add field name to error messages for `getfield` and `getstatic`