### PR TITLE
Reimplement translation of `getstatic` and `putstatic` following JVM spec.

### DIFF
--- a/crucible-jvm/src/Lang/Crucible/JVM/Translation.hs
+++ b/crucible-jvm/src/Lang/Crucible/JVM/Translation.hs
@@ -733,7 +733,7 @@ generateInstruction (pc, instr) =
 
     J.Putstatic fieldId -> do
       val <- popValue
-      lift $ setStaticFieldValue fieldId val
+      lift $ putStaticFieldValue fieldId val
 
 
     -- array creation

--- a/crucible-jvm/src/Lang/Crucible/JVM/Translation/Class.hs
+++ b/crucible-jvm/src/Lang/Crucible/JVM/Translation/Class.hs
@@ -378,7 +378,11 @@ putStaticFieldValue rawFieldId val =
      initializeClass (J.fieldIdClass fieldId)
      setStaticFieldValue fieldId val
 
--- | Update the value of a static field, without doing any field resolution or class initialization.
+-- | Update the value of a static field, without doing any field
+-- resolution or class initialization. This function must be used
+-- instead of 'putStaticFieldValue' for implementing static class
+-- initializers, to avoid calling the class initializer in an infinite
+-- loop.
 setStaticFieldValue :: J.FieldId -> JVMValue s -> JVMGenerator s ret ()
 setStaticFieldValue fieldId val =
   do ctx <- gets jsContext


### PR DESCRIPTION
According to the JVM spec, each of these instructions starts with the same two steps: "The referenced field is resolved (§5.4.3.2). On successful resolution of the field, the class or interface that declared the resolved field is initialized (§5.5) if that class or interface has not already been initialized."