### PR TITLE
WIP: crucible-llvm: Diagnose double-frees

### DIFF
--- a/crux-llvm/test-data/golden/golden/double_free.c
+++ b/crux-llvm/test-data/golden/golden/double_free.c
@@ -1,0 +1,18 @@
+#include <stdlib.h>
+#include <crucible.h>
+
+void do_free(int *p) __attribute__((noinline)) {
+  free(p);
+}
+
+int main() {
+  unsigned int b = crucible_uint32_t("b");
+  int *p = malloc(sizeof(int));
+  *p = b;
+  if (b) {
+    printf("%d\n", *p); // prevent optimizing everything away
+    do_free(p);
+  }
+  free(p);
+  return b;
+}

--- a/crux-llvm/test-data/golden/golden/double_free.good
+++ b/crux-llvm/test-data/golden/golden/double_free.good
@@ -1,0 +1,16 @@
+????
+[Crux] Counter example for test-data/golden/golden/double_free.c:16:3: error: in main
+Undefined behavior encountered
+Details:
+  `free` called on a pointer to already-freed memory
+[Crux] Found counterexample for verification goal
+test-data/golden/golden/double_free.c:16:3: error: in main
+Undefined behavior encountered
+Details:
+  `free` called on a pointer to already-freed memory
+  Pointer: (10, 0x0:[64])
+  Reference: 
+    The C language standard, version C11
+    §7.22.3.3 The free function, ¶2
+    Document URL: http://www.iso-9899.info/n1570.html
+[Crux] Overall status: Invalid.

--- a/crux-llvm/test-data/golden/golden/maybe_free.c
+++ b/crux-llvm/test-data/golden/golden/maybe_free.c
@@ -1,0 +1,13 @@
+#include <crucible.h>
+#include <stdlib.h>
+
+int main() {
+  unsigned int b = crucible_uint32_t("b");
+  int *p = malloc(sizeof(int));
+  *p = b;
+  if (b) {
+    printf("%d\n", *p); // prevent optimizing everything away
+    free(p);
+  }
+  return b;
+}

--- a/crux-llvm/test-data/golden/golden/maybe_free.good
+++ b/crux-llvm/test-data/golden/golden/maybe_free.good
@@ -1,0 +1,2 @@
+????
+[Crux] Overall status: Valid.


### PR DESCRIPTION
Previously, these were treated identically with e.g. frees of non-pointer integers. Now, a new predicate returned by the memory model can distinguish them.

There are three points I'd like to resolve before merging:

- [x] Is this likely to make performance of memory model operations substantially slower? Functions like `isAllocatedMut` are called on pretty much every read or write, and I would hate to slow that down. One approach would be to do a fully separate traversal of the `MemLog` from `doFree`.
- [x] I have a client analysis that I can use to test this, which I'd like to do before merging.
- [x] If it works for the above client analysis I'll add a test to the `crucible-llvm` test suite - perhaps in `testMemAllocs`