### PR TITLE
Add build directory config and track built result

### DIFF
--- a/crux-llvm/src/Crux/LLVM/Compile.hs
+++ b/crux-llvm/src/Crux/LLVM/Compile.hs
@@ -9,7 +9,7 @@ module Crux.LLVM.Compile where
 import Control.Exception
   ( SomeException(..), try, displayException )
 import Control.Monad
-  ( unless, forM_ )
+  ( unless, void, forM_ )
 import qualified Data.Foldable as Fold
 import Data.List
   ( intercalate, isSuffixOf )
@@ -101,26 +101,41 @@ llvmLinkVersion llvmOpts =
        ExitSuccess   -> return (parseLLVMLinkVersion sout)
        ExitFailure n -> throwCError (ClangError n sout serr)
 
-genBitCode :: Logs => CruxOptions -> LLVMOptions -> IO ()
-genBitCode cruxOpts llvmOpts =
-  do let files = (Crux.inputFiles cruxOpts)
-         finalBCFile = Crux.outDir cruxOpts </> "combined.bc"
-         srcBCNames = [ (src, replaceExtension src ".bc") | src <- files ]
-         incs src = takeDirectory src :
-                    (libDir llvmOpts </> "includes") :
-                    incDirs llvmOpts
-         params (src, srcBC)
-           | ".ll" `isSuffixOf` src =
-              ["-c", "-DCRUCIBLE", "-emit-llvm", "-O0", "-o", srcBC, src]
+-- | Generates compiled LLVM bitcode for the set of input files
+-- specified in the 'CruxOptions' argument, writing the output to a
+-- pre-determined filename in the build directory specified in
+-- 'CruxOptions'.
+genBitCode :: Logs => CruxOptions -> LLVMOptions -> IO FilePath
+genBitCode cruxOpts =
+  void . genBitCodeToFile "combined.bc" (Crux.inputFiles cruxOpts) cruxOpts
 
-           | otherwise =
-              [ "-c", "-DCRUCIBLE", "-g", "-emit-llvm" ] ++
-              concat [ [ "-I", dir ] | dir <- incs src ] ++
-              concat [ [ "-fsanitize="++san, "-fsanitize-trap="++san ] | san <- ubSanitizers llvmOpts ] ++
-              [ "-O" ++ show (optLevel llvmOpts), "-o", srcBC, src ]
+-- | Given the target filename and a list of input files, along with
+-- the crux and llvm options, bitcode-compile each input .c file and
+-- link the resulting files, along with any input .ll files into the
+-- target bitcode (BC) file.  Returns the filepath of the target
+-- bitcode file.
+genBitCodeToFile :: Logs
+                 => String -> [FilePath] -> CruxOptions -> LLVMOptions
+                 -> IO FilePath
+genBitCodeToFile finalBCFileName files cruxOpts llvmOpts = do
+  let srcBCNames = [ (src, replaceExtension src ".bc") | src <- files ]
+      finalBCFile = Crux.outDir cruxOpts </> finalBCFileName
+      incs src = takeDirectory src :
+                 (libDir llvmOpts </> "includes") :
+                 incDirs llvmOpts
+      params (src, srcBC)
+        | ".ll" `isSuffixOf` src =
+            ["-c", "-DCRUCIBLE", "-emit-llvm", "-O0", "-o", srcBC, src]
 
-     finalBCExists <- doesFileExist finalBCFile
-     unless (finalBCExists && lazyCompile llvmOpts) $
+        | otherwise =
+            [ "-c", "-DCRUCIBLE", "-g", "-emit-llvm" ] ++
+            concat [ [ "-I", dir ] | dir <- incs src ] ++
+            concat [ [ "-fsanitize="++san, "-fsanitize-trap="++san ]
+                   | san <- ubSanitizers llvmOpts ] ++
+            [ "-O" ++ show (optLevel llvmOpts), "-o", srcBC, src ]
+
+  finalBCExists <- doesFileExist finalBCFile
+  unless (finalBCExists && lazyCompile llvmOpts) $
       do forM_ srcBCNames $ \f@(src,_) ->
            unless (".bc" `isSuffixOf` src) (runClang llvmOpts (params f))
          ver <- llvmLinkVersion llvmOpts
