### PR TITLE
Improve formatting of crux tools help output

### DIFF
--- a/crux/crux.cabal
+++ b/crux/crux.cabal
@@ -29,6 +29,7 @@ library
     parameterized-utils >= 1.0 && < 2.2,
     prettyprinter >= 1.7.0,
     split >= 0.2,
+    terminal-size,
     text,
     time >= 1.8 && < 2.0,
     transformers >= 0.3,

--- a/crux/src/Crux.hs
+++ b/crux/src/Crux.hs
@@ -34,9 +34,12 @@ import Data.Maybe ( fromMaybe )
 import Data.Proxy ( Proxy(..) )
 import qualified Data.Sequence as Seq
 import qualified Data.Text as T
+import qualified Data.Text.Lazy as TL
 import Data.Void
 import Control.Monad(when)
 import Prettyprinter
+import qualified Prettyprinter.Render.Text as PR
+import System.Console.Terminal.Size ( size, Window(..) )
 import System.Exit(exitSuccess, ExitCode(..), exitFailure, exitWith)
 import System.Directory(createDirectoryIfMissing)
 import System.FilePath((</>))
@@ -161,7 +164,10 @@ loadOptions outCfg nm ver config cont =
         Nothing -> sayFail "Crux" (Ex.displayException e) >> exitFailure
 
 showHelp :: Logs => Text -> Config opts -> IO ()
-showHelp nm cfg = outputLn (show (configDocs nm cfg))
+showHelp nm cfg = do
+  outWidth <- maybe 80 (\(Window _ w) -> w) <$> size
+  let opts = LayoutOptions $ AvailablePerLine outWidth 0.98
+  outputLn (TL.unpack $ PR.renderLazy $ layoutPretty opts (configDocs nm cfg))
 
 showVersion :: Logs => Text -> Text -> IO ()
 showVersion nm ver =

--- a/crux/src/Crux/Config/Common.hs
+++ b/crux/src/Crux/Config/Common.hs
@@ -298,14 +298,14 @@ cruxOptions = Config
 
       , Option "t" ["timeout"]
         "Stop executing the simulator after this many seconds (default: 60)"
-        $ OptArg "seconds"
+        $ OptArg "SECS"
         $ dflt "60"
         $ parseNominalDiffTime "seconds"
         $ \v opts -> opts { globalTimeout = Just v }
 
       , Option [] ["goal-timeout"]
         "Stop trying to prove each goal after this many seconds (default: 10)."
-        $ OptArg "seconds"
+        $ OptArg "SECS"
         $ dflt "10"
         $ parseDiffTime "seconds"
         $ \v opts -> opts { goalTimeout = Just v }
@@ -318,20 +318,20 @@ cruxOptions = Config
 
       , Option "p" ["profiling-period"]
         "Time between intermediate profile data reports (default: 5 seconds)"
-        $ OptArg "seconds"
+        $ OptArg "SECS"
         $ dflt "5"
         $ parseNominalDiffTime "seconds"
         $ \v opts -> opts { profileOutputInterval = v }
 
       , Option "i" ["iteration-bound"]
         "Bound all loops to at most this many iterations"
-        $ ReqArg "iterations"
+        $ ReqArg "ITER"
         $ parsePosNum "iterations"
         $ \v opts -> opts { loopBound = Just v }
 
       , Option "r" ["recursion-bound"]
         "Bound all recursive calls to at most this many calls"
-        $ ReqArg "calls"
+        $ ReqArg "CALLS"
         $ parsePosNum "calls"
         $ \v opts -> opts { recursionBound = Just v }
 
@@ -348,11 +348,11 @@ cruxOptions = Config
          "May be a single solver, a comma-separated list of solvers, or the string \"all\". " ++
          "Specifying multiple solvers requires the --force-offline-goal-solving option. " ++
          "(default: \"yices\")")
-        $ ReqArg "solver" $ \v opts -> Right opts { solver = map toLower v }
+        $ ReqArg "SOLVER" $ \v opts -> Right opts { solver = map toLower v }
 
       , Option [] ["path-sat-solver"]
         "Select the solver to use for path satisfiability checking (if different from `solver` and required by the `path-sat` option). (default: use `solver`)"
-        $ OptArg "solver" $ \ms opts -> Right opts { pathSatSolver = ms }
+        $ OptArg "SOLVER" $ \ms opts -> Right opts { pathSatSolver = ms }
 
       , Option [] ["force-offline-goal-solving"]
         "Force goals to be solved using an offline solver, even if the selected solver could have been used in online mode (default: no)"
@@ -402,7 +402,7 @@ cruxOptions = Config
         ("Select floating point representation,"
          ++ " i.e. one of [real|ieee|uninterpreted|default]. "
          ++ "Default representation is solver specific: [cvc4|yices]=>real, z3=>ieee.")
