### PR TITLE
[crucible-llvm] Remove unneeded HasLLVMAnn constraint from explainCex

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Partial.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Partial.hs
@@ -126,7 +126,7 @@ instance Semigroup (CexExplanation sym BaseBoolType) where
   DisjOfFailures xs <> DisjOfFailures ys = DisjOfFailures (xs ++ ys)
 
 explainCex :: forall t st fs sym.
-  (IsSymInterface sym, HasLLVMAnn sym, sym ~ ExprBuilder t st fs) =>
+  (IsSymInterface sym, sym ~ ExprBuilder t st fs) =>
   sym ->
   LLVMAnnMap sym ->
   Maybe (GroundEvalFn t) ->


### PR DESCRIPTION
The annotation map is passed explicitly, so the constraint is not necessary.