@@ -128,6 +143,8 @@ genBitCode cruxOpts llvmOpts =
                            | otherwise = []
          llvmLink llvmOpts (map snd srcBCNames ++ libcxxBitcode) finalBCFile
          mapM_ (\(src,bc) -> unless (src == bc) (removeFile bc)) srcBCNames
+  return finalBCFile
+
 
 makeCounterExamplesLLVM ::
   Logs => CruxOptions -> LLVMOptions -> CruxSimulationResult -> IO ()

--- a/crux-llvm/src/Crux/LLVM/Compile.hs
+++ b/crux-llvm/src/Crux/LLVM/Compile.hs
@@ -19,7 +19,7 @@ import System.Directory
 import System.Exit
   ( ExitCode(..) )
 import System.FilePath
-  ( takeExtension, (</>), takeDirectory, replaceExtension )
+  ( takeExtension, (</>), takeDirectory, takeFileName, (-<.>) )
 import System.Process
   ( readProcess, readProcessWithExitCode )
 
@@ -29,6 +29,7 @@ import What4.ProgramLoc
 import Lang.Crucible.Simulator.SimError
 
 import Crux
+import qualified Crux.Config.Common as CC
 import Crux.Model( toDouble, showBVLiteral, showFloatLiteral, showDoubleLiteral )
 import Crux.Types
 
@@ -121,8 +122,9 @@ genBitCodeToFile :: Logs
                  => String -> [FilePath] -> CruxOptions -> LLVMOptions -> Bool
                  -> IO FilePath
 genBitCodeToFile finalBCFileName files cruxOpts llvmOpts copySrc = do
-  let srcBCNames = [ (src, replaceExtension src ".bc") | src <- files ]
-      finalBCFile = Crux.outDir cruxOpts </> finalBCFileName
+  let srcBCNames = [ (src, CC.bldDir cruxOpts </> takeFileName src -<.> ".bc")
+                   | src <- files ]
+      finalBCFile = CC.bldDir cruxOpts </> finalBCFileName
       incs src = takeDirectory src :
                  (libDir llvmOpts </> "includes") :
                  incDirs llvmOpts

--- a/crux-llvm/src/Crux/LLVM/Compile.hs
+++ b/crux-llvm/src/Crux/LLVM/Compile.hs
@@ -9,7 +9,7 @@ module Crux.LLVM.Compile where
 import Control.Exception
   ( SomeException(..), try, displayException )
 import Control.Monad
-  ( unless, void, forM_ )
+  ( unless, forM_ )
 import qualified Data.Foldable as Fold
 import Data.List
   ( intercalate, isSuffixOf )
@@ -106,8 +106,11 @@ llvmLinkVersion llvmOpts =
 -- pre-determined filename in the build directory specified in
 -- 'CruxOptions'.
 genBitCode :: Logs => CruxOptions -> LLVMOptions -> IO FilePath
-genBitCode cruxOpts =
-  void . genBitCodeToFile "combined.bc" (Crux.inputFiles cruxOpts) cruxOpts
+genBitCode cruxOpts = do
+  -- n.b. use of head here is OK because inputFiles should not be
+  -- empty (and was previously verified as such in CruxLLVMMain).
+  let ofn = "crux~" <> (takeFileName $ head $ Crux.inputFiles cruxOpts) -<.> ".bc"
+  genBitCodeToFile ofn (Crux.inputFiles cruxOpts) cruxOpts
 
 -- | Given the target filename and a list of input files, along with
 -- the crux and llvm options, bitcode-compile each input .c file and

--- a/crux-llvm/src/Crux/LLVM/Simulate.hs
+++ b/crux-llvm/src/Crux/LLVM/Simulate.hs
@@ -121,8 +121,11 @@ registerFunctions llvm_module mtrans =
      mapM_ (registerModuleFn llvm_ctx) $ Map.elems $ cfgMap mtrans
 
 simulateLLVM :: CruxOptions -> LLVMOptions -> Crux.SimulatorCallback
