### PR TITLE
crux-mir: fix library paths when crux-mir directory path contains a symlink

### DIFF
--- a/crux-mir/translate_libs.sh
+++ b/crux-mir/translate_libs.sh
@@ -6,8 +6,15 @@ compile() {
 }
 
 compile_2015() {
+    # We use `--remap-path-prefix` to keep the full path to the `crux-mir`
+    # directory from appearing in the generated artifacts.  Otherwise, some
+    # `crux-mir` error messages will contain the path to the `crux-mir`
+    # directory, which usually contains the user's home directory, and our
+    # golden-file tests will break.  We specifically use `pwd -P` ("physical",
+    # meaning resolve symlinks) because `rustc` itself resolves symlinks before
+    # checking for a matching `--remap-path-prefix` rule.
     rustc -L rlibs_native --out-dir rlibs_native --crate-type rlib \
-        --remap-path-prefix $PWD=. \
+        --remap-path-prefix "$(pwd -P)=." \
         "$@"
 }
 
@@ -17,7 +24,7 @@ translate() {
 
 translate_2015() {
     mir-json -L rlibs --out-dir rlibs --crate-type rlib \
-        --remap-path-prefix $PWD=. \
+        --remap-path-prefix "$(pwd -P)=." \
         "$@"
 }
 


### PR DESCRIPTION
This should fix the test failures in #578, which occur when `./translate_libs.sh` is run while some part of the `$PWD` path is a symlink.