### PR TITLE
crucible-llvm: Add a 'gas' parameter to strlen override

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libc.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libc.hs
@@ -469,7 +469,7 @@ callStrlen
   -> OverrideSim p sym ext r args ret (RegValue sym (BVType wptr))
 callStrlen sym mvar (regValue -> strPtr) = do
   mem <- readGlobal mvar
-  liftIO $ strLen sym mem strPtr
+  liftIO $ strLen sym Nothing mem strPtr
 
 callAssert
   :: (IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym)


### PR DESCRIPTION
Fixes #689. If we merge #673, I can add a testcase in that tool by adding an `strlen` override that passes a non-`Nothing` value, and using a non-terminating program like the one from #689 .