### PR TITLE
WebAssembly support for crucible

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,3 +34,6 @@
 [submodule "dependencies/mir-json"]
 	path = dependencies/mir-json
 	url = https://github.com/GaloisInc/mir-json/
+[submodule "dependencies/haskell-wasm"]
+	path = dependencies/haskell-wasm
+	url = https://github.com/SPY/haskell-wasm

--- a/cabal.project
+++ b/cabal.project
@@ -9,6 +9,7 @@ packages:
   crucible-go/
   crucible-jvm/
   crucible-llvm/
+  crucible-wasm/
   crucible-saw/
   crucible-server/
   crucible-syntax/
@@ -23,6 +24,7 @@ optional-packages:
   dependencies/blt/
   dependencies/golang/
   dependencies/jvm-parser/
+  dependencies/haskell-wasm/
   dependencies/hpb/
   dependencies/llvm-pretty/
   dependencies/llvm-pretty-bc-parser/

--- a/crucible-llvm/crucible-llvm.cabal
+++ b/crucible-llvm/crucible-llvm.cabal
@@ -59,6 +59,9 @@ library
     Lang.Crucible.LLVM.Intrinsics
     Lang.Crucible.LLVM.MalformedLLVMModule
     Lang.Crucible.LLVM.MemModel
+    Lang.Crucible.LLVM.MemModel.Generic
+    Lang.Crucible.LLVM.MemModel.Partial
+    Lang.Crucible.LLVM.MemModel.Pointer
     Lang.Crucible.LLVM.MemType
     Lang.Crucible.LLVM.PrettyPrint
     Lang.Crucible.LLVM.Printf
@@ -78,9 +81,6 @@ library
     Lang.Crucible.LLVM.Intrinsics.LLVM
     Lang.Crucible.LLVM.MemModel.Common
     Lang.Crucible.LLVM.MemModel.MemLog
-    Lang.Crucible.LLVM.MemModel.Generic
-    Lang.Crucible.LLVM.MemModel.Partial
-    Lang.Crucible.LLVM.MemModel.Pointer
     Lang.Crucible.LLVM.MemModel.Options
     Lang.Crucible.LLVM.MemModel.Type
     Lang.Crucible.LLVM.MemModel.Value

--- a/crucible-wasm/LICENSE
+++ b/crucible-wasm/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2020-2021 Galois Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+
+  * Neither the name of Galois, Inc. nor the names of its contributors
+    may be used to endorse or promote products derived from this
+    software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/crucible-wasm/crucible-wasm.cabal
+++ b/crucible-wasm/crucible-wasm.cabal
@@ -1,0 +1,74 @@
+Name:          crucible-wasm
+Version:       0.1
+Author:        Galois Inc.
+Copyright:     (c) Galois, Inc. 2020
+Maintainer:    rdockins@galois.com
+License:       BSD3
+License-file:  LICENSE
+Build-type:    Simple
+Cabal-version: >= 1.10
+Category:      Language
+Synopsis:      Support for translating and executing WebAssembly code in Crucible
+
+executable crucible-wasm
+
+  hs-source-dirs: tool
+  main-is: Main.hs
+
+  build-depends:
+    base >= 4 && < 5,
+    bytestring,
+    bv-sized >= 1.0.0,
+    crux,
+    crucible,
+    crucible-llvm,
+    crucible-wasm,
+    parameterized-utils,
+    wasm
+
+  ghc-options: -Wall -Wcompat -Werror=incomplete-patterns -Werror=missing-methods -Werror=overlapping-patterns
+  ghc-prof-options: -O2 -fprof-auto-top
+
+  default-language: Haskell2010
+
+
+library
+
+  build-depends:
+    base >= 4 && < 5,
+    bv-sized >= 1.0.0,
+    bytestring,
+    containers,
+    crucible,
+    crucible-llvm,
+    crux,
+    directory,
+    filepath,
+    haskeline >= 0.7,
+    lens,
+    mtl >= 2.1,
+    panic >= 0.3,
+    parameterized-utils >= 1.0 && < 2.2,
+    prettyprinter >= 1.7.0 && < 1.8,
+    split >= 0.2,
+    text,
+    transformers >= 0.3,
+    transformers-compat,
+    vector >= 0.7,
+    what4 >= 0.4,
+    wasm
+
+  hs-source-dirs: src
+
+  exposed-modules:
+    Lang.Crucible.Wasm
+    Lang.Crucible.Wasm.Extension
+    Lang.Crucible.Wasm.Instantiate
+    Lang.Crucible.Wasm.Memory
+    Lang.Crucible.Wasm.Translate
+    Lang.Crucible.Wasm.Utils
+  other-modules:
+
+  ghc-options: -Wall -Wcompat -Werror=incomplete-patterns -Werror=missing-methods -Werror=overlapping-patterns
+  ghc-prof-options: -O2 -fprof-auto-top
+  default-language: Haskell2010

