### PR TITLE
Compositional crux-mir support

### DIFF
--- a/crux-mir/crux-mir.cabal
+++ b/crux-mir/crux-mir.cabal
@@ -65,13 +65,12 @@ library
                    Mir.PP
                    Mir.Generate
                    Mir.DefId
-  other-modules:
-                 Mir.FancyMuxTree
-                 Mir.Intrinsics
-                 Mir.Overrides
-                 Mir.TransTy
-                 Mir.Trans
-                 Mir.TransCustom
+                   Mir.FancyMuxTree
+                   Mir.Intrinsics
+                   Mir.Overrides
+                   Mir.TransTy
+                   Mir.Trans
+                   Mir.TransCustom
 
 
 executable crux-mir

--- a/crux-mir/lib/crucible/lib.rs
+++ b/crux-mir/lib/crucible/lib.rs
@@ -1,8 +1,10 @@
 #![no_std]
 #![feature(core_intrinsics)]
 #![feature(crucible_intrinsics)]
+#![feature(unboxed_closures)]
 
 pub mod bitvector;
+pub mod method_spec;
 pub mod sym_bytes;
 pub mod symbolic;
 

--- a/crux-mir/lib/crucible/method_spec/mod.rs
+++ b/crux-mir/lib/crucible/method_spec/mod.rs
@@ -1,0 +1,81 @@
+//! Provides the `MethodSpec` type, used for compositional reasoning.  Also provides
+//! `MethodSpecBuilder`, which is used internally by the compositional reasoning macros to
+//! construct a `MethodSpec` from a symbolic test.
+//!
+//! Note that these types work only when running under `crux-mir-comp`.  Trying to use them under
+//! ordinary `crux-mir` will produce an error.
+use core::fmt;
+
+mod raw;
+
+
+/// The specification of a function.  This can be used when verifying callers of the function to
+/// avoid simulating the entire function itself.
+#[derive(Clone, Copy)]
+pub struct MethodSpec {
+    raw: raw::MethodSpec,
+}
+
+impl MethodSpec {
+    /// Enable this `MethodSpec` to be used as an override for its subject function.
+    pub fn enable(&self) {
+        raw::spec_enable(self.raw);
+    }
+}
+
+impl fmt::Debug for MethodSpec {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let s = raw::spec_pretty_print(self.raw);
+        fmt.write_str("MethodSpec {")?;
+        for (i, chunk) in s.split("\n").enumerate() {
+            if i > 0 {
+                fmt.write_str(", ")?;
+            }
+            fmt.write_str(chunk);
+        }
+        fmt.write_str("}")?;
+        Ok(())
+    }
+}
+
+
+/// Helper type used to incrementally construct a `MethodSpec` for a function.
+pub struct MethodSpecBuilder {
+    raw: raw::MethodSpecBuilder,
+}
+
+impl fmt::Debug for MethodSpecBuilder {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "MethodSpecBuilder {{ .. }}")
+    }
+}
+
+impl MethodSpecBuilder {
+    pub fn new<Args, F: Fn<Args>>(f: F) -> MethodSpecBuilder {
+        MethodSpecBuilder {
+            raw: raw::builder_new::<F>(),
+        }
+    }
+
+    pub fn add_arg<T>(&mut self, x: &T) {
+        self.raw = raw::builder_add_arg(self.raw, x);
+    }
+
+    pub fn gather_assumes(&mut self) {
+        self.raw = raw::builder_gather_assumes(self.raw);
+    }
+
+    pub fn set_return<T>(&mut self, x: &T) {
+        self.raw = raw::builder_set_return(self.raw, x);
+    }
+
+    pub fn gather_asserts(&mut self) {
+        self.raw = raw::builder_gather_asserts(self.raw);
+    }
+
+    pub fn finish(self) -> MethodSpec {
+        MethodSpec {
+            raw: raw::builder_finish(self.raw),
+        }
+    }
+}

--- a/crux-mir/lib/crucible/method_spec/mod.rs
+++ b/crux-mir/lib/crucible/method_spec/mod.rs
@@ -8,6 +8,8 @@ use core::fmt;
 
 mod raw;
 
+pub use self::raw::clobber_globals;
+
 
 /// The specification of a function.  This can be used when verifying callers of the function to
 /// avoid simulating the entire function itself.

