### PR TITLE
Add PartialResultFrame, newtype FunctionBindings update

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM.hs
@@ -53,7 +53,7 @@ registerModuleFn llvm_ctx (decl, AnyCFG cfg) = do
   let h = cfgHandle cfg
       s = UseCFG cfg (postdomInfo cfg)
   binds <- use (stateContext . functionBindings)
-  when (isJust $ lookupHandleMap h binds) $
+  when (isJust $ lookupHandleMap h $ fnBindings binds) $
     showWarning ("LLVM function handle registered twice: " ++ show (handleName h))
   bindFnHandle h s
   let mvar = llvmMemVar llvm_ctx

--- a/crucible/src/Lang/Crucible/Simulator.hs
+++ b/crucible/src/Lang/Crucible/Simulator.hs
@@ -77,7 +77,7 @@ module Lang.Crucible.Simulator
     -- ** Function bindings
   , Override(..)
   , FnState(..)
-  , FunctionBindings
+  , FunctionBindings(..)
 
     -- ** Extensions
   , ExtensionImpl(..)

--- a/crucible/src/Lang/Crucible/Simulator/ExecutionTree.hs
+++ b/crucible/src/Lang/Crucible/Simulator/ExecutionTree.hs
@@ -100,7 +100,7 @@ module Lang.Crucible.Simulator.ExecutionTree
     -- ** Function bindings
   , Override(..)
   , FnState(..)
-  , FunctionBindings
+  , FunctionBindings(..)
 
     -- ** Extensions
   , ExtensionImpl(..)
@@ -970,7 +970,7 @@ data FnState p sym ext (args :: Ctx CrucibleType) (ret :: CrucibleType)
    | forall blocks . UseCFG !(CFG ext blocks args ret) !(CFGPostdom blocks)
 
 -- | A map from function handles to their semantics.
-type FunctionBindings p sym ext = FnHandleMap (FnState p sym ext)
+newtype FunctionBindings p sym ext = FnBindings { fnBindings :: FnHandleMap (FnState p sym ext) }
 
 -- | The type of functions that interpret extension statements.  These
 --   have access to the main simulator state, and can make fairly arbitrary

--- a/crucible/src/Lang/Crucible/Simulator/ExecutionTree.hs
+++ b/crucible/src/Lang/Crucible/Simulator/ExecutionTree.hs
@@ -57,6 +57,7 @@ module Lang.Crucible.Simulator.ExecutionTree
 
     -- * Partial result
   , PartialResult(..)
+  , PartialResultFrame
   , partialValue
 
     -- * Execution states
@@ -602,7 +603,7 @@ data ControlResumption p sym ext rtp f where
 data PausedFrame p sym ext rtp f
    = forall old_args.
        PausedFrame