--- a/crucible-wasm/src/Lang/Crucible/Wasm.hs
+++ b/crucible-wasm/src/Lang/Crucible/Wasm.hs
@@ -1,0 +1,322 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Lang.Crucible.Wasm
+( ExternalType(..)
+, Address
+, Namespace
+, FuncTable
+, lookupFuncTable
+, Store(..)
+, ModuleInstance(..)
+, WasmGlobal(..)
+, instantiateModule
+, execScript
+, emptyScriptState
+, WasmExt
+, extImpl
+, wasmIntrinsicTypes
+) where
+
+import Control.Lens hiding (Empty, (:>),Index )
+import Control.Monad
+import Control.Monad.Trans
+
+import qualified Data.Map as Map
+import qualified Data.Sequence as Seq
+import qualified Data.Text.Lazy as TL
+import qualified Data.BitVector.Sized as BV
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Parameterized.Map as MapF
+import           Data.Word
+
+import Data.Parameterized.Context as Ctx
+import Data.Parameterized.Some
+
+import qualified Language.Wasm as Wasm
+import qualified Language.Wasm.Structure as Wasm
+
+import Lang.Crucible.Backend
+import Lang.Crucible.FunctionHandle
+import Lang.Crucible.Simulator
+import Lang.Crucible.Types
+
+import qualified Lang.Crucible.LLVM.MemModel.Generic as G
+
+import Lang.Crucible.Wasm.Extension
+import Lang.Crucible.Wasm.Instantiate
+import Lang.Crucible.Wasm.Memory
+import Lang.Crucible.Wasm.Translate
+import Lang.Crucible.Wasm.Utils
+
+import What4.Interface
+
+wasmIntrinsicTypes :: IsSymInterface sym => IntrinsicTypes sym
+wasmIntrinsicTypes =
+  MapF.insert (knownSymbol @"Wasm_Mem") IntrinsicMuxFn $
+  MapF.empty
+
+
+data ScriptState =
+  ScriptState
+  { scriptStore :: Store
+  , scriptNamespace :: Namespace
+  , scriptLoadedModules :: Namespace
+  , scriptCurrentModule :: Maybe (Maybe Wasm.Ident, Wasm.ValidModule, ModuleInstance)
+  }
+
+emptyScriptState :: ScriptState
+emptyScriptState =
+  ScriptState
+  { scriptStore = emptyStore
+  , scriptNamespace = emptyNamespace
+  , scriptLoadedModules = emptyNamespace
+  , scriptCurrentModule = Nothing
+  }
+
+type WasmOverride p sym = OverrideSim p sym WasmExt (RegEntry sym UnitType)
+
+execScript :: [Wasm.Command] -> ScriptState -> WasmOverride p sym EmptyCtx UnitType ScriptState
+execScript script ss = foldM (flip execCommand) ss script
+
+execCommand :: Wasm.Command -> ScriptState -> WasmOverride p sym EmptyCtx UnitType ScriptState
+execCommand (Wasm.ModuleDef mdef) ss =
+  do halloc <- use (stateContext . to simHandleAllocator)
+     let st = scriptStore ss
+     let ns = scriptNamespace ss
+     ((nm,vm,im), st') <- runInstM st (defineModule halloc ns mdef)
+
+     initGlobals im st'
+     initMemories im st'
+
+     mapM_ registerFnBinding =<< liftIO (translateFunctions im st')
+     debug (show (instDataSegs im))
+     mapM_ writeDataSegment (instDataSegs im)
+
+     executeStart im
+
+     let lmods' = case nm of
+                    Nothing  -> scriptLoadedModules ss
+                    Just nm' -> namespaceInsertModule nm' im (scriptLoadedModules ss)
+
+     return ss{ scriptStore = st'
+              , scriptLoadedModules = lmods'
+              , scriptCurrentModule = Just (nm,vm,im)
+              }
+
+execCommand (Wasm.Assertion a) ss =
+  do execAssertion a ss
+     return ss
+
+execCommand (Wasm.Action a) ss =
+  do _ <- execAction a ss
+     return ss
+
+execCommand c ss =
+  do liftIO $ putStrLn $ unwords ["Command not implemented", show c] -- TODO!
+     return ss
+
+
+executeStart ::
+  ModuleInstance ->
+  WasmOverride p sym EmptyCtx UnitType ()
+executeStart im =
+  case instStartFunc im of
+    Nothing -> pure ()
+    Just startFn ->
+      do ctx <- getContext
+         ctxSolverProof ctx $ void $
+           callFnVal' (HandleFnVal startFn) Empty
+
+writeDataSegment ::
+  (GlobalVar WasmMem, Word32, LBS.ByteString) ->
+  WasmOverride p sym EmptyCtx UnitType ()
+writeDataSegment (mvar, offset, chunk) =
+  do ctx <- getContext
+     ctxSolverProof ctx $
+       do sym <- getSymInterface
+          mem <- readGlobal mvar
+          mem' <- liftIO $
+                  do offset' <- bvLit sym knownNat (BV.word32 offset)
+                     wasmStoreChunk sym offset' chunk mem
+          debug (show (G.ppMem (wasmMemHeap mem')))
+          writeGlobal mvar mem'
+
+initMemories ::
+  ModuleInstance ->
+  Store ->
+  WasmOverride p sym EmptyCtx UnitType ()
+initMemories im st =
+  do ctx <- getContext
+     sym <- getSymInterface
+     ctxSolverProof ctx $ forM_ (instMemAddrs im) \case
+       (Wasm.Memory lim, True, addr) ->
+         case Seq.lookup addr (storeMemories st) of
+           Nothing -> panic "initMemories" ["could not resolve memory address " ++ show addr]
+           Just gv ->
+             do mem <- liftIO (freshMemory sym lim)
+                writeGlobal gv mem
+
+       -- imported memory, no need to initialize
+       _ -> return ()
+
+initGlobals ::
+  ModuleInstance ->
+  Store ->
+  WasmOverride p sym EmptyCtx UnitType ()
+initGlobals im st =
+  do ctx <- getContext
+     sym <- getSymInterface
+     ctxSolverProof ctx $ forM_ (instGlobalAddrs im) \case
+       (_gty, Just cv, addr) ->
+          case Seq.lookup addr (storeGlobals st) of
+            Nothing -> panic "initGlobals" ["could not resolve global address " ++ show addr]
+            Just (ConstantGlobal _) -> return () -- TODO? shouldn't happen, error?
+            Just (MutableGlobal gv) ->
+              case cv of
+                I32Val w
+                  | Just Refl <- testEquality (globalType gv) (BVRepr (knownNat @32))
+                  -> writeGlobal gv =<< liftIO (bvLit sym knownNat (BV.word32 w))
+                I64Val w
+                  | Just Refl <- testEquality (globalType gv) (BVRepr (knownNat @64))
+                  -> writeGlobal gv =<< liftIO (bvLit sym knownNat (BV.word64 w))
+                F32Val _ -> unimplemented "initGlobals F32Val"
+                F64Val _ -> unimplemented "initGlobals F64Val"
+
+                _ -> panic "initGlobals" ["type mismatch!"]
+
+       -- Imported or constant global value, nothing to initialize
+       (_,Nothing,_) -> return ()
+
+
+getModule ::
+  Maybe Wasm.Ident ->
+  ScriptState ->
+  WasmOverride p sym EmptyCtx UnitType ModuleInstance
+getModule Nothing ss =
+  case scriptCurrentModule ss of
+    Nothing -> fail "No current module loaded"
+    Just (_,_,im) -> pure im
+getModule (Just nm) ss =
+  case namespaceModule nm (scriptLoadedModules ss) of
+    Nothing -> fail $ unwords ["Could not find loaded module", show nm]
+    Just im -> pure im
+
+getModuleFunc ::
+  Maybe Wasm.Ident ->
+  TL.Text ->
+  ModuleInstance ->
+  Store ->
+  WasmOverride p sym EmptyCtx UnitType (Wasm.FuncType, SomeHandle)
+getModuleFunc modNm nm im st =
+  case Map.lookup nm (instExports im) of
+    Just (ExternalFunc fty, addr)
+      | Just h <- Seq.lookup addr (storeFuncs st)
+      -> pure (fty,h)
+    _ -> fail $ unwords ["Could not find function", show nm
+                        , case modNm of Nothing -> "in current module"
+                                        Just m  -> "in module " ++ show m
+                        ]
+
+computeConstantValues :: forall sym ctx.
+  IsSymInterface sym =>
+  sym ->
+  ModuleInstance ->
+  Store ->
+  Assignment TypeRepr ctx ->
+  [Wasm.Expression] ->
+  IO (Assignment (RegEntry sym) ctx)
+computeConstantValues sym im st tps exprs =
+  do (xs,_) <- runInstM st (mapM (evalConst im) exprs)
+     let mkVal :: Index ctx tp -> TypeRepr tp -> IO (RegEntry sym tp)
+         mkVal idx tp =
+           case Prelude.drop (indexVal idx) xs of
+             (I32Val w : _)
+               | Just Refl <- testEquality tp (BVRepr (knownNat @32))
+               -> do v <- bvLit sym (knownNat @32) (BV.word32 w)
+                     return (RegEntry tp v)
+               | otherwise -> fail "type mismatch in computeConstantValues!"
+
+             (I64Val w : _)
+               | Just Refl <- testEquality tp (BVRepr (knownNat @64))
+               -> do v <- bvLit sym (knownNat @64) (BV.word64 w)
+                     return (RegEntry tp v)
+               | otherwise -> fail "type mismatch in computeConstantValues!"
+
+             (F32Val _ : _) -> unimplemented "compute F32"
+             (F64Val _ : _) -> unimplemented "compute F64"
+             [] -> fail "not enough arguments in computeConstantValues!"
+
+     traverseWithIndex mkVal tps
+
+execAction ::
+  Wasm.Action ->
+  ScriptState ->
+  WasmOverride p sym EmptyCtx UnitType (ModuleInstance, Some (RegEntry sym))
+execAction (Wasm.Invoke md nm args) ss =
+  do ctx <- getContext
+     im <- getModule md ss
+     let st = scriptStore ss
+     (_fty, SomeHandle h) <- getModuleFunc md nm im st
+     sym <- getSymInterface
+     ctxSolverProof ctx do
+       args' <- liftIO (computeConstantValues sym im st (handleArgTypes h) args)
+       x <- callFnVal (HandleFnVal h) (RegMap args')
+       pure (im, Some x)
+
+execAction (Wasm.Get _md _nm) _ss = unimplemented "execAction: get"
+
+execAssertion :: Wasm.Assertion -> ScriptState -> WasmOverride p sym EmptyCtx UnitType ()
+
+execAssertion ast@(Wasm.AssertReturn act rets) ss =
+  do ctx <- getContext
+     sym <- getSymInterface
+     (im, Some (RegEntry rty result)) <- execAction act ss
+     ctxSolverProof ctx $
+       case rty of
+         UnitRepr | Prelude.null rets -> return ()
+         StructRepr ts | length rets > 1 -> liftIO $
+               do expected <- computeConstantValues sym im (scriptStore ss) ts rets
+                  assertEqResults sym (show ast) result expected
+         t | length rets == 1 -> liftIO $
+               do expected <- computeConstantValues sym im (scriptStore ss) (Empty :> t) rets
+                  assertEqResults sym (show ast) (Empty :> RV result) expected
+           | otherwise -> fail "type mismatch in execAssertion!"
+
+execAssertion a _ =
+  liftIO $ putStrLn $ unwords ["Assertion not implemented", show a] -- TODO
+
+
+assertEqResults :: forall sym ctx.
+  IsSymInterface sym =>
+  sym ->
+  String ->
+  Assignment (RegValue' sym) ctx ->
+  Assignment (RegEntry sym) ctx ->
+  IO ()
+assertEqResults sym ast xs ys = traverseWithIndex_ f ys
+  where
+  f :: Index ctx tp -> RegEntry sym tp -> IO ()
+  f idx (RegEntry tp y) =
+     let RV x = xs Ctx.! idx in
+     case tp of
+       BVRepr _ ->
+         do p <- bvEq sym x y
+            case asConstantPred p of
+              Just False ->
+                debug $ unlines
+                  [ unwords ["equality postcondition", show (printSymExpr x), show (printSymExpr y)]
+                  , ast
+                  ]
+              _ -> return ()
+            assert sym p (GenericSimError "assert return failed")
+
+       _ -> unimplemented $ unwords ["assert return could not handle type", show tp]

--- a/crucible-wasm/src/Lang/Crucible/Wasm/Extension.hs
+++ b/crucible-wasm/src/Lang/Crucible/Wasm/Extension.hs
@@ -1,0 +1,329 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Lang.Crucible.Wasm.Extension where
+
+import Control.Lens
+import Control.Monad.Trans
+import Control.Monad.Trans.State
+import Data.Kind
+import Prettyprinter
+
+import Data.Parameterized.TraversableFC
+import qualified Data.BitVector.Sized as BV
+
+import Lang.Crucible.Backend
+import Lang.Crucible.CFG.Extension
+import Lang.Crucible.FunctionHandle
+import Lang.Crucible.Simulator
+import Lang.Crucible.Simulator.GlobalState
+import Lang.Crucible.Simulator.ExecutionTree
+import Lang.Crucible.Types
+
+import Lang.Crucible.Wasm.Instantiate
+import Lang.Crucible.Wasm.Memory
+import Lang.Crucible.Wasm.Utils
+
+import What4.Interface
+
+import qualified Language.Wasm.Structure as Wasm
+
+data WasmExt
+
+type instance ExprExtension WasmExt = EmptyExprExtension
+type instance StmtExtension WasmExt = WasmStmt
+
+instance IsSyntaxExtension WasmExt
+
+type WasmPointer = BVType 32
+
+data WasmStmt (f :: CrucibleType -> Type) :: CrucibleType -> Type where
+  Wasm_IndirectFunction ::
+    Wasm.FuncType {- ^ Type of the function to lookup -} ->
+    FuncTable {- ^ table in which to look up functions -} ->
+    TypeRepr (FunctionHandleType args ret) {- ^ Crucible type of the function to look up -} ->
+    !(f (BVType 32)) {- ^ computed table index -} ->
+    WasmStmt f (FunctionHandleType args ret)
+
+  Wasm_MemSize ::
+    GlobalVar WasmMem ->
+    WasmStmt f (BVType 32)
+
+  Wasm_MemGrow ::
+    GlobalVar WasmMem ->
+    !(f (BVType 32)) ->
+    WasmStmt f (BVType 32)
+
+  Wasm_LoadInt8 ::
+    GlobalVar WasmMem ->
+    !(f WasmPointer) ->
+    WasmStmt f (BVType 8)
+
+  Wasm_LoadInt16 ::
+    GlobalVar WasmMem ->
+    !(f WasmPointer) ->
+    WasmStmt f (BVType 16)
+
+  Wasm_LoadInt32 ::
+    GlobalVar WasmMem ->
+    !(f WasmPointer) ->
+    WasmStmt f (BVType 32)
+
+  Wasm_LoadInt64 ::
+    GlobalVar WasmMem ->
+    !(f WasmPointer) ->
+    WasmStmt f (BVType 64)
+
+  Wasm_LoadFloat ::
+    GlobalVar WasmMem ->
+    !(f WasmPointer) ->
+    WasmStmt f (FloatType SingleFloat)
+
+  Wasm_LoadDouble ::
+    GlobalVar WasmMem ->
+    !(f WasmPointer) ->
+    WasmStmt f (FloatType DoubleFloat)
+
+  Wasm_StoreInt8::
+    GlobalVar WasmMem ->
+    !(f WasmPointer) ->
+    !(f (BVType 8)) ->
+    WasmStmt f UnitType
+
+  Wasm_StoreInt16 ::
+    GlobalVar WasmMem ->
+    !(f WasmPointer) ->
+    !(f (BVType 16)) ->
+    WasmStmt f UnitType
+
+  Wasm_StoreInt32 ::
+    GlobalVar WasmMem ->
+    !(f WasmPointer) ->
+    !(f (BVType 32)) ->
+    WasmStmt f UnitType
+
+  Wasm_StoreInt64 ::
+    GlobalVar WasmMem ->
+    !(f WasmPointer) ->
+    !(f (BVType 64)) ->
+    WasmStmt f UnitType
+
+  Wasm_StoreFloat ::
+    GlobalVar WasmMem ->
+    !(f WasmPointer) ->
+    !(f (FloatType SingleFloat)) ->
+    WasmStmt f UnitType
+
+  Wasm_StoreDouble ::
+    GlobalVar WasmMem ->
+    !(f WasmPointer) ->
+    !(f (FloatType DoubleFloat)) ->
+    WasmStmt f UnitType
+
+extImpl :: ExtensionImpl p sym WasmExt
+extImpl =
+  ExtensionImpl
+  { -- There are no interesting extension expression formers
+    extensionEval = \_ _ _ _ -> \case{}
+  , extensionExec = evalWasmExt
+  }
+
+evalWasmExt :: EvalStmtFunc p sym WasmExt
+evalWasmExt stmt cst =
+  let sym = cst^.stateSymInterface
+   in stateSolverProof cst (runStateT (evalStmt sym stmt) cst)
+
+type EvalM p sym ext rtp blocks ret args a =
+  StateT (CrucibleState p sym ext rtp blocks ret args) IO a
+
+evalStmt :: forall p sym ext rtp blocks ret args tp.
+  IsSymInterface sym =>
+  sym ->
+  WasmStmt (RegEntry sym) tp ->
+  EvalM p sym ext rtp blocks ret args (RegValue sym tp)
+evalStmt sym = eval
+  where
+
+  getMem :: GlobalVar WasmMem -> EvalM p sym ext rtp blocks ret args (WasmMemImpl sym)
+  getMem gv =
+    do gs <- use (stateTree.actFrame.gpGlobals)
+       case lookupGlobal gv gs of
+         Just mem -> return mem
+         Nothing -> panic "getMem" ["memory not allocated!"]
+
+  setMem ::
+    GlobalVar WasmMem ->
+    WasmMemImpl sym ->
+    EvalM p sym ext rtp blocks ret args ()
+  setMem gv mem = stateTree.actFrame.gpGlobals %= insertGlobal gv mem
+
+  eval ::
+    WasmStmt (RegEntry sym) tp ->
+    EvalM p sym ext rtp blocks ret args (RegValue sym tp)
+  eval = \case
+    Wasm_IndirectFunction fty ftab rty (regValue -> x)
+      | Just i <- BV.asUnsigned <$> asBV x ->
+          case lookupFuncTable (fromIntegral i) ftab of
+            Nothing -> fail ("Invalid indirect function offset: " ++ show i)
+            Just (ftyActual, SomeHandle hdl)
+              | fty == ftyActual, Just Refl <- testEquality rty (handleType hdl)
+              -> pure (HandleFnVal hdl)
+
+              | otherwise -> fail ("Type error in indirect function: " ++ show i)
+
+      | otherwise ->
+          unimplemented "Wasm_IndirectFunction: cannot handle symbolic inputs"
+
+    Wasm_MemSize gv ->
+      do mem  <- getMem gv
+         return (wasmMemSize mem)
+
+    Wasm_MemGrow gv (regValue -> n) ->
+      do mem <- getMem gv
+         (res, mem') <- liftIO $ wasmGrowMem sym n mem
+         setMem gv mem'
+         return res
+
+    Wasm_StoreInt8 gv (regValue -> p) (regValue -> v) ->
+      do mem <- getMem gv
+         mem' <- liftIO (wasmStoreInt @8 sym p v mem)
+         setMem gv mem'
+
+    Wasm_StoreInt16 gv (regValue -> p) (regValue -> v) ->
+      do mem <- getMem gv
+         mem' <- liftIO (wasmStoreInt @16 sym p v mem)
+         setMem gv mem'
+
+    Wasm_StoreInt32 gv (regValue -> p) (regValue -> v) ->
+      do mem <- getMem gv
+         mem' <- liftIO (wasmStoreInt @32 sym p v mem)
+         setMem gv mem'
+
+    Wasm_StoreInt64 gv (regValue -> p) (regValue -> v) ->
+      do mem <- getMem gv
+         mem' <- liftIO (wasmStoreInt @64 sym p v mem)
+         setMem gv mem'
+
+    Wasm_StoreFloat gv (regValue -> p) (regValue -> v) ->
+      do mem <- getMem gv
+         mem' <- liftIO (wasmStoreFloat sym p v mem)
+         setMem gv mem'
+
+    Wasm_StoreDouble gv (regValue -> p) (regValue -> v) ->
+      do mem <- getMem gv
+         mem' <- liftIO (wasmStoreDouble sym p v mem)
+         setMem gv mem'
+
+    Wasm_LoadInt8 gv (regValue -> p) ->
+      do mem <- getMem gv
+         liftIO (wasmLoadInt sym p (knownNat @8) mem)
+
+    Wasm_LoadInt16 gv (regValue -> p) ->
+      do mem <- getMem gv
+         liftIO (wasmLoadInt sym p (knownNat @16) mem)
+
+    Wasm_LoadInt32 gv (regValue -> p) ->
+      do mem <- getMem gv
+         liftIO (wasmLoadInt sym p (knownNat @32) mem)
+
+    Wasm_LoadInt64 gv (regValue -> p) ->
+      do mem <- getMem gv
+         liftIO (wasmLoadInt sym p (knownNat @64) mem)
+
+    Wasm_LoadFloat gv (regValue -> p) ->
+      do mem <- getMem gv
+         liftIO (wasmLoadFloat sym p mem)
+
+    Wasm_LoadDouble gv (regValue -> p) ->
+      do mem <- getMem gv
+         liftIO (wasmLoadDouble sym p mem)
+
+
+instance PrettyApp WasmStmt where
+  ppApp pp e =
+    case e of
+      Wasm_IndirectFunction fty _tbl _tyr val ->
+        pretty "indirectFunction" <+> viaShow fty <+> pp val
+
+      Wasm_MemSize gv ->
+        pretty "memSize" <+> pretty (globalName gv)
+      Wasm_MemGrow gv x ->
+        pretty "memGrow" <+> pretty (globalName gv) <+> pp x
+
+      Wasm_LoadInt8 gv p ->
+        pretty "loadInt8" <+> pretty (globalName gv) <+> pp p
+      Wasm_LoadInt16 gv p ->
+        pretty "loadInt16" <+> pretty (globalName gv) <+> pp p
+      Wasm_LoadInt32 gv p ->
+        pretty "loadInt32" <+> pretty (globalName gv) <+> pp p
+      Wasm_LoadInt64 gv p ->
+        pretty "loadInt64" <+> pretty (globalName gv) <+> pp p
+      Wasm_LoadFloat gv p ->
+        pretty "loadFloat" <+> pretty (globalName gv) <+> pp p
+      Wasm_LoadDouble gv p ->
+        pretty "loadDouble" <+> pretty (globalName gv) <+> pp p
+
+      Wasm_StoreInt8 gv p x ->
+        pretty "storeInt8" <+> pretty (globalName gv) <+> pp p <+> pp x
+      Wasm_StoreInt16 gv p x ->
+        pretty "storeInt16" <+> pretty (globalName gv) <+> pp p <+> pp x
+      Wasm_StoreInt32 gv p x ->
+        pretty "storeInt32" <+> pretty (globalName gv) <+> pp p <+> pp x
+      Wasm_StoreInt64 gv p x ->
+        pretty "storeInt64" <+> pretty (globalName gv) <+> pp p <+> pp x
+      Wasm_StoreFloat gv p x ->
+        pretty "storeFloat" <+> pretty (globalName gv) <+> pp p <+> pp x
+      Wasm_StoreDouble gv p x ->
+        pretty "storeDouble" <+> pretty (globalName gv) <+> pp p <+> pp x
+
+instance TypeApp WasmStmt where
+  appType e =
+    case e of
+      Wasm_IndirectFunction _fty _tab tpr _idx -> tpr
+      Wasm_MemSize{} -> knownRepr
+      Wasm_MemGrow{} -> knownRepr
+      Wasm_LoadInt8{}  -> knownRepr
+      Wasm_LoadInt16{}  -> knownRepr
+      Wasm_LoadInt32{}  -> knownRepr
+      Wasm_LoadInt64{}  -> knownRepr
+      Wasm_LoadFloat{}  -> knownRepr
+      Wasm_LoadDouble{} -> knownRepr
+      Wasm_StoreInt8{} -> knownRepr
+      Wasm_StoreInt16{} -> knownRepr
+      Wasm_StoreInt32{} -> knownRepr
+      Wasm_StoreInt64{} -> knownRepr
+      Wasm_StoreFloat{} -> knownRepr
+      Wasm_StoreDouble{} -> knownRepr
+
+instance FunctorFC WasmStmt where
+  fmapFC = fmapFCDefault
+instance FoldableFC WasmStmt where
+  foldMapFC = foldMapFCDefault
+instance TraversableFC WasmStmt where
+  traverseFC f e =
+    case e of
+      Wasm_IndirectFunction fty tab tpr idx -> Wasm_IndirectFunction fty tab tpr <$> f idx
+      Wasm_MemSize gv     -> pure (Wasm_MemSize gv)
+      Wasm_MemGrow gv x   -> Wasm_MemGrow gv <$> f x
+      Wasm_LoadInt8  gv p -> Wasm_LoadInt8 gv <$> f p
+      Wasm_LoadInt16 gv p -> Wasm_LoadInt16 gv <$> f p
+      Wasm_LoadInt32 gv p -> Wasm_LoadInt32 gv <$> f p
+      Wasm_LoadInt64 gv p -> Wasm_LoadInt64 gv <$> f p
+      Wasm_LoadFloat gv p  -> Wasm_LoadFloat gv <$> f p
+      Wasm_LoadDouble gv p -> Wasm_LoadDouble gv <$> f p
+
+      Wasm_StoreInt8 gv p x  -> Wasm_StoreInt8 gv <$> f p <*> f x
+      Wasm_StoreInt16 gv p x -> Wasm_StoreInt16 gv <$> f p <*> f x
+      Wasm_StoreInt32 gv p x -> Wasm_StoreInt32 gv <$> f p <*> f x
+      Wasm_StoreInt64 gv p x -> Wasm_StoreInt64 gv <$> f p <*> f x
+      Wasm_StoreFloat gv p x  -> Wasm_StoreFloat gv <$> f p <*> f x
+      Wasm_StoreDouble gv p x -> Wasm_StoreDouble gv <$> f p <*> f x

--- a/crucible-wasm/src/Lang/Crucible/Wasm/Instantiate.hs
+++ b/crucible-wasm/src/Lang/Crucible/Wasm/Instantiate.hs
@@ -1,0 +1,519 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ParallelListComp #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Lang.Crucible.Wasm.Instantiate where
+
+import Control.Exception
+import Control.Monad
+import Control.Monad.Trans
+import Control.Monad.Trans.State
+import Control.Monad.Trans.Except
+import Numeric.Natural
+
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as TL
+import qualified Data.Map as Map
+import qualified Data.IntMap as IntMap
+import qualified Data.Sequence as Seq
+import           Data.String
+import           Data.Word
+
+import Data.Parameterized.Context
+import Data.Parameterized.Some
+
+import qualified Language.Wasm as Wasm
+import qualified Language.Wasm.Structure as Wasm
+import qualified Language.Wasm.Validate as Wasm
+
+import Lang.Crucible.Simulator
+import Lang.Crucible.CFG.Common (freshGlobalVar)
+import Lang.Crucible.FunctionHandle
+import Lang.Crucible.Types
+
+import Lang.Crucible.Wasm.Memory( WasmMem )
+import Lang.Crucible.Wasm.Utils
+
+defineModule ::
+  HandleAllocator ->
+  Namespace ->
+  Wasm.ModuleDef ->
+  InstM (Maybe Wasm.Ident, Wasm.ValidModule, ModuleInstance)
+defineModule halloc ns mdef =
+  do (ident,m) <- buildModule mdef
+     vm <- case Wasm.validate m of
+             Left verr -> throwE (ValidationError verr)
+             Right vm  -> pure vm
+     im <- instantiateModule halloc ns vm
+     pure (ident, vm, im)
+
+
+buildModule :: Wasm.ModuleDef -> InstM (Maybe Wasm.Ident, Wasm.Module)
+buildModule (Wasm.RawModDef ident m) = pure (ident, m)
+buildModule (Wasm.TextModDef{}) = unimplemented "build module: text"
+buildModule (Wasm.BinaryModDef{}) = unimplemented "build module: binary"
+
+data ExternalType
+  = ExternalFunc   Wasm.FuncType
+  | ExternalTable  Wasm.TableType
+  | ExternalMem    Wasm.Memory
+  | ExternalGlobal Wasm.GlobalType
+ deriving (Eq,Show)
+
+type Address = Int
+
+type ExternalValue = (ExternalType, Address)
+
+newtype Namespace =
+  Namespace (Map.Map TL.Text ModuleInstance)
+
+emptyNamespace :: Namespace
+emptyNamespace = Namespace mempty
+
+namespaceInsertModule :: Wasm.Ident -> ModuleInstance -> Namespace -> Namespace
+namespaceInsertModule (Wasm.Ident modName) im (Namespace m) =
+  Namespace (Map.insert modName im m)
+
+namespaceLookup :: Wasm.Ident -> TL.Text -> Namespace -> Maybe ExternalValue
+namespaceLookup sourceModule name ns =
+  Map.lookup name . instExports =<< namespaceModule sourceModule ns
+
+namespaceModule :: Wasm.Ident -> Namespace -> Maybe ModuleInstance
+namespaceModule (Wasm.Ident sourceModule) (Namespace m) =
+  Map.lookup sourceModule m
+
+-- | This is a (potentially sparse) table mapping indices to
+-- function addresses, which can then be looked up in the
+-- @storeFuncs@ field of the @Store@ to get a crucible
+-- function handle.  Tables like this are used to implement
+-- computed functions in Wasm, e.g., for vtables and such.
+data  FuncTable =
+  FuncTable !Wasm.TableType !(IntMap.IntMap (Wasm.FuncType, SomeHandle))
+
+updateFuncTable :: Int -> Wasm.FuncType -> SomeHandle -> FuncTable -> FuncTable
+updateFuncTable i fty hdl (FuncTable tty m) = FuncTable tty (IntMap.insert i (fty,hdl) m)
+
+lookupFuncTable :: Int -> FuncTable -> Maybe (Wasm.FuncType, SomeHandle)
+lookupFuncTable idx (FuncTable _ m) = IntMap.lookup idx m
+
+-- | When we translate a module, there are several layers
+-- of indirection to unwind.  Static indices found in the module syntax
+-- are looked up in a \"module instance\" to get an address.
+-- Addresses are then looked up in the @Store@ to get Crucible or
+-- Haskell layer objects, which can then be used in the translation.
+-- This most closely follows the WebAssembly specification, but it
+-- might be possible and desirable to undwind some of the indirections.
+-- For now, I'm leaving them as-is.
+data Store =
+  Store
+  { storeFuncs    :: Seq.Seq SomeHandle
+  , storeTables   :: Seq.Seq FuncTable
+  , storeMemories :: Seq.Seq (GlobalVar WasmMem)
+  , storeGlobals  :: Seq.Seq WasmGlobal
+  }
+
+emptyStore :: Store
+emptyStore =
+  Store
+  { storeFuncs = mempty
+  , storeTables = mempty
+  , storeMemories = mempty
+  , storeGlobals = mempty
+  }
+
+allocStoreFunc :: SomeHandle -> Store -> (Address, Store)
+allocStoreFunc hdl s = (addr, s')
+   where
+   s'   = s{ storeFuncs = storeFuncs s Seq.|> hdl }
+   addr = Seq.length (storeFuncs s)
+
+allocStoreTable :: Wasm.TableType -> Store -> (Address, Store)
+allocStoreTable tty s = (addr, s')
+  where
+  s'   = s{ storeTables = storeTables s Seq.|> FuncTable tty mempty }
+  addr = Seq.length (storeTables s)
+
+allocStoreMemory :: GlobalVar WasmMem -> Store -> (Address, Store)
+allocStoreMemory gv s = (addr, s')
+  where
+  s'   = s{ storeMemories = storeMemories s Seq.|> gv }
+  addr = Seq.length (storeMemories s)
+
+allocStoreGlobal :: WasmGlobal -> Store -> (Address, Store)
+allocStoreGlobal wg s = (addr, s')
+  where
+  s'   = s{ storeGlobals = storeGlobals s Seq.|> wg }
+  addr = Seq.length (storeGlobals s)
+
+data WasmGlobal
+  = ConstantGlobal ConstantValue
+  | forall tp. MutableGlobal (GlobalVar tp)
+
+data ModuleInstance =
+  ModuleInstance
+  { instTypes       :: Seq.Seq Wasm.FuncType
+  , instFuncAddrs   :: Seq.Seq (Wasm.FuncType, Maybe Wasm.Function, Address)
+  , instTableAddrs  :: Seq.Seq (Wasm.TableType, Address)
+  , instMemAddrs    :: Seq.Seq (Wasm.Memory, Bool, Address)
+  , instGlobalAddrs :: Seq.Seq (Wasm.GlobalType, Maybe ConstantValue, Address)
+  , instExports     :: Map.Map TL.Text ExternalValue
+  , instStartFunc   :: Maybe (FnHandle EmptyCtx UnitType)
+  , instDataSegs    :: [(GlobalVar WasmMem, Word32, LBS.ByteString)]
+  }
+
+resolveTypeIndex :: Wasm.TypeIndex -> ModuleInstance -> Maybe Wasm.FuncType
+resolveTypeIndex idx i = resolveSeq idx (instTypes i)
+
+resolveFuncIndex :: Wasm.FuncIndex -> ModuleInstance -> Maybe (Wasm.FuncType, Maybe Wasm.Function, Address)
+resolveFuncIndex idx i = resolveSeq idx (instFuncAddrs i)
+
+resolveTableIndex :: Wasm.TableIndex -> ModuleInstance -> Maybe (Wasm.TableType, Address)
+resolveTableIndex idx i = resolveSeq idx (instTableAddrs i)
+
+resolveMemIndex :: Wasm.MemoryIndex -> ModuleInstance -> Maybe (Wasm.Memory, Bool, Address)
+resolveMemIndex idx i = resolveSeq idx (instMemAddrs i)
+
+resolveGlobalIndex ::
+  Wasm.GlobalIndex ->
+  ModuleInstance ->
+  Maybe (Wasm.GlobalType, Maybe ConstantValue, Address)
+resolveGlobalIndex idx i = resolveSeq idx (instGlobalAddrs i)
+
+resolveSeq :: Natural -> Seq.Seq a -> Maybe a
+resolveSeq idx xs
+  | idx < fromIntegral (Seq.length xs) = Just (Seq.index xs (fromIntegral idx))
+  | otherwise = Nothing
+
+emptyInstance :: ModuleInstance
+emptyInstance =
+  ModuleInstance
+  { instTypes       = mempty
+  , instFuncAddrs   = mempty
+  , instTableAddrs  = mempty
+  , instMemAddrs    = mempty
+  , instGlobalAddrs = mempty
+  , instExports     = mempty
+  , instStartFunc   = Nothing
+  , instDataSegs    = []
+  }
+
+data ConstantValue
+  = I32Val Word32
+  | I64Val Word64
+  | F32Val Float
+  | F64Val Double
+
+type InstM = ExceptT InstantiationFailure (StateT Store IO)
+
+data InstantiationFailure
+  = InstantiationFailure TL.Text
+  | ValidationError Wasm.ValidationError
+
+instance Show InstantiationFailure where
+  show (InstantiationFailure msg) =
+    "Module instantiation failure: " ++ TL.unpack msg
+  show (ValidationError verr) =
+    "Module validation error: " ++ show verr
+
+instance Exception InstantiationFailure
+
+instErr :: TL.Text -> InstM a
+instErr = throwE . InstantiationFailure
+
+runInstM :: (MonadFail m, MonadIO m) => Store -> (InstM a) -> m (a, Store)
+runInstM st m =
+  do x <- liftIO (runStateT (runExceptT m) st)
+     case x of
+       (Left err, _) -> liftIO (throwIO err)
+       (Right a, st') -> pure (a, st')
+
+allocateModule ::
+  HandleAllocator ->
+  Wasm.Module ->
+  [ConstantValue] ->
+  ModuleInstance ->
+  InstM ModuleInstance
+allocateModule halloc md gvals =
+  allocateFuncs   >=>
+  allocateTables  >=>
+  allocateMems    >=>
+  allocateGlobals >=>
+  prepareExports  >=>
+  resolveStartFn (Wasm.start md)
+
+ where
+  allocateFuncs   i = foldM (allocateFunc halloc) i (Wasm.functions md)
+  allocateTables  i = foldM allocateTable i (Wasm.tables md)
+  allocateMems    i = foldM (allocateMem halloc) i (Wasm.mems md)
+  allocateGlobals i = foldM (allocateGlobal halloc) i (zip gvals (Wasm.globals md))
+  prepareExports  i = foldM prepareExport i (Wasm.exports md)
+  resolveStartFn Nothing i = pure i
+  resolveStartFn (Just (Wasm.StartFunction fidx)) i =
+    case resolveFuncIndex fidx i of
+      Nothing -> instErr ("Could not resolve start function " <> fromString (show fidx))
+      Just (_,_,addr) ->
+        do st <- lift get
+           case Seq.lookup addr (storeFuncs st) of
+             Nothing -> instErr ("Could not resolve start function address " <> fromString (show addr))
+             Just (SomeHandle h)
+               | Just Refl <- testEquality (handleType h) (FunctionHandleRepr Empty UnitRepr)
+               -> pure i{ instStartFunc = Just h }
+               | otherwise -> instErr "Type mismatch in start function"
+
+
+valueTypeToType :: Wasm.ValueType -> Some TypeRepr
+valueTypeToType Wasm.I32 = Some (BVRepr (knownNat @32))
+valueTypeToType Wasm.I64 = Some (BVRepr (knownNat @64))
+valueTypeToType Wasm.F32 = Some (FloatRepr SingleFloatRepr)
+valueTypeToType Wasm.F64 = Some (FloatRepr DoubleFloatRepr)
+
+valueTypesToContext :: [Wasm.ValueType] -> Some (Assignment TypeRepr)
+valueTypesToContext = fromList . map valueTypeToType
+
+returnContextToType ::
+  Assignment TypeRepr ctx ->
+  Some TypeRepr
+returnContextToType Empty        = Some UnitRepr
+returnContextToType (Empty :> t) = Some t
+returnContextToType ctx          = Some (StructRepr ctx)
+
+
+allocateFunc ::
+  HandleAllocator ->
+  ModuleInstance ->
+  Wasm.Function ->
+  InstM ModuleInstance
+allocateFunc halloc i f@Wasm.Function{ funcType = idx } =
+  case resolveTypeIndex idx i of
+    Just fty@Wasm.FuncType{ params = ps, results = rs } ->
+      do Some args <- pure (valueTypesToContext ps)
+         Some rets <- pure (valueTypesToContext rs)
+         Some ret  <- pure (returnContextToType rets)
+         let name = ""
+         h <- liftIO (mkHandle' halloc name args ret)
+         addr <- lift (state (allocStoreFunc (SomeHandle h)))
+         pure i{ instFuncAddrs = instFuncAddrs i Seq.|> (fty,Just f,addr) }
+
+    Nothing -> instErr ("Cannot resolve type index " <> fromString (show idx))
+
+allocateTable ::
+  ModuleInstance ->
+  Wasm.Table ->
+  InstM ModuleInstance
+allocateTable i (Wasm.Table tty) =
+  do addr <- lift (state (allocStoreTable tty))
+     pure i{ instTableAddrs = instTableAddrs i Seq.|> (tty,addr) }
+
+allocateMem ::
+  HandleAllocator ->
+  ModuleInstance ->
+  Wasm.Memory ->
+  InstM ModuleInstance
+allocateMem halloc i mty =
+  do n <- Seq.length . storeMemories <$> lift get
+     let name = ("Wasm Memory " <> T.pack (show n))
+     gv <- liftIO (freshGlobalVar halloc name knownRepr)
+     addr <- lift (state (allocStoreMemory gv))
+     pure i { instMemAddrs = instMemAddrs i Seq.|> (mty,True,addr) }
+
+allocateGlobal ::
+  HandleAllocator ->
+  ModuleInstance ->
+  (ConstantValue, Wasm.Global) ->
+  InstM ModuleInstance
+allocateGlobal _halloc i (initVal, Wasm.Global{ globalType = gt@(Wasm.Const _vt) }) =
+  do addr <- lift (state (allocStoreGlobal (ConstantGlobal initVal)))
+     pure i{ instGlobalAddrs = instGlobalAddrs i Seq.|> (gt,Nothing,addr) }
+
+allocateGlobal halloc i (initVal, Wasm.Global{ globalType = gt@(Wasm.Mut vt) }) =
+  do let name = "" -- TODO, find name info?
+     Some tp <- pure (valueTypeToType vt)
+     gv <- liftIO (freshGlobalVar halloc name tp)
+     addr <- lift (state (allocStoreGlobal (MutableGlobal gv)))
+     pure i{ instGlobalAddrs = instGlobalAddrs i Seq.|> (gt,Just initVal,addr) }
+
+
+prepareExport ::
+  ModuleInstance ->
+  Wasm.Export ->
+  InstM ModuleInstance
+prepareExport i Wasm.Export{..} =
+  do exval <-
+        case desc of
+          Wasm.ExportFunc fidx ->
+            case resolveFuncIndex fidx i of
+              Just (fty, _, addr) -> pure (ExternalFunc fty, addr)
+              Nothing -> instErr ("Could not resolve function index " <> fromString (show fidx))
+          Wasm.ExportTable tidx ->
+            case resolveTableIndex tidx i of
+              Just (tty, addr) -> pure (ExternalTable tty, addr)
+              Nothing -> instErr ("Could not resolve table index " <> fromString (show tidx))
+          Wasm.ExportMemory midx ->
+            case resolveMemIndex midx i of
+              Just (mty, _, addr) -> pure (ExternalMem mty, addr)
+              Nothing -> instErr ("Could not resolve memory index " <> fromString (show midx))
+          Wasm.ExportGlobal gidx ->
+            case resolveGlobalIndex gidx i of
+              Just (gty, _, addr) -> pure (ExternalGlobal gty, addr)
+              Nothing -> instErr ("Could not resolve global index " <> fromString (show gidx))
+     pure i{ instExports = Map.insert name exval (instExports i) }
+
+instantiateModule ::
+  HandleAllocator ->
+  Namespace ->
+  Wasm.ValidModule ->
+  InstM ModuleInstance
+instantiateModule halloc ns (Wasm.getModule -> md) =
+  do i0 <- instantiateImports ns md
+     gvals <- mapM (computeGlobalValue i0) (Wasm.globals md)
+     i <- allocateModule halloc md gvals i0
+
+     mapM_ (installElemSegment i) (Wasm.elems md)
+     ds <- mapM (computeDataSegment i) (Wasm.datas md)
+     pure i{ instDataSegs = ds }
+
+
+computeDataSegment ::
+  ModuleInstance ->
+  Wasm.DataSegment ->
+  InstM (GlobalVar WasmMem, Word32, LBS.ByteString)
+computeDataSegment i Wasm.DataSegment{ .. } =
+  do st <- lift get
+     case resolveMemIndex memIndex i of
+       Nothing -> instErr ("Could not resolve memory index " <> fromString (show memIndex))
+       Just (_,_,addr) ->
+         case Seq.lookup addr (storeMemories st) of
+           Nothing -> instErr ("Could not resolve memory address " <> fromString (show addr))
+           Just gv ->
+             evalConst i offset >>= \case
+               I32Val x -> pure (gv, x, chunk)
+               _ -> instErr "data segment offset type mismatch"
+
+installElemSegment ::
+  ModuleInstance ->
+  Wasm.ElemSegment ->
+  InstM ()
+installElemSegment im es@Wasm.ElemSegment{ .. } =
+  do I32Val tblOff <- evalConst im offset
+     st <- lift get
+     debug "installing element segment"
+     debug (show es)
+     debug (show (instTableAddrs im))
+     case updStore (fromIntegral tblOff) st of
+       Nothing  -> instErr ("failed to evaluate element segment: " <> TL.pack (show es))
+       Just st' -> lift (put st')
+
+ where
+  updTable st ft (loc, (fty,_,faddr)) =
+    do hdl <- Seq.lookup faddr (storeFuncs st)
+       pure (updateFuncTable loc fty hdl ft)
+
+  updStore :: Int -> Store -> Maybe Store
+  updStore off st =
+    do (Wasm.TableType (Wasm.Limit lmin _) Wasm.AnyFunc, addr) <- resolveTableIndex tableIndex im
+       functab <- Seq.lookup addr (storeTables st)
+       guard (toInteger off + toInteger (length funcIndexes) <= toInteger lmin)
+       funaddrs <- mapM (\i -> resolveFuncIndex i im) funcIndexes
+       functab' <- foldM (updTable st) functab (zip [ off .. ] funaddrs)
+       pure st{ storeTables = Seq.update addr functab' (storeTables st) }
+
+
+computeGlobalValue ::
+  ModuleInstance ->
+  Wasm.Global ->
+  InstM ConstantValue
+computeGlobalValue i (Wasm.Global{ globalType = t, initializer = expr }) =
+  do let i' = emptyInstance{ instGlobalAddrs = instGlobalAddrs i }
+     c <- evalConst i' expr
+     case t of
+        Wasm.Const vt -> checkConstantType c vt
+        Wasm.Mut vt -> checkConstantType c vt
+     return c
+
+checkConstantType :: ConstantValue -> Wasm.ValueType -> InstM ()
+checkConstantType _ _ = return () -- TODO!
+
+evalConst ::
+  ModuleInstance ->
+  Wasm.Expression ->
+  InstM ConstantValue
+evalConst _i [Wasm.I32Const x] = pure (I32Val x)
+evalConst _i [Wasm.I64Const x] = pure (I64Val x)
+evalConst _i [Wasm.F32Const x] = pure (F32Val x)
+evalConst _i [Wasm.F64Const x] = pure (F64Val x)
+
+evalConst i [Wasm.GetGlobal idx] =
+  do st <- lift get
+     case resolveGlobalIndex idx i of
+       Just (_,_,addr) | Just gv <- Seq.lookup addr (storeGlobals st)  ->
+         case gv of
+           ConstantGlobal v -> pure v
+           _ -> instErr ("global index not a constant " <> fromString (show idx))
+       _ -> instErr ("could not resolve global index " <> fromString (show idx))
+
+evalConst _ _ = instErr "expression not a constant!"
+
+bindImport :: Namespace -> ModuleInstance -> Wasm.Import -> InstM ExternalValue
+bindImport ns i Wasm.Import{ .. } =
+  case namespaceLookup (Wasm.Ident sourceModule) name ns of
+    Just (et,a)
+      | Just et' <- matchImportDesc i desc et -> pure (et',a)
+      | otherwise -> instErr ("Entity did not have expected type" <> sourceModule <> " " <> name)
+    Nothing -> instErr ("Could not lookup entity " <> sourceModule <> " " <> name)
+
+matchImportDesc :: ModuleInstance -> Wasm.ImportDesc -> ExternalType -> Maybe ExternalType
+matchImportDesc i (Wasm.ImportFunc tidx) (ExternalFunc t)
+  | Just t' <- resolveTypeIndex tidx i, t == t' = Just (ExternalFunc t)
+  | otherwise = Nothing
+
+matchImportDesc _ (Wasm.ImportGlobal gt) (ExternalGlobal gt')
+  | gt == gt' = Just (ExternalGlobal gt)
+
+matchImportDesc _ (Wasm.ImportTable (Wasm.TableType lim tt))
+                    (ExternalTable (Wasm.TableType lim' tt'))
+  | tt == tt' && matchLim lim lim' = Just (ExternalTable (Wasm.TableType lim tt))
+
+matchImportDesc _ (Wasm.ImportMemory mt) (ExternalMem (Wasm.Memory mt'))
+  | matchLim mt mt' = Just (ExternalMem (Wasm.Memory mt))
+
+matchImportDesc _ _ _ = Nothing
+
+-- TODO double check that we have correctly implemented the limit checks
+--  as specified in the Wasm spec.  It's a little tricky to be sure that
+--  we've gotten the inequalities in the right places, etc.
+matchLim ::
+  Wasm.Limit {- ^ requested -} ->
+  Wasm.Limit {- ^ actual -} ->
+  Bool
+matchLim (Wasm.Limit rmin rmax) (Wasm.Limit amin amax) =
+  rmin <= amin &&
+  case (rmax, amax) of
+    (Nothing, _)      -> True
+    (Just _, Nothing) -> False
+    (Just x, Just y)  -> x >= y
+
+instantiateImports ::
+  Namespace ->
+  Wasm.Module ->
+  InstM ModuleInstance
+instantiateImports ns md =
+  do let i0 = emptyInstance{ instTypes = Seq.fromList (Wasm.types md) }
+     evs <- mapM (bindImport ns i0) (Wasm.imports md)
+     pure
+       ModuleInstance
+       { instTypes       = Seq.fromList (Wasm.types md)
+       , instFuncAddrs   = Seq.fromList [ (fty,Nothing,a) | (ExternalFunc fty, a) <- evs ]
+       , instTableAddrs  = Seq.fromList [ (tty,a) | (ExternalTable tty,  a) <- evs ]
+       , instMemAddrs    = Seq.fromList [ (mty,False,a) | (ExternalMem mty,    a) <- evs ]
+       , instGlobalAddrs = Seq.fromList [ (gty,Nothing,a) | (ExternalGlobal gty, a) <- evs ]
+       , instExports     = mempty
+       , instStartFunc   = Nothing
+       , instDataSegs    = []
+       }

--- a/crucible-wasm/src/Lang/Crucible/Wasm/Memory.hs
+++ b/crucible-wasm/src/Lang/Crucible/Wasm/Memory.hs
@@ -1,0 +1,279 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE ImplicitParams #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Lang.Crucible.Wasm.Memory where
+
+import Data.Bits
+import qualified Data.BitVector.Sized as BV
+import qualified Data.ByteString.Lazy as LBS
+import Numeric.Natural
+import Data.Parameterized.Context
+
+import Lang.Crucible.Backend
+import Lang.Crucible.Simulator
+import Lang.Crucible.Simulator.Intrinsics
+import Lang.Crucible.Types
+
+import qualified Language.Wasm.Structure as Wasm
+
+import           Lang.Crucible.LLVM.Bytes
+import           Lang.Crucible.LLVM.DataLayout (EndianForm(..), noAlignment)
+import           Lang.Crucible.LLVM.MemModel
+import qualified Lang.Crucible.LLVM.MemModel.Generic as G
+import qualified Lang.Crucible.LLVM.MemModel.Partial as Partial
+
+import What4.Interface
+import What4.InterpretedFloatingPoint
+
+import Lang.Crucible.Wasm.Utils
+
+type WasmMem = IntrinsicType "Wasm_Mem" EmptyCtx
+
+-- | 64Ki, the number of bytes in a memory page, as defined
+--   by the WebAssembly spec.
+pageSize :: BV.BV 32
+pageSize = BV.word32 (64 * 1024)
+
+-- | 2^16 is the absolute maximum number of pages that can
+--   be allocated in a Wasm memory.
+maxPages :: BV.BV 32
+maxPages = BV.word32 (bit 16)
+
+-- | Implicit allocation number of the memory base pointer
+basePointer :: Natural
+basePointer = 1
+
+freshMemory :: IsSymInterface sym => sym -> Wasm.Limit -> IO (WasmMemImpl sym)
+freshMemory sym lim =
+  do (lo,hi) <- checkLim sym lim
+
+     -- allocate an entire 32-bit address space in little endian mode
+     let heap0 = G.emptyMem LittleEndian
+     let heap1 = G.allocMem @32 G.GlobalAlloc basePointer Nothing noAlignment G.Mutable "" heap0
+
+     -- clear the entire memory space by writing a constant array with the zero byte
+     z32  <- bvLit sym knownNat (BV.word32 0)
+     base <- natLit sym basePointer
+     let bp = LLVMPointer base z32
+
+     z8   <- bvLit sym knownNat (BV.word8 0)
+     zArr <- constantArray sym (Empty :> BaseBVRepr (knownNat @32)) z8
+     (heap,_,_) <- G.writeArrayMem sym (knownNat @32) bp noAlignment zArr Nothing heap1
+
+     pure WasmMemImpl
+          { wasmMemHeap = heap
+          , wasmMemSize = lo
+          , wasmMemMax  = hi
+          }
+
+checkLim :: IsSymInterface sym => sym -> Wasm.Limit -> IO (SymBV sym 32, SymBV sym 32)
+checkLim sym (Wasm.Limit lo Nothing)
+  | lo <= bit 16
+  = do lo' <- bvLit sym knownNat (BV.mkBV knownNat (fromIntegral lo))
+       hi' <- bvLit sym knownNat maxPages
+       pure (lo',hi')
+
+checkLim sym (Wasm.Limit lo (Just hi))
+  | lo <= hi && hi <= bit 16
+  = do lo' <- bvLit sym knownNat (BV.mkBV knownNat (fromIntegral lo))
+       hi' <- bvLit sym knownNat (BV.mkBV knownNat (fromIntegral hi))
+       pure (lo',hi')
+
+checkLim _sym lim =
+  panic "checkLim" ["invalid limit: " ++ show lim]
+
+
+assertInBounds :: IsSymInterface sym => sym -> SymBV sym 32 -> Bytes -> WasmMemImpl sym -> IO ()
+
+assertInBounds sym off (Bytes 0) mem = -- TODO? maybe should be an error condition instead?
+  do offPageNum <- bvUdiv sym off =<< bvLit sym knownNat pageSize
+     lt <- bvUlt sym offPageNum (wasmMemSize mem)
+     assert sym lt (GenericSimError "pointer out of bounds")
+
+assertInBounds sym off (Bytes n) mem =
+  do end <- bvAdd sym off =<< bvLit sym knownNat (BV.mkBV knownNat (n-1))
+
+     -- check that the addition didn't overflow
+     le <- bvUle sym off end
+
+     endPageNum <- bvUdiv sym off =<< bvLit sym knownNat pageSize
+     endlt <- bvUlt sym endPageNum (wasmMemSize mem)
+
+     ok <- andPred sym le endlt
+     assert sym ok (GenericSimError "pointer out of bounds")
+
+wasmGrowMem ::
+  IsSymInterface sym =>
+  sym ->
+  SymBV sym 32 ->
+  WasmMemImpl sym ->
+  IO (SymBV sym 32, WasmMemImpl sym)
+wasmGrowMem sym n mem =
+  do (ov,newsz) <- addUnsignedOF sym n (wasmMemSize mem)
+     le <- bvUle sym newsz (wasmMemMax mem)
+     ok <- andPred sym le =<< notPred sym ov
+
+     neg1 <- bvLit sym knownNat (BV.int32 (-1))
+
+     newsz' <- bvIte sym ok newsz (wasmMemSize mem)
+     res    <- bvIte sym ok newsz neg1
+
+     let mem' = mem{ wasmMemSize = newsz' }
+
+     return (res, mem')
+
+wasmStoreChunk ::
+  IsSymInterface sym =>
+  sym ->
+  SymBV sym 32 ->
+  LBS.ByteString ->
+  WasmMemImpl sym ->
+  IO (WasmMemImpl sym)
+wasmStoreChunk sym offset chunk mem =
+  do let bs = Bytes (toInteger (LBS.length chunk))
+     assertInBounds sym offset bs mem
+     p <- mkPtr sym offset
+     let ?recordLLVMAnnotation = \_ _ -> return ()
+     let val = LLVMValString (LBS.toStrict chunk)
+     let storageType = arrayType (fromIntegral (LBS.length chunk)) (bitvectorType (Bytes 1))
+     (heap',_,_) <- G.writeMem sym knownNat Nothing p storageType noAlignment val (wasmMemHeap mem)
+     return mem{ wasmMemHeap = heap' }
+
+
+wasmStoreInt ::
+  (1 <= w, IsSymInterface sym) =>
+  sym ->
+  SymBV sym 32 ->
+  SymBV sym w ->
+  WasmMemImpl sym ->
+  IO (WasmMemImpl sym)
+wasmStoreInt sym off v mem =
+  do let bs = Bytes (intValue (bvWidth v) `div` 8)
+     assertInBounds sym off bs mem
+     p <- mkPtr sym off
+     let ?recordLLVMAnnotation = \_ _ -> return ()
+     blk <- natLit sym 0
+     let val = LLVMValInt blk v
+     (heap',_,_) <- G.writeMem sym knownNat Nothing p (bitvectorType bs) noAlignment val (wasmMemHeap mem)
+     return mem{ wasmMemHeap = heap' }
+
+wasmStoreFloat ::
+  IsSymInterface sym =>
+  sym ->
+  SymBV sym 32 ->
+  RegValue sym (FloatType SingleFloat) ->
+  WasmMemImpl sym ->
+  IO (WasmMemImpl sym)
+wasmStoreFloat sym off v mem =
+  do let bs = Bytes 4
+     assertInBounds sym off bs mem
+     p <- mkPtr sym off
+     let ?recordLLVMAnnotation = \_ _ -> return ()
+     let val = LLVMValFloat SingleSize v
+     (heap',_,_) <- G.writeMem sym knownNat Nothing p floatType noAlignment val (wasmMemHeap mem)
+     return mem{ wasmMemHeap = heap' }
+
+wasmStoreDouble ::
+  IsSymInterface sym =>
+  sym ->
+  SymBV sym 32 ->
+  RegValue sym (FloatType DoubleFloat) ->
+  WasmMemImpl sym ->
+  IO (WasmMemImpl sym)
+wasmStoreDouble sym off v mem =
+  do let bs = Bytes 8
+     assertInBounds sym off bs mem
+     p <- mkPtr sym off
+     let ?recordLLVMAnnotation = \_ _ -> return ()
+     let val = LLVMValFloat DoubleSize v
+     (heap',_,_) <- G.writeMem sym knownNat Nothing p doubleType noAlignment val (wasmMemHeap mem)
+     return mem{ wasmMemHeap = heap' }
+
+wasmLoadInt :: (1 <= w, IsSymInterface sym) => sym -> SymBV sym 32 -> NatRepr w -> WasmMemImpl sym -> IO (SymBV sym w)
+wasmLoadInt sym off w mem =
+  do let bs = Bytes (intValue w `div` 8)
+     assertInBounds sym off bs mem
+     p <- mkPtr sym off
+     let ?recordLLVMAnnotation = \_ _ -> return ()
+     pval <- G.readMem sym knownNat Nothing p (bitvectorType bs) noAlignment (wasmMemHeap mem)
+     Partial.assertSafe sym pval >>= \case
+       LLVMValZero _ -> bvLit sym w (BV.zero w)
+       LLVMValInt _ v | Just Refl <- testEquality (bvWidth v) w -> pure v
+       _ -> panic "wasmLoadInt" ["type mismatch"]
+
+wasmLoadFloat ::
+  IsSymInterface sym =>
+  sym ->
+  SymBV sym 32 ->
+  WasmMemImpl sym ->
+  IO (RegValue sym (FloatType SingleFloat))
+wasmLoadFloat sym off mem =
+  do let bs = Bytes 4
+     assertInBounds sym off bs mem
+     p <- mkPtr sym off
+     let ?recordLLVMAnnotation = \_ _ -> return ()
+     pval <- G.readMem sym knownNat Nothing p floatType noAlignment (wasmMemHeap mem)
+     Partial.assertSafe sym pval >>= \case
+       LLVMValZero _ -> iFloatLit sym SingleFloatRepr 0
+       LLVMValFloat SingleSize v -> pure v
+       _ -> panic "wasmLoadFloat" ["type mismatch"]
+
+wasmLoadDouble ::
+  IsSymInterface sym =>
+  sym ->
+  SymBV sym 32 ->
+  WasmMemImpl sym ->
+  IO (RegValue sym (FloatType DoubleFloat))
+wasmLoadDouble sym off mem =
+  do let bs = Bytes 8
+     assertInBounds sym off bs mem
+     p <- mkPtr sym off
+     let ?recordLLVMAnnotation = \_ _ -> return ()
+     pval <- G.readMem sym knownNat Nothing p doubleType noAlignment (wasmMemHeap mem)
+     Partial.assertSafe sym pval >>= \case
+       LLVMValZero _ -> iFloatLit sym DoubleFloatRepr 0
+       LLVMValFloat DoubleSize v -> pure v
+       _ -> panic "wasmLoadDouble" ["type mismatch"]
+
+
+mkPtr :: IsSymInterface sym => sym -> SymBV sym 32 -> IO (LLVMPtr sym 32)
+mkPtr sym off =
+  do blk <- natLit sym basePointer
+     pure (LLVMPointer blk off)
+
+data WasmMemImpl sym =
+  WasmMemImpl
+  { wasmMemHeap    :: !(G.Mem sym)
+      -- ^ main heap datastructure
+  , wasmMemSize    :: !(SymBV sym 32)
+      -- ^ number of data pages in this memory
+  , wasmMemMax     :: !(SymBV sym 32)
+      -- ^ maximum number of pages this memory can grow to
+  }
+
+instance IsSymInterface sym => IntrinsicClass sym "Wasm_Mem" where
+  type Intrinsic sym "Wasm_Mem" ctx = WasmMemImpl sym
+
+  muxIntrinsic sym _ _nm _ctx p mem1 mem2 =
+    do let WasmMemImpl heap1 sz1 mx1 = mem1
+       let WasmMemImpl heap2 sz2 mx2 = mem2
+       sz <- bvIte sym p sz1 sz2
+       mx <- bvIte sym p mx1 mx2
+       return $ WasmMemImpl (G.mergeMem p heap1 heap2) sz mx
+
+  pushBranchIntrinsic _sym _iTypes _nm _ctx mem =
+    do let WasmMemImpl heap sz mx = mem
+       return $ WasmMemImpl (G.branchMem heap) sz mx
+
+  abortBranchIntrinsic _sym _iTypes _nm _ctx mem =
+    do let WasmMemImpl heap sz mx = mem
+       return $ WasmMemImpl (G.branchAbortMem heap) sz mx

--- a/crucible-wasm/src/Lang/Crucible/Wasm/Translate.hs
+++ b/crucible-wasm/src/Lang/Crucible/Wasm/Translate.hs
@@ -1,0 +1,861 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Lang.Crucible.Wasm.Translate where
+
+import Control.Monad
+import Control.Monad.State.Strict
+import Data.Foldable(toList)
+import Data.Word
+import Numeric.Natural
+import GHC.Stack
+
+import qualified Data.Sequence as Seq
+
+import Data.Parameterized.Context
+import Data.Parameterized.Some
+import Data.Parameterized.Nonce
+
+import qualified Data.BitVector.Sized as BV
+import Data.List (genericDrop)
+
+import qualified Language.Wasm.Structure as Wasm
+
+import qualified Lang.Crucible.Simulator as Sim
+import Lang.Crucible.FunctionHandle
+import Lang.Crucible.Types
+
+import Lang.Crucible.Analysis.Postdom
+import Lang.Crucible.CFG.Generator
+import qualified Lang.Crucible.CFG.Core as C
+import Lang.Crucible.CFG.Expr
+import Lang.Crucible.CFG.SSAConversion
+
+import What4.ProgramLoc
+import What4.Utils.StringLiteral
+
+import Lang.Crucible.Wasm.Extension
+import Lang.Crucible.Wasm.Memory
+import Lang.Crucible.Wasm.Instantiate
+import Lang.Crucible.Wasm.Utils
+
+translateFunctions ::
+  ModuleInstance ->
+  Store ->
+  IO [Sim.FnBinding p sym WasmExt]
+translateFunctions im st = sequence
+  [ case Seq.lookup addr (storeFuncs st) of
+      Nothing -> panic "translateFunction" ["function not found"]
+      Just (SomeHandle h) -> translateFunction fty fn im st h
+  | (fty,Just fn,addr) <- toList (instFuncAddrs im)
+  ]
+
+type WasmGenerator s ret = Generator WasmExt s WasmGenState ret IO
+
+data WasmGenState s =
+  WasmGenState
+  { genLocals :: Seq.Seq (Some (Reg s))
+     -- ^ Function-local variables
+  , genStack  :: Seq.Seq (StackVal s)
+     -- ^ Value stack.  Back/right end of the sequence is
+     --   the working end of the stack to match the
+     --   order presented in the Wasm specification.
+  }
+
+emptyGenState :: WasmGenState s
+emptyGenState =
+  WasmGenState
+  { genLocals = mempty
+  , genStack  = mempty
+  }
+
+addLocal :: Reg s tp -> WasmGenState s -> WasmGenState s
+addLocal r st = st{ genLocals = genLocals st Seq.|> Some r }
+
+data StackVal s
+  = StackI32 (Atom s (BVType 32))
+  | StackI64 (Atom s (BVType 64))
+  | StackF32 (Atom s (FloatType SingleFloat))
+  | StackF64 (Atom s (FloatType DoubleFloat))
+
+  | StackBool (Atom s BoolType)
+    -- ^ A @StackBool@ constructor represents a delayed coersion of a boolean
+    --   value into a bitvector.  Boolean values do not exist in the Wasm
+    --   spec; but we represent them explicitly to avoid noisy round trip
+    --   expressions that coerce to and from bitvectors.
+    --   Where boolean stack values appear, they should be understood as
+    --   representing either the 0 or the 1 value of the appropriate
+    --   bitvector size.
+
+class PushStack s x where
+  pushStack :: x -> WasmGenerator s ret ()
+
+instance PushStack s (StackVal s) where
+  pushStack x = modify (\st -> st{ genStack = genStack st Seq.|> x })
+
+instance PushStack s (Atom s BoolType) where
+  pushStack = pushStack . StackBool
+
+instance PushStack s (Atom s (BVType 32)) where
+  pushStack = pushStack . StackI32
+
+instance PushStack s (Atom s (BVType 64)) where
+  pushStack = pushStack . StackI64
+
+instance PushStack s (Atom s (FloatType SingleFloat)) where
+  pushStack = pushStack . StackF32
+
+instance PushStack s (Atom s (FloatType DoubleFloat)) where
+  pushStack = pushStack . StackF64
+
+instance PushStack s (Atom s tp) => PushStack s (Expr WasmExt s tp) where
+  pushStack x = pushStack =<< mkAtom x
+
+instance PushStack s Word32 where
+  pushStack x = pushStack =<< mkAtom (App (BVLit (knownNat @32) (BV.word32 x)))
+
+instance PushStack s Word64 where
+  pushStack x = pushStack =<< mkAtom (App (BVLit (knownNat @64) (BV.word64 x)))
+
+instance PushStack s Float where
+  pushStack x = pushStack =<< mkAtom (App (FloatLit x))
+
+instance PushStack s Double where
+  pushStack x = pushStack =<< mkAtom (App (DoubleLit x))
+
+instance PushStack s ConstantValue where
+  pushStack (I32Val x) = pushStack x
+  pushStack (I64Val x) = pushStack x
+  pushStack (F32Val x) = pushStack x
+  pushStack (F64Val x) = pushStack x
+
+
+iteVals ::
+  Expr WasmExt s BoolType ->
+  StackVal s ->
+  StackVal s ->
+  WasmGenerator s ret (StackVal s)
+
+-- promote boolean values as required
+iteVals c (StackI32 x) (StackBool b) =
+  do y <- mkAtom (App (BoolToBV knownNat (AtomExpr b)))
+     iteVals c (StackI32 x) (StackI32 y)
+iteVals c (StackI64 x) (StackBool b) =
+  do y <- mkAtom (App (BoolToBV knownNat (AtomExpr b)))
+     iteVals c (StackI64 x) (StackI64 y)
+iteVals c (StackBool b) (StackI32 y) =
+  do x <- mkAtom (App (BoolToBV knownNat (AtomExpr b)))
+     iteVals c (StackI32 x) (StackI32 y)
+iteVals c (StackBool b) (StackI64 y) =
+  do x <- mkAtom (App (BoolToBV knownNat (AtomExpr b)))
+     iteVals c (StackI64 x) (StackI64 y)
+
+iteVals c (StackBool x) (StackBool y) =
+  StackBool <$> mkAtom (App (BoolIte c (AtomExpr x) (AtomExpr y)))
+
+iteVals c (StackI32 x) (StackI32 y) =
+  StackI32 <$> mkAtom (App (BVIte c knownRepr (AtomExpr x) (AtomExpr y)))
+
+iteVals c (StackI64 x) (StackI64 y) =
+  StackI64 <$> mkAtom (App (BVIte c knownRepr (AtomExpr x) (AtomExpr y)))
+
+iteVals c (StackF32 x) (StackF32 y) =
+  StackF32 <$> mkAtom (App (FloatIte knownRepr c (AtomExpr x) (AtomExpr y)))
+
+iteVals c (StackF64 x) (StackF64 y) =
+  StackF64 <$> mkAtom (App (FloatIte knownRepr c (AtomExpr x) (AtomExpr y)))
+
+iteVals _ _ _ = panic "iteVals" ["Type mismatch in iteVals"]
+
+
+pushStackByType :: HasCallStack => TypeRepr t -> Expr WasmExt s t -> WasmGenerator s reg ()
+pushStackByType t x = pushStack =<< stackValueByType t x
+
+stackValueByType :: HasCallStack => TypeRepr t -> Expr WasmExt s t -> WasmGenerator s reg (StackVal s)
+stackValueByType (BVRepr w) x
+  | Just Refl <- testEquality w (knownNat @32)  = StackI32 <$> mkAtom x
+  | Just Refl <- testEquality w (knownNat @64)  = StackI64 <$> mkAtom x
+stackValueByType (FloatRepr SingleFloatRepr) x  = StackF32 <$> mkAtom x
+stackValueByType (FloatRepr DoubleFloatRepr) x  = StackF64 <$> mkAtom x
+stackValueByType t _ = panic "stackValueByType" ["invalid type " ++ show t]
+
+checkStackVal :: TypeRepr ty -> StackVal s -> WasmGenerator s ret (Expr WasmExt s ty)
+checkStackVal (BVRepr w) (StackI32 x)
+   | Just Refl <- testEquality w (knownNat @32) = pure (AtomExpr x)
+checkStackVal (BVRepr w) (StackI64 x)
+   | Just Refl <- testEquality w (knownNat @64) = pure (AtomExpr x)
+checkStackVal (BVRepr w) (StackBool b)
+   | Just Refl <- testEquality w (knownNat @32) = pure (App (BoolToBV knownNat (AtomExpr b)))
+   | Just Refl <- testEquality w (knownNat @64) = pure (App (BoolToBV knownNat (AtomExpr b)))
+checkStackVal (FloatRepr SingleFloatRepr) (StackF32 x) = pure (AtomExpr x)
+checkStackVal (FloatRepr DoubleFloatRepr) (StackF64 x) = pure (AtomExpr x)
+checkStackVal _ _ = panic "checkStackVal" ["Type mismatch!"]
+
+
+pushInteger :: NatRepr w -> Expr WasmExt s (BVType w) -> WasmGenerator s reg ()
+pushInteger w x
+  | Just Refl <- testEquality w (knownNat @32) = pushStack . StackI32 =<< mkAtom x
+  | Just Refl <- testEquality w (knownNat @64) = pushStack . StackI64 =<< mkAtom x
+  | otherwise = panic "pushInteger" ["invalid size " ++ show w]
+
+peekStack :: HasCallStack => WasmGenerator s ret (StackVal s)
+peekStack =
+  do st <- get
+     case genStack st of
+       Seq.Empty -> panic "peekStack" ["empty stack"]
+       _stk' Seq.:|> x -> pure x
+
+popStack :: HasCallStack => WasmGenerator s ret (StackVal s)
+popStack =
+  do st <- get
+     case genStack st of
+       Seq.Empty -> panic "popStack" ["empty stack"]
+       stk' Seq.:|> x -> put st{ genStack = stk' } >> pure x
+
+popFloat :: HasCallStack => WasmGenerator s ret (Expr WasmExt s (FloatType SingleFloat))
+popFloat = popStack >>= \case
+  StackF32 f -> pure (AtomExpr f)
+  _ -> panic "popFloat" ["unexpected type"]
+
+popDouble :: HasCallStack => WasmGenerator s ret (Expr WasmExt s (FloatType DoubleFloat))
+popDouble = popStack >>= \case
+  StackF64 d -> pure (AtomExpr d)
+  _ -> panic "popDouble" ["unexpected type"]
+
+popInteger :: (1 <= w, HasCallStack) => NatRepr w -> WasmGenerator s ret (Expr WasmExt s (BVType w))
+popInteger w = popStack >>= \case
+  StackBool b -> pure (App (BoolToBV w (AtomExpr b)))
+  StackI32 x
+    | Just Refl <- testEquality w (knownNat @32) -> pure (AtomExpr x)
+  StackI64 x
+    | Just Refl <- testEquality w (knownNat @64) -> pure (AtomExpr x)
+  _ -> panic "popInteger"  ["unexpected type"]
+
+popInteger32 :: HasCallStack => WasmGenerator s ret (Expr WasmExt s (BVType 32))
+popInteger32 = popStack >>= \case
+  StackBool b -> pure (App (BoolToBV knownNat (AtomExpr b)))
+  StackI32 x -> pure (AtomExpr x)
+  _ -> panic "popInteger32" ["unexpected type"]
+
+popInteger64 :: HasCallStack => WasmGenerator s ret (Expr WasmExt s (BVType 64))
+popInteger64 = popStack >>= \case
+  StackBool b -> pure (App (BoolToBV knownNat (AtomExpr b)))
+  StackI64 x -> pure (AtomExpr x)
+  _ -> panic "popInteger64" ["unexpected type"]
+
+popPointer :: HasCallStack => Wasm.MemArg -> WasmGenerator s ret (Expr WasmExt s (BVType 32))
+popPointer Wasm.MemArg{ offset = o }
+  | o == 0 = popInteger32
+  | otherwise =
+  do x <- popInteger32
+     let off = (App (BVLit knownNat (BV.mkBV knownNat (toInteger o))))
+     forceEvaluation (App (BVAdd knownNat x off))
+
+popTest :: HasCallStack => WasmGenerator s reg (Expr WasmExt s BoolType)
+popTest = popStack >>= \case
+  StackBool b -> pure (AtomExpr b)
+  StackI32 x  -> pure (App (BVNonzero knownNat (AtomExpr x)))
+  _ -> panic "popTest" ["unexpected type"]
+
+
+pushStackN :: Seq.Seq (StackVal s) -> WasmGenerator s ret ()
+pushStackN vals = modify (\st -> st{ genStack = genStack st <> vals })
+
+popStackN :: HasCallStack => Int -> WasmGenerator s ret (Seq.Seq (StackVal s))
+popStackN n =
+  do st <- get
+     let toDrop = Seq.length (genStack st) - n
+     if toDrop >= 0 then
+       do let (stk',xs) = Seq.splitAt toDrop (genStack st)
+          put st{ genStack = stk' }
+          return xs
+     else
+       panic "popStackN" ["too many values to pop:" ++ show n, "Stack height:" ++ show (Seq.length (genStack st))]
+
+restoreStack :: WasmGenerator s ret a -> WasmGenerator s ret a
+restoreStack m =
+  do stk <- genStack <$> get
+     x <- m
+     modify (\st -> st{ genStack = stk })
+     pure x
+
+translateFunction :: forall p sym args ret.
+  Wasm.FuncType ->
+  Wasm.Function ->
+  ModuleInstance ->
+  Store ->
+  FnHandle args ret ->
+  IO (Sim.FnBinding p sym WasmExt)
+translateFunction fty fn@Wasm.Function{ .. } im st hdl =
+  do debug $ unlines ["Translating function", show fn]
+     (SomeCFG g, []) <- defineFunction InternalPos (Some globalNonceGenerator) hdl defn
+     case toSSA g of
+       C.SomeCFG g' ->
+         do debug (show g')
+            pure (Sim.FnBinding hdl (Sim.UseCFG g' (postdomInfo g')))
+
+  where
+  defn :: FunctionDef WasmExt WasmGenState args ret IO
+  defn args = (emptyGenState, setupLocals args >> genBody)
+
+  setupLocals :: Assignment (Atom s) args -> WasmGenerator s ret ()
+  setupLocals args =
+    do traverseWithIndex_ setupArgument args
+       mapM_ setupLocal localTypes
+
+  setupArgument :: Index ctx tp -> Atom s tp -> WasmGenerator s ret ()
+  setupArgument _idx inputArg =
+    do r <- newReg (AtomExpr inputArg)
+       modify (addLocal r)
+
+  setupLocal :: Wasm.ValueType -> WasmGenerator s ret ()
+  setupLocal Wasm.I32 =
+    do r <- newReg (App (BVLit (knownNat @32) (BV.zero knownNat)))
+       modify (addLocal r)
+  setupLocal Wasm.I64 =
+    do r <- newReg (App (BVLit (knownNat @64) (BV.zero knownNat)))
+       modify (addLocal r)
+  setupLocal Wasm.F32 =
+    do r <- newReg (App (FloatLit 0.0))
+       modify (addLocal r)
+  setupLocal Wasm.F64 =
+    do r <- newReg (App (DoubleLit 0.0))
+       modify (addLocal r)
+
+  genReturn :: WasmGenerator s ret (Expr WasmExt s ret)
+  genReturn = computeReturn (handleReturnType hdl) (Wasm.results fty)
+
+  genBody :: WasmGenerator s ret (Expr WasmExt s ret)
+  genBody =
+    do let body' = Wasm.Block (Wasm.results fty) body
+       genInstruction (genReturn >>= returnFromFunction) im st [] body'
+       genReturn
+
+-- | Control-flow labels, together with registers that
+--   are used for passing stack values between labels.
+--   Note: front/left end of the sequence is the working
+--   end of the stack so relative indexing works as expected.
+type ControlStack s = [ControlLabel s]
+
+type ControlLabel s = (Label s, Seq.Seq (Some (Reg s)))
+
+setupWasmLabel :: [Wasm.ValueType] -> WasmGenerator s ret (ControlLabel s)
+setupWasmLabel vts = do
+    regs <- Seq.fromList <$> mapM allocReg vts
+    l    <- newLabel
+    pure (l, regs)
+  where
+    allocReg = traverseSome newUnassignedReg . valueTypeToType
+
+jumpToWasmLabel :: ControlLabel s -> Seq.Seq (StackVal s) -> WasmGenerator s ret a
+jumpToWasmLabel (l, regs) vals =
+  do assignLabelRegs (l,regs) vals
+     jump l
+
+assignLabelRegs :: ControlLabel s -> Seq.Seq (StackVal s) -> WasmGenerator s ret ()
+assignLabelRegs (_,regs) vals = mapM_ asgn (Seq.zip regs vals)
+ where
+   asgn :: (Some (Reg s), StackVal s) -> WasmGenerator s ret ()
+   asgn (Some r, a) = assignReg r =<< checkStackVal (typeOfReg r) a
+
+setupLabelStack :: Seq.Seq (Some (Reg s)) -> WasmGenerator s ret ()
+setupLabelStack regs =
+    do vals <- traverse rd regs
+       pushStackN vals
+ where
+  rd :: Some (Reg s) -> WasmGenerator s reg (StackVal s)
+  rd (Some r) = stackValueByType (typeOfReg r) =<< readReg r
+
+popControlStack :: Natural -> ControlStack s -> WasmGenerator s reg (ControlLabel s)
+popControlStack n stk =
+  case genericDrop n stk of
+    []    -> panic "popControlStack" ["control stack too short:" ++ show n, "control stack height: " ++ show (length stk)]
+    (x:_) -> pure x
+
+computeArgs ::
+  Assignment TypeRepr ctx ->
+  [Wasm.ValueType] ->
+  WasmGenerator s ret (Assignment (Expr WasmExt s) ctx)
+computeArgs ctx ts =
+  do xs <- popStackN (length ts)
+     traverseWithIndex (checkArgVal xs) ctx
+
+computeReturn :: forall s ret. HasCallStack => TypeRepr ret -> [Wasm.ValueType] -> WasmGenerator s ret (Expr WasmExt s ret)
+computeReturn UnitRepr [] =
+    pure (App EmptyApp)
+computeReturn r [_] =
+    checkStackVal r =<< popStack
+computeReturn (StructRepr rtys) ts | length ts >= 2 =
+    do xs <- popStackN (length ts)
+       rets <- traverseWithIndex (checkArgVal xs) rtys
+       pure (App (MkStruct rtys rets))
+computeReturn _ _ = panic "computeReturn" ["Type mismatch at return!"]
+
+checkArgVal :: HasCallStack => Seq.Seq (StackVal s) -> Index ctx ty -> TypeRepr ty -> WasmGenerator s ret (Expr WasmExt s ty)
+checkArgVal xs idx ty =
+  case Seq.lookup (indexVal idx) xs of
+    Just a -> checkStackVal ty a
+    _ -> panic "checkArgVal" ["Type mismatch!"]
+
+getMemVar :: HasCallStack => ModuleInstance -> Store -> WasmGenerator s ret (GlobalVar WasmMem)
+getMemVar im st =
+   -- memory index hardcoded to 0
+   case resolveMemIndex 0 im of
+     Nothing -> panic "getMemVar" ["Could not load memory index 0"]
+     Just (_gty, _, addr) ->
+       case Seq.lookup addr (storeMemories st) of
+         Nothing -> panic "getMemVar" ["Could not resolve memory address", show addr]
+         Just gv -> pure gv
+
+genInstruction ::
+  WasmGenerator s ret () ->
+  ModuleInstance ->
+  Store ->
+  ControlStack s ->
+  Wasm.Instruction Natural ->
+  WasmGenerator s ret ()
+genInstruction genReturn im st ctrlStack instr =
+  case instr of
+    Wasm.Nop ->
+      return ()
+
+    Wasm.Unreachable ->
+      reportError (App (StringLit (UnicodeLiteral "unreachable")))
+
+    Wasm.Block{ resultType = vts, body = is } ->
+      do let n = length vts
+         blockEnd <- setupWasmLabel vts
+
+         -- Translate the body of the block, jumping
+         -- to the block end label at the end of the body.
+         -- Then, continue translating in the context of
+         -- the block continuation label.
+         restoreStack $ continue (fst blockEnd) $
+           do mapM_ (genInstruction genReturn im st (blockEnd:ctrlStack)) is
+              jumpToWasmLabel blockEnd =<< popStackN n
+
+         -- Grab our stack values out of the block registers
+         -- and continue translation
+         setupLabelStack (snd blockEnd)
+
+    Wasm.Loop{ resultType = _vts, body = is } ->
+      do -- NB in WebAssembly 1.0, loop-carried dependencies cannot
+         -- be on the stack, so we just need a standard label
+         loopHead <- newLabel
+
+         -- jump to the loop head, and start translating there
+         continue loopHead (jump loopHead)
+
+         -- Define the body of the loop
+         mapM_ (genInstruction genReturn im st ((loopHead,mempty):ctrlStack)) is
+
+    Wasm.If{ resultType = vts, true = true_is, false = false_is } ->
+      do let n = length vts
+         blockEnd <- setupWasmLabel vts
+         trueLab  <- newLabel
+         falseLab <- newLabel
+
+         c <- popTest
+
+         restoreStack $ defineBlock trueLab
+           do mapM_ (genInstruction genReturn im st (blockEnd:ctrlStack)) true_is
+              jumpToWasmLabel blockEnd =<< popStackN n
+
+         restoreStack $ defineBlock falseLab
+           do mapM_ (genInstruction genReturn im st (blockEnd:ctrlStack)) false_is
+              jumpToWasmLabel blockEnd =<< popStackN n
+
+         -- terminate our current block by branching, and continue
+         -- translation in the continuation label
+         continue (fst blockEnd) (branch c trueLab falseLab)
+
+         -- Grab our stack values out of the block registers
+         -- and continue translation
+         setupLabelStack (snd blockEnd)
+
+    Wasm.Br idx ->
+      do cl <- popControlStack idx ctrlStack
+         jumpToWasmLabel cl =<< popStackN (Seq.length (snd cl))
+
+    Wasm.BrIf idx ->
+      do falseLab <- newLabel
+         cl <- popControlStack idx ctrlStack
+         c <- popTest
+         topVals <- popStackN (Seq.length (snd cl))
+         assignLabelRegs cl topVals
+         continue falseLab (branch c (fst cl) falseLab)
+         pushStackN topVals
+
+    Wasm.BrTable ls def ->
+      do cls   <- mapM (\i -> popControlStack i ctrlStack) ls
+         cldef <- popControlStack def ctrlStack
+         c <- popInteger32
+         topVals <- popStackN (Seq.length (snd (cldef)))
+         buildBrTable c cls cldef topVals
+
+    Wasm.Return -> genReturn
+
+    Wasm.Call idx ->
+      case resolveFuncIndex idx im of
+        Nothing -> panic "genInstruction: Call" ["Could not resolve function index " ++ show idx]
+        Just (fty,_,addr) ->
+          case Seq.lookup addr (storeFuncs st) of
+            Nothing -> panic "genInstruction: Call" ["Could not resolve function address " ++ show addr]
+            Just (SomeHandle h) -> invokeFn fty (handleType h) (App (HandleLit h))
+
+    Wasm.CallIndirect tidx ->
+      case resolveTypeIndex tidx im of
+        Nothing -> panic "genInstruction: CallIndirect" ["Could not resolve type index " ++ show tidx]
+        Just fty ->
+          -- NB, table index hard-coded to 0 in Wasm 1.0
+          case resolveTableIndex 0 im of
+            Nothing -> panic "genInstruction: CallIndirect" ["Could not resolve table index 0"]
+            Just (_tty, tbladdr) ->
+              case Seq.lookup tbladdr (storeTables st) of
+                Nothing -> panic "genInstruction: CallIndirect" ["Could not resolve table address " ++ show tbladdr]
+                Just ftab ->
+                  do Some argTys <- pure (valueTypesToContext (Wasm.params fty))
+                     Some retTys <- pure (valueTypesToContext (Wasm.results fty))
+                     Some retTy  <- pure (returnContextToType retTys)
+                     let tpr = FunctionHandleRepr argTys retTy
+                     x  <- popInteger32
+                     fn <- extensionStmt (Wasm_IndirectFunction fty ftab tpr x)
+                     invokeFn fty tpr fn
+
+    Wasm.Drop ->
+      void $ popStack
+
+    Wasm.Select ->
+      do c <- popTest
+         y <- popStack
+         x <- popStack
+         pushStack =<< iteVals c x y
+
+    Wasm.GetLocal idx ->
+      do locals <- genLocals <$> get
+         case resolveSeq idx locals of
+           Nothing -> panic "genInstruction: GetLocal" ["Could not find local " ++ show idx]
+           Just (Some r) -> pushStackByType (typeOfReg r) =<< readReg r
+
+    Wasm.SetLocal idx ->
+      do locals <- genLocals <$> get
+         case resolveSeq idx locals of
+           Nothing -> panic "genInstruction: SetLocal" ["Could not find local " ++ show idx]
+           Just (Some r) ->
+             assignReg r =<< checkStackVal (typeOfReg r) =<< popStack
+
+    Wasm.TeeLocal idx ->
+      do locals <- genLocals <$> get
+         case resolveSeq idx locals of
+           Nothing -> panic "genInstruction: TeeLocal" ["Could not find local " ++ show idx]
+           Just (Some r) ->
+             assignReg r =<< checkStackVal (typeOfReg r) =<< peekStack
+
+    Wasm.GetGlobal idx ->
+      case resolveGlobalIndex idx im of
+        Nothing -> panic "getInstruction: GetGlobal" ["Could not find global " ++ show idx]
+        Just (_gty, _, addr) ->
+          case Seq.lookup addr (storeGlobals st) of
+            Nothing -> panic "genInstruction: GetGlobal" ["Could not resolve global address " ++ show addr]
+            Just (ConstantGlobal cv) -> pushStack cv
+            Just (MutableGlobal gv)  -> pushStackByType (globalType gv) =<< readGlobal gv
+
+    Wasm.SetGlobal idx ->
+      case resolveGlobalIndex idx im of
+        Nothing -> panic "genInstruction: SetGlobal" ["Could not find global " ++ show idx]
+        Just (_gty, _, addr) ->
+          case Seq.lookup addr (storeGlobals st) of
+            Nothing -> panic "genInstruction: SetGlobal" ["Could not resolve global address " ++ show addr]
+            Just (ConstantGlobal _) -> panic "genInstruction: SetGlobal" ["setGlobal of constant global"]
+            Just (MutableGlobal gv) -> writeGlobal gv =<< checkStackVal (globalType gv) =<< popStack
+
+    Wasm.CurrentMemory ->
+      do gv <- getMemVar im st
+         pushStack =<< extensionStmt (Wasm_MemSize gv)
+
+    Wasm.GrowMemory ->
+      do gv <- getMemVar im st
+         n <- popInteger32
+         void $ extensionStmt (Wasm_MemGrow gv n)
+
+    Wasm.I32Store8 ma ->
+      do gv <- getMemVar im st
+         v <- popInteger32
+         p <- popPointer ma
+         v' <- forceEvaluation (App (BVTrunc (knownNat @8) (knownNat @32) v))
+         void $ extensionStmt (Wasm_StoreInt8 gv p v')
+
+    Wasm.I32Store16 ma ->
+      do gv <- getMemVar im st
+         v <- popInteger32
+         p <- popPointer ma
+         v' <- forceEvaluation (App (BVTrunc (knownNat @16) (knownNat @32) v))
+         void $ extensionStmt (Wasm_StoreInt16 gv p v')
+
+    Wasm.I32Store ma ->
+      do gv <- getMemVar im st
+         v <- popInteger32
+         p <- popPointer ma
+         void $ extensionStmt (Wasm_StoreInt32 gv p v)
+
+    Wasm.I64Store8 ma ->
+      do gv <- getMemVar im st
+         v <- popInteger64
+         p <- popPointer ma
+         v' <- forceEvaluation (App (BVTrunc (knownNat @8) (knownNat @64) v))
+         void $ extensionStmt (Wasm_StoreInt8 gv p v')
+
+    Wasm.I64Store16 ma ->
+      do gv <- getMemVar im st
+         v <- popInteger64
+         p <- popPointer ma
+         v' <- forceEvaluation (App (BVTrunc (knownNat @16) (knownNat @64) v))
+         void $ extensionStmt (Wasm_StoreInt16 gv p v')
+
+    Wasm.I64Store32 ma ->
+      do gv <- getMemVar im st
+         v <- popInteger64
+         p <- popPointer ma
+         v' <- forceEvaluation (App (BVTrunc (knownNat @32) (knownNat @64) v))
+         void $ extensionStmt (Wasm_StoreInt32 gv p v')
+
+    Wasm.I64Store ma ->
+      do gv <- getMemVar im st
+         v <- popInteger64
+         p <- popPointer ma
+         void $ extensionStmt (Wasm_StoreInt64 gv p v)
+
+    Wasm.F32Store ma ->
+      do gv <- getMemVar im st
+         v  <- popFloat
+         p  <- popPointer ma
+         void $ extensionStmt (Wasm_StoreFloat gv p v)
+
+    Wasm.F64Store ma ->
+      do gv <- getMemVar im st
+         v  <- popDouble
+         p  <- popPointer ma
+         void $ extensionStmt (Wasm_StoreDouble gv p v)
+
+    Wasm.I32Load8S ma ->
+      do gv <- getMemVar im st
+         p <- popPointer ma
+         v <- extensionStmt (Wasm_LoadInt8 gv p)
+         pushStack (App (BVSext (knownNat @32) (knownNat @8) v))
+
+    Wasm.I32Load8U ma ->
+      do gv <- getMemVar im st
+         p <- popPointer ma
+         v <- extensionStmt (Wasm_LoadInt8 gv p)
+         pushStack (App (BVZext (knownNat @32) (knownNat @8) v))
+
+    Wasm.I32Load16S ma ->
+      do gv <- getMemVar im st
+         p <- popPointer ma
+         v <- extensionStmt (Wasm_LoadInt16 gv p)
+         pushStack (App (BVSext (knownNat @32) (knownNat @16) v))
+
+    Wasm.I32Load16U ma ->
+      do gv <- getMemVar im st
+         p <- popPointer ma
+         v <- extensionStmt (Wasm_LoadInt16 gv p)
+         pushStack (App (BVZext (knownNat @32) (knownNat @16) v))
+
+    Wasm.I32Load ma ->
+      do gv <- getMemVar im st
+         p <- popPointer ma
+         v <- extensionStmt (Wasm_LoadInt32 gv p)
+         pushStack v
+
+    Wasm.I64Load8S ma ->
+      do gv <- getMemVar im st
+         p <- popPointer ma
+         v <- extensionStmt (Wasm_LoadInt8 gv p)
+         pushStack (App (BVSext (knownNat @64) (knownNat @8) v))
+
+    Wasm.I64Load8U ma ->
+      do gv <- getMemVar im st
+         p <- popPointer ma
+         v <- extensionStmt (Wasm_LoadInt8 gv p)
+         pushStack (App (BVZext (knownNat @64) (knownNat @8) v))
+
+    Wasm.I64Load16S ma ->
+      do gv <- getMemVar im st
+         p <- popPointer ma
+         v <- extensionStmt (Wasm_LoadInt16 gv p)
+         pushStack (App (BVSext (knownNat @64) (knownNat @16) v))
+
+    Wasm.I64Load16U ma ->
+      do gv <- getMemVar im st
+         p <- popPointer ma
+         v <- extensionStmt (Wasm_LoadInt16 gv p)
+         pushStack (App (BVZext (knownNat @64) (knownNat @16) v))
+
+    Wasm.I64Load32S ma ->
+      do gv <- getMemVar im st
+         p <- popPointer ma
+         v <- extensionStmt (Wasm_LoadInt32 gv p)
+         pushStack (App (BVSext (knownNat @64) (knownNat @32) v))
+
+    Wasm.I64Load32U ma ->
+      do gv <- getMemVar im st
+         p <- popPointer ma
+         v <- extensionStmt (Wasm_LoadInt32 gv p)
+         pushStack (App (BVZext (knownNat @64) (knownNat @32) v))
+
+    Wasm.I64Load ma ->
+      do gv <- getMemVar im st
+         p <- popPointer ma
+         v <- extensionStmt (Wasm_LoadInt64 gv p)
+         pushStack v
+
+    Wasm.F32Load ma ->
+      do gv <- getMemVar im st
+         p  <- popPointer ma
+         v  <- extensionStmt (Wasm_LoadFloat gv p)
+         pushStack v
+
+    Wasm.F64Load ma ->
+      do gv <- getMemVar im st
+         p  <- popPointer ma
+         v  <- extensionStmt (Wasm_LoadDouble gv p)
+         pushStack v
+
+    Wasm.I32Const w -> pushStack w
+    Wasm.I64Const w -> pushStack w
+    Wasm.F32Const f -> pushStack f
+    Wasm.F64Const d -> pushStack d
+
+    Wasm.IUnOp  sz op -> withBitSize sz \w -> genIUnOp w op
+    Wasm.IBinOp sz op -> withBitSize sz \w -> genIBinOp w op
+    Wasm.IRelOp sz op -> withBitSize sz \w -> genIRelOp w op
+
+    Wasm.I32Eqz ->
+      do v <- popInteger32
+         t <- mkAtom . App . Not . App . BVNonzero knownNat $ v
+         pushStack t
+
+    Wasm.I64Eqz ->
+      do v <- popInteger64
+         t <- mkAtom . App . Not . App . BVNonzero knownNat $ v
+         pushStack t
+
+
+    -- FUnOp TODO
+    -- FBinOp TODO
+    -- FRelOp TODO
+
+    -- I32WrapI64
+    -- ITruncFU
+    -- ITruncFS
+    -- I64ExtendSI32
+    -- I64ExtendUI32
+    -- FConvertIU {- Float Size -} BitSize {- Int Size -} BitSize
+    -- FConvertIS {- Float Size -} BitSize {- Int Size -} BitSize
+    -- F32DemoteF64
+    -- F64PromoteF32
+    -- IReinterpretF BitSize
+    -- FReinterpretI BitSize
+
+    _ -> unimplemented $ unwords ["Instruction not implemented", show instr]
+
+invokeFn ::
+  Wasm.FuncType ->
+  TypeRepr (FunctionHandleType i o) ->
+  Expr WasmExt s (FunctionHandleType i o) ->
+  WasmGenerator s ret ()
+invokeFn fty (FunctionHandleRepr argTys retTy) fn =
+  do args <- computeArgs argTys (Wasm.params fty)
+     ret <- call fn args
+     case (Wasm.results fty) of
+       []  -> return ()
+       [_] -> pushStackByType retTy ret
+       _   -> panic "invokeFn" [ "Multi-return functions not supported in Wasm 1.0"
+                               , "This function should not have passed validation"
+                               ]
+
+buildBrTable ::
+  Expr WasmExt s (BVType 32) ->
+  [ControlLabel s] ->
+  ControlLabel s ->
+  Seq.Seq (StackVal s) ->
+  WasmGenerator s ret a
+buildBrTable c cls0 cldef vals = loop 0 cls0
+  where
+    loop _  [] = jumpToWasmLabel cldef vals
+    loop !i (cl:cls) =
+      do falseLab <- newLabel
+         let ilit = App (BVLit knownNat (BV.word32 i))
+         let test = App (BVEq knownNat c ilit)
+         assignLabelRegs cl vals
+         continue falseLab (branch test (fst cl) falseLab)
+         loop (i+1) cls
+
+withBitSize :: Wasm.BitSize -> (forall w. (1 <= w) => NatRepr w -> a) -> a
+withBitSize Wasm.BS32 f = f (knownNat @32)
+withBitSize Wasm.BS64 f = f (knownNat @64)
+
+genIUnOp :: (1 <= w) => NatRepr w -> Wasm.IUnOp -> WasmGenerator s ret ()
+genIUnOp w op =
+  do v <- popInteger w
+     pushInteger w case op of
+       Wasm.IClz    -> App (BVCountLeadingZeros w v)
+       Wasm.ICtz    -> App (BVCountTrailingZeros w v)
+       Wasm.IPopcnt -> App (BVPopcount w v)
+
+genIBinOp :: (1 <= w) => NatRepr w -> Wasm.IBinOp -> WasmGenerator s ret ()
+genIBinOp w op =
+  do v2 <- popInteger w
+     v1 <- popInteger w
+     let v2mod = App (BVUrem w v2 (App (BVLit w (BV.width w))))
+     pushInteger w case op of
+       Wasm.IAdd    -> App (BVAdd w v1 v2)
+       Wasm.ISub    -> App (BVSub w v1 v2)
+       Wasm.IMul    -> App (BVMul w v1 v2)
+       Wasm.IDivU   -> App (BVUdiv w v1 v2)
+       Wasm.IDivS   -> App (BVSdiv w v1 v2)
+       Wasm.IRemU   -> App (BVUrem w v1 v2)
+       Wasm.IRemS   -> App (BVSrem w v1 v2)
+       Wasm.IAnd    -> App (BVAnd w v1 v2)
+       Wasm.IOr     -> App (BVOr w v1 v2)
+       Wasm.IXor    -> App (BVXor w v1 v2)
+       Wasm.IRotl   -> App (BVRol w v1 v2)
+       Wasm.IRotr   -> App (BVRor w v1 v2)
+
+       -- Wasm defines shift amounts modulo w.
+       -- This differs from What4's semantics for
+       -- overshift, which saturate instead.
+       Wasm.IShl    -> App (BVShl w v1 v2mod)
+       Wasm.IShrU   -> App (BVLshr w v1 v2mod)
+       Wasm.IShrS   -> App (BVAshr w v1 v2mod)
+
+genIRelOp :: (1 <= w) => NatRepr w -> Wasm.IRelOp -> WasmGenerator s ret ()
+genIRelOp w op =
+  do v2 <- popInteger w
+     v1 <- popInteger w
+     pushStack case op of
+       Wasm.IEq  -> App (BVEq w v1 v2)
+       Wasm.INe  -> App (Not (App (BVEq w v1 v2)))
+
+       Wasm.ILtU -> App (BVUlt w v1 v2)
+       Wasm.ILtS -> App (BVSlt w v1 v2)
+       Wasm.IGtU -> App (BVUlt w v2 v1)
+       Wasm.IGtS -> App (BVSlt w v2 v1)
+
+       Wasm.ILeU -> App (BVUle w v1 v2)
+       Wasm.ILeS -> App (BVSle w v1 v2)
+       Wasm.IGeU -> App (BVUle w v2 v1)
+       Wasm.IGeS -> App (BVSle w v2 v1)

--- a/crucible-wasm/src/Lang/Crucible/Wasm/Utils.hs
+++ b/crucible-wasm/src/Lang/Crucible/Wasm/Utils.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Lang.Crucible.Wasm.Utils where
+
+import Control.Monad.IO.Class
+import Control.Exception (Exception, throwIO)
+import GHC.Stack
+
+import Panic hiding (panic)
+import qualified Panic
+
+data CrucibleWasm = CrucibleWasm
+
+panic :: HasCallStack => String -> [String] -> a
+panic = Panic.panic CrucibleWasm
+
+instance PanicComponent CrucibleWasm where
+  panicComponentName _ = "Crucible-wasm"
+  panicComponentIssues _ = "https://github.com/GaloisInc/crucible/issues"
+
+  {-# Noinline panicComponentRevision #-}
+  panicComponentRevision = $useGitRevision
+
+
+data Unimplemented = Unimplemented CallStack String
+instance Show Unimplemented where
+  show (Unimplemented stk msg) = "Unimplmenented! " ++ msg ++ "\n" ++ prettyCallStack stk
+instance Exception Unimplemented
+
+unimplemented :: (HasCallStack, MonadIO m) => String -> m a
+unimplemented msg = liftIO (throwIO (Unimplemented callStack msg))
+
+-- | Print debugging information
+debug :: MonadIO m  => String -> m ()
+debug msg = liftIO (putStrLn msg)

--- a/crucible-wasm/tool/Main.hs
+++ b/crucible-wasm/tool/Main.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import System.Exit
+import System.IO
+
+import qualified Data.ByteString.Lazy as LBS
+
+import Lang.Crucible.Backend
+import Lang.Crucible.Types
+import Lang.Crucible.Simulator
+import Lang.Crucible.FunctionHandle
+
+import qualified Crux
+import qualified Crux.Model as Crux
+import qualified Crux.Types as Crux
+
+import qualified Language.Wasm as Wasm
+
+import Lang.Crucible.Wasm
+
+data WasmOptions = WasmOptions
+
+defaultWasmOptions :: WasmOptions
+defaultWasmOptions = WasmOptions
+
+cruxWasmConfig :: Crux.Config WasmOptions
+cruxWasmConfig = Crux.Config
+  { Crux.cfgFile = pure defaultWasmOptions
+  , Crux.cfgEnv  = []
+  , Crux.cfgCmdLineFlag = []
+  }
+
+setupWasmState :: IsSymInterface sym =>
+  sym -> Wasm.Script -> IO (ExecState (Crux.Model sym) sym WasmExt (RegEntry sym UnitType))
+setupWasmState sym s =
+  do halloc <- newHandleAllocator
+
+     let globals = emptyGlobals
+     let bindings = emptyHandleMap
+     let simctx = initSimContext sym wasmIntrinsicTypes halloc stdout bindings extImpl Crux.emptyModel
+     let m = execScript s emptyScriptState >> pure ()
+
+     pure (InitialState simctx globals defaultAbortHandler knownRepr (runOverrideSim knownRepr m))
+
+simulateWasm :: Crux.CruxOptions -> WasmOptions -> Crux.SimulatorCallback
+simulateWasm cruxOpts _wasmOpts = Crux.SimulatorCallback $ \sym _mOnline ->
+   do let files = Crux.inputFiles cruxOpts
+
+      fl <- case files of
+              [fl] -> return fl
+              _ -> fail "crux-wasm requires one script file"
+
+      script <-
+        do escript <- Wasm.parseScript <$> LBS.readFile fl
+           case escript of
+             Left msg -> fail msg
+             Right s -> return s
+
+      initSt <- setupWasmState sym script
+
+      return (Crux.RunnableState initSt, \_ _ -> return mempty)
+
+main :: IO ()
+main =
+  Crux.loadOptions Crux.defaultOutputConfig "crux-wasm" "0.1" cruxWasmConfig
+   \(cruxOpts, wasmOpts) ->
+       do res <- Crux.runSimulator cruxOpts (simulateWasm cruxOpts wasmOpts)
+          exitWith =<< Crux.postprocessSimResult cruxOpts res

--- a/crucible/src/Lang/Crucible/CFG/Expr.hs
+++ b/crucible/src/Lang/Crucible/CFG/Expr.hs
@@ -765,6 +765,42 @@ data App (ext :: Type) (f :: CrucibleType -> Type) (tp :: CrucibleType) where
          -> !(f (BVType w)) -- The shift amount as an unsigned integer.
          -> App ext f (BVType w)
 
+  -- Rotate left
+  BVRol :: (1 <= w)
+        => !(NatRepr w)
+        -> !(f (BVType w)) -- Value to rotate
+        -> !(f (BVType w)) -- The rotate amount as an unsigned integer
+        -> App ext f (BVType w)
+
+  -- Rotate right
+  BVRor :: (1 <= w)
+        => !(NatRepr w)
+        -> !(f (BVType w)) -- Value to rotate
+        -> !(f (BVType w)) -- The rotate amount as an unsigned integer
+        -> App ext f (BVType w)
+
+  -- Return the number of consecutive 0 bits in the input, starting from
+  -- the most significant bit position.  If the input is zero, all bits are counted
+  -- as leading.
+  BVCountLeadingZeros :: (1 <= w)
+        => !(NatRepr w)
+        -> !(f (BVType w))
+        -> App ext f (BVType w)
+
+  -- Return the number of consecutive 0 bits in the input, starting from
+  -- the least significant bit position.  If the input is zero, all bits are counted
+  -- as trailing.
+  BVCountTrailingZeros :: (1 <= w)
+        => !(NatRepr w)
+        -> !(f (BVType w))
+        -> App ext f (BVType w)
+
+  -- popcount
+  BVPopcount :: (1 <= w)
+        => !(NatRepr w)
+        -> !(f (BVType w))
+        -> App ext f (BVType w)
+
   -- Return the minimum of the two arguments using unsigned comparisons
   BVUMin ::
     (1 <= w) =>
@@ -1202,6 +1238,11 @@ instance TypeApp (ExprExtension ext) => TypeApp (App ext) where
     BVShl w _ _ -> BVRepr w
     BVLshr w _ _ -> BVRepr w
     BVAshr w _ _ -> BVRepr w
+    BVRol w _ _ -> BVRepr w
+    BVRor w _ _ -> BVRepr w
+    BVCountTrailingZeros w _ -> BVRepr w
+    BVCountLeadingZeros w _ -> BVRepr w
+    BVPopcount w _ -> BVRepr w
     BVUMax w _ _ -> BVRepr w
     BVUMin w _ _ -> BVRepr w
     BVSMax w _ _ -> BVRepr w

--- a/crucible/src/Lang/Crucible/CFG/Generator.hs
+++ b/crucible/src/Lang/Crucible/CFG/Generator.hs
@@ -284,6 +284,9 @@ instance Monad m => MonadState (t s) (Generator ext s t ret m) where
   get = Generator $ use gsState
   put v = Generator $ gsState .= v
 
+instance MonadIO m => MonadIO (Generator ext s t ret m) where
+  liftIO m = lift (liftIO m)
+
 -- This function only works for 'Generator' actions that terminate
 -- early, i.e. do not call their continuation. This includes actions
 -- that end with block-terminating statements defined with

--- a/crucible/src/Lang/Crucible/Simulator/Evaluation.hs
+++ b/crucible/src/Lang/Crucible/Simulator/Evaluation.hs
@@ -776,6 +776,23 @@ evalApp sym itefns _logFn evalExt (evalSub :: forall tp. f tp -> IO (RegValue sy
       x <- evalSub xe
       y <- evalSub ye
       bvAshr sym x y
+    BVRol _ xe ye -> do
+      x <- evalSub xe
+      y <- evalSub ye
+      bvRol sym x y
+    BVRor _ xe ye -> do
+      x <- evalSub xe
+      y <- evalSub ye
+      bvRor sym x y
+    BVCountTrailingZeros _ xe -> do
+      x <- evalSub xe
+      bvCountTrailingZeros sym x
+    BVCountLeadingZeros _ xe -> do
+      x <- evalSub xe
+      bvCountLeadingZeros sym x
+    BVPopcount _ xe -> do
+      x <- evalSub xe
+      bvPopcount sym x
     BVCarry _ xe ye -> do
       x <- evalSub xe
       y <- evalSub ye


### PR DESCRIPTION
This PR implements a rough first cut at providing WebAssembly translation support for Crucible.  Support is currently incomplete in a variety of ways.  For reference, I have been following the WebAssembly 1.0 specification, which may be found here:
https://www.w3.org/TR/2019/REC-wasm-core-1-20191205 (there is a newer 1.1 spec, but it doesn't seem to have much uptake yet, and the changes seem relatively small).

What works:

- Parsing and loading modules via "Script" format from the `haskell-wasm` package
- Much of the module instantiation/linking phase
- Instruction translations for integer value arithmetic, control flow, direct function calls and memory access
- Running `assert_return` clauses of the `haskell-wasm` test suite

What doesn't work yet:

- Most floating-point instructions
- Numeric conversions
- data segment initialization
- table segment initialization
- the indirect function call instruction

Other rough edges:

- This code doesn't compile as-is without exposing more of the abstract syntax data structures from `haskell-wasm`.  I have not yet tried to get these changes incorporated upstream
- Error handling is a bit of a mess.  Many `error` calls should be converted to `panic`, as they should be ruled out by module verification, and others should be reported in more appropriate ways.
- Comments are currently sparse on the ground
- No test suite yet
- I'm not confident we are doing the correct thing WRT partial numeric instructions.  We should ensure that we are making appropriate assertions regarding divide-by-zero, etc.