--- a/crux-mir/lib/crucible/method_spec/raw.rs
+++ b/crux-mir/lib/crucible/method_spec/raw.rs
@@ -1,0 +1,57 @@
+/// Crucible `MethodSpecType`, exposed to Rust.
+///
+/// As usual for Crucible types, this implements `Copy`, since it's backed by a boxed,
+/// garbage-collected Haskell value.  It contains a dummy field to ensure the Rust compiler sees it
+/// as having non-zero size.  The representation is overridden within `crux-mir`, so the field
+/// should not be accessed when running symbolically.
+#[derive(Clone, Copy)]
+pub struct MethodSpec(u8);
+
+// We only have `libcore` available, so we can't return `String` here.  Instead, the override for
+// this function within `crux-mir` will construct and leak a `str`.
+pub fn spec_pretty_print(ms: MethodSpec) -> &'static str {
+    "(unknown MethodSpec)"
+}
+
+/// Enable using `ms` in place of calls to the actual function.  The function to override is
+/// determined by the `F` type parameter of `builder_new` during the construction of the
+/// `MethodSpec`.
+pub fn spec_enable(ms: MethodSpec) {
+}
+
+
+/// Crucible `MethodSpecBuilderType`, exposed to Rust.
+#[derive(Clone, Copy)]
+pub struct MethodSpecBuilder(u8);
+
+pub fn builder_new<F>() -> MethodSpecBuilder {
+    // If the program is running under ordinary `crux-mir` instead of `crux-mir-comp`, then the
+    // override for this function will be missing.  We could provide a dummy implementation for
+    // that case, but it's better to fail early.  Otherwise users will get cryptic errors when
+    // invoking their spec functions, as `builder_finish` won't have its usual effect of discarding
+    // any new goals added by the spec function.
+    unimplemented!("MethodSpecBuilder is not supported on this version of crux-mir")
+}
+
+pub fn builder_add_arg<T>(msb: MethodSpecBuilder, x: &T) -> MethodSpecBuilder {
+    let _ = x;
+    msb
+}
+
+pub fn builder_gather_assumes(msb: MethodSpecBuilder) -> MethodSpecBuilder {
+    msb
+}
+
+pub fn builder_set_return<T>(msb: MethodSpecBuilder, x: &T) -> MethodSpecBuilder {
+    let _ = x;
+    msb
+}
+
+pub fn builder_gather_asserts(msb: MethodSpecBuilder) -> MethodSpecBuilder {
+    msb
+}
+
+pub fn builder_finish(msb: MethodSpecBuilder) -> MethodSpec {
+    let _ = msb;
+    MethodSpec(0)
+}

--- a/crux-mir/lib/crucible/method_spec/raw.rs
+++ b/crux-mir/lib/crucible/method_spec/raw.rs
@@ -55,3 +55,10 @@ pub fn builder_finish(msb: MethodSpecBuilder) -> MethodSpec {
     let _ = msb;
     MethodSpec(0)
 }
+
+
+/// Replace all mutable global data with arbitrary values.  This is used at the start of tests to
+/// ensure that the property holds in any context.
+pub fn clobber_globals() {
+    unimplemented!("MethodSpecBuilder is not supported on this version of crux-mir")
+}

--- a/crux-mir/lib/crucible/method_spec/raw.rs
+++ b/crux-mir/lib/crucible/method_spec/raw.rs
@@ -1,3 +1,12 @@
+//! Bindings for low-level MethodSpec APIs.
+//!
+//! Like most functions in the `crucible` crate, these functions are left unimplemented in Rust
+//! and are replaced by a real implementation via the Crucible override mechanism.  However, unlike
+//! most other functions, the necessary overrides are not provided by `crux-mir`; instead, they are
+//! provided by the `crux-mir-comp` package in the `saw-script` repository, which extends ordinary
+//! `crux-mir` with additional overrides using `crux-mir`'s new `mainWithExtraOverrides` entry
+//! point.  Trying to use these APIs under ordinary `crux-mir` will produce an error.
+
 /// Crucible `MethodSpecType`, exposed to Rust.
 ///
 /// As usual for Crucible types, this implements `Copy`, since it's backed by a boxed,

--- a/crux-mir/src/Mir/Generate.hs
+++ b/crux-mir/src/Mir/Generate.hs
@@ -77,10 +77,10 @@ needsRebuild output inputs = do
 mirJsonOutFile :: FilePath -> FilePath
 mirJsonOutFile rustFile = rustFile -<.> "mir"
 
-getRlibsDir :: IO FilePath
-getRlibsDir = maybe "rlibs" id <$> lookupEnv "CRUX_RUST_LIBRARY_PATH"
+getRlibsDir :: (?defaultRlibsDir :: FilePath) => IO FilePath
+getRlibsDir = maybe ?defaultRlibsDir id <$> lookupEnv "CRUX_RUST_LIBRARY_PATH"
 
-compileMirJson :: Bool -> Bool -> FilePath -> IO ()
+compileMirJson :: (?defaultRlibsDir :: FilePath) => Bool -> Bool -> FilePath -> IO ()
 compileMirJson keepRlib quiet rustFile = do
     let outFile = rustFile -<.> "bin"
 
@@ -103,7 +103,7 @@ compileMirJson keepRlib quiet rustFile = do
             True  -> removeFile outFile
             False -> return ()
 
-maybeCompileMirJson :: Bool -> Bool -> FilePath -> IO ()
+maybeCompileMirJson :: (?defaultRlibsDir :: FilePath) => Bool -> Bool -> FilePath -> IO ()
 maybeCompileMirJson keepRlib quiet rustFile = do
     build <- needsRebuild (mirJsonOutFile rustFile) [rustFile]
     when build $ compileMirJson keepRlib quiet rustFile
