### PR TITLE
[crux-llvm] only generate tests for the current available clang version.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ cabal.project.local
 *.tix
 .ghc.environment.*
 *~
+_darcs
+.boring

--- a/crux-llvm/crux-llvm.cabal
+++ b/crux-llvm/crux-llvm.cabal
@@ -96,7 +96,6 @@ executable crux-llvm
     process,
     template-haskell,
     text,
-    versions < 4.0,
     what4
 
   main-is: Main.hs
@@ -174,6 +173,7 @@ test-suite crux-llvm-test
                 deepseq,
                 directory,
                 filepath,
+                microlens,
                 parsec,
                 process,
                 QuickCheck,
@@ -181,6 +181,7 @@ test-suite crux-llvm-test
                 tasty-hunit      >= 0.10,
                 tasty-sugar      >= 1.1 && < 1.2,
                 text,
+                versions,
                 what4
 
   default-language: Haskell2010

--- a/crux-llvm/test-data/golden/golden/strlen_test2.pre-clang11.good
+++ b/crux-llvm/test-data/golden/golden/strlen_test2.pre-clang11.good
@@ -26,5 +26,4 @@ i = 12
 string[(length - i) - 1] = ????
 i = 13
 string[(length - i) - 1] = ????
-i = 14
 [Crux] Overall status: Valid.

--- a/crux-llvm/test/Test.hs
+++ b/crux-llvm/test/Test.hs
@@ -259,7 +259,7 @@ mkTest clangVer sweet _ expct =
           let specMatchesInstalled v =
                 or [ v == vcTag clangVer
                    , and [ v == "pre-clang11"
-                         , vcMajor clangVer `elem` (show <$> [3..10])
+                         , vcMajor clangVer `elem` (show <$> [3..10 :: Int])
                          ]
                    ]
           in case lookup "clang-range" (TS.expParamsMatch expct) of


### PR DESCRIPTION
Also updates strlen_test2.c output for pre-clang11 build verification.