### PR TITLE
Update the README for crux-llvm

### DIFF
--- a/crux-llvm/README.md
+++ b/crux-llvm/README.md
@@ -19,32 +19,32 @@ software:
 
 * The Clang compiler: <http://releases.llvm.org/download.html>
 
-We have tested `crux-llvm` most heavily with GHC 8.6.5 and GHC 8.8.4,
-and `cabal` version 3.2.0.0. We recommend Yices 2.6.x, and Z3 4.8.x.
-Technically, only one of Yices or Z3 is required, and CVC4 will work, as
-well. However, in practice, having both tends to be convenient. Finally,
-LLVM versions from 3.6 through 10 are likely to work well, and any
-failures with versions in that range should be considered
-[bugs](https://github.com/GaloisInc/crucible/issues).
+We have tested `crux-llvm` most heavily with GHC 8.6.5, GHC 8.8.4, GHC
+8.10.4, and `cabal` version 3.2.0.0. We recommend Yices 2.6.x, and Z3
+4.8.x. Technically, only one of Yices or Z3 is required, and CVC4 is
+also supported. However, in practice, having both tends to be
+convenient. Finally, LLVM versions from 3.6 through 11 are likely to
+work well, and any failures with versions in that range should be
+[reported as bugs](https://github.com/GaloisInc/crucible/issues).
 
 # Building
 
 The `crux-llvm` tool can be built by doing the following:
 
-* Clone the enclosing `crucible` repository:
+* Clone the `crucible` repository:
 
         git clone https://github.com/GaloisInc/crucible.git
 
-* Change to the `crux-llvm` directory and run the build script:
+* Build the `crux-llvm` package:
 
-        cd crucible/crux-llvm
-        cabal v2-build
+        cabal build crux-llvm
 
 This will compile `crux-llvm` and supporting libraries such that they
-can be executed with `cabal v2-run`. To install the binaries in the
-standard Cabal binary path, run the following:
+can be executed with `cabal run`. To install the binaries in the
+standard Cabal binary path (usually `$HOME/.cabal/bin`), run the
+following:
 
-        cabal v2-install exe:crux-llvm --overwrite-policy=always
+        cabal install exe:crux-llvm --overwrite-policy=always
 
 You can also use the `--installdir` flag to install binaries in a
 different location.
@@ -54,6 +54,11 @@ different location.
 In the `crux-llvm` directory (either in the repository or the root of
 the directory extracted from a distribution tarball), to analyze
 `file.c`, run
+
+        cabal run exe:crux-llvm file.c
+
+If you've installed `crux-llvm` somewhere on your `PATH`, you can
+instead run
 
         crux-llvm file.c
 
@@ -77,10 +82,11 @@ directory:
 * `print-model-NNN`: an executable file that prints out the values
   associated with the counter-example.
 
-To define properties and assumptions about the code to analyze, you
-may have to annotate the source code with inline properties (CRUCIBLE
-is defined to help specify crucible-specific functionality. The following
-simple example is included in the `crux-llvm` distribution.
+To define properties and assumptions about the code to analyze, you may
+have to annotate the source code with inline properties (`CRUCIBLE` is
+defined to help specify Crucible-specific functionality). The following
+simple example includes on version of `main` when running with
+`crux-llvm` and different one when compiled normally.
 
 ~~~~ .c
 #include <stdint.h>
@@ -101,23 +107,25 @@ int main() {
 }
 #else
 int main(int argc, char **argv) {
-  return f(argv);
+  return f(argc);
 }
+#endif
 ~~~~
 
-This file includes the `crucible.h` header file that declares functions
-and macros such as `crucible_int8_t`, `assuming`, and `check`. The call
-to `crucible_int8_t` marks variable `x` as a symbolic variable whose
-value can be any 8-bit signed integer. The C expression within the
-assuming statement states that `x` must be less than 100. The expression
-within the check statement is a proof goal: `crux-llvm` will attempt to
-prove that property `f(x) < 100` holds whenever the assumption on `x` is
+When running under `crux-llvm`, this file includes the `crucible.h`
+header file that declares functions and macros such as
+`crucible_int8_t`, `assuming`, and `check`. The call to
+`crucible_int8_t` marks variable `x` as a symbolic variable whose value
+can be any 8-bit signed integer. The C expression within the assuming
+statement states that `x` must be less than 100. The expression within
+the check statement is a proof goal: `crux-llvm` will attempt to prove
+that property `f(x) < 100` holds whenever the assumption on `x` is
 satisfied. The proof will fail in this case and `crux-llvm` will produce
-a counterexample.
+a counterexample describing the case where `x` is 99.
 
 # API
 
-The `crux-llvm` [header file](c-src/includes/crucible.h) contains
+The [`crucible.h` header file](c-src/includes/crucible.h) contains
 declarations of several functions that can be used to describe the
 properties of a program that you would like to prove.
 
@@ -136,8 +144,9 @@ properties of a program that you would like to prove.
   values for the corresponding type, all `crucible_assert` calls will
   succeed.
 
-For programs that have been written for the SV-COMP competition, the
-following alternative API is available.
+For programs that have been written for the [SV-COMP
+competition](https://sv-comp.sosy-lab.org/), the following alternative
+API is available.
 
 * The `__VERIFIER_assume` function is equivalent to `crucible_assume`,
   but does not take location information as an argument.
@@ -212,7 +221,8 @@ In addition, the following LLVM intrinsic functions are supported:
 For C++ code, several core functions have built-in support, but
 `crux-llvm` will also link with a precompiled LLVM bitcode file
 containing the `libc++` library included with the `clang` compiler, so
-most C++ code that doesn't use third-party libraries should work.
+most C++ code that doesn't use third-party libraries (or that includes
+those libraries linked into a single bitcode file) should work.
 
 # Command-line Flags
 
@@ -225,37 +235,107 @@ In addition, the following flags can optionally be provided:
 
 * `--help`, `-h`, `-?`: Print all options with brief descriptions.
 
-* `--version`, `-V`: Show the version of the tool.
+* `--include-dirs=DIRS`, `-I DIRS`: Set directories to search for C/C++
+  include files. This will be passed along to `clang`.
 
-* `--config=FILE`: Load configuration from `FILE`. A configuration file
-  can specify the same settings as command-line flags. Details of the
-  format for configuration files appear in the next section.
+* `-O NUM`: Set the optimization level for `clang`.
+
+* `--version`, `-V`: Show the version of the tool.
 
 * `--sim-verbose=NUM`, `-d NUM`: Set the verbosity level of the symbolic
   simulator to `N`.
+  
+* `--floating-point=FPREP`, `-f FPREP`: Select the floating point
+  representation to use. The value of `FPREP` can be one of `real`,
+  `ieee`, `uninterpreted`, or `default`. Default representation is
+  solver specific: `real` for CVC4 and Yices, and `ieee` for Z3.
 
-* `--path-sat`: Enable path satisfiability checking, which can help
-  programs terminate, particularly in the case where the bounds on loops
-  are complex.
+* `--iteration-bound=N`, `-i N`: Set a bound on the number of times a
+  single loop can iterate. This can also make it more likely to get at
+  least a partial verification result for complex programs, and can be
+  more clearly connected to the execution of the program than a
+  time-based bound.
 
-* `--output-directory=DIR`: Set the directory to use to store output
-  files (default: `results`).
+* `--profiling-period=N`, `-p N`: Set how many seconds to wait between
+  each dump of profiling data (default: 5). Intermediate profiling data
+  can be helpful for diagnosing a run that does not terminate in a
+  reasonable amount of time.
 
-* `--profile-crucible`: Enable profiling of the symbolic execution
-  process. Produces an additional HTML file in the output directory that
-  provides a graphical and tabular depiction of the execution time
-  profile.
+* `--quiet`, `-q`: Quiet mode; produce minimal output.
 
-* `--profile-solver`: Include profiling of SMT solver calls in the
-  symbolic execution profile.
+* `--recursion-bound=N`, `-i N`: Set a bound on the number of times a
+  single function can recur. This can also make it more likely to get at
+  least a partial verification result for complex programs, and can be
+  more clearly connected to the execution of the program than a
+  time-based bound.
+
+* `--solver=NAME`, `-s NAME`: Use the given SMT solver to discharge
+  proof obligations. Valid values for `NAME` are `cvc4`, `yices`, and
+  `z3`.
 
 * `--timeout=N`, `-t N`: Set the timeout for the first phase of analysis
   (symbolic execution) which happens before sending the main goals to an
   SMT solver. Setting this to a low value can give you a result more
   quickly, but the result is more likely to be "Unknown" (default: 60).
 
+* `--no-execs`, `-x`: Do not create executables to demonstrate
+  counter-examples.
+
+* `--branch-coverage`: Record branch coverage information.
+
+* `--config=FILE`: Load configuration from `FILE`. A configuration file
+  can specify the same settings as command-line flags. Details of the
+  format for configuration files appear in the next section.
+
+* `--entry-point=SYMBOL`: Start symbolic execution at `SYMBOL`.
+
+* `--fail-fast`: Stop attempting to prove goals as soon as one of them
+  is disproved.
+
+* `--force-offline-goal-solving`: Force goals to be solved using an
+  offline solver, even if the selected solver could have been used in
+  online mode.
+
 * `--goal-timeout=N`: Set the timeout for each call to the SMT solver to
   `N` seconds.
+  
+* `--hash-consing`: Enable hash-consing in the symbolic expression
+  backend.
+
+* `--lax-arithmetic`: Allow arithmetic overflow.
+
+* `--lax-pointers`: Allow order comparisons between pointers from
+  different allocation blocks.
+
+* `--lazy-compile`: Avoid compiling bitcode from source if intermediate
+  files already exist.
+
+* `--mcsat`: Enable the MC-SAT engine when using the Yices SMT solver.
+  This disables the use of UNSAT cores, so the HTML rendering of proved
+  goals won't include highlighting a set of the assumptions that were
+  necessary for proving the goal.
+
+* `--no-unsat-cores`: Disable computing unsat cores for successful
+  proofs.
+
+* `--online-solver-output=FILE`: Store a log of interaction with the
+  online goal solver in `FILE`.
+
+* `--opt-loop-merge`: Insert merge blocks in loops with early exits.
+
+* `--output-directory=DIR`: Set the directory to use to store output
+  files (default: `results`).
+
+* `--path-sat`: Enable path satisfiability checking, which can help
+  programs terminate, particularly in the case where the bounds on loops
+  are complex.
+
+* `--path-sat-solver=SOLVER`: Select the solver to use for path
+  satisfiability checking, in order to use a different solver than for
+  discharging goals.
+
+* `--path-sat-solver-output`: Store a log of interaction with the path
+  satisfiability solver in `FILE`.
 
 * `--path-strategy=STRATEGY`: Set the strategy to use for exploring
   paths during symbolic execution. A `STRATEGY` of `always-merge` (the
@@ -267,44 +347,35 @@ In addition, the following flags can optionally be provided:
   Sometimes, however `split-dfs` can lead to faster full verification
   times.
 
-* `--profiling-period=N`, `-p N`: Set how many seconds to wait between
-  each dump of profiling data (default: 5). Intermediate profiling data
-  can be helpful for diagnosing a run that does not terminate in a
-  reasonable amount of time.
+* `--profile-crucible`: Enable profiling of the symbolic execution
+  process. Produces an additional HTML file in the output directory that
+  provides a graphical and tabular depiction of the execution time
+  profile.
 
-* `--iteration-bound=N`, `-i N`: Set a bound on the number of times a
-  single loop can iterate. This can also make it more likely to get at
-  least a partial verification result for complex programs, and can be
-  more clearly connected to the execution of the program than a
-  time-based bound.
+* `--profile-solver`: Include profiling of SMT solver calls in the
+  symbolic execution profile.
 
-* `--recursion-bound=N`, `-i N`: Set a bound on the number of times a
-  single function can recur. This can also make it more likely to get at
-  least a partial verification result for complex programs, and can be
-  more clearly connected to the execution of the program than a
-  time-based bound.
+* `--skip-incomplete-reports`: Skip reporting on proof obligations that
+  arise from timeouts and resource exhaustion.
 
-* `--no-execs`, `-x`: Do not create executables to demonstrate
-  counter-examples.
+* `--skip-print-failures`: Skip printing messages related to failed
+  verification goals.
 
-* `--solver=NAME`, `-s NAME`: Use the given SMT solver to discharge
-  proof obligations. Valid values for `NAME` are `cvc4`, `yices`, and
-  `z3`.
+* `--skip-report`: Skip producing the HTML report following
+  verification.
 
-* `--mcsat`: Enable the MC-SAT engine when using the Yices SMT solver.
-  This disables the use of UNSAT cores, so the HTML rendering of proved
-  goals won't include highlighting a set of the assumptions that were
-  necessary for proving the goal.
+* `--skip-success-reports`: Skip reporting on successful proof
+  obligations.
 
-* `--include-dirs=DIRS`, `-I DIRS`: Set directories to search for C/C++
-  include files. This will be passed along to `clang`.
-
-* `--lax-pointers`: Allow order comparisons between pointers from
-  different allocation blocks.
+* `--target=ARCH`: Pass `ARCH` as the target architecture to LLVM build
+  operations.
 
 # Environment Variables
 
 The following environment variables are supported:
+
+* `BLDDIR`: Specify the directory for writing build files generated from
+  the input files.
 
 * `CLANG`: Specify the name of the `clang` compiler command used to
   translate from C/C++ to LLVM.

--- a/crux-llvm/README.md
+++ b/crux-llvm/README.md
@@ -82,9 +82,10 @@ directory:
 * `print-model-NNN`: an executable file that prints out the values
   associated with the counter-example.
 
-To define properties and assumptions about the code to analyze, you may
-have to annotate the source code with inline properties (`CRUCIBLE` is
-defined to help specify Crucible-specific functionality). The following
+To define properties and assumptions about the code to analyze, you can
+annotate the source code with inline properties. When `crux-llvm`
+compiles your code, it defines the CPP macro `CRUCIBLE` to help specify
+Crucible-specific functionality such as inline properties. The following
 simple example includes on version of `main` when running with
 `crux-llvm` and different one when compiled normally.
 


### PR DESCRIPTION
This improves build instructions and adds documentation for all command-line flags, among a few other minor fixes.

Ultimately, the documentation for command-line flags should probably directly use the output from `crux-llvm -h`, but this current version has slightly more detailed descriptions for some options. Maybe we should include those in the executable, too?