### PR TITLE
Derive Eq, Ord instances for MemType, SymType, and others

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/DataLayout.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/DataLayout.hs
@@ -87,7 +87,7 @@ alignmentToExponent :: Alignment -> Natural
 alignmentToExponent (Alignment n) = fromIntegral n
 
 newtype AlignInfo = AT (Map Natural Alignment)
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 -- | Make alignment info containing no alignments.
 emptyAlignInfo :: AlignInfo
@@ -158,7 +158,7 @@ instance At AlignInfo where
 
 -- | Flags byte orientation of target machine.
 data EndianForm = BigEndian | LittleEndian
-  deriving (Eq,Show)
+  deriving (Eq, Ord, Show)
 
 -- | Parsed data layout
 data DataLayout
@@ -173,6 +173,7 @@ data DataLayout
         , _stackInfo   :: !AlignInfo
         , _layoutWarnings :: [L.LayoutSpec]
         }
+  deriving (Eq, Ord)
 
 instance Show DataLayout where
    show _ = "<<DataLayout>>"


### PR DESCRIPTION
This makes the API easier to work with, e.g. I can derive `Ord` for a datatype containing a `MemType` and put it in a `Set`.

The new, derived `Eq` instance change for `StructInfo` is backwards incompatible, but the old instance didn't distinguish between `StructInfo`s with different `DataLayout`s. Since there was no comment, I assumed that no code is *relying* on that unconventional choice, but might be worth a changelog note?