### PR TITLE
[crucible-llvm] Use panic instead of error in buildIdentMap failure case.

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Monad.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Monad.hs
@@ -216,8 +216,12 @@ buildIdentMap [] _ ctx _ m
       panic "crucible-llvm:Translation.buildIdentMap"
       [ "buildIdentMap: passed arguments do not match LLVM input signature" ]
 buildIdentMap (ti:ts) _ ctx asgn m = do
-  -- ?? FIXME, irrefutable pattern...
-  let Right ty = liftMemType (L.typedType ti)
+  let ty = case liftMemType (L.typedType ti) of
+             Right t -> t
+             Left err -> panic "crucible-llvm:Translation.buildIdentMap"
+                         [ "Error attempting to lift type " <> show ti
+                         , show err
+                         ]
   packType ty ctx asgn $ \x ctx' asgn' ->
      buildIdentMap ts False ctx' asgn' (Map.insert (L.typedValue ti) (Right x) m)
 

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Monad.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Monad.hs
@@ -58,6 +58,7 @@ import           Data.Parameterized.NatRepr as NatRepr
 import           Data.Parameterized.Some
 
 import           Lang.Crucible.CFG.Generator
+import           Lang.Crucible.Panic ( panic )
 
 import           Lang.Crucible.LLVM.DataLayout
 import           Lang.Crucible.LLVM.Extension
@@ -212,7 +213,8 @@ buildIdentMap ts True ctx asgn m =
 buildIdentMap [] _ ctx _ m
   | Ctx.null ctx = m
   | otherwise =
-      error "buildIdentMap: passed arguments do not match LLVM input signature"
+      panic "crucible-llvm:Translation.buildIdentMap"
+      [ "buildIdentMap: passed arguments do not match LLVM input signature" ]
 buildIdentMap (ti:ts) _ ctx asgn m = do
   -- ?? FIXME, irrefutable pattern...
   let Right ty = liftMemType (L.typedType ti)


### PR DESCRIPTION
I think this represents and internal error and not something that would normally fail due to input or user error.