-        $ ReqArg "floating-point" $ \v opts -> Right opts { floatMode = map toLower v }
+        $ ReqArg "FPREP" $ \v opts -> Right opts { floatMode = map toLower v }
       ]
   }
 

--- a/crux/src/Crux/Config/Doc.hs
+++ b/crux/src/Crux/Config/Doc.hs
@@ -2,28 +2,73 @@
 
 module Crux.Config.Doc (configDocs) where
 
-import Config.Schema (sectionsSpec,generateDocs)
-import Data.Text (Text)
-import Prettyprinter
-import SimpleGetOpt (usageString)
+import           Config.Schema (sectionsSpec,generateDocs)
+import           Data.Function ( on )
+import qualified Data.List as L
+import           Data.Text ( Text )
+import qualified Data.Text as T
+import           Prettyprinter
+import           Prettyprinter.Util ( reflow )
+import           SimpleGetOpt ( OptSpec(..) )
 
-import Crux.Config
-import Crux.Config.Load (commandLineOptions)
+import           Crux.Config
+import           Crux.Config.Load (commandLineOptions)
 
 configDocs :: Text -> Config opts -> Doc ann
 configDocs nm cfg =
   vcat [ heading "Command line flags:"
-       , nest 2 (pretty $ usageString (commandLineOptions cfg))
+       , indent 2 $ cmdLineDocs $ commandLineOptions cfg
        , envVarDocs cfg
        , heading "Configuration file format:"
        , nest 2 (viaShow $ generateDocs (sectionsSpec nm (cfgFile cfg)))
        ]
 
+cmdLineDocs :: OptSpec a -> Doc ann
+cmdLineDocs opts =
+  vcat [ nest 2 $ vcat $ "Parameters:" : ppParams
+       , mempty
+       , nest 2 $ vcat $ "Flags:" : ppFlags
+       ]
+  where
+    ppParams = let maxLen = maximum $ (length . fst) <$> progParamDocs opts
+               in map (ppParam maxLen) $ progParamDocs opts
+    ppParam l (n,d) = let pad = max 0 $ l - length d
+                      in hcat [ pretty n
+                              , pretty $ T.replicate (pad + 4) " "
+                              , nest 2 $ reflow $ T.pack d ]
+    ppFlags = let flagset = fmap ppFlag $ L.sortBy (compare `on` optSort)  $ progOptions opts
+                  optSort o = (L.sort $ optShortFlags o <> "zzzzz", L.sort $ optLongFlags o)
+                  lengths = fmap (maximum . fmap T.length) $ L.transpose flagset
+                  textLen (l,t) = let f = T.replicate (max 0 $ l - T.length t) " " in t <> f
+                  sizedCols = fmap (fmap textLen . zip lengths) $ flagset
+                  padLast = align . reflow
+                  prettyLine = hcat . fst . foldr (\c (p,g) -> (g c : space : p, pretty)) ([], padLast)
+              in fmap prettyLine sizedCols
+    ppFlag :: OptDescr a -> [Text]
+    ppFlag od = let sfs = if null (optShortFlags od) then ""
+                          else let each =
+                                     let f = case optArgument od of
+                                            NoArg _ -> T.singleton
+                                            ReqArg a _ -> (\c -> T.singleton c <> " " <> T.pack a)
+                                            OptArg a _ -> (\c -> T.singleton c <> " [" <> T.pack a <> "]")
+                                     in f <$> optShortFlags od
+                               in "-" <> T.intercalate ",-" each
+                    lfs = if null (optLongFlags od) then ""
+                          else let each =
+                                     let f = case optArgument od of
+                                           NoArg _ -> T.pack
+                                           ReqArg a _ -> (\s -> T.pack s <> "=" <> T.pack a)
+                                           OptArg a _ -> (\s -> T.pack s <> "=[" <> T.pack a <> "]")
+                                     in f <$> optLongFlags od
+                               in "--" <> T.intercalate ",--" each
+                in [ sfs, lfs, T.pack $ optDescription od ]
+
+
 envVarDocs :: Config a -> Doc ann
 envVarDocs cfg
   | null vs = mempty
   | otherwise = vcat [ heading "Environment variables:"
-                     , nest 2 (vcat (map pp vs))
+                     , indent 2 (vcat (map pp vs))
                      ]
     where
     vs = cfgEnv cfg


### PR DESCRIPTION
Improves the formatting of `--help` information from crux tools like `crux-llvm`.

* Options descriptions are wrapped at terminal width and stay in their column
* Terminal width for output is auto-detected and defaults to 80 for non-terminals.
* Options are displayed alphabetically (by short option, then long option).
* Option values are consistently UPPERCASE to signify a user-supplied value position.