### PR TITLE
Define CRUCIBLE when performing crux-llvm build of input sources.

### DIFF
--- a/crux-llvm/README.md
+++ b/crux-llvm/README.md
@@ -77,23 +77,31 @@ directory:
 * `print-model-NNN`: an executable file that prints out the values
   associated with the counter-example.
 
-To define properties and assumptions about the code to analyze, you may
-have to annotate the source code with inline properties. The following
+To define properties and assumptions about the code to analyze, you
+may have to annotate the source code with inline properties (CRUCIBLE
+is defined to help specify crucible-specific functionality. The following
 simple example is included in the `crux-llvm` distribution.
 
 ~~~~ .c
 #include <stdint.h>
+#ifdef CRUCIBLE
 #include <crucible.h>
+#endif
 
 int8_t f(int8_t x) {
   return x + 1;
 }
 
+#ifdef CRUCIBLE
 int main() {
   int8_t x = crucible_int8_t("x");
   assuming(x < 100);
   check(f(x) < 100);
   return 0;
+}
+#else
+int main(int argc, char **argv) {
+  return f(argv);
 }
 ~~~~
 

--- a/crux-llvm/src/Crux/LLVM/Compile.hs
+++ b/crux-llvm/src/Crux/LLVM/Compile.hs
@@ -111,10 +111,10 @@ genBitCode cruxOpts llvmOpts =
                     incDirs llvmOpts
          params (src, srcBC)
            | ".ll" `isSuffixOf` src =
-              ["-c", "-emit-llvm", "-O0", "-o", srcBC, src]
+              ["-c", "-DCRUCIBLE", "-emit-llvm", "-O0", "-o", srcBC, src]
 
            | otherwise =
-              [ "-c", "-g", "-emit-llvm" ] ++
+              [ "-c", "-DCRUCIBLE", "-g", "-emit-llvm" ] ++
               concat [ [ "-I", dir ] | dir <- incs src ] ++
               concat [ [ "-fsanitize="++san, "-fsanitize-trap="++san ] | san <- ubSanitizers llvmOpts ] ++
               [ "-O" ++ show (optLevel llvmOpts), "-o", srcBC, src ]


### PR DESCRIPTION
This helps the user include Crucible validation interspersed with
regular code implementation.