@@ -159,7 +159,7 @@ libJsonFiles =
 -- NOTE: If the rust file has not been modified since the
 -- last .mir file was created, this function does nothing
 -- This function uses 'failIO' if any error occurs
-generateMIR :: (HasCallStack, ?debug::Int) =>
+generateMIR :: (HasCallStack, ?debug::Int, ?defaultRlibsDir :: FilePath) =>
                FilePath          -- ^ location of input file
             -> Bool              -- ^ `True` to keep the generated .rlib
             -> IO Collection

--- a/crux-mir/src/Mir/Intrinsics.hs
+++ b/crux-mir/src/Mir/Intrinsics.hs
@@ -1551,7 +1551,7 @@ mirRef_indexAndLenIO sym s (MirReferenceMux ref) = do
 
 mirRef_indexAndLenSim :: IsSymInterface sym =>
     MirReferenceMux sym tp ->
-    OverrideSim (Model sym) sym MIR rtp args ret
+    OverrideSim p sym MIR rtp args ret
         (PartExpr (Pred sym) (RegValue sym UsizeType, RegValue sym UsizeType))
 mirRef_indexAndLenSim ref = do
     sym <- getSymInterface

--- a/crux-mir/src/Mir/Intrinsics.hs
+++ b/crux-mir/src/Mir/Intrinsics.hs
@@ -1885,9 +1885,10 @@ getSliceLen e = getStruct i2of2 e
 -- ** MethodSpec and MethodSpecBuilder
 --
 -- We define the intrinsics here so they can be used in `TransTy.tyToRepr`, and
