### PR TITLE
Move SVCOMP skipping message to viable location; remove duplicate check.

### DIFF
--- a/crux-llvm/svcomp/Main.hs
+++ b/crux-llvm/svcomp/Main.hs
@@ -99,7 +99,11 @@ genSVCOMPBitCode cruxOpts llvmOpts svOpts tm = concat <$> mapM goTask (zip [0::I
 
  processVerificationTask _tgt _num task
    | or [ isSuffixOf bl (verificationSourceFile task) | bl <- svcompBlacklist svOpts ]
-   = return True
+   = do sayWarn "SVCOMP" $ unlines
+          [ "Skipping:"
+          , "  " ++ verificationSourceFile task
+          ]
+        return True
 
  processVerificationTask tgt num task =
    do let files = verificationInputFiles task
@@ -164,13 +168,6 @@ evaluateBenchmarkLLVM cruxOpts llvmOpts svOpts ts =
    setResourceLimit res (ResourceLimits (ResourceLimit lim) ResourceLimitUnknown)
 
  root = Crux.outDir cruxOpts
-
- evaluateVerificationTask _ (_num, task, _)
-   | or [ isSuffixOf bl (verificationSourceFile task) | bl <- svcompBlacklist svOpts ]
-   = sayWarn "SVCOMP" $ unlines
-        [ "Skipping:"
-        , "  " ++ verificationSourceFile task
-        ]
 
  evaluateVerificationTask jsonOutHdl (num, task, compileErr) =
     do ed <- case compileErr of


### PR DESCRIPTION
The `processVerificationTask` determines if a task is skipped; for any task that is skipped, the `evaluateVerificationTask` is not called, and so the "skipped" message would never be provided.  This PR moves the message and removes the duplicated check.