### PR TITLE
[crux-llvm] Add CI_TEST_LEVEL to test and github action CI config.

### DIFF
--- a/.github/workflows/crux-llvm-build.yml
+++ b/.github/workflows/crux-llvm-build.yml
@@ -25,6 +25,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: [outputs]
     continue-on-error: ${{ matrix.allow-failure }}
+    env:
+      CI_TEST_LEVEL: "1"
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
A CI_TEST_LEVEL of 0 (the default if unspecified) will run a set of
tests expected to complete in under a minute, suitable for a normal
development environment.

A CI_TEST_LEVEL of 1 (specified for github actions) will run the full
set of tests, even those that can take an extended period of time.