--- also define their interfaces (as typeclasses), but the concrete
--- implementations of these types are in `saw-script/crux-mir-comp`, since they
--- depend on some SAW components (notably SAW's `MethodSpec` and `Term` types).
+-- also define their interfaces (as typeclasses), but we don't provide any
+-- concrete implementations in `crux-mir`.  Instead, implementations of these
+-- types are in `saw-script/crux-mir-comp`, since they depend on some SAW
+-- components, such as `saw-script`'s `MethodSpec`.
 
 class MethodSpecImpl sym ms where
     -- | Pretty-print the MethodSpec, returning the result as a Rust string

--- a/crux-mir/src/Mir/Intrinsics.hs
+++ b/crux-mir/src/Mir/Intrinsics.hs
@@ -1504,6 +1504,17 @@ execMirStmt stmt s =
 -- MirReferenceType manipulation within the OverrideSim monad.  These are
 -- useful for implementing overrides that work with MirReferences.
 
+newMirRefSim :: IsSymInterface sym =>
+    TypeRepr tp ->
+    OverrideSim m sym MIR rtp args ret (MirReferenceMux sym tp)
+newMirRefSim tpr = do
+    sym <- getSymInterface
+    s <- get
+    let halloc = simHandleAllocator $ s ^. stateContext
+    rc <- liftIO $ freshRefCell halloc tpr
+    let ref = MirReference (RefCell_RefRoot rc) Empty_RefPath
+    return $ MirReferenceMux $ toFancyMuxTree sym ref
+
 readRefMuxSim :: IsSymInterface sym =>
     TypeRepr tp' ->
     (MirReference sym tp -> MuxLeafT sym IO (RegValue sym tp')) ->
@@ -1514,6 +1525,17 @@ readRefMuxSim tpr' f (MirReferenceMux ref) = do
     ctx <- getContext
     let iTypes = ctxIntrinsicTypes ctx
     liftIO $ readFancyMuxTree' sym f (muxRegForType sym iTypes tpr') ref
+
+readRefMuxIO :: IsSymInterface sym =>
+    sym -> SimState p sym ext rtp f a ->
+    TypeRepr tp' ->
+    (MirReference sym tp -> MuxLeafT sym IO (RegValue sym tp')) ->
+    MirReferenceMux sym tp ->
+    IO (RegValue sym tp')
+readRefMuxIO sym s tpr' f (MirReferenceMux ref) = do
+    let ctx = s ^. stateContext
+    let iTypes = ctxIntrinsicTypes ctx
+    readFancyMuxTree' sym f (muxRegForType sym iTypes tpr') ref
 
 modifyRefMuxSim :: IsSymInterface sym =>
     (MirReference sym tp -> MuxLeafT sym IO (MirReference sym tp')) ->
@@ -1531,7 +1553,22 @@ readMirRefSim :: IsSymInterface sym =>
 readMirRefSim tpr ref = do
     sym <- getSymInterface
     s <- get
-    readRefMuxSim tpr (readMirRefLeaf s sym) ref
+    liftIO $ readMirRefIO sym s tpr ref
+
+readMirRefIO :: IsSymInterface sym =>
+    sym -> SimState p sym ext rtp f a ->
+    TypeRepr tp -> MirReferenceMux sym tp ->
+    IO (RegValue sym tp)
+readMirRefIO sym s tpr ref = readRefMuxIO sym s tpr (readMirRefLeaf s sym) ref
+
+writeMirRefSim :: IsSymInterface sym =>
+    TypeRepr tp -> MirReferenceMux sym tp -> RegValue sym tp ->
+    OverrideSim m sym MIR rtp args ret ()
+writeMirRefSim tpr (MirReferenceMux ref) x = do
+    sym <- getSymInterface
+    s <- get
+    s' <- liftIO $ foldFancyMuxTree sym (\s' ref' -> writeMirRefLeaf s' sym ref' x) s ref
+    put s'
 
 subindexMirRefSim :: IsSymInterface sym =>
     TypeRepr tp -> MirReferenceMux sym (MirVectorType tp) -> RegValue sym UsizeType ->

--- a/crux-mir/src/Mir/Intrinsics.hs
+++ b/crux-mir/src/Mir/Intrinsics.hs
@@ -1300,6 +1300,11 @@ mirRef_eqLeaf sym _ _ =
     -- All valid references are disjoint from all integer references.
     return $ falsePred sym
 
+mirRef_eqIO :: IsSymInterface sym => sym ->
+    MirReferenceMux sym tp -> MirReferenceMux sym tp -> IO (RegValue sym BoolType)
+mirRef_eqIO sym (MirReferenceMux r1) (MirReferenceMux r2) =
+    zipFancyMuxTrees' sym (mirRef_eqLeaf sym) (itePred sym) r1 r2
+
 mirRef_offsetLeaf :: IsSymInterface sym => sym ->
     TypeRepr tp -> MirReference sym tp -> RegValue sym IsizeType ->
     MuxLeafT sym IO (MirReference sym tp)

--- a/crux-mir/src/Mir/Language.hs
+++ b/crux-mir/src/Mir/Language.hs
@@ -111,12 +111,13 @@ mainWithOutputConfig outCfg bindExtra =
 type BindExtraOverridesFn = forall args ret blocks sym rtp a r.
     C.IsSymInterface sym =>
     Maybe (Crux.SomeOnlineSolver sym) ->
+    CollectionState ->
     Text ->
     C.CFG MIR blocks args ret ->
     Maybe (C.OverrideSim (Model sym) sym MIR rtp a r ())
 
 noExtraOverrides :: BindExtraOverridesFn
-noExtraOverrides _ _ _ = Nothing
+noExtraOverrides _ _ _ _ = Nothing
 
 runTests :: (Crux.Logs) =>
     (Crux.CruxOptions, MIROptions) -> IO ExitCode
@@ -185,9 +186,9 @@ runTestsWithExtraOverrides bindExtra (cruxOpts, mirOpts) = do
             Maybe (Crux.SomeOnlineSolver sym) -> C.OverrideSim (Model sym) sym MIR rtp a r ()
         linkOverrides symOnline =
             forM_ (Map.toList cfgMap) $ \(fn, C.AnyCFG cfg) -> do
-                case bindExtra symOnline fn cfg of
+                case bindExtra symOnline (mir ^. rmCS) fn cfg of
                     Just f -> f
-                    Nothing -> bindFn symOnline fn cfg
+                    Nothing -> bindFn symOnline (mir ^. rmCS) fn cfg
     let entry = W4.mkProgramLoc "<entry>" W4.InternalPos
     let testStartLoc fnName =
             W4.mkProgramLoc (W4.functionNameFromText $ idText fnName) (W4.OtherPos "<start>")

--- a/crux-mir/src/Mir/Language.hs
+++ b/crux-mir/src/Mir/Language.hs
@@ -133,6 +133,7 @@ runTestsWithExtraOverrides bindExtra (cruxOpts, mirOpts) = do
     --let ?assertFalseOnError = assertFalse mirOpts
     let ?assertFalseOnError = True
     let ?printCrucible      = printCrucible mirOpts
+    let ?defaultRlibsDir    = defaultRlibsDir mirOpts
 
     let (filename, nameFilter) = case cargoTestFile mirOpts of
             -- This case is terrible a hack.  The goal is to mimic the behavior
@@ -346,6 +347,11 @@ data MIROptions = MIROptions
     , printResultOnly :: Bool
     , testFilter   :: Maybe Text
     , cargoTestFile :: Maybe FilePath
+    , defaultRlibsDir :: FilePath
+    -- ^ Directory to search for builds of `crux-mir`'s custom standard
+    -- library, if `$CRUX_RUST_LIBRARY_PATH` is unset.  This option exists for
+    -- the purposes of the `crux-mir-comp` test suite; there's no user-facing
+    -- flag to set it.
     }
 
 defaultMirOptions :: MIROptions
@@ -357,6 +363,7 @@ defaultMirOptions = MIROptions
     , printResultOnly = False
     , testFilter = Nothing
     , cargoTestFile = Nothing
+    , defaultRlibsDir = "rlibs"
     }
 
 mirConfig :: Crux.Config MIROptions

--- a/crux-mir/src/Mir/Mir.hs
+++ b/crux-mir/src/Mir/Mir.hs
@@ -19,6 +19,7 @@ License          : BSD3
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE TypeFamilies #-}
 
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -34,9 +35,7 @@ import qualified Data.ByteString as B
 import Data.Map.Strict (Map)
 import Data.Text (Text)
 
-import Data.Semigroup (Semigroup(..))
-
-import Control.Lens (makeLenses)
+import Control.Lens (makeLenses, makeWrapped)
 
 import GHC.Generics 
 
@@ -540,6 +539,7 @@ makeLenses ''Vtable
 makeLenses ''Intrinsic
 makeLenses ''Instance
 makeLenses ''NamedTy
+makeWrapped ''Substs
 
 --------------------------------------------------------------------------------------
 -- Other instances for ADT types

--- a/crux-mir/src/Mir/TransTy.hs
+++ b/crux-mir/src/Mir/TransTy.hs
@@ -243,6 +243,10 @@ dynRefRepr = C.StructRepr dynRefCtx
 -- fields are wrapped in `Maybe` to support field-by-field initialization.
 canInitialize :: M.Ty -> Bool
 canInitialize ty = case ty of
+    -- Custom types
+    CTyMethodSpec -> False
+    CTyMethodSpecBuilder -> False
+
     -- Primitives
     M.TyBool -> True
     M.TyChar -> True

--- a/crux-mir/src/Mir/TransTy.hs
+++ b/crux-mir/src/Mir/TransTy.hs
@@ -258,6 +258,14 @@ canInitialize ty = case ty of
     --M.TyRef ty' _ -> canInitialize ty'
     _ -> False
 
+isUnsized :: M.Ty -> Bool
+isUnsized ty = case ty of
+    M.TyStr -> True
+    M.TySlice _ -> True
+    M.TyDynamic _ -> True
+    -- TODO: struct types whose last field is unsized ("custom DSTs")
+    _ -> False
+
 
 variantFields :: TransTyConstraint => M.Variant -> Some C.CtxRepr
 variantFields (M.Variant _vn _vd vfs _vct) =

--- a/crux-mir/src/Mir/TransTy.hs
+++ b/crux-mir/src/Mir/TransTy.hs
@@ -65,6 +65,7 @@ import           Mir.Intrinsics
     , SizeBits, pattern UsizeRepr, pattern IsizeRepr
     , isizeLit
     , RustEnumType, pattern RustEnumRepr, mkRustEnum, rustEnumVariant, rustEnumDiscriminant
+    , pattern MethodSpecRepr, pattern MethodSpecBuilderRepr
     , DynRefType)
 
 
@@ -123,6 +124,12 @@ pattern CTyBv512 = CTyBv CTyBvSize512
 pattern CTyAny <- M.TyAdt _ $(M.normDefIdPat "core::crucible::any::Any") (M.Substs [])
   where CTyAny = M.TyAdt (M.textId "type::adt") (M.textId "core::crucible::any::Any") (M.Substs [])
 
+pattern CTyMethodSpec <- M.TyAdt _ $(M.normDefIdPat "crucible::method_spec::raw::MethodSpec") (M.Substs [])
+  where CTyMethodSpec = M.TyAdt (M.textId "type::adt") (M.textId "crucible::method_spec::raw::MethodSpec") (M.Substs [])
+
+pattern CTyMethodSpecBuilder <- M.TyAdt _ $(M.normDefIdPat "crucible::method_spec::raw::MethodSpecBuilder") (M.Substs [])
+  where CTyMethodSpecBuilder = M.TyAdt (M.textId "type::adt") (M.textId "crucible::method_spec::raw::MethodSpecBuilder") (M.Substs [])
+
 
 -- These don't have custom representation, but are referenced in various
 -- places.
@@ -150,6 +157,8 @@ tyToRepr t0 = case t0 of
       Some (C.SymbolicArrayRepr (Ctx.Empty Ctx.:> C.BaseBVRepr (knownNat @SizeBits)) btr)
     | otherwise -> error $ "unsupported: crucible arrays of non-base type"
   CTyAny -> Some C.AnyRepr
+  CTyMethodSpec -> Some MethodSpecRepr
+  CTyMethodSpecBuilder -> Some MethodSpecBuilderRepr
 
   -- Defined as `union MaybeUninit<T> { uninit: (), value: ManuallyDrop<T> }`.
   -- We skip the outer union, leaving only `ManuallyDrop<T>`, which is a

--- a/crux-mir/src/Mir/TransTy.hs
+++ b/crux-mir/src/Mir/TransTy.hs
@@ -104,6 +104,10 @@ pattern CTyBox t <- M.TyAdt _ $(M.normDefIdPat "alloc::boxed::Box") (M.Substs [t
   where CTyBox t = M.TyAdt (M.textId "type::adt") (M.textId "alloc::boxed::Box") (M.Substs [t])
 pattern CTyMaybeUninit t <- M.TyAdt _ $(M.normDefIdPat "core::mem::maybe_uninit::MaybeUninit") (M.Substs [t])
   where CTyMaybeUninit t = M.TyAdt (M.textId "type::adt") (M.textId "core::mem::maybe_uninit::MaybeUninit") (M.Substs [t])
+-- `UnsafeCell` isn't handled specially inside baseline `crux-mir`, but
+-- `crux-mir-comp` looks for it (using this pattern synonym).
+pattern CTyUnsafeCell t <- M.TyAdt _ $(M.normDefIdPat "core::cell::UnsafeCell") (M.Substs [t])
+  where CTyUnsafeCell t = M.TyAdt (M.textId "type::adt") (M.textId "core::cell::UnsafeCell") (M.Substs [t])
 pattern CTyVector t <- M.TyAdt _ $(M.normDefIdPat "crucible::vector::Vector") (M.Substs [t])
   where CTyVector t = M.TyAdt (M.textId "type::adt") (M.textId "crucible::vector::Vector") (M.Substs [t])
 pattern CTyArray t <- M.TyAdt _ $(M.normDefIdPat "crucible::array::Array") (M.Substs [t])

--- a/crux-mir/test/symb_eval/concretize/assert.good
+++ b/crux-mir/test/symb_eval/concretize/assert.good
@@ -3,7 +3,7 @@ test assert/3a1fbbbh::crux_test[0]: returned 1, FAILED
 failures:
 
 ---- assert/3a1fbbbh::crux_test[0] counterexamples ----
-Failure for ./lib/crucible/lib.rs:44:17: 44:82 !test/symb_eval/concretize/assert.rs:10:5: 10:82: error: in assert/3a1fbbbh::crux_test[0]
+Failure for ./lib/crucible/lib.rs:46:17: 46:82 !test/symb_eval/concretize/assert.rs:10:5: 10:82: error: in assert/3a1fbbbh::crux_test[0]
 MIR assertion at test/symb_eval/concretize/assert.rs:10:5:
 	100 + 157 == 1
 Failure for test/symb_eval/concretize/assert.rs:11:16: 11:17: error: in assert/3a1fbbbh::crux_test[0]

--- a/crux-mir/test/symb_eval/crux/early_fail.good
+++ b/crux-mir/test/symb_eval/crux/early_fail.good
@@ -8,7 +8,7 @@ Failure for internal: error: in early_fail/3a1fbbbh::fail1[0]
 panicking::begin_panic, called from early_fail/3a1fbbbh::fail1[0]
 
 ---- early_fail/3a1fbbbh::fail2[0] counterexamples ----
-Failure for ./lib/crucible/lib.rs:34:41: 34:58 !test/symb_eval/crux/early_fail.rs:17:5: 17:30: error: in early_fail/3a1fbbbh::fail2[0]
+Failure for ./lib/crucible/lib.rs:36:41: 36:58 !test/symb_eval/crux/early_fail.rs:17:5: 17:30: error: in early_fail/3a1fbbbh::fail2[0]
 MIR assertion at test/symb_eval/crux/early_fail.rs:17:5:
 	x == 0
 

--- a/crux-mir/test/symb_eval/crux/fail_return.good
+++ b/crux-mir/test/symb_eval/crux/fail_return.good
@@ -6,14 +6,14 @@ failures:
 ---- fail_return/3a1fbbbh::fail1[0] counterexamples ----
 Failure for test/symb_eval/crux/fail_return.rs:8:22: 8:27: error: in fail_return/3a1fbbbh::fail1[0]
 attempt to add with overflow
-Failure for ./lib/crucible/lib.rs:34:41: 34:58 !test/symb_eval/crux/fail_return.rs:8:5: 8:33: error: in fail_return/3a1fbbbh::fail1[0]
+Failure for ./lib/crucible/lib.rs:36:41: 36:58 !test/symb_eval/crux/fail_return.rs:8:5: 8:33: error: in fail_return/3a1fbbbh::fail1[0]
 MIR assertion at test/symb_eval/crux/fail_return.rs:8:5:
 	x + 1 > x
 
 ---- fail_return/3a1fbbbh::fail2[0] counterexamples ----
 Failure for test/symb_eval/crux/fail_return.rs:15:22: 15:27: error: in fail_return/3a1fbbbh::fail2[0]
 attempt to add with overflow
-Failure for ./lib/crucible/lib.rs:34:41: 34:58 !test/symb_eval/crux/fail_return.rs:15:5: 15:33: error: in fail_return/3a1fbbbh::fail2[0]
+Failure for ./lib/crucible/lib.rs:36:41: 36:58 !test/symb_eval/crux/fail_return.rs:15:5: 15:33: error: in fail_return/3a1fbbbh::fail2[0]
 MIR assertion at test/symb_eval/crux/fail_return.rs:15:5:
 	x + 1 > x
 

--- a/crux-mir/test/symb_eval/crux/mixed_fail.good
+++ b/crux-mir/test/symb_eval/crux/mixed_fail.good
@@ -8,14 +8,14 @@ failures:
 ---- mixed_fail/3a1fbbbh::fail1[0] counterexamples ----
 Failure for test/symb_eval/crux/mixed_fail.rs:8:22: 8:27: error: in mixed_fail/3a1fbbbh::fail1[0]
 attempt to add with overflow
-Failure for ./lib/crucible/lib.rs:34:41: 34:58 !test/symb_eval/crux/mixed_fail.rs:8:5: 8:33: error: in mixed_fail/3a1fbbbh::fail1[0]
+Failure for ./lib/crucible/lib.rs:36:41: 36:58 !test/symb_eval/crux/mixed_fail.rs:8:5: 8:33: error: in mixed_fail/3a1fbbbh::fail1[0]
 MIR assertion at test/symb_eval/crux/mixed_fail.rs:8:5:
 	x + 1 > x
 
 ---- mixed_fail/3a1fbbbh::fail2[0] counterexamples ----
 Failure for test/symb_eval/crux/mixed_fail.rs:14:22: 14:27: error: in mixed_fail/3a1fbbbh::fail2[0]
 attempt to add with overflow
-Failure for ./lib/crucible/lib.rs:34:41: 34:58 !test/symb_eval/crux/mixed_fail.rs:14:5: 14:33: error: in mixed_fail/3a1fbbbh::fail2[0]
+Failure for ./lib/crucible/lib.rs:36:41: 36:58 !test/symb_eval/crux/mixed_fail.rs:14:5: 14:33: error: in mixed_fail/3a1fbbbh::fail2[0]
 MIR assertion at test/symb_eval/crux/mixed_fail.rs:14:5:
 	x + 2 > x
 

--- a/crux-mir/test/symb_eval/crux/multi.good
+++ b/crux-mir/test/symb_eval/crux/multi.good
@@ -7,7 +7,7 @@ failures:
 ---- multi/3a1fbbbh::fail1[0] counterexamples ----
 Failure for test/symb_eval/crux/multi.rs:8:22: 8:27: error: in multi/3a1fbbbh::fail1[0]
 attempt to add with overflow
-Failure for ./lib/crucible/lib.rs:34:41: 34:58 !test/symb_eval/crux/multi.rs:8:5: 8:33: error: in multi/3a1fbbbh::fail1[0]
+Failure for ./lib/crucible/lib.rs:36:41: 36:58 !test/symb_eval/crux/multi.rs:8:5: 8:33: error: in multi/3a1fbbbh::fail1[0]
 MIR assertion at test/symb_eval/crux/multi.rs:8:5:
 	x + 1 > x
 
@@ -16,7 +16,7 @@ Failure for internal: error: in multi/3a1fbbbh::fail2[0]
 panicking::begin_panic, called from multi/3a1fbbbh::fail2[0]
 
 ---- multi/3a1fbbbh::fail3[0] counterexamples ----
-Failure for ./lib/crucible/lib.rs:34:41: 34:58 !test/symb_eval/crux/multi.rs:20:5: 20:30: error: in multi/3a1fbbbh::assert_zero[0]
+Failure for ./lib/crucible/lib.rs:36:41: 36:58 !test/symb_eval/crux/multi.rs:20:5: 20:30: error: in multi/3a1fbbbh::assert_zero[0]
 MIR assertion at test/symb_eval/crux/multi.rs:20:5:
 	x == 0
 

--- a/crux-mir/test/symb_eval/crypto/bytes.good
+++ b/crux-mir/test/symb_eval/crypto/bytes.good
@@ -3,19 +3,19 @@ test bytes/3a1fbbbh::f[0]: FAILED
 failures:
 
 ---- bytes/3a1fbbbh::f[0] counterexamples ----
-Failure for ./lib/crucible/lib.rs:34:41: 34:58 !test/symb_eval/crypto/bytes.rs:85:7: 85:38: error: in bytes/3a1fbbbh::f[0]
+Failure for ./lib/crucible/lib.rs:36:41: 36:58 !test/symb_eval/crypto/bytes.rs:85:7: 85:38: error: in bytes/3a1fbbbh::f[0]
 MIR assertion at test/symb_eval/crypto/bytes.rs:85:7:
 	a[i] == b[i]
-Failure for ./lib/crucible/lib.rs:34:41: 34:58 !test/symb_eval/crypto/bytes.rs:85:7: 85:38: error: in bytes/3a1fbbbh::f[0]
+Failure for ./lib/crucible/lib.rs:36:41: 36:58 !test/symb_eval/crypto/bytes.rs:85:7: 85:38: error: in bytes/3a1fbbbh::f[0]
 MIR assertion at test/symb_eval/crypto/bytes.rs:85:7:
 	a[i] == b[i]
-Failure for ./lib/crucible/lib.rs:34:41: 34:58 !test/symb_eval/crypto/bytes.rs:85:7: 85:38: error: in bytes/3a1fbbbh::f[0]
+Failure for ./lib/crucible/lib.rs:36:41: 36:58 !test/symb_eval/crypto/bytes.rs:85:7: 85:38: error: in bytes/3a1fbbbh::f[0]
 MIR assertion at test/symb_eval/crypto/bytes.rs:85:7:
 	a[i] == b[i]
-Failure for ./lib/crucible/lib.rs:34:41: 34:58 !test/symb_eval/crypto/bytes.rs:85:7: 85:38: error: in bytes/3a1fbbbh::f[0]
+Failure for ./lib/crucible/lib.rs:36:41: 36:58 !test/symb_eval/crypto/bytes.rs:85:7: 85:38: error: in bytes/3a1fbbbh::f[0]
 MIR assertion at test/symb_eval/crypto/bytes.rs:85:7:
 	a[i] == b[i]
-Failure for ./lib/crucible/lib.rs:34:41: 34:58 !test/symb_eval/crypto/bytes.rs:85:7: 85:38: error: in bytes/3a1fbbbh::f[0]
+Failure for ./lib/crucible/lib.rs:36:41: 36:58 !test/symb_eval/crypto/bytes.rs:85:7: 85:38: error: in bytes/3a1fbbbh::f[0]
 MIR assertion at test/symb_eval/crypto/bytes.rs:85:7:
 	a[i] == b[i]
 

--- a/crux-mir/test/symb_eval/overrides/override2.good
+++ b/crux-mir/test/symb_eval/overrides/override2.good
@@ -3,7 +3,7 @@ test override2/3a1fbbbh::f[0]: FAILED
 failures:
 
 ---- override2/3a1fbbbh::f[0] counterexamples ----
-Failure for ./lib/crucible/lib.rs:34:41: 34:58 !test/symb_eval/overrides/override2.rs:9:5: 9:50: error: in override2/3a1fbbbh::f[0]
+Failure for ./lib/crucible/lib.rs:36:41: 36:58 !test/symb_eval/overrides/override2.rs:9:5: 9:50: error: in override2/3a1fbbbh::f[0]
 MIR assertion at test/symb_eval/overrides/override2.rs:9:5:
 	foo.wrapping_add(1) == foo
 

--- a/crux-mir/test/symb_eval/overrides/override5.good
+++ b/crux-mir/test/symb_eval/overrides/override5.good
@@ -3,7 +3,7 @@ test override5/3a1fbbbh::f[0]: FAILED
 failures:
 
 ---- override5/3a1fbbbh::f[0] counterexamples ----
-Failure for ./lib/crucible/lib.rs:34:41: 34:58 !test/symb_eval/overrides/override5.rs:10:5: 10:48: error: in override5/3a1fbbbh::f[0]
+Failure for ./lib/crucible/lib.rs:36:41: 36:58 !test/symb_eval/overrides/override5.rs:10:5: 10:48: error: in override5/3a1fbbbh::f[0]
 MIR assertion at test/symb_eval/overrides/override5.rs:10:5:
 	foo.wrapping_add(1) != 0
 

--- a/crux-mir/test/symb_eval/sym_bytes/construct.good
+++ b/crux-mir/test/symb_eval/sym_bytes/construct.good
@@ -3,7 +3,7 @@ test construct/3a1fbbbh::crux_test[0]: returned Symbolic BV, FAILED
 failures:
 
 ---- construct/3a1fbbbh::crux_test[0] counterexamples ----
-Failure for ./lib/crucible/lib.rs:34:41: 34:58 !test/symb_eval/sym_bytes/construct.rs:13:5: 13:36: error: in construct/3a1fbbbh::crux_test[0]
+Failure for ./lib/crucible/lib.rs:36:41: 36:58 !test/symb_eval/sym_bytes/construct.rs:13:5: 13:36: error: in construct/3a1fbbbh::crux_test[0]
 MIR assertion at test/symb_eval/sym_bytes/construct.rs:13:5:
 	sym2[0] == 0
 


### PR DESCRIPTION
This is the crucible/crux-mir component of GaloisInc/saw-script#1117.  This branch adds various infrastructure needed to support the main compositional crux-mir implementation in the saw-script repo.

Specifically, this branch adds new Crucible intrinsic types `MethodSpec` and `MethodSpecBuilder`, and adds functions for manipulating them to the `crucible` Rust library.  However, the intrinsics are defined as existential types, using typeclasses to provide the operations for each type, and no implementations of those typeclasses or overrides for the Rust API functions are included in `crux-mir`.  Instead, `saw-script/crux-mir-comp` defines concrete implementation types and extends `crux-mir` with the necessary overrides, so that these implementations can use `saw-script`'s `MethodSpec` and related SAW types.

This branch also adds some additional functions for manipulating `MirReference`s, which are used in `crux-mir-comp`'s handling of memory.
