### PR TITLE
[crux-llvm] Add -Wcompat and remove profiling flags from cabal config.

### DIFF
--- a/crux-llvm/crux-llvm.cabal
+++ b/crux-llvm/crux-llvm.cabal
@@ -47,8 +47,8 @@ library
     template-haskell,
     text,
     what4
-  ghc-options: -Wall -Werror=incomplete-patterns -Werror=missing-methods -Werror=overlapping-patterns
-  ghc-prof-options: -O2 -fprof-auto-top
+  ghc-options: -Wall -Wcompat -Werror=incomplete-patterns -Werror=missing-methods -Werror=overlapping-patterns
+  ghc-prof-options: -O2
 
   default-language: Haskell2010
 
@@ -90,8 +90,8 @@ executable crux-llvm
 
   other-modules: RealMain
 
-  ghc-options: -Wall -Werror=incomplete-patterns -Werror=missing-methods -Werror=overlapping-patterns
-  ghc-prof-options: -O2 -fprof-auto-top
+  ghc-options: -Wall -Wcompat -Werror=incomplete-patterns -Werror=missing-methods -Werror=overlapping-patterns
+  ghc-prof-options: -O2
 
   default-language: Haskell2010
 
@@ -130,8 +130,8 @@ executable crux-llvm-svcomp
     unix,
     what4
 
-  ghc-options: -Wall
-  ghc-prof-options: -O2 -fprof-auto-top
+  ghc-options: -Wall -Wcompat
+  ghc-prof-options: -O2
 
   default-language: Haskell2010
 
@@ -140,8 +140,8 @@ test-suite crux-llvm-test
   type: exitcode-stdio-1.0
   hs-source-dirs: test
 
-  ghc-options: -Wall -Werror=incomplete-patterns -Werror=missing-methods -Werror=overlapping-patterns
-  ghc-prof-options: -fprof-auto -O2
+  ghc-options: -Wall -Wcompat -Werror=incomplete-patterns -Werror=missing-methods -Werror=overlapping-patterns
+  ghc-prof-options: -O2
 
   main-is: Test.hs
 


### PR DESCRIPTION
The profiling operations were removed because if crux-llvm is used as
a library elsewhere this would cause potentially unwanted cluttering
of the profile information for the downstream package.

Per the Cabal
documentation (https://cabal.readthedocs.io/en/3.4/cabal-package.html#pkg-field-ghc-prof-options),
the preferred way to handle this is to manually specify the
`--profiling-detail` or `--library-profiling-detail` command-line
options if a build with profiling detail from this package is desired.