### PR TITLE
crux-mir: increase test timeout as a temporary CI fix

### DIFF
--- a/crux-mir/test/Test.hs
+++ b/crux-mir/test/Test.hs
@@ -71,11 +71,15 @@ runCrux rustFile outHandle mode = do
     -- goalTimeout is bumped from 60 to 180 because scalar.rs symbolic
     -- verification runs close to the timeout, causing flaky results
     -- (especially in CI).
+    --
+    -- The timeout is temporarily increased even further due to a performance
+    -- regression (#627).  This keeps CI from breaking while we investigate.
+    -- TODO: revert the timeout to 180 once performance is fixed
     let quiet = True
     let options = (defaultCruxOptions { Crux.inputFiles = [rustFile],
                                         Crux.simVerbose = 0,
-                                        Crux.globalTimeout = Just 180,
-                                        Crux.goalTimeout = Just 180,
+                                        Crux.globalTimeout = Just 600,
+                                        Crux.goalTimeout = Just 600,
                                         Crux.solver = "z3",
                                         Crux.quietMode = quiet,
                                         Crux.checkPathSat = (mode == RcmCoverage),


### PR DESCRIPTION
The performance regression in #627 has been causing crux-mir's `scalar/test1.rs` test to exceed its timeout on the macOS CI runners.  This branch increases the timeout (180s -> 600s) so CI will stop breaking.  Once #627 is fixed, we should revert this.