### PR TITLE
[crucible-llvm] Update tests for new optLoopMerge implicit parameter.

### DIFF
--- a/.github/workflows/crux-llvm-build.yml
+++ b/.github/workflows/crux-llvm-build.yml
@@ -70,7 +70,23 @@ jobs:
         run: .github/ci.sh build exe:crux-llvm
 
       - shell: bash
-        name: Test (Linux)
+        name: Test crucible (Linux)
+        run: .github/ci.sh test crucible
+        if: runner.os == 'Linux'
+        env:
+          LLVM_LINK: "llvm-link-10"
+          CLANG: "clang-10"
+
+      - shell: bash
+        name: Test crucible-llvm (Linux)
+        run: .github/ci.sh test crucible-llvm
+        if: runner.os == 'Linux'
+        env:
+          LLVM_LINK: "llvm-link-10"
+          CLANG: "clang-10"
+
+      - shell: bash
+        name: Test crux-llvm (Linux)
         run: .github/ci.sh test crux-llvm
         if: runner.os == 'Linux'
         env:
@@ -78,7 +94,23 @@ jobs:
           CLANG: "clang-10"
 
       - shell: bash
-        name: Test (macOS)
+        name: Test crucible (macOS)
+        run: .github/ci.sh test crucible
+        if: runner.os == 'macOS'
+        env:
+          LLVM_LINK: "/usr/local/opt/llvm/bin/llvm-link"
+          CLANG: "/usr/local/opt/llvm/bin/clang"
+
+      - shell: bash
+        name: Test crucible-llvm (macOS)
+        run: .github/ci.sh test crucible-llvm
+        if: runner.os == 'macOS'
+        env:
+          LLVM_LINK: "/usr/local/opt/llvm/bin/llvm-link"
+          CLANG: "/usr/local/opt/llvm/bin/clang"
+
+      - shell: bash
+        name: Test crux-llvm (macOS)
         run: .github/ci.sh test crux-llvm
         if: runner.os == 'macOS'
         env:
@@ -86,7 +118,23 @@ jobs:
           CLANG: "/usr/local/opt/llvm/bin/clang"
 
       - shell: bash
-        name: Test (Windows)
+        name: Test crucible (Windows)
+        run: .github/ci.sh test crucible
+        if: runner.os == 'Windows'
+        env:
+          LLVM_LINK: "/c/Program Files/LLVM/bin/llvm-link"
+          CLANG: "/c/Program Files/LLVM/bin/clang"
+
+      - shell: bash
+        name: Test crucible-llvm (Windows)
+        run: .github/ci.sh test crucible-llvm
+        if: runner.os == 'Windows'
+        env:
+          LLVM_LINK: "/c/Program Files/LLVM/bin/llvm-link"
+          CLANG: "/c/Program Files/LLVM/bin/clang"
+
+      - shell: bash
+        name: Test crux-llvm (Windows)
         run: .github/ci.sh test crux-llvm
         if: runner.os == 'Windows'
         env:

--- a/.github/workflows/crux-llvm-build.yml
+++ b/.github/workflows/crux-llvm-build.yml
@@ -83,6 +83,7 @@ jobs:
         if: runner.os == 'Linux'
         env:
           LLVM_LINK: "llvm-link-10"
+          LLVM_AS: "llvm-as-10"
           CLANG: "clang-10"
 
       - shell: bash
@@ -107,6 +108,7 @@ jobs:
         if: runner.os == 'macOS'
         env:
           LLVM_LINK: "/usr/local/opt/llvm/bin/llvm-link"
+          LLVM_AS: "/usr/local/opt/llvm/bin/llvm-as"
           CLANG: "/usr/local/opt/llvm/bin/clang"
 
       - shell: bash
@@ -131,6 +133,7 @@ jobs:
         if: runner.os == 'Windows'
         env:
           LLVM_LINK: "/c/Program Files/LLVM/bin/llvm-link"
+          LLVM_AS: "/c/Program Files/LLVM/bin/llvm-as"
           CLANG: "/c/Program Files/LLVM/bin/clang"
 
       - shell: bash

--- a/crucible-llvm/test/MemSetup.hs
+++ b/crucible-llvm/test/MemSetup.hs
@@ -60,6 +60,7 @@ withLLVMCtx mod' action =
       with nonceGen halloc = do
         sym <- CBS.newSimpleBackend CBS.FloatRealRepr nonceGen
         let ?laxArith = False
+        let ?optLoopMerge = False
         Some (LLVMTr.ModuleTranslation _ ctx _ _) <- LLVMTr.translateModule halloc mod'
         case LLVMTr.llvmArch ctx            of { LLVME.X86Repr width ->
         case assertLeq (knownNat @1)  width of { LeqProof      ->

--- a/crucible-llvm/test/Tests.hs
+++ b/crucible-llvm/test/Tests.hs
@@ -219,6 +219,7 @@ testBuildTranslation srcPath llvmTransTests =
 
       trans = do halloc <- newHandleAllocator
                  let ?laxArith = False
+                 let ?optLoopMerge = False
                  translateModule halloc =<<
                    (fromRight (error "parsing was already verified") <$> parseLLVM bcPath)
 


### PR DESCRIPTION
Also enables tests for crucible and crucible-llvm as dependencies of crux-llvm.