### PR TITLE
[crucible-llvm] Use general ext type parameter instead of "LLVM arch"

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM.hs
@@ -31,7 +31,7 @@ import           Lang.Crucible.Backend
 import           Lang.Crucible.CFG.Core
 import           Lang.Crucible.FunctionHandle (lookupHandleMap, handleName)
 import           Lang.Crucible.LLVM.Eval (llvmExtensionEval)
-import           Lang.Crucible.LLVM.Extension (ArchWidth)
+import           Lang.Crucible.LLVM.Extension (ArchRepr, ArchWidth)
 import           Lang.Crucible.LLVM.Intrinsics
 import           Lang.Crucible.LLVM.MemModel
                    ( llvmStatementExec, HasPtrWidth, HasLLVMAnn, MemOptions, MemImpl
@@ -47,8 +47,8 @@ import           Lang.Crucible.Utils.MonadVerbosity (showWarning)
 registerModuleFn
    :: (1 <= ArchWidth arch, HasPtrWidth (ArchWidth arch), IsSymInterface sym) =>
    LLVMContext arch ->
-   (L.Declare, AnyCFG (LLVM arch)) ->
-   OverrideSim p sym (LLVM arch) rtp l a ()
+   (L.Declare, AnyCFG ext) ->
+   OverrideSim p sym ext rtp l a ()
 registerModuleFn llvm_ctx (decl, AnyCFG cfg) = do
   let h = cfgHandle cfg
       s = UseCFG cfg (postdomInfo cfg)
@@ -71,12 +71,14 @@ llvmGlobals ctx mem = emptyGlobals & insertGlobal var mem
   where var = llvmMemVar $ ctx
 
 llvmExtensionImpl ::
-  (HasPtrWidth (ArchWidth arch), HasLLVMAnn sym) =>
+  (HasPtrWidth (ArchWidth arch),
+   HasLLVMAnn sym) =>
+  ArchRepr arch ->
   MemOptions ->
-  ExtensionImpl p sym (LLVM arch)
-llvmExtensionImpl mo =
+  ExtensionImpl p sym LLVM
+llvmExtensionImpl arch mo =
   let ?memOpts = mo in
   ExtensionImpl
   { extensionEval = llvmExtensionEval
-  , extensionExec = llvmStatementExec
+  , extensionExec = llvmStatementExec arch
   }

--- a/crucible-llvm/src/Lang/Crucible/LLVM.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM.hs
@@ -31,7 +31,7 @@ import           Lang.Crucible.Backend
 import           Lang.Crucible.CFG.Core
 import           Lang.Crucible.FunctionHandle (lookupHandleMap, handleName)
 import           Lang.Crucible.LLVM.Eval (llvmExtensionEval)
-import           Lang.Crucible.LLVM.Extension (ArchRepr, ArchWidth)
+import           Lang.Crucible.LLVM.Extension (ArchWidth)
 import           Lang.Crucible.LLVM.Intrinsics
 import           Lang.Crucible.LLVM.MemModel
                    ( llvmStatementExec, HasPtrWidth, HasLLVMAnn, MemOptions, MemImpl
@@ -71,14 +71,12 @@ llvmGlobals ctx mem = emptyGlobals & insertGlobal var mem
   where var = llvmMemVar $ ctx
 
 llvmExtensionImpl ::
-  (HasPtrWidth (ArchWidth arch),
-   HasLLVMAnn sym) =>
-  ArchRepr arch ->
+  (HasLLVMAnn sym) =>
   MemOptions ->
   ExtensionImpl p sym LLVM
-llvmExtensionImpl arch mo =
+llvmExtensionImpl mo =
   let ?memOpts = mo in
   ExtensionImpl
   { extensionEval = llvmExtensionEval
-  , extensionExec = llvmStatementExec arch
+  , extensionExec = llvmStatementExec
   }

--- a/crucible-llvm/src/Lang/Crucible/LLVM/ArraySizeProfile.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/ArraySizeProfile.hs
@@ -171,7 +171,7 @@ updateProfiles ::
   (C.IsSymInterface sym, C.HasLLVMAnn sym, C.HasPtrWidth (C.ArchWidth arch)) =>
   C.LLVMContext arch ->
   IORef (Map Text [FunctionProfile]) ->
-  C.ExecState p sym (C.LLVM arch) rtp ->
+  C.ExecState p sym ext rtp ->
   IO ()
 updateProfiles llvm cell state
   | C.CallState _ (C.CrucibleCall _ frame) sim <- state
@@ -190,11 +190,11 @@ updateProfiles llvm cell state
   | otherwise = pure ()
 
 arraySizeProfile ::
-  forall sym arch p rtp.
+  forall sym ext arch p rtp.
   (C.IsSymInterface sym, C.HasLLVMAnn sym, C.HasPtrWidth (C.ArchWidth arch)) =>
   C.LLVMContext arch ->
   IORef (Map Text [FunctionProfile]) ->
-  IO (C.ExecutionFeature p sym (C.LLVM arch) rtp)
+  IO (C.ExecutionFeature p sym ext rtp)
 arraySizeProfile llvm profiles = do
   pure . C.ExecutionFeature $ \s -> do
     updateProfiles llvm profiles s

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Ctors.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Ctors.hs
@@ -133,7 +133,7 @@ globalCtors mod_ =
 -- | Call some or all of the functions in @llvm.global_ctors@
 callCtors :: (Ctor -> Bool) -- ^ Filter function
           -> L.Module
-          -> LLVMGenerator s arch UnitType (Expr (LLVM arch) s UnitType)
+          -> LLVMGenerator s arch UnitType (Expr LLVM s UnitType)
 callCtors select mod_ = do
   let err msg = malformedLLVMModule "Error loading @llvm.global_ctors" [fromString msg]
   let ty = L.FunTy (L.PrimType L.Void) [] False
@@ -144,7 +144,7 @@ callCtors select mod_ = do
   return (App EmptyApp)
 
 -- | Call each function in @llvm.global_ctors@ in order of decreasing priority
-callAllCtors :: L.Module -> LLVMGenerator s arch UnitType (Expr (LLVM arch) s UnitType)
+callAllCtors :: L.Module -> LLVMGenerator s arch UnitType (Expr LLVM s UnitType)
 callAllCtors = callCtors (const True)
 
 ----------------------------------------------------------------------
@@ -156,12 +156,12 @@ generatorToCFG :: forall arch wptr ret. (HasPtrWidth wptr, wptr ~ ArchWidth arch
                => Text
                -> HandleAllocator
                -> LLVMContext arch
-               -> (forall s. LLVMGenerator s arch ret (Expr (LLVM arch) s ret))
+               -> (forall s. LLVMGenerator s arch ret (Expr LLVM s ret))
                -> TypeRepr ret
-               -> IO (Core.SomeCFG (LLVM arch) Core.EmptyCtx ret)
+               -> IO (Core.SomeCFG LLVM Core.EmptyCtx ret)
 generatorToCFG name halloc llvmctx gen ret = do
   let ?lc = _llvmTypeCtx llvmctx
-  let def :: forall args. FunctionDef (LLVM arch) (LLVMState arch) args ret IO
+  let def :: forall args. FunctionDef LLVM (LLVMState arch) args ret IO
       def _inputs = (state, gen)
         where state = LLVMState { _identMap     = empty
                                 , _blockInfoMap = empty
@@ -179,6 +179,6 @@ callCtorsCFG :: forall arch wptr. (HasPtrWidth wptr, wptr ~ ArchWidth arch, 16 <
              -> L.Module
              -> HandleAllocator
              -> LLVMContext arch
-             -> IO (Core.SomeCFG (LLVM arch) Core.EmptyCtx UnitType)
+             -> IO (Core.SomeCFG LLVM Core.EmptyCtx UnitType)
 callCtorsCFG select mod_ halloc llvmctx = do
   generatorToCFG "llvm_global_ctors" halloc llvmctx (callCtors select mod_) UnitRepr

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Eval.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Eval.hs
@@ -34,12 +34,12 @@ assertSideCondition sym (LLVMSideCondition (RV p) ub) =
      let err = AssertFailureSimError "Undefined behavior encountered" (show (UB.explain ub))
      assert sym p' err
 
-llvmExtensionEval :: forall sym arch.
+llvmExtensionEval :: forall sym.
   (HasLLVMAnn sym, IsSymInterface sym) =>
   sym ->
   IntrinsicTypes sym ->
   (Int -> String -> IO ()) ->
-  EvalAppFunc sym (LLVMExtensionExpr arch)
+  EvalAppFunc sym LLVMExtensionExpr
 
 llvmExtensionEval sym _iTypes _logFn eval e =
   case e of

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Extension.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Extension.hs
@@ -10,16 +10,10 @@
 -- Syntax extension definitions for LLVM
 ------------------------------------------------------------------------
 
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE EmptyDataDeriving #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 
 module Lang.Crucible.LLVM.Extension
   ( module Lang.Crucible.LLVM.Extension.Arch
@@ -27,24 +21,23 @@ module Lang.Crucible.LLVM.Extension
   , LLVM
   ) where
 
-import           Data.Data (Data)
-import           Data.Typeable (Typeable)
-import           GHC.Generics (Generic, Generic1)
+import Data.Data (Data)
+import Data.Typeable (Typeable)
+import GHC.Generics ( Generic )
 
-import           Lang.Crucible.CFG.Extension
-import           Lang.Crucible.Types
+import Lang.Crucible.CFG.Extension
 
-import           Lang.Crucible.LLVM.Extension.Arch
-import           Lang.Crucible.LLVM.Extension.Syntax
+import Lang.Crucible.LLVM.Extension.Arch
+import Lang.Crucible.LLVM.Extension.Syntax
 
 -- | The Crucible extension type marker for LLVM.
-data LLVM (arch :: LLVMArch)
-  deriving (Data, Eq, Generic, Generic1, Ord, Typeable)
+data LLVM
+  deriving (Data, Eq, Generic , Ord, Typeable)
 
 -- -----------------------------------------------------------------------
 -- ** Syntax
 
-type instance ExprExtension (LLVM arch) = LLVMExtensionExpr arch
-type instance StmtExtension (LLVM arch) = LLVMStmt (ArchWidth arch)
+type instance ExprExtension LLVM = LLVMExtensionExpr
+type instance StmtExtension LLVM = LLVMStmt
 
-instance (1 <= ArchWidth arch) => IsSyntaxExtension (LLVM arch)
+instance IsSyntaxExtension LLVM

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Extension/Syntax.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Extension/Syntax.hs
@@ -11,7 +11,6 @@
 ------------------------------------------------------------------------
 
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
@@ -43,7 +42,6 @@ import           Lang.Crucible.LLVM.Arch.X86 as X86
 import           Lang.Crucible.LLVM.Bytes
 import           Lang.Crucible.LLVM.DataLayout
 import           Lang.Crucible.LLVM.Errors.UndefinedBehavior( UndefinedBehavior )
-import           Lang.Crucible.LLVM.Extension.Arch
 import           Lang.Crucible.LLVM.MemModel.Pointer
 import           Lang.Crucible.LLVM.MemModel.Type
 import           Lang.Crucible.LLVM.Types
@@ -70,58 +68,60 @@ instance TraversableF LLVMSideCondition where
   traverseF f (LLVMSideCondition p desc) =
       LLVMSideCondition <$> f p <*> traverseF f desc
 
-data LLVMExtensionExpr (arch :: LLVMArch) :: (CrucibleType -> Type) -> (CrucibleType -> Type) where
-  X86Expr :: !(X86.ExtX86 f t) -> LLVMExtensionExpr (X86 wptr) f t
+data LLVMExtensionExpr :: (CrucibleType -> Type) -> (CrucibleType -> Type) where
+
+  X86Expr :: !(X86.ExtX86 f t) -> LLVMExtensionExpr f t
 
   LLVM_SideConditions ::
     !(TypeRepr tp) ->
     !(NonEmpty (LLVMSideCondition f)) ->
     !(f tp) ->
-    LLVMExtensionExpr arch f tp
+    LLVMExtensionExpr f tp
 
   LLVM_PointerExpr ::
     (1 <= w) => !(NatRepr w) -> !(f NatType) -> !(f (BVType w)) ->
-    LLVMExtensionExpr arch f (LLVMPointerType w)
+    LLVMExtensionExpr f (LLVMPointerType w)
 
   LLVM_PointerBlock ::
     (1 <= w) => !(NatRepr w) -> !(f (LLVMPointerType w)) ->
-    LLVMExtensionExpr arch f NatType
+    LLVMExtensionExpr f NatType
 
   LLVM_PointerOffset ::
     (1 <= w) => !(NatRepr w) -> !(f (LLVMPointerType w)) ->
-    LLVMExtensionExpr arch f (BVType w)
+    LLVMExtensionExpr f (BVType w)
 
   LLVM_PointerIte ::
     (1 <= w) => !(NatRepr w) ->
     !(f BoolType) -> !(f (LLVMPointerType w)) -> !(f (LLVMPointerType w)) ->
-    LLVMExtensionExpr arch f (LLVMPointerType w)
+    LLVMExtensionExpr f (LLVMPointerType w)
 
 
 -- | Extension statements for LLVM.  These statements represent the operations
 --   necessary to interact with the LLVM memory model.
-data LLVMStmt (wptr :: Nat) (f :: CrucibleType -> Type) :: CrucibleType -> Type where
+data LLVMStmt (f :: CrucibleType -> Type) :: CrucibleType -> Type where
 
   -- | Indicate the beginning of a new stack frame upon entry to a function.
   LLVM_PushFrame ::
      !Text ->
      !(GlobalVar Mem) {- Memory global variable -} ->
-     LLVMStmt wptr f UnitType
+     LLVMStmt f UnitType
 
   -- | Indicate the end of the current stack frame upon exit from a function.
   LLVM_PopFrame ::
      !(GlobalVar Mem) {- Memory global variable -} ->
-     LLVMStmt wptr f UnitType
+     LLVMStmt f UnitType
 
   -- | Allocate a new memory object in the current stack frame.  This memory
   --   will be automatically deallocated when the corresponding PopFrame
   --   statement is executed.
   LLVM_Alloca ::
+     HasPtrWidth wptr =>
      !(NatRepr wptr)       {- Pointer width -} ->
      !(GlobalVar Mem)      {- Memory global variable -} ->
      !(f (BVType wptr))    {- Number of bytes to allocate -} ->
      !Alignment            {- Minimum alignment of this allocation -} ->
      !String               {- Location string to identify this allocation for debugging purposes -} ->
-     LLVMStmt wptr f (LLVMPointerType wptr)
+     LLVMStmt f (LLVMPointerType wptr)
 
   -- | Load a value from the memory.  The load is defined only if
   --   the given pointer is a live pointer; if the bytes in the memory
@@ -129,72 +129,79 @@ data LLVMStmt (wptr :: Nat) (f :: CrucibleType -> Type) :: CrucibleType -> Type 
   --   desired type; and if the given pointer is actually aligned according
   --   to the given alignment value.
   LLVM_Load ::
+     HasPtrWidth wptr =>
      !(GlobalVar Mem)            {- Memory global variable -} ->
      !(f (LLVMPointerType wptr)) {- Pointer to load from -} ->
      !(TypeRepr tp)              {- Expected crucible type of the result -} ->
      !StorageType                {- Storage type -} ->
      !Alignment                  {- Assumed alignment of the pointer -} ->
-     LLVMStmt wptr f tp
+     LLVMStmt f tp
 
   -- | Store a value in to the memory.  The store is defined only if the given
   --   pointer is a live pointer; if the given value fits into the memory object
   --   at the location pointed to; and the given pointer is aligned according
   --   to the given alignment value.
   LLVM_Store ::
+     HasPtrWidth wptr =>
      !(GlobalVar Mem)            {- Memory global variable -} ->
      !(f (LLVMPointerType wptr)) {- Pointer to store at -} ->
      !(TypeRepr tp)              {- Crucible type of the value being stored -} ->
      !StorageType                {- Storage type of the value -} ->
      !Alignment                  {- Assumed alignment of the pointer -} ->
      !(f tp)                     {- Value to store -} ->
-     LLVMStmt wptr f UnitType
+     LLVMStmt f UnitType
 
   -- | Clear a region of memory by setting all the bytes in it to the zero byte.
   --   This is primarily used for initializing the value of global variables,
   --   but can also result from zero initializers.
   LLVM_MemClear ::
+     HasPtrWidth wptr =>
      !(GlobalVar Mem)            {- Memory global variable -} ->
      !(f (LLVMPointerType wptr)) {- Pointer to store at -} ->
      !Bytes                      {- Number of bytes to clear -} ->
-     LLVMStmt wptr f UnitType
+     LLVMStmt f UnitType
 
   -- | Load the Crucible function handle that corresponds to a function pointer value.
   --   This load is defined only if the given pointer was previously allocated as
   --   a function pointer value and associated with a Crucible function handle of
   --   the expected type.
   LLVM_LoadHandle ::
+     HasPtrWidth wptr =>
      !(GlobalVar Mem)            {- Memory global variable -} ->
      !L.Type                     {- expected LLVM type of the function -} ->
      !(f (LLVMPointerType wptr)) {- Pointer to load from -} ->
      !(CtxRepr args)             {- Expected argument types of the function -} ->
      !(TypeRepr ret)             {- Expected return type of the function -} ->
-     LLVMStmt wptr f (FunctionHandleType args ret)
+     LLVMStmt f (FunctionHandleType args ret)
 
   -- | Resolve the given global symbol name to a pointer value.
   LLVM_ResolveGlobal ::
+     HasPtrWidth wptr =>
      !(NatRepr wptr)      {- Pointer width -} ->
      !(GlobalVar Mem)     {- Memory global variable -} ->
      GlobalSymbol         {- The symbol to resolve -} ->
-     LLVMStmt wptr f (LLVMPointerType wptr)
+     LLVMStmt f (LLVMPointerType wptr)
 
   -- | Test two pointer values for equality.
   --   Note! This operation is defined only
   --   in case both pointers are live or null.
   LLVM_PtrEq ::
+     HasPtrWidth wptr =>
      !(GlobalVar Mem)            {- Pointer width -} ->
      !(f (LLVMPointerType wptr)) {- First pointer to compare -} ->
      !(f (LLVMPointerType wptr)) {- First pointer to compare -} ->
-     LLVMStmt wptr f BoolType
+     LLVMStmt f BoolType
 
   -- | Test two pointer values for ordering.
   --   Note! This operation is only defined if
   --   both pointers are live pointers into the
   --   same memory object.
   LLVM_PtrLe ::
+     HasPtrWidth wptr =>
      !(GlobalVar Mem)            {- Pointer width -} ->
      !(f (LLVMPointerType wptr)) {- First pointer to compare -} ->
      !(f (LLVMPointerType wptr)) {- First pointer to compare -} ->
-     LLVMStmt wptr f BoolType
+     LLVMStmt f BoolType
 
   -- | Add an offset value to a pointer.
   --   Note! This operation is only defined if both
@@ -202,25 +209,27 @@ data LLVMStmt (wptr :: Nat) (f :: CrucibleType -> Type) :: CrucibleType -> Type 
   --   the resulting computed pointer remains in the bounds
   --   of its associated memory object (or one past the end).
   LLVM_PtrAddOffset ::
+     HasPtrWidth wptr =>
      !(NatRepr wptr)             {- Pointer width -} ->
      !(GlobalVar Mem)            {- Memory global variable -} ->
      !(f (LLVMPointerType wptr)) {- Pointer value -} ->
      !(f (BVType wptr))          {- Offset value -} ->
-     LLVMStmt wptr f (LLVMPointerType wptr)
+     LLVMStmt f (LLVMPointerType wptr)
 
   -- | Compute the offset between two pointer values.
   --   Note! This operation is only defined if both pointers
   --   are live pointers into the same memory object.
   LLVM_PtrSubtract ::
+     HasPtrWidth wptr =>
      !(NatRepr wptr)             {- Pointer width -} ->
      !(GlobalVar Mem)            {- Memory global value -} ->
      !(f (LLVMPointerType wptr)) {- First pointer -} ->
      !(f (LLVMPointerType wptr)) {- Second pointer -} ->
-     LLVMStmt wptr f (BVType wptr)
+     LLVMStmt f (BVType wptr)
 
 $(return [])
 
-instance TypeApp (LLVMExtensionExpr arch) where
+instance TypeApp LLVMExtensionExpr where
   appType e =
     case e of
       X86Expr ex             -> appType ex
@@ -230,7 +239,7 @@ instance TypeApp (LLVMExtensionExpr arch) where
       LLVM_PointerOffset w _ -> BVRepr w
       LLVM_PointerIte w _ _ _ -> LLVMPointerRepr w
 
-instance PrettyApp (LLVMExtensionExpr arch) where
+instance PrettyApp LLVMExtensionExpr where
   ppApp pp e =
     case e of
       X86Expr ex -> ppApp pp ex
@@ -245,10 +254,10 @@ instance PrettyApp (LLVMExtensionExpr arch) where
       LLVM_PointerIte _ cond x y ->
         pretty "pointerIte" <+> pp cond <+> pp x <+> pp y
 
-instance TestEqualityFC (LLVMExtensionExpr arch) where
+instance TestEqualityFC LLVMExtensionExpr where
   testEqualityFC testSubterm =
     $(U.structuralTypeEquality [t|LLVMExtensionExpr|]
-       [ (U.DataArg 1 `U.TypeApp` U.AnyType, [|testSubterm|])
+       [ (U.DataArg 0 `U.TypeApp` U.AnyType, [|testSubterm|])
        , (U.ConType [t|NatRepr|] `U.TypeApp` U.AnyType, [|testEquality|])
        , (U.ConType [t|TypeRepr|] `U.TypeApp` U.AnyType, [|testEquality|])
        , (U.ConType [t|X86.ExtX86|] `U.TypeApp` U.AnyType `U.TypeApp` U.AnyType, [|testEqualityFC testSubterm|])
@@ -257,10 +266,10 @@ instance TestEqualityFC (LLVMExtensionExpr arch) where
          )
        ])
 
-instance OrdFC (LLVMExtensionExpr arch) where
+instance OrdFC LLVMExtensionExpr where
   compareFC testSubterm =
     $(U.structuralTypeOrd [t|LLVMExtensionExpr|]
-       [ (U.DataArg 1 `U.TypeApp` U.AnyType, [|testSubterm|])
+       [ (U.DataArg 0 `U.TypeApp` U.AnyType, [|testSubterm|])
        , (U.ConType [t|NatRepr|] `U.TypeApp` U.AnyType, [|compareF|])
        , (U.ConType [t|TypeRepr|] `U.TypeApp` U.AnyType, [|compareF|])
        , (U.ConType [t|X86.ExtX86|] `U.TypeApp` U.AnyType `U.TypeApp` U.AnyType, [|compareFC testSubterm|])
@@ -269,10 +278,10 @@ instance OrdFC (LLVMExtensionExpr arch) where
          )
        ])
 
-instance FunctorFC (LLVMExtensionExpr arch) where
+instance FunctorFC LLVMExtensionExpr where
   fmapFC = fmapFCDefault
 
-instance FoldableFC (LLVMExtensionExpr arch) where
+instance FoldableFC LLVMExtensionExpr where
   foldMapFC = foldMapFCDefault
 
 
@@ -284,7 +293,7 @@ traverseConds ::
 traverseConds f = traverse (traverseF f)
 
 
-instance TraversableFC (LLVMExtensionExpr arch) where
+instance TraversableFC LLVMExtensionExpr where
   traverseFC = $(U.structuralTraversal [t|LLVMExtensionExpr|]
      [(U.ConType [t|X86.ExtX86|] `U.TypeApp` U.AnyType `U.TypeApp` U.AnyType, [|traverseFC|])
      ,(U.ConType [t|NonEmpty|] `U.TypeApp` (U.ConType [t|LLVMSideCondition|] `U.TypeApp` U.AnyType)
@@ -292,7 +301,7 @@ instance TraversableFC (LLVMExtensionExpr arch) where
       )
      ])
 
-instance (1 <= wptr) => TypeApp (LLVMStmt wptr) where
+instance TypeApp LLVMStmt where
   appType = \case
     LLVM_PushFrame{} -> knownRepr
     LLVM_PopFrame{} -> knownRepr
@@ -307,7 +316,7 @@ instance (1 <= wptr) => TypeApp (LLVMStmt wptr) where
     LLVM_PtrAddOffset w _ _ _ -> LLVMPointerRepr w
     LLVM_PtrSubtract w _ _ _ -> BVRepr w
 
-instance PrettyApp (LLVMStmt wptr) where
+instance PrettyApp LLVMStmt where
   ppApp pp = \case
     LLVM_PushFrame nm mvar ->
        pretty "pushFrame" <+> pretty nm <+> ppGlobalVar mvar
@@ -342,32 +351,32 @@ ppGlobalVar = viaShow
 ppAlignment :: Alignment -> Doc ann
 ppAlignment = viaShow
 
-instance TestEqualityFC (LLVMStmt wptr) where
+instance TestEqualityFC LLVMStmt where
   testEqualityFC testSubterm =
     $(U.structuralTypeEquality [t|LLVMStmt|]
-       [(U.DataArg 1 `U.TypeApp` U.AnyType, [|testSubterm|])
+       [(U.DataArg 0 `U.TypeApp` U.AnyType, [|testSubterm|])
        ,(U.ConType [t|NatRepr|] `U.TypeApp` U.AnyType, [|testEquality|])
        ,(U.ConType [t|GlobalVar|] `U.TypeApp` U.AnyType, [|testEquality|])
        ,(U.ConType [t|CtxRepr|] `U.TypeApp` U.AnyType, [|testEquality|])
        ,(U.ConType [t|TypeRepr|] `U.TypeApp` U.AnyType, [|testEquality|])
        ])
 
-instance OrdFC (LLVMStmt wptr) where
+instance OrdFC LLVMStmt where
   compareFC compareSubterm =
     $(U.structuralTypeOrd [t|LLVMStmt|]
-       [(U.DataArg 1 `U.TypeApp` U.AnyType, [|compareSubterm|])
+       [(U.DataArg 0 `U.TypeApp` U.AnyType, [|compareSubterm|])
        ,(U.ConType [t|NatRepr|] `U.TypeApp` U.AnyType, [|compareF|])
        ,(U.ConType [t|GlobalVar|] `U.TypeApp` U.AnyType, [|compareF|])
        ,(U.ConType [t|CtxRepr|] `U.TypeApp` U.AnyType, [|compareF|])
        ,(U.ConType [t|TypeRepr|] `U.TypeApp` U.AnyType, [|compareF|])
        ])
 
-instance FunctorFC (LLVMStmt wptr) where
+instance FunctorFC LLVMStmt where
   fmapFC = fmapFCDefault
 
-instance FoldableFC (LLVMStmt wptr) where
+instance FoldableFC LLVMStmt where
   foldMapFC = foldMapFCDefault
 
-instance TraversableFC (LLVMStmt wptr) where
+instance TraversableFC LLVMStmt where
   traverseFC =
     $(U.structuralTraversal [t|LLVMStmt|] [])

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Globals.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Globals.hs
@@ -149,7 +149,7 @@ makeGlobalMap ctx m = foldl' addAliases globalMap (Map.toList (llvmGlobalAliases
 -- allocates space for global variables, but does not set their
 -- initial values.
 initializeAllMemory
-   :: (IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
+   :: (IsSymInterface sym, HasPtrWidth wptr)
    => sym
    -> LLVMContext arch
    -> L.Module
@@ -157,7 +157,7 @@ initializeAllMemory
 initializeAllMemory = initializeMemory (const True)
 
 initializeMemoryConstGlobals
-   :: (IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
+   :: (IsSymInterface sym, HasPtrWidth wptr)
    => sym
    -> LLVMContext arch
    -> L.Module
@@ -165,7 +165,7 @@ initializeMemoryConstGlobals
 initializeMemoryConstGlobals = initializeMemory (L.gaConstant . L.globalAttrs)
 
 initializeMemory
-   :: (IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
+   :: (IsSymInterface sym, HasPtrWidth wptr)
    => (L.Global -> Bool)
    -> sym
    -> LLVMContext arch
@@ -219,7 +219,7 @@ initializeMemory predicate sym llvm_ctx m = do
 
 
 allocLLVMFunPtr ::
-  (IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch) =>
+  (IsSymInterface sym, HasPtrWidth wptr) =>
   sym ->
   LLVMContext arch ->
   MemImpl sym ->

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics.hs
@@ -107,7 +107,6 @@ filterTemplates ts decl = filter (f . overrideTemplateMatcher) ts
 
 -- | Helper function for registering overrides
 register_llvm_overrides_ ::
-  (IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch) =>
   LLVMContext arch ->
   [OverrideTemplate p sym arch rtp l a] ->
   [L.Declare] ->

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics.hs
@@ -71,7 +71,7 @@ register_llvm_overrides ::
   [OverrideTemplate p sym arch rtp l a] {- ^ Additional "define" overrides -} ->
   [OverrideTemplate p sym arch rtp l a] {- ^ Additional "declare" overrides -} ->
   LLVMContext arch ->
-  OverrideSim p sym (LLVM arch) rtp l a ()
+  OverrideSim p sym LLVM rtp l a ()
 register_llvm_overrides llvmModule defineOvrs declareOvrs llvmctx =
   do register_llvm_define_overrides llvmModule defineOvrs llvmctx
      register_llvm_declare_overrides llvmModule declareOvrs llvmctx
@@ -111,7 +111,7 @@ register_llvm_overrides_ ::
   LLVMContext arch ->
   [OverrideTemplate p sym arch rtp l a] ->
   [L.Declare] ->
-  OverrideSim p sym (LLVM arch) rtp l a ()
+  OverrideSim p sym LLVM rtp l a ()
 register_llvm_overrides_ llvmctx acts decls =
     forM_ decls $ \decl ->
       do let acts' = filterTemplates acts decl
@@ -124,7 +124,7 @@ register_llvm_define_overrides ::
   L.Module ->
   [OverrideTemplate p sym arch rtp l a] ->
   LLVMContext arch ->
-  OverrideSim p sym (LLVM arch) rtp l a ()
+  OverrideSim p sym LLVM rtp l a ()
 register_llvm_define_overrides llvmModule addlOvrs llvmctx =
   let ?lc = llvmctx^.llvmTypeCtx in
   register_llvm_overrides_ llvmctx (addlOvrs ++ define_overrides) $
@@ -135,7 +135,7 @@ register_llvm_declare_overrides ::
   L.Module ->
   [OverrideTemplate p sym arch rtp l a] ->
   LLVMContext arch ->
-  OverrideSim p sym (LLVM arch) rtp l a ()
+  OverrideSim p sym LLVM rtp l a ()
 register_llvm_declare_overrides llvmModule addlOvrs llvmctx =
   let ?lc = llvmctx^.llvmTypeCtx
   in register_llvm_overrides_ llvmctx (addlOvrs ++ declare_overrides) $

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Common.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Common.hs
@@ -195,7 +195,7 @@ build_llvm_override sym fnm args ret args' ret' llvmOverride =
                applyValTransformer fret =<< llvmOverride =<< applyArgTransformer fargs xs
 
 polymorphic1_llvm_override :: forall p sym arch wptr l a rtp.
-  (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch) =>
+  (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr) =>
   String ->
   (forall w. (1 <= w) => NatRepr w -> SomeLLVMOverride p sym) ->
   OverrideTemplate p sym arch rtp l a
@@ -203,7 +203,7 @@ polymorphic1_llvm_override prefix fn =
   OverrideTemplate (PrefixMatch prefix) (register_1arg_polymorphic_override prefix fn)
 
 register_1arg_polymorphic_override :: forall p sym arch wptr l a rtp.
-  (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch) =>
+  (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr) =>
   String ->
   (forall w. (1 <= w) => NatRepr w -> SomeLLVMOverride p sym) ->
   RegOverrideM p sym arch rtp l a ()

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/LLVM.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/LLVM.hs
@@ -359,7 +359,7 @@ llvmObjectsizeOverride_64_null_dynamic =
   (\memOps sym args -> Ctx.uncurryAssignment (callObjectsize_null_dynamic sym memOps knownNat) args)
 
 llvmFshl ::
-  (1 <= w, IsSymInterface sym, HasPtrWidth wptr) =>
+  (1 <= w, IsSymInterface sym) =>
   NatRepr w ->
   LLVMOverride p sym
     (EmptyCtx ::> BVType w ::> BVType w ::> BVType w)
@@ -370,7 +370,7 @@ llvmFshl w =
  (\_memOps sym args -> Ctx.uncurryAssignment (callFshl sym w) args)
 
 llvmFshr ::
-  (1 <= w, IsSymInterface sym, HasPtrWidth wptr) =>
+  (1 <= w, IsSymInterface sym) =>
   NatRepr w ->
   LLVMOverride p sym
     (EmptyCtx ::> BVType w ::> BVType w ::> BVType w)
@@ -381,7 +381,7 @@ llvmFshr w =
  (\_memOps sym args -> Ctx.uncurryAssignment (callFshr sym w) args)
 
 llvmSaddWithOverflow
-  :: (1 <= w, IsSymInterface sym, HasPtrWidth wptr)
+  :: (1 <= w, IsSymInterface sym)
   => NatRepr w ->
      LLVMOverride p sym
          (EmptyCtx ::> BVType w ::> BVType w)
@@ -392,7 +392,7 @@ llvmSaddWithOverflow w =
   (\memOps sym args -> Ctx.uncurryAssignment (callSaddWithOverflow sym memOps) args)
 
 llvmUaddWithOverflow
-  :: (1 <= w, IsSymInterface sym, HasPtrWidth wptr)
+  :: (1 <= w, IsSymInterface sym)
   => NatRepr w ->
      LLVMOverride p sym
          (EmptyCtx ::> BVType w ::> BVType w)
@@ -404,7 +404,7 @@ llvmUaddWithOverflow w =
 
 
 llvmSsubWithOverflow
-  :: (1 <= w, IsSymInterface sym, HasPtrWidth wptr)
+  :: (1 <= w, IsSymInterface sym)
   => NatRepr w ->
      LLVMOverride p sym
          (EmptyCtx ::> BVType w ::> BVType w)
@@ -416,7 +416,7 @@ llvmSsubWithOverflow w =
 
 
 llvmUsubWithOverflow
-  :: (1 <= w, IsSymInterface sym, HasPtrWidth wptr)
+  :: (1 <= w, IsSymInterface sym)
   => NatRepr w ->
      LLVMOverride p sym
          (EmptyCtx ::> BVType w ::> BVType w)
@@ -427,7 +427,7 @@ llvmUsubWithOverflow w =
     (\memOps sym args -> Ctx.uncurryAssignment (callUsubWithOverflow sym memOps) args)
 
 llvmSmulWithOverflow
-  :: (1 <= w, IsSymInterface sym, HasPtrWidth wptr)
+  :: (1 <= w, IsSymInterface sym)
   => NatRepr w ->
      LLVMOverride p sym
          (EmptyCtx ::> BVType w ::> BVType w)
@@ -438,7 +438,7 @@ llvmSmulWithOverflow w =
     (\memOps sym args -> Ctx.uncurryAssignment (callSmulWithOverflow sym memOps) args)
 
 llvmUmulWithOverflow
-  :: (1 <= w, IsSymInterface sym, HasPtrWidth wptr)
+  :: (1 <= w, IsSymInterface sym)
   => NatRepr w ->
      LLVMOverride p sym
          (EmptyCtx ::> BVType w ::> BVType w)
@@ -449,7 +449,7 @@ llvmUmulWithOverflow w =
   (\memOps sym args -> Ctx.uncurryAssignment (callUmulWithOverflow sym memOps) args)
 
 llvmCtlz
-  :: (1 <= w, IsSymInterface sym, HasPtrWidth wptr)
+  :: (1 <= w, IsSymInterface sym)
   => NatRepr w ->
      LLVMOverride p sym
          (EmptyCtx ::> BVType w ::> BVType 1)
@@ -460,7 +460,7 @@ llvmCtlz w =
     (\memOps sym args -> Ctx.uncurryAssignment (callCtlz sym memOps) args)
 
 llvmCttz
-  :: (1 <= w, IsSymInterface sym, HasPtrWidth wptr)
+  :: (1 <= w, IsSymInterface sym)
   => NatRepr w
   -> LLVMOverride p sym
          (EmptyCtx ::> BVType w ::> BVType 1)
@@ -471,7 +471,7 @@ llvmCttz w =
     (\memOps sym args -> Ctx.uncurryAssignment (callCttz sym memOps) args)
 
 llvmCtpop
-  :: (1 <= w, IsSymInterface sym, HasPtrWidth wptr)
+  :: (1 <= w, IsSymInterface sym)
   => NatRepr w
   -> LLVMOverride p sym
          (EmptyCtx ::> BVType w)
@@ -482,7 +482,7 @@ llvmCtpop w =
     (\memOps sym args -> Ctx.uncurryAssignment (callCtpop sym memOps) args)
 
 llvmBitreverse
-  :: (1 <= w, IsSymInterface sym, HasPtrWidth wptr)
+  :: (1 <= w, IsSymInterface sym)
   => NatRepr w
   -> LLVMOverride p sym
          (EmptyCtx ::> BVType w)
@@ -494,8 +494,8 @@ llvmBitreverse w =
 
 -- | <https://llvm.org/docs/LangRef.html#llvm-bswap-intrinsics LLVM docs>
 llvmBSwapOverride
-  :: forall width sym wptr p
-   . ( 1 <= width, IsSymInterface sym, HasPtrWidth wptr)
+  :: forall width sym p
+   . ( 1 <= width, IsSymInterface sym)
   => NatRepr width
   -> LLVMOverride p sym
          (EmptyCtx ::> BVType (width * 8))
@@ -520,8 +520,8 @@ llvmBSwapOverride widthRepr =
 
 
 llvmFabsF32
-  :: forall sym wptr p
-   . ( IsSymInterface sym, HasPtrWidth wptr)
+  :: forall sym p
+   . ( IsSymInterface sym)
   => LLVMOverride p sym
         (EmptyCtx ::> FloatType SingleFloat)
         (FloatType SingleFloat)
@@ -531,8 +531,8 @@ llvmFabsF32 =
 
 
 llvmFabsF64
-  :: forall sym wptr p
-   . ( IsSymInterface sym, HasPtrWidth wptr)
+  :: forall sym p
+   . ( IsSymInterface sym)
   => LLVMOverride p sym
         (EmptyCtx ::> FloatType DoubleFloat)
         (FloatType DoubleFloat)

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/LLVM.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/LLVM.hs
@@ -50,7 +50,6 @@ import           Lang.Crucible.Simulator.SimError (SimErrorReason(AssertFailureS
 
 import           Lang.Crucible.LLVM.Bytes (Bytes(..))
 import           Lang.Crucible.LLVM.DataLayout (noAlignment)
-import           Lang.Crucible.LLVM.Extension (ArchWidth, LLVM)
 import           Lang.Crucible.LLVM.MemModel
 import           Lang.Crucible.LLVM.QQ( llvmOvr )
 
@@ -67,8 +66,8 @@ import qualified Lang.Crucible.LLVM.Intrinsics.Libc as Libc
 --
 -- <https://llvm.org/docs/LangRef.html#llvm-lifetime-start-intrinsic LLVM docs>
 llvmLifetimeStartOverride
-  :: (IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch (EmptyCtx ::> BVType 64 ::> LLVMPointerType wptr) UnitType
+  :: (IsSymInterface sym, HasPtrWidth wptr)
+  => LLVMOverride p sym (EmptyCtx ::> BVType 64 ::> LLVMPointerType wptr) UnitType
 llvmLifetimeStartOverride =
   [llvmOvr| void @llvm.lifetime.start( i64, i8* ) |]
   (\_ops _sym _args -> return ())
@@ -77,8 +76,8 @@ llvmLifetimeStartOverride =
 --
 -- <https://llvm.org/docs/LangRef.html#llvm-lifetime-end-intrinsic LLVM docs>
 llvmLifetimeEndOverride
-  :: (IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch (EmptyCtx ::> BVType 64 ::> LLVMPointerType wptr) UnitType
+  :: (IsSymInterface sym, HasPtrWidth wptr)
+  => LLVMOverride p sym (EmptyCtx ::> BVType 64 ::> LLVMPointerType wptr) UnitType
 llvmLifetimeEndOverride =
   [llvmOvr| void @llvm.lifetime.end( i64, i8* ) |]
   (\_ops _sym _args -> return ())
@@ -87,12 +86,12 @@ llvmLifetimeEndOverride =
 --
 -- The language reference doesn't mention the use of this intrinsic.
 llvmLifetimeOverrideOverload
-  :: forall width sym wptr arch p
+  :: forall width sym wptr p
    . ( 1 <= width, KnownNat width
-     , IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
+     , IsSymInterface sym, HasPtrWidth wptr)
   => String -- ^ "start" or "end"
   -> NatRepr width
-  -> LLVMOverride p sym arch
+  -> LLVMOverride p sym
         (EmptyCtx ::> BVType 64 ::> LLVMPointerType wptr)
         UnitType -- It appears in practice that this is always void
 llvmLifetimeOverrideOverload startOrEnd w =
@@ -107,9 +106,9 @@ llvmLifetimeOverrideOverload startOrEnd w =
 --
 -- <https://llvm.org/docs/LangRef.html#llvm-invariant-start-intrinsic LLVM docs>
 llvmInvariantStartOverride
-  :: (IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
+  :: (IsSymInterface sym, HasPtrWidth wptr)
   => NatRepr width
-  -> LLVMOverride p sym arch
+  -> LLVMOverride p sym
        (EmptyCtx ::> BVType 64 ::> LLVMPointerType wptr)
        (LLVMPointerType wptr)
 llvmInvariantStartOverride w =
@@ -119,9 +118,9 @@ llvmInvariantStartOverride w =
 
 -- | See comment on 'llvmInvariantStartOverride'.
 llvmInvariantEndOverride
-  :: (IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
+  :: (IsSymInterface sym, HasPtrWidth wptr)
   => NatRepr width
-  -> LLVMOverride p sym arch
+  -> LLVMOverride p sym
        (EmptyCtx ::> LLVMPointerType wptr ::> BVType 64 ::> LLVMPointerType wptr)
        UnitType
 llvmInvariantEndOverride w =
@@ -136,7 +135,7 @@ llvmInvariantEndOverride w =
 llvmExpectOverride
   :: (IsSymInterface sym, 1 <= width)
   => NatRepr width
-  -> LLVMOverride p sym arch
+  -> LLVMOverride p sym
        (EmptyCtx ::> BVType width ::> BVType width)
        (BVType width)
 llvmExpectOverride w =
@@ -151,7 +150,7 @@ llvmExpectOverride w =
 -- clang compiler bugs (or Crucible bugs) more than user code bugs.
 llvmAssumeOverride
   :: (IsSymInterface sym)
-  => LLVMOverride p sym arch (EmptyCtx ::> BVType 1) UnitType
+  => LLVMOverride p sym (EmptyCtx ::> BVType 1) UnitType
 llvmAssumeOverride =
    [llvmOvr| void @llvm.assume ( i1 ) |]
    (\_ops _sym _args -> return ())
@@ -160,29 +159,29 @@ llvmAssumeOverride =
 --   as an assertion failure, similar to calling @abort()@.
 llvmTrapOverride
   :: (IsSymInterface sym)
-  => LLVMOverride p sym arch EmptyCtx UnitType
+  => LLVMOverride p sym EmptyCtx UnitType
 llvmTrapOverride =
   [llvmOvr| void @llvm.trap() |]
   (\_ops sym _args -> liftIO $ addFailedAssertion sym $ AssertFailureSimError "llvm.trap() called" "")
 
 
 llvmStacksave
-  :: (IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch EmptyCtx (LLVMPointerType wptr)
+  :: (IsSymInterface sym, HasPtrWidth wptr)
+  => LLVMOverride p sym EmptyCtx (LLVMPointerType wptr)
 llvmStacksave =
   [llvmOvr| i8* @llvm.stacksave() |]
   (\_memOps sym _args -> liftIO (mkNullPointer sym PtrWidth))
 
 llvmStackrestore
-  :: (IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch (EmptyCtx ::> LLVMPointerType wptr) UnitType
+  :: (IsSymInterface sym, HasPtrWidth wptr)
+  => LLVMOverride p sym (EmptyCtx ::> LLVMPointerType wptr) UnitType
 llvmStackrestore =
   [llvmOvr| void @llvm.stackrestore( i8* ) |]
   (\_memOps _sym _args -> return ())
 
 llvmMemmoveOverride_8_8_32
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
+  => LLVMOverride p sym
          (EmptyCtx ::> LLVMPointerType wptr ::> LLVMPointerType wptr
                    ::> BVType 32 ::> BVType 32 ::> BVType 1)
          UnitType
@@ -191,8 +190,8 @@ llvmMemmoveOverride_8_8_32 =
   (\memOps sym args -> Ctx.uncurryAssignment (\dst src len _align v -> Libc.callMemmove sym memOps dst src len v) args)
 
 llvmMemmoveOverride_8_8_32_noalign
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
+  => LLVMOverride p sym
          (EmptyCtx ::> LLVMPointerType wptr ::> LLVMPointerType wptr
                    ::> BVType 32 ::> BVType 1)
          UnitType
@@ -202,8 +201,8 @@ llvmMemmoveOverride_8_8_32_noalign =
 
 
 llvmMemmoveOverride_8_8_64
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
+  => LLVMOverride p sym
          (EmptyCtx ::> LLVMPointerType wptr ::> LLVMPointerType wptr
                    ::> BVType 64 ::> BVType 32 ::> BVType 1)
          UnitType
@@ -213,8 +212,8 @@ llvmMemmoveOverride_8_8_64 =
 
 
 llvmMemmoveOverride_8_8_64_noalign
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
+  => LLVMOverride p sym
          (EmptyCtx ::> LLVMPointerType wptr ::> LLVMPointerType wptr
                    ::> BVType 64 ::> BVType 1)
          UnitType
@@ -223,8 +222,8 @@ llvmMemmoveOverride_8_8_64_noalign =
   (\memOps sym args -> Ctx.uncurryAssignment (Libc.callMemmove sym memOps) args)
 
 llvmMemsetOverride_8_64
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
+  => LLVMOverride p sym
          (EmptyCtx ::> LLVMPointerType wptr
                    ::> BVType  8
                    ::> BVType 64
@@ -236,8 +235,8 @@ llvmMemsetOverride_8_64 =
   (\memOps sym args -> Ctx.uncurryAssignment (\dst val len _align v -> Libc.callMemset sym memOps dst val len v) args)
 
 llvmMemsetOverride_8_64_noalign
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
+  => LLVMOverride p sym
          (EmptyCtx ::> LLVMPointerType wptr
                    ::> BVType  8
                    ::> BVType 64
@@ -249,8 +248,8 @@ llvmMemsetOverride_8_64_noalign =
 
 
 llvmMemsetOverride_8_32
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
+  => LLVMOverride p sym
          (EmptyCtx ::> LLVMPointerType wptr
                    ::> BVType  8
                    ::> BVType 32
@@ -262,8 +261,8 @@ llvmMemsetOverride_8_32 =
   (\memOps sym args -> Ctx.uncurryAssignment (\dst val len _align v -> Libc.callMemset sym memOps dst val len v) args)
 
 llvmMemsetOverride_8_32_noalign
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
+  => LLVMOverride p sym
          (EmptyCtx ::> LLVMPointerType wptr
                    ::> BVType  8
                    ::> BVType 32
@@ -275,8 +274,8 @@ llvmMemsetOverride_8_32_noalign =
 
 
 llvmMemcpyOverride_8_8_32
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
+  => LLVMOverride p sym
           (EmptyCtx ::> LLVMPointerType wptr ::> LLVMPointerType wptr
                     ::> BVType 32 ::> BVType 32 ::> BVType 1)
           UnitType
@@ -285,8 +284,8 @@ llvmMemcpyOverride_8_8_32 =
   (\memOps sym args -> Ctx.uncurryAssignment (\dst src len _align v -> Libc.callMemcpy sym memOps dst src len v) args)
 
 llvmMemcpyOverride_8_8_32_noalign
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
+  => LLVMOverride p sym
           (EmptyCtx ::> LLVMPointerType wptr ::> LLVMPointerType wptr
                     ::> BVType 32 ::> BVType 1)
           UnitType
@@ -296,8 +295,8 @@ llvmMemcpyOverride_8_8_32_noalign =
 
 
 llvmMemcpyOverride_8_8_64
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
+  => LLVMOverride p sym
          (EmptyCtx ::> LLVMPointerType wptr ::> LLVMPointerType wptr
                    ::> BVType 64 ::> BVType 32 ::> BVType 1)
          UnitType
@@ -307,8 +306,8 @@ llvmMemcpyOverride_8_8_64 =
 
 
 llvmMemcpyOverride_8_8_64_noalign
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
+  => LLVMOverride p sym
          (EmptyCtx ::> LLVMPointerType wptr ::> LLVMPointerType wptr
                    ::> BVType 64 ::> BVType 1)
          UnitType
@@ -318,51 +317,51 @@ llvmMemcpyOverride_8_8_64_noalign =
 
 
 llvmObjectsizeOverride_32
-  :: (IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch (EmptyCtx ::> LLVMPointerType wptr ::> BVType 1) (BVType 32)
+  :: (IsSymInterface sym, HasPtrWidth wptr)
+  => LLVMOverride p sym (EmptyCtx ::> LLVMPointerType wptr ::> BVType 1) (BVType 32)
 llvmObjectsizeOverride_32 =
   [llvmOvr| i32 @llvm.objectsize.i32.p0i8( i8*, i1 ) |]
   (\memOps sym args -> Ctx.uncurryAssignment (callObjectsize sym memOps knownNat) args)
 
 llvmObjectsizeOverride_32_null
-  :: (IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch (EmptyCtx ::> LLVMPointerType wptr ::> BVType 1 ::> BVType 1) (BVType 32)
+  :: (IsSymInterface sym, HasPtrWidth wptr)
+  => LLVMOverride p sym (EmptyCtx ::> LLVMPointerType wptr ::> BVType 1 ::> BVType 1) (BVType 32)
 llvmObjectsizeOverride_32_null =
   [llvmOvr| i32 @llvm.objectsize.i32.p0i8( i8*, i1, i1 ) |]
   (\memOps sym args -> Ctx.uncurryAssignment (callObjectsize_null sym memOps knownNat) args)
 
 llvmObjectsizeOverride_32_null_dynamic
-  :: (IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch (EmptyCtx ::> LLVMPointerType wptr ::> BVType 1 ::> BVType 1 ::> BVType 1) (BVType 32)
+  :: (IsSymInterface sym, HasPtrWidth wptr)
+  => LLVMOverride p sym (EmptyCtx ::> LLVMPointerType wptr ::> BVType 1 ::> BVType 1 ::> BVType 1) (BVType 32)
 llvmObjectsizeOverride_32_null_dynamic =
   [llvmOvr| i32 @llvm.objectsize.i32.p0i8( i8*, i1, i1, i1 ) |]
   (\memOps sym args -> Ctx.uncurryAssignment (callObjectsize_null_dynamic sym memOps knownNat) args)
 
 llvmObjectsizeOverride_64
-  :: (IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch (EmptyCtx ::> LLVMPointerType wptr ::> BVType 1) (BVType 64)
+  :: (IsSymInterface sym, HasPtrWidth wptr)
+  => LLVMOverride p sym (EmptyCtx ::> LLVMPointerType wptr ::> BVType 1) (BVType 64)
 llvmObjectsizeOverride_64 =
   [llvmOvr| i64 @llvm.objectsize.i64.p0i8( i8*, i1 ) |]
   (\memOps sym args -> Ctx.uncurryAssignment (callObjectsize sym memOps knownNat) args)
 
 llvmObjectsizeOverride_64_null
-  :: (IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch (EmptyCtx ::> LLVMPointerType wptr ::> BVType 1 ::> BVType 1) (BVType 64)
+  :: (IsSymInterface sym, HasPtrWidth wptr)
+  => LLVMOverride p sym (EmptyCtx ::> LLVMPointerType wptr ::> BVType 1 ::> BVType 1) (BVType 64)
 llvmObjectsizeOverride_64_null =
   [llvmOvr| i64 @llvm.objectsize.i64.p0i8( i8*, i1, i1 ) |]
   (\memOps sym args -> Ctx.uncurryAssignment (callObjectsize_null sym memOps knownNat) args)
 
 llvmObjectsizeOverride_64_null_dynamic
-  :: (IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch (EmptyCtx ::> LLVMPointerType wptr ::> BVType 1 ::> BVType 1 ::> BVType 1) (BVType 64)
+  :: (IsSymInterface sym, HasPtrWidth wptr)
+  => LLVMOverride p sym (EmptyCtx ::> LLVMPointerType wptr ::> BVType 1 ::> BVType 1 ::> BVType 1) (BVType 64)
 llvmObjectsizeOverride_64_null_dynamic =
   [llvmOvr| i64 @llvm.objectsize.i64.p0i8( i8*, i1, i1, i1 ) |]
   (\memOps sym args -> Ctx.uncurryAssignment (callObjectsize_null_dynamic sym memOps knownNat) args)
 
 llvmFshl ::
-  (1 <= w, IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch) =>
+  (1 <= w, IsSymInterface sym, HasPtrWidth wptr) =>
   NatRepr w ->
-  LLVMOverride p sym arch
+  LLVMOverride p sym
     (EmptyCtx ::> BVType w ::> BVType w ::> BVType w)
     (BVType w)
 llvmFshl w =
@@ -371,9 +370,9 @@ llvmFshl w =
  (\_memOps sym args -> Ctx.uncurryAssignment (callFshl sym w) args)
 
 llvmFshr ::
-  (1 <= w, IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch) =>
+  (1 <= w, IsSymInterface sym, HasPtrWidth wptr) =>
   NatRepr w ->
-  LLVMOverride p sym arch
+  LLVMOverride p sym
     (EmptyCtx ::> BVType w ::> BVType w ::> BVType w)
     (BVType w)
 llvmFshr w =
@@ -382,9 +381,9 @@ llvmFshr w =
  (\_memOps sym args -> Ctx.uncurryAssignment (callFshr sym w) args)
 
 llvmSaddWithOverflow
-  :: (1 <= w, IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
+  :: (1 <= w, IsSymInterface sym, HasPtrWidth wptr)
   => NatRepr w ->
-     LLVMOverride p sym arch
+     LLVMOverride p sym
          (EmptyCtx ::> BVType w ::> BVType w)
          (StructType (EmptyCtx ::> BVType w ::> BVType 1))
 llvmSaddWithOverflow w =
@@ -393,9 +392,9 @@ llvmSaddWithOverflow w =
   (\memOps sym args -> Ctx.uncurryAssignment (callSaddWithOverflow sym memOps) args)
 
 llvmUaddWithOverflow
-  :: (1 <= w, IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
+  :: (1 <= w, IsSymInterface sym, HasPtrWidth wptr)
   => NatRepr w ->
-     LLVMOverride p sym arch
+     LLVMOverride p sym
          (EmptyCtx ::> BVType w ::> BVType w)
          (StructType (EmptyCtx ::> BVType w ::> BVType 1))
 llvmUaddWithOverflow w =
@@ -405,9 +404,9 @@ llvmUaddWithOverflow w =
 
 
 llvmSsubWithOverflow
-  :: (1 <= w, IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
+  :: (1 <= w, IsSymInterface sym, HasPtrWidth wptr)
   => NatRepr w ->
-     LLVMOverride p sym arch
+     LLVMOverride p sym
          (EmptyCtx ::> BVType w ::> BVType w)
          (StructType (EmptyCtx ::> BVType w ::> BVType 1))
 llvmSsubWithOverflow w =
@@ -417,9 +416,9 @@ llvmSsubWithOverflow w =
 
 
 llvmUsubWithOverflow
-  :: (1 <= w, IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
+  :: (1 <= w, IsSymInterface sym, HasPtrWidth wptr)
   => NatRepr w ->
-     LLVMOverride p sym arch
+     LLVMOverride p sym
          (EmptyCtx ::> BVType w ::> BVType w)
          (StructType (EmptyCtx ::> BVType w ::> BVType 1))
 llvmUsubWithOverflow w =
@@ -428,9 +427,9 @@ llvmUsubWithOverflow w =
     (\memOps sym args -> Ctx.uncurryAssignment (callUsubWithOverflow sym memOps) args)
 
 llvmSmulWithOverflow
-  :: (1 <= w, IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
+  :: (1 <= w, IsSymInterface sym, HasPtrWidth wptr)
   => NatRepr w ->
-     LLVMOverride p sym arch
+     LLVMOverride p sym
          (EmptyCtx ::> BVType w ::> BVType w)
          (StructType (EmptyCtx ::> BVType w ::> BVType 1))
 llvmSmulWithOverflow w =
@@ -439,9 +438,9 @@ llvmSmulWithOverflow w =
     (\memOps sym args -> Ctx.uncurryAssignment (callSmulWithOverflow sym memOps) args)
 
 llvmUmulWithOverflow
-  :: (1 <= w, IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
+  :: (1 <= w, IsSymInterface sym, HasPtrWidth wptr)
   => NatRepr w ->
-     LLVMOverride p sym arch
+     LLVMOverride p sym
          (EmptyCtx ::> BVType w ::> BVType w)
          (StructType (EmptyCtx ::> BVType w ::> BVType 1))
 llvmUmulWithOverflow w =
@@ -450,9 +449,9 @@ llvmUmulWithOverflow w =
   (\memOps sym args -> Ctx.uncurryAssignment (callUmulWithOverflow sym memOps) args)
 
 llvmCtlz
-  :: (1 <= w, IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
+  :: (1 <= w, IsSymInterface sym, HasPtrWidth wptr)
   => NatRepr w ->
-     LLVMOverride p sym arch
+     LLVMOverride p sym
          (EmptyCtx ::> BVType w ::> BVType 1)
          (BVType w)
 llvmCtlz w =
@@ -461,9 +460,9 @@ llvmCtlz w =
     (\memOps sym args -> Ctx.uncurryAssignment (callCtlz sym memOps) args)
 
 llvmCttz
-  :: (1 <= w, IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
+  :: (1 <= w, IsSymInterface sym, HasPtrWidth wptr)
   => NatRepr w
-  -> LLVMOverride p sym arch
+  -> LLVMOverride p sym
          (EmptyCtx ::> BVType w ::> BVType 1)
          (BVType w)
 llvmCttz w =
@@ -472,9 +471,9 @@ llvmCttz w =
     (\memOps sym args -> Ctx.uncurryAssignment (callCttz sym memOps) args)
 
 llvmCtpop
-  :: (1 <= w, IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
+  :: (1 <= w, IsSymInterface sym, HasPtrWidth wptr)
   => NatRepr w
-  -> LLVMOverride p sym arch
+  -> LLVMOverride p sym
          (EmptyCtx ::> BVType w)
          (BVType w)
 llvmCtpop w =
@@ -483,9 +482,9 @@ llvmCtpop w =
     (\memOps sym args -> Ctx.uncurryAssignment (callCtpop sym memOps) args)
 
 llvmBitreverse
-  :: (1 <= w, IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
+  :: (1 <= w, IsSymInterface sym, HasPtrWidth wptr)
   => NatRepr w
-  -> LLVMOverride p sym arch
+  -> LLVMOverride p sym
          (EmptyCtx ::> BVType w)
          (BVType w)
 llvmBitreverse w =
@@ -495,10 +494,10 @@ llvmBitreverse w =
 
 -- | <https://llvm.org/docs/LangRef.html#llvm-bswap-intrinsics LLVM docs>
 llvmBSwapOverride
-  :: forall width sym wptr arch p
-   . ( 1 <= width, IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
+  :: forall width sym wptr p
+   . ( 1 <= width, IsSymInterface sym, HasPtrWidth wptr)
   => NatRepr width
-  -> LLVMOverride p sym arch
+  -> LLVMOverride p sym
          (EmptyCtx ::> BVType (width * 8))
          (BVType (width * 8))
 llvmBSwapOverride widthRepr =
@@ -521,9 +520,9 @@ llvmBSwapOverride widthRepr =
 
 
 llvmFabsF32
-  :: forall sym wptr arch p
-   . ( IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch
+  :: forall sym wptr p
+   . ( IsSymInterface sym, HasPtrWidth wptr)
+  => LLVMOverride p sym
         (EmptyCtx ::> FloatType SingleFloat)
         (FloatType SingleFloat)
 llvmFabsF32 =
@@ -532,9 +531,9 @@ llvmFabsF32 =
 
 
 llvmFabsF64
-  :: forall sym wptr arch p
-   . ( IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch
+  :: forall sym wptr p
+   . ( IsSymInterface sym, HasPtrWidth wptr)
+  => LLVMOverride p sym
         (EmptyCtx ::> FloatType DoubleFloat)
         (FloatType DoubleFloat)
 llvmFabsF64 =
@@ -544,8 +543,8 @@ llvmFabsF64 =
 
 llvmX86_pclmulqdq
 --declare <2 x i64> @llvm.x86.pclmulqdq(<2 x i64>, <2 x i64>, i8) #1
-  :: (IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch
+  :: (IsSymInterface sym, HasPtrWidth wptr)
+  => LLVMOverride p sym
          (EmptyCtx ::> VectorType (BVType 64)
                    ::> VectorType (BVType 64)
                    ::> BVType 8)
@@ -556,8 +555,8 @@ llvmX86_pclmulqdq =
 
 
 llvmX86_SSE2_storeu_dq
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
+  => LLVMOverride p sym
          (EmptyCtx ::> LLVMPointerType wptr
                    ::> VectorType (BVType 8))
          UnitType
@@ -568,14 +567,14 @@ llvmX86_SSE2_storeu_dq =
 ------------------------------------------------------------------------
 -- ** Implementations
 
-callX86_pclmulqdq :: forall p sym arch wptr r args ret.
-  (IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch) =>
+callX86_pclmulqdq :: forall p sym ext wptr r args ret.
+  (IsSymInterface sym, HasPtrWidth wptr) =>
   sym ->
   GlobalVar Mem ->
   RegEntry sym (VectorType (BVType 64)) ->
   RegEntry sym (VectorType (BVType 64)) ->
   RegEntry sym (BVType 8) ->
-  OverrideSim p sym (LLVM arch) r args ret (RegValue sym (VectorType (BVType 64)))
+  OverrideSim p sym ext r args ret (RegValue sym (VectorType (BVType 64)))
 callX86_pclmulqdq sym _mvar
   (regValue -> xs)
   (regValue -> ys)
@@ -607,12 +606,12 @@ callX86_pclmulqdq sym _mvar
        return $ V.fromList [ lo, hi ]
 
 callStoreudq
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
   => sym
   -> GlobalVar Mem
   -> RegEntry sym (LLVMPointerType wptr)
   -> RegEntry sym (VectorType (BVType 8))
-  -> OverrideSim p sym (LLVM arch) r args ret ()
+  -> OverrideSim p sym ext r args ret ()
 callStoreudq sym mvar
   (regValue -> dest)
   (regValue -> vec) =
@@ -658,7 +657,7 @@ callObjectsize
   -> NatRepr w
   -> RegEntry sym (LLVMPointerType wptr)
   -> RegEntry sym (BVType 1)
-  -> OverrideSim p sym (LLVM arch) r args ret (RegValue sym (BVType w))
+  -> OverrideSim p sym ext r args ret (RegValue sym (BVType w))
 callObjectsize sym _mvar w
   (regValue -> _ptr)
   (regValue -> flag) = liftIO $ do
@@ -679,7 +678,7 @@ callObjectsize_null
   -> RegEntry sym (LLVMPointerType wptr)
   -> RegEntry sym (BVType 1)
   -> RegEntry sym (BVType 1)
-  -> OverrideSim p sym (LLVM arch) r args ret (RegValue sym (BVType w))
+  -> OverrideSim p sym ext r args ret (RegValue sym (BVType w))
 callObjectsize_null sym mvar w ptr flag _nullUnknown = callObjectsize sym mvar w ptr flag
 
 callObjectsize_null_dynamic
@@ -691,7 +690,7 @@ callObjectsize_null_dynamic
   -> RegEntry sym (BVType 1)
   -> RegEntry sym (BVType 1)
   -> RegEntry sym (BVType 1)
-  -> OverrideSim p sym (LLVM arch) r args ret (RegValue sym (BVType w))
+  -> OverrideSim p sym ext r args ret (RegValue sym (BVType w))
 callObjectsize_null_dynamic sym mvar w ptr flag _nullUnknown (regValue -> dynamic) =
   do liftIO $
        do notDynamic <- notPred sym =<< bvIsNonzero sym dynamic
@@ -704,7 +703,7 @@ callCtlz
   -> GlobalVar Mem
   -> RegEntry sym (BVType w)
   -> RegEntry sym (BVType 1)
-  -> OverrideSim p sym (LLVM arch) r args ret (RegValue sym (BVType w))
+  -> OverrideSim p sym ext r args ret (RegValue sym (BVType w))
 callCtlz sym _mvar
   (regValue -> val)
   (regValue -> isZeroUndef) = liftIO $
@@ -721,7 +720,7 @@ callFshl
   -> RegEntry sym (BVType w)
   -> RegEntry sym (BVType w)
   -> RegEntry sym (BVType w)
-  -> OverrideSim p sym (LLVM arch) r args ret (RegValue sym (BVType w))
+  -> OverrideSim p sym ext r args ret (RegValue sym (BVType w))
 callFshl sym w x y amt = liftIO $
   do LeqProof <- return (dblPosIsPos (leqProof (knownNat @1) w))
      Just LeqProof <- return (testLeq (addNat w (knownNat @1)) (addNat w w))
@@ -745,7 +744,7 @@ callFshr
   -> RegEntry sym (BVType w)
   -> RegEntry sym (BVType w)
   -> RegEntry sym (BVType w)
-  -> OverrideSim p sym (LLVM arch) r args ret (RegValue sym (BVType w))
+  -> OverrideSim p sym ext r args ret (RegValue sym (BVType w))
 callFshr sym w x y amt = liftIO $
   do LeqProof <- return (dblPosIsPos (leqProof (knownNat @1) w))
      LeqProof <- return (addPrefixIsLeq w w)
@@ -769,7 +768,7 @@ callSaddWithOverflow
   -> GlobalVar Mem
   -> RegEntry sym (BVType w)
   -> RegEntry sym (BVType w)
-  -> OverrideSim p sym (LLVM arch) r args ret (RegValue sym (StructType (EmptyCtx ::> BVType w ::> BVType 1)))
+  -> OverrideSim p sym ext r args ret (RegValue sym (StructType (EmptyCtx ::> BVType w ::> BVType 1)))
 callSaddWithOverflow sym _mvar
   (regValue -> x)
   (regValue -> y) = liftIO $
@@ -783,7 +782,7 @@ callUaddWithOverflow
   -> GlobalVar Mem
   -> RegEntry sym (BVType w)
   -> RegEntry sym (BVType w)
-  -> OverrideSim p sym (LLVM arch) r args ret (RegValue sym (StructType (EmptyCtx ::> BVType w ::> BVType 1)))
+  -> OverrideSim p sym ext r args ret (RegValue sym (StructType (EmptyCtx ::> BVType w ::> BVType 1)))
 callUaddWithOverflow sym _mvar
   (regValue -> x)
   (regValue -> y) = liftIO $
@@ -797,7 +796,7 @@ callUsubWithOverflow
   -> GlobalVar Mem
   -> RegEntry sym (BVType w)
   -> RegEntry sym (BVType w)
-  -> OverrideSim p sym (LLVM arch) r args ret (RegValue sym (StructType (EmptyCtx ::> BVType w ::> BVType 1)))
+  -> OverrideSim p sym ext r args ret (RegValue sym (StructType (EmptyCtx ::> BVType w ::> BVType 1)))
 callUsubWithOverflow sym _mvar
   (regValue -> x)
   (regValue -> y) = liftIO $
@@ -811,7 +810,7 @@ callSsubWithOverflow
   -> GlobalVar Mem
   -> RegEntry sym (BVType w)
   -> RegEntry sym (BVType w)
-  -> OverrideSim p sym (LLVM arch) r args ret (RegValue sym (StructType (EmptyCtx ::> BVType w ::> BVType 1)))
+  -> OverrideSim p sym ext r args ret (RegValue sym (StructType (EmptyCtx ::> BVType w ::> BVType 1)))
 callSsubWithOverflow sym _mvar
   (regValue -> x)
   (regValue -> y) = liftIO $
@@ -825,7 +824,7 @@ callSmulWithOverflow
   -> GlobalVar Mem
   -> RegEntry sym (BVType w)
   -> RegEntry sym (BVType w)
-  -> OverrideSim p sym (LLVM arch) r args ret (RegValue sym (StructType (EmptyCtx ::> BVType w ::> BVType 1)))
+  -> OverrideSim p sym ext r args ret (RegValue sym (StructType (EmptyCtx ::> BVType w ::> BVType 1)))
 callSmulWithOverflow sym _mvar
   (regValue -> x)
   (regValue -> y) = liftIO $
@@ -839,7 +838,7 @@ callUmulWithOverflow
   -> GlobalVar Mem
   -> RegEntry sym (BVType w)
   -> RegEntry sym (BVType w)
-  -> OverrideSim p sym (LLVM arch) r args ret (RegValue sym (StructType (EmptyCtx ::> BVType w ::> BVType 1)))
+  -> OverrideSim p sym ext r args ret (RegValue sym (StructType (EmptyCtx ::> BVType w ::> BVType 1)))
 callUmulWithOverflow sym _mvar
   (regValue -> x)
   (regValue -> y) = liftIO $
@@ -854,7 +853,7 @@ callCttz
   -> GlobalVar Mem
   -> RegEntry sym (BVType w)
   -> RegEntry sym (BVType 1)
-  -> OverrideSim p sym (LLVM arch) r args ret (RegValue sym (BVType w))
+  -> OverrideSim p sym ext r args ret (RegValue sym (BVType w))
 callCttz sym _mvar
   (regValue -> val)
   (regValue -> isZeroUndef) = liftIO $
@@ -869,7 +868,7 @@ callCtpop
   => sym
   -> GlobalVar Mem
   -> RegEntry sym (BVType w)
-  -> OverrideSim p sym (LLVM arch) r args ret (RegValue sym (BVType w))
+  -> OverrideSim p sym ext r args ret (RegValue sym (BVType w))
 callCtpop sym _mvar
   (regValue -> val) = liftIO $ bvPopcount sym val
 
@@ -878,6 +877,6 @@ callBitreverse
   => sym
   -> GlobalVar Mem
   -> RegEntry sym (BVType w)
-  -> OverrideSim p sym (LLVM arch) r args ret (RegValue sym (BVType w))
+  -> OverrideSim p sym ext r args ret (RegValue sym (BVType w))
 callBitreverse sym _mvar
   (regValue -> val) = liftIO $ bvBitreverse sym val

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libc.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libc.hs
@@ -434,7 +434,7 @@ callMemset sym mvar
 -- *** Strings and I/O
 
 callPutChar
-  :: (IsSymInterface sym, HasPtrWidth wptr)
+  :: (IsSymInterface sym)
   => sym
   -> GlobalVar Mem
   -> RegEntry sym (BVType 32)
@@ -661,7 +661,7 @@ llvmAssertFailOverride =
 
 
 llvmAbortOverride
-  :: (IsSymInterface sym, HasPtrWidth wptr)
+  :: (IsSymInterface sym)
   => LLVMOverride p sym EmptyCtx UnitType
 llvmAbortOverride =
   [llvmOvr| void @abort() |]

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libc.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libc.hs
@@ -51,7 +51,6 @@ import           Lang.Crucible.Simulator.SimError
 
 import           Lang.Crucible.LLVM.Bytes
 import           Lang.Crucible.LLVM.DataLayout
-import           Lang.Crucible.LLVM.Extension
 import           Lang.Crucible.LLVM.MemModel
 import qualified Lang.Crucible.LLVM.MemModel.Type as G
 import qualified Lang.Crucible.LLVM.MemModel.Generic as G
@@ -66,8 +65,8 @@ import           Lang.Crucible.LLVM.Intrinsics.Common
 
 
 llvmMemcpyOverride
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
+  => LLVMOverride p sym
            (EmptyCtx ::> LLVMPointerType wptr
                      ::> LLVMPointerType wptr
                      ::> BVType wptr)
@@ -83,8 +82,8 @@ llvmMemcpyOverride =
 
 
 llvmMemcpyChkOverride
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
+  => LLVMOverride p sym
          (EmptyCtx ::> LLVMPointerType wptr
                    ::> LLVMPointerType wptr
                    ::> BVType wptr
@@ -101,8 +100,8 @@ llvmMemcpyChkOverride =
     )
 
 llvmMemmoveOverride
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
+  => LLVMOverride p sym
          (EmptyCtx ::> (LLVMPointerType wptr)
                    ::> (LLVMPointerType wptr)
                    ::> BVType wptr)
@@ -116,9 +115,9 @@ llvmMemmoveOverride =
          return $ regValue $ args^._1 -- return first argument
     )
 
-llvmMemsetOverride :: forall p sym arch wptr.
-     (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch
+llvmMemsetOverride :: forall p sym wptr.
+     (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
+  => LLVMOverride p sym
          (EmptyCtx ::> LLVMPointerType wptr
                    ::> BVType 32
                    ::> BVType wptr)
@@ -137,8 +136,8 @@ llvmMemsetOverride =
     )
 
 llvmMemsetChkOverride
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
+  => LLVMOverride p sym
          (EmptyCtx ::> LLVMPointerType wptr
                  ::> BVType 32
                  ::> BVType wptr
@@ -161,8 +160,8 @@ llvmMemsetChkOverride =
 -- *** Allocation
 
 llvmCallocOverride
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch, ?lc :: TypeContext)
-  => LLVMOverride p sym arch
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, ?lc :: TypeContext)
+  => LLVMOverride p sym
          (EmptyCtx ::> BVType wptr ::> BVType wptr)
          (LLVMPointerType wptr)
 llvmCallocOverride =
@@ -172,8 +171,8 @@ llvmCallocOverride =
 
 
 llvmReallocOverride
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch, ?lc :: TypeContext)
-  => LLVMOverride p sym arch
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, ?lc :: TypeContext)
+  => LLVMOverride p sym
          (EmptyCtx ::> LLVMPointerType wptr ::> BVType wptr)
          (LLVMPointerType wptr)
 llvmReallocOverride =
@@ -182,8 +181,8 @@ llvmReallocOverride =
   (\memOps sym args -> Ctx.uncurryAssignment (callRealloc sym memOps alignment) args)
 
 llvmMallocOverride
-  :: (IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch, ?lc :: TypeContext)
-  => LLVMOverride p sym arch
+  :: (IsSymInterface sym, HasPtrWidth wptr, ?lc :: TypeContext)
+  => LLVMOverride p sym
          (EmptyCtx ::> BVType wptr)
          (LLVMPointerType wptr)
 llvmMallocOverride =
@@ -192,8 +191,8 @@ llvmMallocOverride =
   (\memOps sym args -> Ctx.uncurryAssignment (callMalloc sym memOps alignment) args)
 
 posixMemalignOverride ::
-  (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch, ?lc :: TypeContext) =>
-  LLVMOverride p sym arch
+  (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, ?lc :: TypeContext) =>
+  LLVMOverride p sym
       (EmptyCtx ::> LLVMPointerType wptr
                 ::> BVType wptr
                 ::> BVType wptr)
@@ -204,8 +203,8 @@ posixMemalignOverride =
 
 
 llvmFreeOverride
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
+  => LLVMOverride p sym
          (EmptyCtx ::> LLVMPointerType wptr)
          UnitType
 llvmFreeOverride =
@@ -216,8 +215,8 @@ llvmFreeOverride =
 -- *** Strings and I/O
 
 llvmPrintfOverride
-  :: (IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch
+  :: (IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym)
+  => LLVMOverride p sym
          (EmptyCtx ::> LLVMPointerType wptr
                    ::> VectorType AnyType)
          (BVType 32)
@@ -226,8 +225,8 @@ llvmPrintfOverride =
   (\memOps sym args -> Ctx.uncurryAssignment (callPrintf sym memOps) args)
 
 llvmPrintfChkOverride
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
+  => LLVMOverride p sym
          (EmptyCtx ::> BVType 32
                    ::> LLVMPointerType wptr
                    ::> VectorType AnyType)
@@ -238,23 +237,23 @@ llvmPrintfChkOverride =
 
 
 llvmPutCharOverride
-  :: (IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch (EmptyCtx ::> BVType 32) (BVType 32)
+  :: (IsSymInterface sym, HasPtrWidth wptr)
+  => LLVMOverride p sym (EmptyCtx ::> BVType 32) (BVType 32)
 llvmPutCharOverride =
   [llvmOvr| i32 @putchar( i32 ) |]
   (\memOps sym args -> Ctx.uncurryAssignment (callPutChar sym memOps) args)
 
 
 llvmPutsOverride
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch (EmptyCtx ::> LLVMPointerType wptr) (BVType 32)
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
+  => LLVMOverride p sym (EmptyCtx ::> LLVMPointerType wptr) (BVType 32)
 llvmPutsOverride =
   [llvmOvr| i32 @puts( i8* ) |]
   (\memOps sym args -> Ctx.uncurryAssignment (callPuts sym memOps) args)
 
 llvmStrlenOverride
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch (EmptyCtx ::> LLVMPointerType wptr) (BVType wptr)
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
+  => LLVMOverride p sym (EmptyCtx ::> LLVMPointerType wptr) (BVType wptr)
 llvmStrlenOverride =
   [llvmOvr| size_t @strlen( i8* ) |]
   (\memOps sym args -> Ctx.uncurryAssignment (callStrlen sym memOps) args)
@@ -266,13 +265,13 @@ llvmStrlenOverride =
 -- *** Allocation
 
 callRealloc
-  :: (IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch, HasLLVMAnn sym)
+  :: (IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym)
   => sym
   -> GlobalVar Mem
   -> Alignment
   -> RegEntry sym (LLVMPointerType wptr)
   -> RegEntry sym (BVType wptr)
-  -> OverrideSim p sym (LLVM arch) r args ret (RegValue sym (LLVMPointerType wptr))
+  -> OverrideSim p sym ext r args ret (RegValue sym (LLVMPointerType wptr))
 callRealloc sym mvar alignment (regValue -> ptr) (regValue -> sz) =
   do szZero  <- liftIO (notPred sym =<< bvIsNonzero sym sz)
      ptrNull <- liftIO (ptrIsNull sym PtrWidth ptr)
@@ -307,13 +306,13 @@ callRealloc sym mvar alignment (regValue -> ptr) (regValue -> sz) =
 
 
 callPosixMemalign
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch, ?lc :: TypeContext)
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, ?lc :: TypeContext)
   => sym
   -> GlobalVar Mem
   -> RegEntry sym (LLVMPointerType wptr)
   -> RegEntry sym (BVType wptr)
   -> RegEntry sym (BVType wptr)
-  -> OverrideSim p sym (LLVM arch) r args ret (RegValue sym (BVType 32))
+  -> OverrideSim p sym ext r args ret (RegValue sym (BVType 32))
 callPosixMemalign sym mvar (regValue -> outPtr) (regValue -> align) (regValue -> sz) =
   case asBV align of
     Nothing -> fail $ unwords ["posix_memalign: alignment value must be concrete:", show (printSymExpr align)]
@@ -331,12 +330,12 @@ callPosixMemalign sym mvar (regValue -> outPtr) (regValue -> align) (regValue ->
                 return (z, mem'')
 
 callMalloc
-  :: (IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
+  :: (IsSymInterface sym, HasPtrWidth wptr)
   => sym
   -> GlobalVar Mem
   -> Alignment
   -> RegEntry sym (BVType wptr)
-  -> OverrideSim p sym (LLVM arch) r args ret (RegValue sym (LLVMPointerType wptr))
+  -> OverrideSim p sym ext r args ret (RegValue sym (LLVMPointerType wptr))
 callMalloc sym mvar alignment (regValue -> sz) =
   modifyGlobal mvar $ \mem -> liftIO $
     do loc <- plSourceLoc <$> getCurrentProgramLoc sym
@@ -344,13 +343,13 @@ callMalloc sym mvar alignment (regValue -> sz) =
        doMalloc sym G.HeapAlloc G.Mutable displayString mem sz alignment
 
 callCalloc
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
   => sym
   -> GlobalVar Mem
   -> Alignment
   -> RegEntry sym (BVType wptr)
   -> RegEntry sym (BVType wptr)
-  -> OverrideSim p sym (LLVM arch) r args ret (RegValue sym (LLVMPointerType wptr))
+  -> OverrideSim p sym ext r args ret (RegValue sym (LLVMPointerType wptr))
 callCalloc sym mvar alignment
            (regValue -> sz)
            (regValue -> num) =
@@ -358,11 +357,11 @@ callCalloc sym mvar alignment
     doCalloc sym mem sz num alignment
 
 callFree
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
   => sym
   -> GlobalVar Mem
   -> RegEntry sym (LLVMPointerType wptr)
-  -> OverrideSim p sym (LLVM arch) r args ret ()
+  -> OverrideSim p sym ext r args ret ()
 callFree sym mvar
            (regValue -> ptr) =
   modifyGlobal mvar $ \mem -> liftIO $
@@ -373,14 +372,14 @@ callFree sym mvar
 -- *** Memory manipulation
 
 callMemcpy
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
   => sym
   -> GlobalVar Mem
   -> RegEntry sym (LLVMPointerType wptr)
   -> RegEntry sym (LLVMPointerType wptr)
   -> RegEntry sym (BVType w)
   -> RegEntry sym (BVType 1)
-  -> OverrideSim p sym (LLVM arch) r args ret ()
+  -> OverrideSim p sym ext r args ret ()
 callMemcpy sym mvar
            (regValue -> dest)
            (regValue -> src)
@@ -395,14 +394,14 @@ callMemcpy sym mvar
 -- ranges are disjoint.  The underlying operation
 -- works correctly in both cases.
 callMemmove
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
   => sym
   -> GlobalVar Mem
   -> RegEntry sym (LLVMPointerType wptr)
   -> RegEntry sym (LLVMPointerType wptr)
   -> RegEntry sym (BVType w)
   -> RegEntry sym (BVType 1)
-  -> OverrideSim p sym (LLVM arch) r args ret ()
+  -> OverrideSim p sym ext r args ret ()
 callMemmove sym mvar
            (regValue -> dest)
            (regValue -> src)
@@ -414,14 +413,14 @@ callMemmove sym mvar
        return ((), mem')
 
 callMemset
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
   => sym
   -> GlobalVar Mem
   -> RegEntry sym (LLVMPointerType wptr)
   -> RegEntry sym (BVType 8)
   -> RegEntry sym (BVType w)
   -> RegEntry sym (BVType 1)
-  -> OverrideSim p sym (LLVM arch) r args ret ()
+  -> OverrideSim p sym ext r args ret ()
 callMemset sym mvar
            (regValue -> dest)
            (regValue -> val)
@@ -439,7 +438,7 @@ callPutChar
   => sym
   -> GlobalVar Mem
   -> RegEntry sym (BVType 32)
-  -> OverrideSim p sym (LLVM arch) r args ret (RegValue sym (BVType 32))
+  -> OverrideSim p sym ext r args ret (RegValue sym (BVType 32))
 callPutChar _sym _mvar
  (regValue -> ch) = do
     h <- printHandle <$> getContext
@@ -452,7 +451,7 @@ callPuts
   => sym
   -> GlobalVar Mem
   -> RegEntry sym (LLVMPointerType wptr)
-  -> OverrideSim p sym (LLVM arch) r args ret (RegValue sym (BVType 32))
+  -> OverrideSim p sym ext r args ret (RegValue sym (BVType 32))
 callPuts sym mvar
   (regValue -> strPtr) = do
     mem <- readGlobal mvar
@@ -467,7 +466,7 @@ callStrlen
   => sym
   -> GlobalVar Mem
   -> RegEntry sym (LLVMPointerType wptr)
-  -> OverrideSim p sym (LLVM arch) r args ret (RegValue sym (BVType wptr))
+  -> OverrideSim p sym ext r args ret (RegValue sym (BVType wptr))
 callStrlen sym mvar (regValue -> strPtr) = do
   mem <- readGlobal mvar
   liftIO $ strLen sym mem strPtr
@@ -481,7 +480,7 @@ callAssert
                   ::> LLVMPointerType wptr
                   ::> BVType 32
                   ::> LLVMPointerType wptr)
-  -> OverrideSim p sym (LLVM arch) r args reg (RegValue sym UnitType)
+  -> OverrideSim p sym ext r args reg (RegValue sym UnitType)
 callAssert mvar sym (Empty :> _pfn :> _pfile :> _pline :> ptxt ) =
      do mem <- readGlobal mvar
         txt <- liftIO $ loadString sym mem (regValue ptxt) Nothing
@@ -494,7 +493,7 @@ callPrintf
   -> GlobalVar Mem
   -> RegEntry sym (LLVMPointerType wptr)
   -> RegEntry sym (VectorType AnyType)
-  -> OverrideSim p sym (LLVM arch) r args ret (RegValue sym (BVType 32))
+  -> OverrideSim p sym ext r args ret (RegValue sym (BVType 32))
 callPrintf sym mvar
   (regValue -> strPtr)
   (regValue -> valist) = do
@@ -636,8 +635,8 @@ printfOps sym valist =
 
 -- from OSX libc
 llvmAssertRtnOverride
-  :: (IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch
+  :: (IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym)
+  => LLVMOverride p sym
         (EmptyCtx ::> LLVMPointerType wptr
                   ::> LLVMPointerType wptr
                   ::> BVType 32
@@ -649,8 +648,8 @@ llvmAssertRtnOverride =
 
 -- From glibc
 llvmAssertFailOverride
-  :: (IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch
+  :: (IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym)
+  => LLVMOverride p sym
         (EmptyCtx ::> LLVMPointerType wptr
                   ::> LLVMPointerType wptr
                   ::> BVType 32
@@ -662,8 +661,8 @@ llvmAssertFailOverride =
 
 
 llvmAbortOverride
-  :: (IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch EmptyCtx UnitType
+  :: (IsSymInterface sym, HasPtrWidth wptr)
+  => LLVMOverride p sym EmptyCtx UnitType
 llvmAbortOverride =
   [llvmOvr| void @abort() |]
   (\_ sym _args ->
@@ -672,8 +671,8 @@ llvmAbortOverride =
   )
 
 llvmGetenvOverride
-  :: (IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch
+  :: (IsSymInterface sym, HasPtrWidth wptr)
+  => LLVMOverride p sym
         (EmptyCtx ::> LLVMPointerType wptr)
         (LLVMPointerType wptr)
 llvmGetenvOverride =
@@ -684,8 +683,8 @@ llvmGetenvOverride =
 -- atexit stuff
 
 cxa_atexitOverride
-  :: (IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => LLVMOverride p sym arch
+  :: (IsSymInterface sym, HasPtrWidth wptr)
+  => LLVMOverride p sym
         (EmptyCtx ::> LLVMPointerType wptr ::> LLVMPointerType wptr ::> LLVMPointerType wptr)
         (BVType 32)
 cxa_atexitOverride =

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libcxx.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libcxx.hs
@@ -124,7 +124,7 @@ panic_ from decl args ret =
 
 -- | If the requested declaration's symbol matches the filter, look up its
 -- function handle in the symbol table and use that to construct an override
-mkOverride :: (IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
+mkOverride :: (IsSymInterface sym, HasPtrWidth (ArchWidth arch))
            => [String] -- ^ Substrings for name filtering
            -> (forall args ret. L.Declare -> CtxRepr args -> TypeRepr ret -> Maybe (SomeLLVMOverride p sym))
            -> (L.Symbol -> ABI.DecodedName -> Bool)

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libcxx.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libcxx.hs
@@ -89,7 +89,7 @@ register_cpp_override someCPPOverride =
 data SomeCPPOverride p sym arch =
   SomeCPPOverride
   { cppOverrideSubstrings :: [String]
-  , cppOverrideAction :: L.Declare -> ABI.DecodedName -> LLVMContext arch -> Maybe (SomeLLVMOverride p sym arch)
+  , cppOverrideAction :: L.Declare -> ABI.DecodedName -> LLVMContext arch -> Maybe (SomeLLVMOverride p sym)
   }
 
 ------------------------------------------------------------------------
@@ -126,7 +126,7 @@ panic_ from decl args ret =
 -- function handle in the symbol table and use that to construct an override
 mkOverride :: (IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
            => [String] -- ^ Substrings for name filtering
-           -> (forall args ret. L.Declare -> CtxRepr args -> TypeRepr ret -> Maybe (SomeLLVMOverride p sym arch))
+           -> (forall args ret. L.Declare -> CtxRepr args -> TypeRepr ret -> Maybe (SomeLLVMOverride p sym))
            -> (L.Symbol -> ABI.DecodedName -> Bool)
            -> SomeCPPOverride p sym arch
 mkOverride substrings ov filt =

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libcxx.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libcxx.hs
@@ -66,7 +66,7 @@ import           Lang.Crucible.LLVM.Translation.Types
 -- | C++ overrides generally have a bit more work to do: their types are more
 -- complex, their names are mangled in the LLVM module, it's a big mess.
 register_cpp_override ::
-  (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch) =>
+  (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr) =>
   SomeCPPOverride p sym arch ->
   OverrideTemplate p sym arch rtp l a
 register_cpp_override someCPPOverride =

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
@@ -347,12 +347,11 @@ instance IsSymInterface sym => IntrinsicClass sym "LLVM_memory" where
 -- | Top-level evaluation function for LLVM extension statements.
 --   LLVM extension statements are used to implement the memory model operations.
 llvmStatementExec ::
-  (HasPtrWidth (ArchWidth arch), Partial.HasLLVMAnn sym, ?memOpts :: MemOptions) =>
-  ArchRepr arch ->
+  (Partial.HasLLVMAnn sym, ?memOpts :: MemOptions) =>
   EvalStmtFunc p sym LLVM
-llvmStatementExec arch stmt cst =
+llvmStatementExec stmt cst =
   let sym = cst^.stateSymInterface
-   in stateSolverProof cst (runStateT (evalStmt sym arch stmt) cst)
+   in stateSolverProof cst (runStateT (evalStmt sym stmt) cst)
 
 type EvalM p sym ext rtp blocks ret args a =
   StateT (CrucibleState p sym ext rtp blocks ret args) IO a
@@ -361,13 +360,12 @@ type EvalM p sym ext rtp blocks ret args a =
 --   The semantics are explicitly organized as a state transformer monad
 --   that modifies the global state of the simulator; this captures the
 --   memory accessing effects of these statements.
-evalStmt :: forall p sym ext arch rtp blocks ret args tp.
+evalStmt :: forall p sym ext rtp blocks ret args tp.
   (IsSymInterface sym, Partial.HasLLVMAnn sym, HasCallStack, ?memOpts :: MemOptions) =>
   sym ->
-  ArchRepr arch ->
   LLVMStmt (RegEntry sym) tp ->
   EvalM p sym ext rtp blocks ret args (RegValue sym tp)
-evalStmt sym _arch = eval
+evalStmt sym = eval
  where
   getMem :: GlobalVar Mem ->
             EvalM p sym ext rtp blocks ret args (MemImpl sym)

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
@@ -528,7 +528,7 @@ mkMemVar halloc = freshGlobalVar halloc "llvm_memory" knownRepr
 -- | For now, the core message should be on the first line, with details
 -- on further lines. Later we should make it more structured.
 ptrMessage ::
-  (IsSymInterface sym, HasPtrWidth wptr) =>
+  (IsSymInterface sym) =>
   String ->
   LLVMPtr sym wptr {- ^ pointer involved in message -} ->
   StorageType      {- ^ type of value pointed to    -} ->
@@ -687,7 +687,7 @@ bindLLVMFunPtr sym dec h mem
        doInstallHandle sym ptr (SomeFnHandle h) mem
 
 doInstallHandle
-  :: (Typeable a, IsSymInterface sym, HasPtrWidth wptr)
+  :: (Typeable a, IsSymInterface sym)
   => sym
   -> LLVMPtr sym wptr
   -> a {- ^ handle -}
@@ -725,7 +725,7 @@ doMallocHandle sym allocType loc mem x = do
 
 -- | Look up the handle associated with the given pointer, if any.
 doLookupHandle
-  :: (Typeable a, IsSymInterface sym, HasPtrWidth wptr)
+  :: (Typeable a, IsSymInterface sym)
   => sym
   -> MemImpl sym
   -> LLVMPtr sym wptr
@@ -1164,7 +1164,7 @@ storeRaw sym mem ptr valType alignment val = do
 --
 -- Asserts that the write operation is valid when cond is true.
 doConditionalWriteOperation
-  :: (IsSymInterface sym, HasPtrWidth wptr)
+  :: (IsSymInterface sym)
   => sym
   -> MemImpl sym
   -> Pred sym {- ^ write condition -}
@@ -1180,7 +1180,7 @@ doConditionalWriteOperation sym mem cond write_op =
 -- Asserts that the true branch write operation is valid when cond is true, and
 -- that the false branch write operation is valid when cond is not true.
 mergeWriteOperations
-  :: (IsSymInterface sym, HasPtrWidth wptr)
+  :: (IsSymInterface sym)
   => sym
   -> MemImpl sym
   -> Pred sym {- ^ merge condition -}

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Generic.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Generic.hs
@@ -1132,7 +1132,7 @@ isAligned sym _ _ _ =
 -- blocks.
 notAliasable ::
   forall sym w .
-  (1 <= w, IsSymInterface sym) =>
+  (IsSymInterface sym) =>
   sym ->
   LLVMPtr sym w ->
   LLVMPtr sym w ->

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Pointer.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Pointer.hs
@@ -301,7 +301,7 @@ ppPtr (llvmPointerView -> (blk, bv))
 -- and matches the address of the global on the nose. It is used in SAWscript
 -- for friendly error messages.
 isGlobalPointer ::
-  forall sym w. (IsSymInterface sym, 1 <= w) =>
+  forall sym w. (IsSymInterface sym) =>
   Map Natural L.Symbol {- ^ c.f. 'memImplSymbolMap' -} ->
   LLVMPtr sym w -> Maybe L.Symbol
 isGlobalPointer symbolMap needle =

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Run.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Run.hs
@@ -18,7 +18,7 @@ module Lang.Crucible.LLVM.Run
   , findCFG
   ) where
 
-import Control.Lens ( (^.), to )
+import Control.Lens ( (^.) )
 import System.IO(Handle)
 import Data.String(fromString)
 import qualified Data.Map as Map
@@ -44,7 +44,7 @@ import Lang.Crucible.LLVM.Intrinsics
         (llvmIntrinsicTypes, LLVM)
 import Lang.Crucible.LLVM(llvmExtensionImpl, llvmGlobals)
 import Lang.Crucible.LLVM.Translation
-        (globalInitMap,transContext,translateModule,ModuleTranslation,cfgMap,llvmArch,llvmPtrWidth,llvmTypeCtx)
+        (globalInitMap,transContext,translateModule,ModuleTranslation,cfgMap,llvmPtrWidth,llvmTypeCtx)
 import Lang.Crucible.LLVM.Globals(populateAllGlobals,initializeAllMemory)
 
 import Lang.Crucible.LLVM.MemModel(withPtrWidth,HasPtrWidth,MemOptions,HasLLVMAnn)
@@ -113,7 +113,7 @@ runCruxLLVM llvm_mod memOpts laxArith optLoopMerge (CruxLLVM setup) =
                               halloc
                               cruxOutput
                               (fnBindingsFromList [])
-                              (llvmExtensionImpl (trans ^. transContext . to llvmArch) memOpts)
+                              (llvmExtensionImpl memOpts)
                               cruxUserState
 
               cruxGo $ InitialState simctx globSt defaultAbortHandler cruxInitCodeReturns

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Run.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Run.hs
@@ -18,7 +18,7 @@ module Lang.Crucible.LLVM.Run
   , findCFG
   ) where
 
-import Control.Lens((^.))
+import Control.Lens ( (^.), to )
 import System.IO(Handle)
 import Data.String(fromString)
 import qualified Data.Map as Map
@@ -44,11 +44,10 @@ import Lang.Crucible.LLVM.Intrinsics
         (llvmIntrinsicTypes, LLVM)
 import Lang.Crucible.LLVM(llvmExtensionImpl, llvmGlobals)
 import Lang.Crucible.LLVM.Translation
-        (globalInitMap,transContext,translateModule,ModuleTranslation,cfgMap,llvmPtrWidth,llvmTypeCtx)
+        (globalInitMap,transContext,translateModule,ModuleTranslation,cfgMap,llvmArch,llvmPtrWidth,llvmTypeCtx)
 import Lang.Crucible.LLVM.Globals(populateAllGlobals,initializeAllMemory)
 
 import Lang.Crucible.LLVM.MemModel(withPtrWidth,HasPtrWidth,MemOptions,HasLLVMAnn)
-
 import Lang.Crucible.LLVM.Extension(ArchWidth)
 
 import Lang.Crucible.Backend(IsSymInterface)
@@ -56,7 +55,7 @@ import Lang.Crucible.Backend(IsSymInterface)
 
 -- | LLVM specific crucible initialization.
 newtype CruxLLVM res =
-  CruxLLVM (forall arch. ModuleTranslation arch -> IO (Setup (LLVM arch) res))
+  CruxLLVM (forall arch. ModuleTranslation arch -> IO (Setup LLVM res))
 
 
 -- | Generic Crucible initialization.
@@ -114,7 +113,7 @@ runCruxLLVM llvm_mod memOpts laxArith optLoopMerge (CruxLLVM setup) =
                               halloc
                               cruxOutput
                               (fnBindingsFromList [])
-                              (llvmExtensionImpl memOpts)
+                              (llvmExtensionImpl (trans ^. transContext . to llvmArch) memOpts)
                               cruxUserState
 
               cruxGo $ InitialState simctx globSt defaultAbortHandler cruxInitCodeReturns
@@ -131,6 +130,6 @@ withPtrWidthOf trans k =
   llvmPtrWidth (trans^.transContext) (\ptrW -> withPtrWidth ptrW k)
 
 
-findCFG :: ModuleTranslation arch -> String -> Maybe (AnyCFG (LLVM arch))
+findCFG :: ModuleTranslation arch -> String -> Maybe (AnyCFG LLVM)
 findCFG trans fun = snd <$> Map.lookup (fromString fun) (cfgMap trans)
 

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation.hs
@@ -126,12 +126,12 @@ import           Lang.Crucible.Types
 ------------------------------------------------------------------------
 -- Translation results
 
-type ModuleCFGMap arch = Map L.Symbol (L.Declare, C.AnyCFG (LLVM arch))
+type ModuleCFGMap = Map L.Symbol (L.Declare, C.AnyCFG LLVM)
 
 -- | The result of translating an LLVM module into Crucible CFGs.
 data ModuleTranslation arch
    = ModuleTranslation
-      { cfgMap        :: ModuleCFGMap arch
+      { cfgMap        :: ModuleCFGMap
       , _transContext :: LLVMContext arch
       , globalInitMap :: GlobalInitializerMap
         -- ^ A map from global names to their (constant) values
@@ -329,7 +329,7 @@ defineLLVMBlock _ _ _ = fail "LLVM basic block has no label!"
 genDefn :: (?laxArith :: Bool)
         => L.Define
         -> TypeRepr ret
-        -> LLVMGenerator s arch ret (Expr (LLVM arch) s ret)
+        -> LLVMGenerator s arch ret (Expr ext s ret)
 genDefn defn retType =
   case L.defBody defn of
     [] -> fail "LLVM define with no blocks!"
@@ -361,7 +361,7 @@ transDefine :: forall arch wptr.
             => HandleAllocator
             -> LLVMContext arch
             -> L.Define
-            -> IO (L.Symbol, (L.Declare, C.AnyCFG (LLVM arch)))
+            -> IO (L.Symbol, (L.Declare, C.AnyCFG LLVM))
 transDefine halloc ctx d = do
   let ?lc = ctx^.llvmTypeCtx
   let decl = declareFromDefine d
@@ -370,7 +370,7 @@ transDefine halloc ctx d = do
 
   llvmDeclToFunHandleRepr' decl $ \(argTypes :: CtxRepr args) (retType :: TypeRepr ret) -> do
     h <- mkHandle' halloc fn_name argTypes retType
-    let def :: FunctionDef (LLVM arch) (LLVMState arch) args ret IO
+    let def :: FunctionDef LLVM (LLVMState arch) args ret IO
         def inputs = (s, f)
             where s = initialState d ctx argTypes inputs
                   f = genDefn d retType

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Expr.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Expr.hs
@@ -105,6 +105,15 @@ import           What4.InterpretedFloatingPoint (X86_80Val(..))
 
 -------------------------------------------------------------------------
 -- LLVMExpr
+--
+-- As noted in "Lang.Crucible.LLVM.Translation.Types", this code uses
+-- a polymorphic continuation-passing style to convert to
+-- strongly-typed Crucible types from less-strongly-typed LLVM
+-- types. As part of that, the LLVM architecture (notably the pointer
+-- width) must be unified between the outer context and the
+-- continuation; the 'proxy#' arguments here and below represent a
+-- 'Proxy# arch' type that is used to maintain that architecture
+-- definition and corresponding pointer width for the conversions.
 
 -- | An intermediate form of LLVM expressions that retains some structure
 --   that would otherwise be more difficult to retain if we translated directly

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Monad.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Monad.hs
@@ -220,7 +220,7 @@ buildIdentMap (ti:ts) _ ctx asgn m = do
      buildIdentMap ts False ctx' asgn' (Map.insert (L.typedValue ti) (Right x) m)
 
 -- | Build the initial LLVM generator state upon entry to to the entry point of a function.
-initialState :: (?lc :: TypeContext, HasPtrWidth wptr, wptr ~ ArchWidth arch)
+initialState :: (?lc :: TypeContext, HasPtrWidth wptr)
              => L.Define
              -> LLVMContext arch
              -> CtxRepr args

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Monad.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Monad.hs
@@ -126,11 +126,11 @@ mkLLVMContext halloc m = do
 -- to CFGs.
 type LLVMGenerator s arch ret a =
   (?lc :: TypeContext, HasPtrWidth (ArchWidth arch)) =>
-    Generator (LLVM arch) s (LLVMState arch) ret IO a
+    Generator LLVM s (LLVMState arch) ret IO a
 
 -- | @LLVMGenerator@ without the constraint, can be nested further inside monads.
 type LLVMGenerator' s arch ret =
-  Generator (LLVM arch) s (LLVMState arch) ret IO
+  Generator LLVM s (LLVMState arch) ret IO
 
 
 -- LLVMState

--- a/crux-llvm/src/Crux/LLVM/Overrides.hs
+++ b/crux-llvm/src/Crux/LLVM/Overrides.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MagicHash #-}
 {-# Language ConstraintKinds #-}
 {-# Language DataKinds #-}
 {-# Language ImplicitParams #-}
@@ -21,6 +22,7 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
 import Control.Lens((%=))
 import Control.Monad.IO.Class(liftIO)
+import GHC.Exts ( Proxy# )
 import System.IO (hPutStrLn)
 import qualified Data.Text as T
 
@@ -64,7 +66,7 @@ import Lang.Crucible.LLVM.MemModel
 import           Lang.Crucible.LLVM.TypeContext( TypeContext )
 import           Lang.Crucible.LLVM.Intrinsics
 
-import Lang.Crucible.LLVM.Extension ( ArchRepr, ArchWidth )
+import Lang.Crucible.LLVM.Extension ( ArchWidth )
 
 import Crux.Types
 import Crux.Model
@@ -77,7 +79,7 @@ type TBits n        = BVType n
 
 cruxLLVMOverrides ::
   (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch, ?lc :: TypeContext, HasModel personality) =>
-  ArchRepr arch ->
+  Proxy# arch ->
   [OverrideTemplate (personality sym) sym arch rtp l a]
 cruxLLVMOverrides arch =
   [ basic_llvm_override $
@@ -151,7 +153,7 @@ cruxLLVMOverrides arch =
 
 cbmcOverrides ::
   (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch, ?lc :: TypeContext, HasModel personality) =>
-  ArchRepr arch ->
+  Proxy# arch ->
   [OverrideTemplate (personality sym) sym arch rtp l a]
 cbmcOverrides arch =
   [ basic_llvm_override $
@@ -338,7 +340,7 @@ mkFreshFloat nm fi = do
 
 lookupString ::
   (IsSymInterface sym, HasLLVMAnn sym, ArchOk arch) =>
-  ArchRepr arch ->
+  Proxy# arch ->
   GlobalVar Mem -> RegEntry sym (TPtr arch) -> OverM personality sym ext String
 lookupString _ mvar ptr =
   do sym <- getSymInterface
@@ -366,7 +368,7 @@ sv_comp_fresh_float fi _mvar _sym Empty = mkFreshFloat "X" fi
 
 fresh_bits ::
   (ArchOk arch, HasLLVMAnn sym, IsSymInterface sym, 1 <= w, HasModel personality) =>
-  ArchRepr arch ->
+  Proxy# arch ->
   NatRepr w ->
   GlobalVar Mem ->
   sym ->
@@ -378,7 +380,7 @@ fresh_bits arch w mvar _ (Empty :> pName) =
 
 fresh_float ::
   (ArchOk arch, IsSymInterface sym, HasLLVMAnn sym, HasModel personality) =>
-  ArchRepr arch ->
+  Proxy# arch ->
   FloatInfoRepr fi ->
   GlobalVar Mem ->
   sym ->
@@ -390,7 +392,7 @@ fresh_float arch fi mvar _ (Empty :> pName) =
 
 fresh_str ::
   (ArchOk arch, IsSymInterface sym, HasLLVMAnn sym) =>
-  ArchRepr arch ->
+  Proxy# arch ->
   GlobalVar Mem ->
   sym ->
   Assignment (RegEntry sym) (EmptyCtx ::> TPtr arch ::> BVType (ArchWidth arch)) ->
@@ -427,7 +429,7 @@ fresh_str arch mvar sym (Empty :> pName :> maxLen) =
 
 do_assume ::
   (ArchOk arch, IsSymInterface sym, HasLLVMAnn sym) =>
-  ArchRepr arch ->
+  Proxy# arch ->
   GlobalVar Mem ->
   sym ->
   Assignment (RegEntry sym) (EmptyCtx ::> TBits 8 ::> TPtr arch ::> TBits 32) ->
@@ -446,7 +448,7 @@ do_assume arch mvar sym (Empty :> p :> pFile :> line) =
 
 do_assert ::
   (ArchOk arch, IsSymInterface sym, HasLLVMAnn sym) =>
-  ArchRepr arch ->
+  Proxy# arch ->
   GlobalVar Mem ->
   sym ->
   Assignment (RegEntry sym) (EmptyCtx ::> TBits 8 ::> TPtr arch ::> TBits 32) ->
@@ -475,7 +477,7 @@ do_print_uint32 _mvar _sym (Empty :> x) =
 
 do_havoc_memory ::
   (ArchOk arch, IsSymInterface sym, HasLLVMAnn sym) =>
-  ArchRepr arch ->
+  Proxy# arch ->
   GlobalVar Mem ->
   sym ->
   Assignment (RegEntry sym) (EmptyCtx ::> TPtr arch ::> TBits (ArchWidth arch)) ->
@@ -502,7 +504,7 @@ cprover_assume _mvar sym (Empty :> p) = liftIO $
 
 cprover_assert ::
   (ArchOk arch, IsSymInterface sym, HasLLVMAnn sym) =>
-  ArchRepr arch ->
+  Proxy# arch ->
   GlobalVar Mem ->
   sym ->
   Assignment (RegEntry sym) (EmptyCtx ::> TBits 32 ::> TPtr arch) ->
@@ -516,7 +518,7 @@ cprover_assert arch mvar sym (Empty :> p :> pMsg) =
 
 cprover_r_ok ::
   (ArchOk arch, IsSymInterface sym, HasLLVMAnn sym) =>
-  ArchRepr arch ->
+  Proxy# arch ->
   GlobalVar Mem ->
   sym ->
   Assignment (RegEntry sym) (EmptyCtx ::> TPtr arch ::>  BVType (ArchWidth arch)) ->
@@ -528,7 +530,7 @@ cprover_r_ok _ mvar sym (Empty :> (regValue -> p) :> (regValue -> sz)) =
 
 cprover_w_ok ::
   (ArchOk arch, IsSymInterface sym, HasLLVMAnn sym) =>
-  ArchRepr arch ->
+  Proxy# arch ->
   GlobalVar Mem ->
   sym ->
   Assignment (RegEntry sym) (EmptyCtx ::> TPtr arch ::>  BVType (ArchWidth arch)) ->

--- a/crux-llvm/src/Crux/LLVM/Overrides.hs
+++ b/crux-llvm/src/Crux/LLVM/Overrides.hs
@@ -243,7 +243,7 @@ cbmcOverrides arch =
 
 
 svCompOverrides ::
-  (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch, ?lc :: TypeContext, HasModel personality) =>
+  (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, HasModel personality) =>
   [OverrideTemplate (personality sym) sym arch rtp l a]
 svCompOverrides =
   [ basic_llvm_override $

--- a/crux-llvm/src/Crux/LLVM/Simulate.hs
+++ b/crux-llvm/src/Crux/LLVM/Simulate.hs
@@ -90,7 +90,7 @@ setupSimCtxt halloc sym mo llvmCtxt =
                  halloc
                  stdout
                  (fnBindingsFromList [])
-                 (llvmExtensionImpl (llvmArch llvmCtxt) mo)
+                 (llvmExtensionImpl mo)
                  emptyModel
     & profilingMetrics %~ Map.union (llvmMetrics llvmCtxt)
 

--- a/crux-llvm/src/Crux/LLVM/Simulate.hs
+++ b/crux-llvm/src/Crux/LLVM/Simulate.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MagicHash #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
@@ -11,9 +12,10 @@ module Crux.LLVM.Simulate where
 import Data.String (fromString)
 import qualified Data.Map.Strict as Map
 import Data.IORef
-import Control.Lens ((&), (%~), (^.), to, view)
+import Control.Lens ((&), (%~), (^.), view)
 import Control.Monad.State(liftIO)
 import Data.Text (Text)
+import GHC.Exts ( proxy# )
 
 import System.IO (stdout)
 
@@ -56,7 +58,7 @@ import Lang.Crucible.LLVM.MemModel
         )
 import Lang.Crucible.LLVM.Translation
         ( translateModule, ModuleTranslation, globalInitMap
-        , transContext, llvmArch, cfgMap
+        , transContext, cfgMap
         , LLVMContext, llvmMemVar, ModuleCFGMap
         , llvmPtrWidth, llvmTypeCtx
         )
@@ -114,9 +116,9 @@ registerFunctions llvm_module mtrans =
 
      -- register the callable override functions
      register_llvm_overrides llvm_module []
-       (concat [ cruxLLVMOverrides (mtrans ^. transContext . to llvmArch)
+       (concat [ cruxLLVMOverrides proxy#
                , svCompOverrides
-               , cbmcOverrides (mtrans ^. transContext . to llvmArch)
+               , cbmcOverrides proxy#
                ])
        llvm_ctx
 

--- a/crux-llvm/src/Crux/LLVM/Simulate.hs
+++ b/crux-llvm/src/Crux/LLVM/Simulate.hs
@@ -78,7 +78,7 @@ import Crux.LLVM.Overrides
 
 -- | Create a simulator context for the given architecture.
 setupSimCtxt ::
-  (ArchOk arch, IsSymInterface sym, HasLLVMAnn sym) =>
+  (IsSymInterface sym, HasLLVMAnn sym) =>
   HandleAllocator ->
   sym ->
   MemOptions ->


### PR DESCRIPTION
This separates the extension identification from the architecture (and corresponding pointer width) identification.

The identification of  the architecture and pointer width is now explicitly provided where needed to express that context or information in the crucible-llvm and crux-llvm code base without obtaining it from the `ext` parameter.

A significant portion of this PR is adjustment of type signatures to express `ext` as either `ext` or `LLVM` instead of `(LLVM arch)`, or to switch from, add, or remove `arch` or `ext` and corresponding `arch` constraints.  Significant changes include:
* The extension type no longer includes the architecture encoding
* ~~statement execution and evaluation in MemModel.hs are now provided an explicit `ArchRepr arch` argument.~~
*  In LLVM/Translation/Expr, the `ScalarView` and associated functions now thread a `Proxy#` representative of the `arch` parameter through the datastructure and callbacks to provide the necessary ptrwidth information.  This impacts other portions of the Translation (like Instruction.hs) but is not expected to have much impact outside of the Translation elements.
* Crux LLVM override initialiation is passed a `Proxy# arch` where needed (as provided from the `ModuleTranslation`), and where not needed, the `ArchOk arch` constraint is removed.
* Extends many of the `LLVMStmt` constructors to add the `HasPtrWidth` constraint to the constructor, carrying the constraint in the `LLVMStmt` object instead of the `ext` or the code path.

The net effect is to remove the `arch` parameterization from a large number of places where it isn't needed or used.

This is a precursor to changes for polyglot support of multiple active extensions.