### PR TITLE
[crucible] Add deadman timeout for online solver actions

### DIFF
--- a/crucible/crucible.cabal
+++ b/crucible/crucible.cabal
@@ -27,6 +27,7 @@ flag unsafe-operations
 
 library
   build-depends:
+    async,
     base >= 4.8 && < 4.15,
     bimap,
     bv-sized >= 1.0.0 && < 1.1,


### PR DESCRIPTION
Fixes https://github.com/GaloisInc/crucible/issues/439 by implementing
a parallel timeout operation (at 1 second longer than the timeout
requested of the solver itself) whose expiration causes the solver
process to be killed.

This helps with issue 439 because Yices encounters some internal
divergence issue that is not stopped by the specified timeout
value (demonstrable by running the crux-llvm
test-data/golden/strlen_test2 with the Yices solver option).

This also helps provide timeout management for solvers that do not
provide a built-in timeout capability (like Boolector).