-simulateLLVM cruxOpts llvmOpts = Crux.SimulatorCallback $ \sym _maybeOnline ->
-  do llvm_mod   <- parseLLVM (Crux.outDir cruxOpts </> "combined.bc")
+simulateLLVM cruxOpts = simulateLLVMFile (Crux.outDir cruxOpts </> "combined.bc")
+
+simulateLLVMFile :: FilePath -> LLVMOptions -> Crux.SimulatorCallback
+simulateLLVMFile llvm_file llvmOpts = Crux.SimulatorCallback $ \sym _maybeOnline ->
+  do llvm_mod   <- parseLLVM llvm_file
      halloc     <- newHandleAllocator
      let ?laxArith = laxArithmetic llvmOpts
      let ?optLoopMerge = loopMerge llvmOpts

--- a/crux-llvm/src/Crux/LLVM/Simulate.hs
+++ b/crux-llvm/src/Crux/LLVM/Simulate.hs
@@ -15,7 +15,6 @@ import Control.Lens ((&), (%~), (^.), view)
 import Control.Monad.State(liftIO)
 import Data.Text (Text)
 
-import System.FilePath( (</>) )
 import System.IO (stdout)
 
 import Data.Parameterized.Some (Some(..))
@@ -73,7 +72,6 @@ import qualified Crux
 import Crux.Types
 import Crux.Model
 import Crux.Log
-import Crux.Config.Common
 
 import Crux.LLVM.Config
 import Crux.LLVM.Overrides
@@ -119,9 +117,6 @@ registerFunctions llvm_module mtrans =
 
      -- register all the functions defined in the LLVM module
      mapM_ (registerModuleFn llvm_ctx) $ Map.elems $ cfgMap mtrans
-
-simulateLLVM :: CruxOptions -> LLVMOptions -> Crux.SimulatorCallback
-simulateLLVM cruxOpts = simulateLLVMFile (Crux.outDir cruxOpts </> "combined.bc")
 
 simulateLLVMFile :: FilePath -> LLVMOptions -> Crux.SimulatorCallback
 simulateLLVMFile llvm_file llvmOpts = Crux.SimulatorCallback $ \sym _maybeOnline ->

--- a/crux-llvm/src/CruxLLVMMain.hs
+++ b/crux-llvm/src/CruxLLVMMain.hs
@@ -31,8 +31,8 @@ mainWithOutputConfig outCfg = do
   cfg <- llvmCruxConfig
   Crux.loadOptions outCfg "crux-llvm" "0.1" cfg $ \initOpts ->
     do (cruxOpts, llvmOpts) <- processLLVMOptions initOpts
-       genBitCode cruxOpts llvmOpts
-       res <- Crux.runSimulator cruxOpts (simulateLLVM cruxOpts llvmOpts)
+       bcFile <- genBitCode cruxOpts llvmOpts
+       res <- Crux.runSimulator cruxOpts (simulateLLVMFile bcFile llvmOpts)
        makeCounterExamplesLLVM cruxOpts llvmOpts res
        Crux.postprocessSimResult cruxOpts res
 


### PR DESCRIPTION
* Previously crux-llvm placed build results in the `resultDir`, but the `resultDir` is optional, and this placed temporary, intermediate artifacts in the results directly.  This change adds a `--build-dir` argument and a `BLDDIR` environment variable to allow specification of where those intermediate build files should be placed.
* The crux-llvm build process used a hard-coded internal filename of `combined.bc` as the output of the compile+link operation for analysis.  This filename was hard-coded in three different places in the code, and was also not unique so it could result in analysis of the wrong binary (previously ameliorated by using the `resultDir`, but still a concern).  This patch changes to use a more specific generated filename for the output, and returns that filename to be passed to subsequent stages instead of relying on re-specification of a hard-coded internal name.
* Exposes the ability to compile+link and also to simulate a specific named file instead of a hard-coded internal name.