-       { pausedFrame  :: !(PartialResult sym ext (SimFrame sym ext f ('Just old_args)))
+       { pausedFrame  :: !(PartialResultFrame sym ext f ('Just old_args))
        , resume       :: !(ControlResumption p sym ext rtp f)
        , pausedLoc    :: !(Maybe ProgramLoc)
        }
@@ -626,7 +627,7 @@ data VFFOtherPath p sym ext ret f args
    | VFFCompletePath
         !(Seq (Assumption sym))
           {- Assumptions that we collected while analyzing the branch -}
-        !(PartialResult sym ext (SimFrame sym ext f args))
+        !(PartialResultFrame sym ext f args)
           {- Result of running the other branch -}
 
 
@@ -895,13 +896,16 @@ data ReturnHandler (ret :: CrucibleType) p sym ext root f args where
 ------------------------------------------------------------------------
 -- ActiveTree
 
+type PartialResultFrame sym ext f args =
+  PartialResult sym ext (SimFrame sym ext f args)
+
 {- | An active execution tree contains at least one active execution.
      The data structure is organized so that the current execution
      can be accessed rapidly. -}
 data ActiveTree p sym ext root (f :: Type) args
    = ActiveTree
       { _actContext :: !(ValueFromFrame p sym ext root f)
-      , _actResult  :: !(PartialResult sym ext (SimFrame sym ext f args))
+      , _actResult  :: !(PartialResultFrame sym ext f args)
       }
 
 -- | Create a tree with a single top frame.

--- a/crucible/src/Lang/Crucible/Simulator/Operations.hs
+++ b/crucible/src/Lang/Crucible/Simulator/Operations.hs
@@ -167,8 +167,7 @@ mergePartialResult ::
   IsSymInterface sym =>
   SimState p sym ext root f args ->
   CrucibleBranchTarget f args ->
-  MuxFn (Pred sym)
-     (PartialResult sym ext (SimFrame sym ext f args))
+  MuxFn (Pred sym) (PartialResultFrame sym ext f args)
 mergePartialResult s tgt pred x y =
   let sym       = s^.stateSymInterface
       iteFns    = s^.stateIntrinsicTypes
@@ -285,8 +284,8 @@ abortPartialResult ::
   IsSymInterface sym =>
   SimState p sym ext r f args ->
   CrucibleBranchTarget f a' ->
-  PartialResult sym ext (SimFrame sym ext f a') ->
-  IO (PartialResult sym ext (SimFrame sym ext f a'))
+  PartialResultFrame sym ext f a' ->
+  IO (PartialResultFrame sym ext f a')
 abortPartialResult s tgt pr =
   let sym                    = s^.stateSymInterface
       muxFns                 = s^.stateIntrinsicTypes

--- a/crucible/src/Lang/Crucible/Simulator/Operations.hs
+++ b/crucible/src/Lang/Crucible/Simulator/Operations.hs
@@ -373,7 +373,7 @@ resolveCall bindings c0 args loc callStack =
       resolveCall bindings (HandleFnVal h) (packVarargs addlTypes args) loc callStack
 
     HandleFnVal h -> do
-      case lookupHandleMap h bindings of
+      case lookupHandleMap h (fnBindings bindings) of
         Nothing -> Ex.throw (UnresolvableFunction loc callStack h)
         Just (UseOverride o) -> do
           let f = OverrideFrame { _override = overrideName o

--- a/crucible/src/Lang/Crucible/Simulator/OverrideSim.hs
+++ b/crucible/src/Lang/Crucible/Simulator/OverrideSim.hs
@@ -239,7 +239,7 @@ bindFnHandle ::
   FnState p sym ext args ret ->
   OverrideSim p sym ext rtp a r ()
 bindFnHandle h s =
-  stateContext . functionBindings %= insertHandleMap h s
+  stateContext . functionBindings %= FnBindings . insertHandleMap h s . fnBindings
 
 ------------------------------------------------------------------------
 -- Mutable variables
@@ -573,12 +573,12 @@ data FnBinding p sym ext where
 insertFnBinding :: FunctionBindings p sym ext
                 -> FnBinding p sym ext
                 -> FunctionBindings p sym ext
-insertFnBinding m (FnBinding h s) = insertHandleMap h s m
+insertFnBinding m (FnBinding h s) = FnBindings $ insertHandleMap h s $ fnBindings m
 
 -- | Build a map of function bindings from a list of
 --   handle/binding pairs.
 fnBindingsFromList :: [FnBinding p sym ext] -> FunctionBindings p sym ext
-fnBindingsFromList = foldl' insertFnBinding emptyHandleMap
+fnBindingsFromList = foldl' insertFnBinding $ FnBindings emptyHandleMap
 
 registerFnBinding :: FnBinding p sym ext
                    -> OverrideSim p sym ext rtp a r ()

--- a/crux-mir/src/Mir/Language.hs
+++ b/crux-mir/src/Mir/Language.hs
@@ -209,7 +209,7 @@ runTests (cruxOpts, mirOpts) = do
             let outH = view outputHandle ?outputConfig
             setSimulatorVerbosity (Crux.simVerbose cruxOpts) sym
             let simCtx = C.initSimContext sym mirIntrinsicTypes halloc outH
-                    C.emptyHandleMap mirExtImpl Crux.emptyModel
+                    (C.FnBindings C.emptyHandleMap) mirExtImpl Crux.emptyModel
             return (Crux.RunnableState $
                     C.InitialState simCtx C.emptyGlobals C.defaultAbortHandler C.UnitRepr $
                      C.runOverrideSim C.UnitRepr $ simTest symOnline fnName


### PR DESCRIPTION
This introduces a couple of changes that will be useful for later polyglot changes, but which can stand on their own.
* Adds a PartialResultFrame type alias for brevity
* Change FunctionBindings from a type alias to a newtype.
