### PR TITLE
crucible-llvm: Add another test for the SMT array memory model

### DIFF
--- a/crucible-llvm/test/Tests.hs
+++ b/crucible-llvm/test/Tests.hs
@@ -337,6 +337,7 @@ tests int struct uninitialized _ lifetime = do
     , [ testArrayStride
       , testMemArray
       , testMemAllocs
+      , testMemArrayWithConstants
       ]
     ]
 
@@ -476,8 +477,13 @@ testArrayStride = testCase "array stride" $ withMem BigEndian $ \sym mem0 -> do
     =<< doLoad sym mem4 ptr_j' byte_storage_type ptr_byte_repr noAlignment
   (Just (BV.one knownNat)) @=? What4.asBV at_j'_val
 
+-- | This test case verifies that the symbolic aspects of the SMT-backed array
+-- memory model works (e.g., that constraints on symbolic indexes work as
+-- expected)
 testMemArray :: TestTree
 testMemArray = testCase "smt array memory model" $ withMem BigEndian $ \sym mem0 -> do
+  -- Make a fresh allocation (backed by a fresh SMT array) of size 1024*1024 bytes.
+  -- The base pointer of the array is base_ptr
   sz <- What4.bvLit sym ?ptrWidth $ BV.mkBV ?ptrWidth (1024 * 1024)
   (base_ptr, mem1) <- mallocRaw sym mem0 sz noAlignment
 
@@ -493,17 +499,25 @@ testMemArray = testCase "smt array memory model" $ withMem BigEndian $ \sym mem0
   let long_storage_type = bitvectorType 8
   let ptr_long_repr = LLVMPointerRepr $ knownNat @64
 
