### PR TITLE
crux-mir: implement overflow checks for Mul/Div/Rem

### DIFF
--- a/crux-mir/src/Mir/Trans.hs
+++ b/crux-mir/src/Mir/Trans.hs
@@ -379,10 +379,10 @@ evalBinOp bop mat me1 me2 =
                 return (MirExp (C.BVRepr n) (S.app $ E.BVSub n e1 e2), S.app $ borrow n e1 e2)
               -- FIXME: implement overflow checks for Mul, Div, and Rem
               (M.Mul, _) -> return (MirExp (C.BVRepr n) (S.app $ E.BVMul n e1 e2), unknownOverflow)
-              (M.Div, Just M.Unsigned) -> return (MirExp (C.BVRepr n) (S.app $ E.BVUdiv n e1 e2), unknownOverflow)
-              (M.Div, Just M.Signed) -> return (MirExp (C.BVRepr n) (S.app $ E.BVSdiv n e1 e2), unknownOverflow)
-              (M.Rem, Just M.Unsigned) -> return (MirExp (C.BVRepr n) (S.app $ E.BVUrem n e1 e2), unknownOverflow)
-              (M.Rem, Just M.Signed) -> return (MirExp (C.BVRepr n) (S.app $ E.BVSrem n e1 e2), unknownOverflow)
+              (M.Div, Just M.Unsigned) -> return (MirExp (C.BVRepr n) (S.app $ E.BVUdiv n e1 e2), errorOverflow)
+              (M.Div, Just M.Signed) -> return (MirExp (C.BVRepr n) (S.app $ E.BVSdiv n e1 e2), errorOverflow)
+              (M.Rem, Just M.Unsigned) -> return (MirExp (C.BVRepr n) (S.app $ E.BVUrem n e1 e2), errorOverflow)
+              (M.Rem, Just M.Signed) -> return (MirExp (C.BVRepr n) (S.app $ E.BVSrem n e1 e2), errorOverflow)
               -- Bitwise ops never overflow
               (M.BitXor, _) -> return (MirExp (C.BVRepr n) (S.app $ E.BVXor n e1 e2), noOverflow)
               (M.BitAnd, _) -> return (MirExp (C.BVRepr n) (S.app $ E.BVAnd n e1 e2), noOverflow)
@@ -471,6 +471,10 @@ evalBinOp bop mat me1 me2 =
     -- For now, assume unsupported operations don't overflow.  Eventually all
     -- overflow checks should be implemented, and we can remove this.
     unknownOverflow = noOverflow
+
+    -- Computing overflow is not supported for this operation
+    errorOverflow :: HasCallStack => R.Expr MIR s C.BoolType
+    errorOverflow = error "checking overflow is not supported for this operation"
 
     -- Check that shift amount `e` is less than the input width `w`.
     shiftOverflowNat w e =

--- a/crux-mir/src/Mir/Trans.hs
+++ b/crux-mir/src/Mir/Trans.hs
@@ -474,13 +474,6 @@ evalBinOp bop mat me1 me2 =
   where
     noOverflow :: R.Expr MIR s C.BoolType
     noOverflow = S.app $ E.BoolLit False
-    -- For now, assume unsupported operations don't overflow.  Eventually all
-    -- overflow checks should be implemented, and we can remove this.
-    unknownOverflow = noOverflow
-
-    -- Computing overflow is not supported for this operation
-    errorOverflow :: HasCallStack => R.Expr MIR s C.BoolType
-    errorOverflow = error "checking overflow is not supported for this operation"
 
     -- Check whether unsigned multiplication of `e1 * e2` overflows `w` bits.
     -- If `zext e1 * zext e2 /= zext (e1 * e2)`, then overflow has occurred.

