### PR TITLE
Add targetArch to crux config; crux-llvm-svcomp use normal compile/link

### DIFF
--- a/crux-llvm/src/Crux/LLVM/Compile.hs
+++ b/crux-llvm/src/Crux/LLVM/Compile.hs
@@ -128,12 +128,16 @@ genBitCodeToFile finalBCFileName files cruxOpts llvmOpts copySrc = do
       incs src = takeDirectory src :
                  (libDir llvmOpts </> "includes") :
                  incDirs llvmOpts
+      commonFlags = [ "-c", "-DCRUCIBLE", "-emit-llvm" ] <>
+                    case targetArch llvmOpts of
+                      Nothing -> []
+                      Just a -> [ "--target=" <> a ]
       params (src, srcBC)
         | ".ll" `isSuffixOf` src =
-            ["-c", "-DCRUCIBLE", "-emit-llvm", "-O0", "-o", srcBC, src]
+            commonFlags <> ["-O0", "-o", srcBC, src]
 
         | otherwise =
-            [ "-c", "-DCRUCIBLE", "-g", "-emit-llvm" ] ++
+            commonFlags <> [ "-g" ] ++
             concat [ [ "-I", dir ] | dir <- incs src ] ++
             concat [ [ "-fsanitize="++san, "-fsanitize-trap="++san ]
                    | san <- ubSanitizers llvmOpts ] ++

--- a/crux-llvm/src/Crux/LLVM/Config.hs
+++ b/crux-llvm/src/Crux/LLVM/Config.hs
@@ -58,6 +58,7 @@ data LLVMOptions = LLVMOptions
   , clangOpts  :: [String]
   , libDir     :: FilePath
   , incDirs    :: [FilePath]
+  , targetArch :: Maybe String
   , ubSanitizers :: [String]
   , memOpts    :: MemOptions
   , laxArithmetic :: Bool
@@ -89,6 +90,10 @@ llvmCruxConfig = do
          incDirs <- Crux.section "include-dirs"
                         (Crux.oneOrList Crux.dirSpec) []
                     "Additional include directories."
+
+         targetArch <- Crux.sectionMaybe "target-architecture" Crux.stringSpec
+                       "Target architecture to pass to LLVM build operations.\
+                       \ Default is no specification for current system architecture"
 
          memOpts <- do laxPointerOrdering <-
                          Crux.section "lax-pointer-ordering" Crux.yesOrNoSpec False
@@ -135,6 +140,11 @@ llvmCruxConfig = do
         "Additional include directories."
         $ Crux.ReqArg "DIR"
         $ \d opts -> Right opts { incDirs = d : incDirs opts }
+
+      , Crux.Option [] ["target"]
+        "Target architecture to pass to LLVM build operations"
+        $ Crux.OptArg "ARCH"
+        $ \a opts -> Right opts { targetArch = a }
 
       , Crux.Option [] ["lax-pointers"]
         "Turn on lax rules for pointer comparisons"


### PR DESCRIPTION
The `crux-llvm-svcomp` tool had an internal compile/link process that duplicated the compilation/linking process in the `crux-llvm` core library (and repeated a hard-coded internal filename). This removes the special case compilation to use the standard compilation process for `crux-llvm-svcomp`, adding the ability to specify the `crux-llvm` target architecture for compilation.