### PR TITLE
Pin LLVM versions in github actions

### DIFF
--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -112,29 +112,13 @@ build() {
 }
 
 test() {
-  # System-agnostic path
-  export PATH="$PATH:/usr/local/opt/llvm/bin:/c/Program Files/LLVM/bin"
   cabal v2-test "$@"
-}
-
-install_llvm() {
-  if [[ "$RUNNER_OS" = "Linux" ]]; then
-    sudo apt-get update -q && sudo apt-get install -y clang-10 llvm-10-tools
-  elif [[ "$RUNNER_OS" = "macOS" ]]; then
-    brew install llvm@10
-  elif [[ "$RUNNER_OS" = "Windows" ]]; then
-    choco install llvm
-  else
-    echo "Unknown platform!"
-    return 1
-  fi
 }
 
 install_system_deps() {
   install_z3 &
   # install_cvc4 &
   install_yices &
-  install_llvm &
   wait
   export PATH=$PWD/$BIN:$PATH
   echo "$PWD/$BIN" >> $GITHUB_PATH

--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuxo pipefail
 
-DATE=`date "+%Y-%m-%d"`
+DATE=$(date "+%Y-%m-%d")
 [[ "$RUNNER_OS" == 'Windows' ]] && IS_WIN=true || IS_WIN=false
 BIN=bin
 EXT=""
@@ -166,7 +166,7 @@ zip_dist() {
 bundle_crux_llvm_files() {
   setup_dist
   extract_exe crux-llvm dist/bin
-  if ! $IS_WIN ; then
+  if ! $IS_WIN; then
     extract_exe crux-llvm-svcomp dist/bin
   fi
   cp crux-llvm/README.md dist/doc

--- a/.github/workflows/crux-llvm-build.yml
+++ b/.github/workflows/crux-llvm-build.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v1
         with:
-          version: "9"
+          version: "10"
           directory: ${{ runner.temp }}/llvm
 
       - uses: actions/setup-haskell@v1
@@ -64,28 +64,11 @@ jobs:
         run: .github/ci.sh build exe:crux-llvm
 
       - shell: bash
-        name: Test (Linux)
+        name: Test
         run: .github/ci.sh test crux-llvm
-        if: runner.os == 'Linux'
         env:
-          LLVM_LINK: "llvm-link-10"
-          CLANG: "clang-10"
-
-      - shell: bash
-        name: Test (macOS)
-        run: .github/ci.sh test crux-llvm
-        if: runner.os == 'macOS'
-        env:
-          LLVM_LINK: "/usr/local/opt/llvm/bin/llvm-link"
-          CLANG: "/usr/local/opt/llvm/bin/clang"
-
-      - shell: bash
-        name: Test (Windows)
-        run: .github/ci.sh test crux-llvm
-        if: runner.os == 'Windows'
-        env:
-          LLVM_LINK: "/c/Program Files/LLVM/bin/llvm-link"
-          CLANG: "/c/Program Files/LLVM/bin/clang"
+          LLVM_LINK: llvm-link
+          CLANG: clang
 
       - shell: bash
         run: .github/ci.sh build exe:crux-llvm-svcomp

--- a/.github/workflows/crux-llvm-build.yml
+++ b/.github/workflows/crux-llvm-build.yml
@@ -68,6 +68,7 @@ jobs:
         run: .github/ci.sh test crux-llvm
         env:
           LLVM_LINK: llvm-link
+          LIBCLANG_PATH: ${{ runner.temp }}/llvm/lib
           CLANG: clang
 
       - shell: bash

--- a/.github/workflows/crux-llvm-build.yml
+++ b/.github/workflows/crux-llvm-build.yml
@@ -42,6 +42,11 @@ jobs:
         with:
           submodules: true
 
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v1
+        with:
+          version: "9"
+
       - uses: actions/setup-haskell@v1
         id: setup-haskell
         with:

--- a/.github/workflows/crux-llvm-build.yml
+++ b/.github/workflows/crux-llvm-build.yml
@@ -34,6 +34,7 @@ jobs:
         uses: KyleMayes/install-llvm-action@v1
         with:
           version: "9"
+          directory: ${{ runner.temp }}/llvm
 
       - uses: actions/setup-haskell@v1
         id: setup-haskell

--- a/.github/workflows/crux-llvm-build.yml
+++ b/.github/workflows/crux-llvm-build.yml
@@ -36,6 +36,9 @@ jobs:
           version: "10"
           directory: ${{ runner.temp }}/llvm
 
+      - uses: mxschmitt/action-tmate@v3
+        if: runner.os == 'macOS' && matrix.ghc == '8.6.5'
+
       - uses: actions/setup-haskell@v1
         id: setup-haskell
         with:

--- a/.github/workflows/crux-llvm-build.yml
+++ b/.github/workflows/crux-llvm-build.yml
@@ -36,9 +36,6 @@ jobs:
           version: "10"
           directory: ${{ runner.temp }}/llvm
 
-      - uses: mxschmitt/action-tmate@v3
-        if: runner.os == 'macOS' && matrix.ghc == '8.6.5'
-
       - uses: actions/setup-haskell@v1
         id: setup-haskell
         with:
@@ -70,9 +67,12 @@ jobs:
         name: Test
         run: .github/ci.sh test crux-llvm
         env:
-          LLVM_LINK: llvm-link
+          LLVM_LINK: ${{ runner.temp }}/llvm/bin/llvm-link
           LIBCLANG_PATH: ${{ runner.temp }}/llvm/lib
-          CLANG: clang
+          CLANG: ${{ runner.temp }}/llvm/bin/clang
+
+      - uses: mxschmitt/action-tmate@v3
+        if: runner.os == 'macOS' && matrix.ghc == '8.6.5'
 
       - shell: bash
         run: .github/ci.sh build exe:crux-llvm-svcomp

--- a/.github/workflows/crux-llvm-build.yml
+++ b/.github/workflows/crux-llvm-build.yml
@@ -6,24 +6,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  outputs:
-    runs-on: ubuntu-latest
-    outputs:
-      changed: ${{ steps.outputs.outputs.changed-files }}
-      name: ${{ steps.outputs.outputs.name }}
-      crux-llvm-version: ${{ steps.outputs.outputs.crux-llvm-version }}
-      release: ${{ steps.env.outputs.release }}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - id: outputs
-        run: |
-          .github/ci.sh set_crux_llvm_version
-
   build:
     runs-on: ${{ matrix.os }}
-    needs: [outputs]
     strategy:
       fail-fast: false
       matrix:
@@ -41,6 +25,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+
+      - name: Set version
+        run: .github/ci.sh set_crux_llvm_version
+        id: version
 
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v1
@@ -107,7 +95,7 @@ jobs:
         env:
           SIGNING_PASSPHRASE: ${{ secrets.SIGNING_PASSPHRASE }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
-          VERSION: ${{ needs.outputs.outputs.crux-llvm-version }}
+          VERSION: ${{ steps.version.outputs.crux-llvm-version }}
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/crux-mir-build.yml
+++ b/.github/workflows/crux-mir-build.yml
@@ -60,8 +60,13 @@ jobs:
           Z3_VERSION: "4.8.8"
           YICES_VERSION: "2.6.2"
 
+      - uses: Swatinem/rust-cache@v1
+        with:
+          working-directory: dependencies/mir-json
+
       - shell: bash
-        run: cd dependencies/mir-json && cargo install --locked --force --path .
+        run: cargo install --locked --force --path .
+        working-directory: dependencies/mir-json
 
       - shell: bash
         run: .github/ci.sh configure
@@ -70,7 +75,8 @@ jobs:
         run: .github/ci.sh build exe:crux-mir
 
       - shell: bash
-        run: cd crux-mir && bash ./translate_libs.sh
+        run: ./translate_libs.sh
+        working-directory: crux-mir
 
       - shell: bash
         run: .github/ci.sh test crux-mir

--- a/.github/workflows/crux-mir-build.yml
+++ b/.github/workflows/crux-mir-build.yml
@@ -6,24 +6,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  outputs:
-    runs-on: ubuntu-latest
-    outputs:
-      changed: ${{ steps.outputs.outputs.changed-files }}
-      name: ${{ steps.outputs.outputs.name }}
-      crux-mir-version: ${{ steps.outputs.outputs.crux-mir-version }}
-      release: ${{ steps.env.outputs.release }}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - id: outputs
-        run: |
-          .github/ci.sh set_crux_mir_version
-
   build:
     runs-on: ${{ matrix.os }}
-    needs: [outputs]
     strategy:
       fail-fast: false
       matrix:
@@ -43,6 +27,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+
+      - name: Set version
+        run: .github/ci.sh set_crux_mir_version
+        id: version
 
       - uses: actions/setup-haskell@v1
         id: setup-haskell
@@ -92,7 +80,7 @@ jobs:
         env:
           SIGNING_PASSPHRASE: ${{ secrets.SIGNING_PASSPHRASE }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
-          VERSION: ${{ needs.outputs.outputs.crux-mir-version }}
+          VERSION: ${{ steps.version.outputs.crux-mir-version }}
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/crux-mir-build.yml
+++ b/.github/workflows/crux-mir-build.yml
@@ -73,7 +73,7 @@ jobs:
           YICES_VERSION: "2.6.2"
 
       - shell: bash
-        run: cd dependencies/mir-json && cargo install --locked --force
+        run: cd dependencies/mir-json && cargo install --locked --force --path .
 
       - shell: bash
         run: .github/ci.sh configure

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ cabal.project.local
 *.tix
 .ghc.environment.*
 *~
+cabal.project.freeze


### PR DESCRIPTION
This should prevent our builds from failing if LLVM changes underneath as previously we were relying on the first LLVM to be found on the path, which can change without warning.