--- a/crux-mir/test/symb_eval/crypto/double.rs
+++ b/crux-mir/test/symb_eval/crypto/double.rs
@@ -6,7 +6,7 @@ use crucible::*;
 
 
 fn double_ref(x : u32) -> u32 {
-    return x * 2;
+    return x.wrapping_mul(2);
 }
 
 fn double_imp(x : u32) -> u32 {

--- a/crux-mir/test/symb_eval/num/checked_div.good
+++ b/crux-mir/test/symb_eval/num/checked_div.good
@@ -1,0 +1,13 @@
+test checked_div/3a1fbbbh::crux_test[0]: returned 65, FAILED
+
+failures:
+
+---- checked_div/3a1fbbbh::crux_test[0] counterexamples ----
+Failure for test/symb_eval/num/checked_div.rs:3:5: 3:10: error: in checked_div/3a1fbbbh::div_signed[0]
+attempt to divide with overflow
+Failure for test/symb_eval/num/checked_div.rs:3:5: 3:10: error: in checked_div/3a1fbbbh::div_signed[0]
+attempt to divide by zero
+Failure for test/symb_eval/num/checked_div.rs:8:5: 8:10: error: in checked_div/3a1fbbbh::div_unsigned[0]
+attempt to divide by zero
+
+[Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/num/checked_div.rs
+++ b/crux-mir/test/symb_eval/num/checked_div.rs
@@ -1,0 +1,27 @@
+#[inline(never)]
+fn div_signed(x: i8, y: i8) -> i8 {
+    x / y
+}
+
+#[inline(never)]
+fn div_unsigned(x: u8, y: u8) -> u8 {
+    x / y
+}
+
+#[cfg_attr(crux, crux_test)]
+fn crux_test() -> u8 {
+    let a: i8 = div_signed(1, 1);
+    let b: i8 = div_signed(-128, -1);   // Should fail
+    let c: i8 = div_signed(-128, -2);
+    let d: i8 = div_signed(-127, -1);
+    let e: i8 = div_signed(-1, 0);      // Should fail
+
+    let f: u8 = div_unsigned(1, 1);
+    let g: u8 = div_unsigned(1, 0);     // Should fail
+
+    (a + b + c + d + e) as u8 + (f + g)
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/symb_eval/num/checked_mul.good
+++ b/crux-mir/test/symb_eval/num/checked_mul.good
@@ -1,3 +1,9 @@
-test checked_mul/3a1fbbbh::crux_test[0]: returned 44, ok
+test checked_mul/3a1fbbbh::crux_test[0]: returned 44, FAILED
 
-[Crux] Overall status: Valid.
+failures:
+
+---- checked_mul/3a1fbbbh::crux_test[0] counterexamples ----
+Failure for test/symb_eval/num/checked_mul.rs:6:5: 6:12: error: in checked_mul/3a1fbbbh::crux_test[0]
+attempt to multiply with overflow
+
+[Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/num/checked_mul.good
+++ b/crux-mir/test/symb_eval/num/checked_mul.good
@@ -3,7 +3,7 @@ test checked_mul/3a1fbbbh::crux_test[0]: returned 44, FAILED
 failures:
 
 ---- checked_mul/3a1fbbbh::crux_test[0] counterexamples ----
-Failure for test/symb_eval/num/checked_mul.rs:6:5: 6:12: error: in checked_mul/3a1fbbbh::crux_test[0]
+Failure for test/symb_eval/num/checked_mul.rs:4:5: 4:12: error: in checked_mul/3a1fbbbh::crux_test[0]
 attempt to multiply with overflow
 
 [Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/num/checked_mul.rs
+++ b/crux-mir/test/symb_eval/num/checked_mul.rs
@@ -1,5 +1,3 @@
-// FIXME: currently passes, but should fail
-
 #[cfg_attr(crux, crux_test)]
 fn crux_test() -> u8 {
     let x = 3;

--- a/crux-mir/test/symb_eval/num/checked_mul_signed.good
+++ b/crux-mir/test/symb_eval/num/checked_mul_signed.good
@@ -1,0 +1,9 @@
+test checked_mul_signed/3a1fbbbh::crux_test[0]: returned 44, FAILED
+
+failures:
+
+---- checked_mul_signed/3a1fbbbh::crux_test[0] counterexamples ----
+Failure for test/symb_eval/num/checked_mul_signed.rs:4:5: 4:13: error: in checked_mul_signed/3a1fbbbh::crux_test[0]
+attempt to multiply with overflow
+
+[Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/num/checked_mul_signed.rs
+++ b/crux-mir/test/symb_eval/num/checked_mul_signed.rs
@@ -1,0 +1,9 @@
+#[cfg_attr(crux, crux_test)]
+fn crux_test() -> i8 {
+    let x = -3;
+    -100 * x
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}


### PR DESCRIPTION
We previously had overflow checks for Add and Sub, so `crux-mir` could detect panics due to arithmetic overflow in those operations.  This branch adds support for the remaining arithmetic operations: Mul, Div, and Rem.  `crux-mir` now supports overflow checks everywhere that `rustc` itself does.

The overflow rules are:
* `a * b` overflows if the truncated NxN -> N bit multiply produces a different result than the fully precise NxN -> 2N multiply.  Specifically, we check whether `ext(a) * ext(b) != ext(a * b)`, where `ext` is zero-extension to 2N bits for unsigned types and sign-extension for signed types.
* `a / b` and `a % b` "overflow" if `b == 0`, or (if `a` and `b` are signed) if `a` is the most negative possible value (such as `-128_i8`) and `b == -1`.

Fixes #612