+  -- Store a large known 8 byte value at a symbolic location in the array (at
+  -- @i@ bytes from the beginning of the array).  The assumption constrains it
+  -- such that the location is within the first 1024 bytes of the array.
   i <- What4.freshConstant sym (userSymbol' "i") $ What4.BaseBVRepr ?ptrWidth
   ptr_i <- ptrAdd sym ?ptrWidth base_ptr i
   assume sym =<< What4.bvUlt sym i =<< What4.bvLit sym ?ptrWidth (BV.mkBV ?ptrWidth 1024)
   some_val <- What4.bvLit sym (knownNat @64) (BV.mkBV knownNat 0x88888888f0f0f0f0)
   mem3 <-
     doStore sym mem2 ptr_i long_type_repr long_storage_type noAlignment some_val
+
+  -- Read that same value back and make sure that they are the same
   at_i_val <- projectLLVM_bv sym
     =<< doLoad sym mem3 ptr_i long_storage_type ptr_long_repr noAlignment
   res_i <- checkSat sym =<< What4.bvNe sym some_val at_i_val
   True @=? What4.isUnsat res_i
 
+  -- Allocate another fresh arbitrary constant and add it to the base pointer.
+  -- Assume that i = j, then verify that reading from j yields the same value as
+  -- was written at i.
   j <- What4.freshConstant sym (userSymbol' "j") $ What4.BaseBVRepr ?ptrWidth
   ptr_j <- ptrAdd sym ?ptrWidth base_ptr j
   assume sym =<< What4.bvEq sym i j
@@ -511,6 +525,81 @@ testMemArray = testCase "smt array memory model" $ withMem BigEndian $ \sym mem0
     =<< doLoad sym mem3 ptr_j long_storage_type ptr_long_repr noAlignment
   res_j <- checkSat sym =<< What4.bvNe sym some_val at_j_val
   True @=? What4.isUnsat res_j
+
+-- | Like testMemArray, but using some concrete indexes in a few places.  This
+-- test checks the implementation of saturated addition of two numbers.
+--
+-- This is simulating the use of an SMT array to represent a program stack, and
+-- ensures that:
+--
+-- * Concrete indexing works as expected
+-- * Goals that depend on the values of values stored in memory work
+testMemArrayWithConstants :: TestTree
+testMemArrayWithConstants = testCase "smt array memory model (with constant indexing)" $ do
+  withMem LittleEndian $ \sym mem0 -> do
+    sz <- What4.bvLit sym ?ptrWidth (BV.mkBV ?ptrWidth (2 * 1024))
+    (region_ptr, mem1) <- mallocRaw sym mem0 sz noAlignment
+    let mRepr = What4.BaseArrayRepr (Ctx.singleton (What4.BaseBVRepr ?ptrWidth)) (What4.BaseBVRepr (knownNat @8))
+    backingArray <- What4.freshConstant sym (userSymbol' "backingArray") mRepr
+    mem2 <- doArrayStore sym mem1 region_ptr noAlignment backingArray sz
+
+    let long_type_repr = Crucible.baseToType $ What4.BaseBVRepr $ knownNat @64
+    let long_storage_type = bitvectorType 8
+    let ptr_long_repr = LLVMPointerRepr $ knownNat @64
+
+    -- Make our actual base pointer the middle of the stack, to simulate having
+    -- some active frames above us
+    base_off <- What4.freshConstant sym (userSymbol' "baseOffset") (What4.BaseBVRepr ?ptrWidth)
+    assume sym =<< What4.bvUlt sym base_off =<< (What4.bvLit sym ?ptrWidth (BV.mkBV ?ptrWidth 10))
+    base_ptr <- ptrAdd sym ?ptrWidth region_ptr base_off -- =<< What4.bvLit sym ?ptrWidth (BV.mkBV ?ptrWidth 1024)
+
+    -- Assume we have two arguments to our virtual function:
+    param_a <- What4.freshConstant sym (userSymbol' "paramA") (What4.BaseBVRepr (knownNat @64))
+    param_b <- What4.freshConstant sym (userSymbol' "paramB") (What4.BaseBVRepr (knownNat @64))
+
+    -- The fake stack frame will start at @sp@ be:
+    --
+    -- sp+8  : Stack slot for spilling a
+    slot_a <- ptrAdd sym ?ptrWidth base_ptr =<< What4.bvLit sym ?ptrWidth (BV.mkBV ?ptrWidth 8)
+    -- sp+16 : Stack slot for spilling b
+    slot_b <- ptrAdd sym ?ptrWidth base_ptr =<< What4.bvLit sym ?ptrWidth (BV.mkBV ?ptrWidth 16)
+    -- sp+24 : Stack slot for local variable c
+    slot_c <- ptrAdd sym ?ptrWidth base_ptr =<< What4.bvLit sym ?ptrWidth (BV.mkBV ?ptrWidth 24)
+
+    -- Store a and b onto the stack
+    mem3 <- doStore sym mem2 slot_a long_type_repr long_storage_type noAlignment param_a
+    mem4 <- doStore sym mem3 slot_b long_type_repr long_storage_type noAlignment param_b
+
+    -- Read a and b off of the stack and compute c = a+b (storing the result on the stack in c's slot)
+    valA0 <- projectLLVM_bv sym =<< doLoad sym mem4 slot_a long_storage_type ptr_long_repr noAlignment
+    valB0 <- projectLLVM_bv sym =<< doLoad sym mem4 slot_b long_storage_type ptr_long_repr noAlignment
+    mem5 <- doStore sym mem4 slot_c long_type_repr long_storage_type noAlignment =<< What4.bvAdd sym valA0 valB0
+
+
+    valA1 <- projectLLVM_bv sym =<< doLoad sym mem5 slot_a long_storage_type ptr_long_repr noAlignment
+    valB1 <- projectLLVM_bv sym =<< doLoad sym mem5 slot_b long_storage_type ptr_long_repr noAlignment
+    valC1 <- projectLLVM_bv sym =<< doLoad sym mem5 slot_c long_storage_type ptr_long_repr noAlignment
+
+    -- Add some assumptions to make our assertion actually hold (i.e., avoiding overflow)
+    let n64 = knownNat @64
+    -- assume sym =<< What4.bvUlt sym param_a =<< What4.bvLit sym n64 (BV.mkBV n64 100)
+    -- assume sym =<< What4.bvUlt sym param_b =<< What4.bvLit sym n64 (BV.mkBV n64 100)
+    cLessThanA <- What4.bvSlt sym valC1 valA1
+    cLessThanB <- What4.bvSlt sym valC1 valB1
+    ifOverflow <- What4.orPred sym cLessThanA cLessThanB
+
+    i64Max <- What4.bvLit sym n64 (BV.mkBV n64 0x7fffffffffffffff)
+    clamped_c <- What4.bvIte sym ifOverflow i64Max valC1
+    mem6 <- doStore sym mem5 slot_c long_type_repr long_storage_type noAlignment clamped_c
+
+    valC2 <- projectLLVM_bv sym =<< doLoad sym mem6 slot_c long_storage_type ptr_long_repr noAlignment
+
+    aLessThanC <- What4.bvSle sym param_a valC2
+    bLessThanC <- What4.bvSle sym param_b valC2
+    assertion <- What4.andPred sym aLessThanC bLessThanC
+    goal <- What4.notPred sym assertion
+    res <- checkSat sym goal
+    True @=? What4.isUnsat res
 
 testMemWritesIndexed :: TestTree
 testMemWritesIndexed = testCase "indexed memory writes" $ withMem BigEndian $ \sym mem0 -> do


### PR DESCRIPTION
This one ensures that concrete indexing is respected, and also provides a test
case where the goal requires the contents of memory to persist across writes.