### PR TITLE
crucible-go: Remove unused dependencies

### DIFF
--- a/crucible-go/crucible-go.cabal
+++ b/crucible-go/crucible-go.cabal
@@ -17,27 +17,10 @@ executable crux-go
 
   build-depends:
     base >= 4 && < 5,
-    aig,
-    ansi-wl-pprint,
-    array,
-    containers,
     crucible,
-    directory,
-    filepath,
-    haskeline >= 0.7,
-    lens,
-    mtl >= 2.1,
     parameterized-utils >= 1.0 && < 2.2,
-    pretty >= 1.1,
-    split >= 0.2,
-    text,
-    transformers >= 0.3,
-    transformers-compat,
-    vector >= 0.7,
     golang,
-    what4 >= 0.4,
     crucible-go,
-    ansi-terminal,
     crux,
     bytestring
 
@@ -55,21 +38,18 @@ library
                        Lang.Crucible.Go.Translation
                        Lang.Crucible.Go.TransUtil
                        Lang.Crucible.Go.Types
-  -- other-modules:       
-  -- other-extensions:    
+  -- other-modules:
+  -- other-extensions:
   build-depends:       base >=4.8 && < 5
                      , golang
                      , text
                      , crucible
-                     , containers
                      , unordered-containers
                      , parameterized-utils
                      , mtl
                      , data-default-class
-                     , lens-simple
                      , what4
                      , transformers >= 0.3
-                     , ansi-wl-pprint
                      , crux
                      , vector
                      , bv-sized

--- a/crucible-go/crucible-go.cabal
+++ b/crucible-go/crucible-go.cabal
@@ -46,12 +46,12 @@ library
                      , crucible
                      , unordered-containers
                      , parameterized-utils
-                     , mtl
+                     , mtl >= 2.1
                      , data-default-class
-                     , what4
+                     , what4 >= 0.4
                      , transformers >= 0.3
                      , crux
-                     , vector
+                     , vector >= 0.7
                      , bv-sized
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
This was originally motivated by discovering that the `lens-simple` dependency (which does not compile on GHC 9.0) goes unused in `crucible-go`. I then decided to leverage GHC's `-Wunused-packages` flag to discover other unused dependencies. This patch removes all such dependencies.