### PR TITLE
uc-crux-llvm: Add unsound overrides for getenv, gethostname

### DIFF
--- a/uc-crux-llvm/src/UCCrux/LLVM/Config.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Config.hs
@@ -42,8 +42,7 @@ data UCCruxLLVMOptions = UCCruxLLVMOptions
     exploreParallel :: Bool,
     entryPoints :: [String],
     skipFunctions :: [String],
-    verbosity :: Int,
-    unsoundOverrides :: Bool
+    verbosity :: Int
   }
 
 -- | Crucible will infinitely loop when it encounters unbounded program loops,
@@ -95,14 +94,6 @@ skipDoc = "List of functions to skip during exploration"
 verbDoc :: Text
 verbDoc = "Verbosity of logging. (0: minimal, 1: informational, 2: debug)"
 
-unsoundOverridesDoc :: Text
-unsoundOverridesDoc =
-  Text.unwords
-    [ "Apply unsound (underapproximate) overrides for these functions:",
-      "gethostname, and getenv. This can lead to more code coverage, but any",
-      "safety claims about functions that call these ones might not hold."
-    ]
-
 ucCruxLLVMConfig :: IO (Crux.Config UCCruxLLVMOptions)
 ucCruxLLVMConfig = do
   llvmOpts <- llvmCruxConfig
@@ -118,8 +109,7 @@ ucCruxLLVMConfig = do
             <*> Crux.section "explore-parallel" Crux.yesOrNoSpec False exploreParallelDoc
             <*> Crux.section "entry-points" (Crux.listSpec Crux.stringSpec) [] entryPointsDoc
             <*> Crux.section "skip-functions" (Crux.listSpec Crux.stringSpec) [] skipDoc
-            <*> Crux.section "verbosity" Crux.numSpec 0 verbDoc
-            <*> Crux.section "unsound-overrides" Crux.yesOrNoSpec False unsoundOverridesDoc,
+            <*> Crux.section "verbosity" Crux.numSpec 0 verbDoc,
         Crux.cfgEnv =
           map
             ( \envDescr ->
@@ -212,13 +202,6 @@ ucCruxLLVMConfig = do
                      Crux.parsePosNum
                        "LEVEL"
                        $ \v opts ->
-                         opts {verbosity = v},
-                 Crux.Option
-                   []
-                   ["unsound-overrides"]
-                   (Text.unpack unsoundOverridesDoc)
-                   $ Crux.NoArg $
-                     \opts ->
-                       Right opts {unsoundOverrides = True}
+                         opts {verbosity = v}
                ]
       }

--- a/uc-crux-llvm/src/UCCrux/LLVM/Errors/Unimplemented.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Errors/Unimplemented.hs
@@ -36,6 +36,8 @@ data Unimplemented
   | GeneratingArrays
   | IndexCursor
   | ConstrainGlobal
+  | GetHostNameNegativeSize
+  | GetHostNameSmallSize
   deriving (Bounded, Enum, Eq, Ord)
 
 ppUnimplemented :: Unimplemented -> String
@@ -50,6 +52,8 @@ ppUnimplemented =
     GeneratingArrays -> "Arrays in globals or arguments"
     IndexCursor -> "Deduced preconditions on array elements"
     ConstrainGlobal -> "Constraints on a global variable"
+    GetHostNameNegativeSize -> "`gethostname` called with a negative length"
+    GetHostNameSmallSize -> "`gethostname` called with a small length"
 
 instance PanicComponent Unimplemented where
   panicComponentName _ = "uc-crux-llvm"

--- a/uc-crux-llvm/src/UCCrux/LLVM/Overrides.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Overrides.hs
@@ -92,7 +92,6 @@ unsoundOverrides ::
   proxy arch ->
   [OverrideTemplate (personality sym) sym arch rtp l a]
 unsoundOverrides arch =
-  -- NOTE(lb): The list here should match that in the "Config" module.
   [ basic_llvm_override $
       [llvmOvr| i32 @gethostname( i8* , size_t ) |]
         (\memOps sym args -> Ctx.uncurryAssignment (callGetHostName arch sym memOps) args),

--- a/uc-crux-llvm/src/UCCrux/LLVM/Overrides.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Overrides.hs
@@ -92,6 +92,7 @@ unsoundOverrides ::
   proxy arch ->
   [OverrideTemplate (personality sym) sym arch rtp l a]
 unsoundOverrides arch =
+  -- NOTE(lb): The list here should match that in the "Config" module.
   [ basic_llvm_override $
       [llvmOvr| i32 @gethostname( i8* , size_t ) |]
         (\memOps sym args -> Ctx.uncurryAssignment (callGetHostName arch sym memOps) args),

--- a/uc-crux-llvm/src/UCCrux/LLVM/Overrides.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Overrides.hs
@@ -1,0 +1,140 @@
+{-
+Module       : UCCrux.LLVM.Overrides
+Description  : Additional overrides
+Copyright    : (c) Galois, Inc 2021
+License      : BSD3
+Maintainer   : Langston Barrett <langston@galois.com>
+Stability    : provisional
+-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module UCCrux.LLVM.Overrides
+  ( registerUnsoundOverrides,
+  )
+where
+
+{- ORMOLU_DISABLE -}
+import           Control.Lens ((^.))
+import           Control.Monad.IO.Class (liftIO)
+import qualified Data.BitVector.Sized as BV
+import qualified Data.ByteString as BS
+
+import qualified Text.LLVM.AST as L
+
+import qualified Data.Parameterized.Context as Ctx
+import           Data.Parameterized.NatRepr (knownNat)
+
+import qualified What4.Interface as What4
+
+-- crucible
+import           Lang.Crucible.Backend (IsSymInterface)
+import           Lang.Crucible.CFG.Common (GlobalVar)
+import           Lang.Crucible.Simulator.OverrideSim (OverrideSim)
+import qualified Lang.Crucible.Simulator.OverrideSim as Override
+import           Lang.Crucible.Simulator.RegMap (RegEntry, emptyRegMap, regValue)
+import           Lang.Crucible.Simulator.RegValue (RegValue)
+import           Lang.Crucible.Types (BVType)
+
+-- crucible-llvm
+import           Lang.Crucible.LLVM.DataLayout (noAlignment)
+import           Lang.Crucible.LLVM.Extension (ArchWidth, LLVM)
+import           Lang.Crucible.LLVM.QQ (llvmOvr)
+import           Lang.Crucible.LLVM.MemModel (HasLLVMAnn, Mem, LLVMPointerType)
+import qualified Lang.Crucible.LLVM.MemModel as LLVMMem
+import           Lang.Crucible.LLVM.Translation (ModuleTranslation, transContext, llvmTypeCtx)
+import           Lang.Crucible.LLVM.TypeContext (TypeContext)
+import           Lang.Crucible.LLVM.Intrinsics (OverrideTemplate(..), register_llvm_overrides, basic_llvm_override)
+
+import           Crux.Types (OverM, Model, HasModel)
+
+-- crux-llvm
+import           Crux.LLVM.Overrides (ArchOk)
+
+-- uc-crux-llvm
+import           UCCrux.LLVM.Errors.Unimplemented (unimplemented)
+import qualified UCCrux.LLVM.Errors.Unimplemented as Unimplemented
+{- ORMOLU_ENABLE -}
+
+-- | Register some additional overrides that are useful for bugfinding, but not
+-- for verification. They unsoundly under-approximate the environment. This
+-- helps symbolic execution reach more code.
+registerUnsoundOverrides ::
+  (ArchOk arch, IsSymInterface sym, HasLLVMAnn sym) =>
+  proxy arch ->
+  L.Module ->
+  ModuleTranslation arch ->
+  OverM Model sym LLVM ()
+registerUnsoundOverrides proxy llvmModule mtrans =
+  do
+    let llvmCtx = mtrans ^. transContext
+    let ?lc = llvmCtx ^. llvmTypeCtx
+    register_llvm_overrides llvmModule [] (unsoundOverrides proxy) llvmCtx
+
+unsoundOverrides ::
+  ( IsSymInterface sym,
+    HasLLVMAnn sym,
+    ArchOk arch,
+    ?lc :: TypeContext,
+    HasModel personality
+  ) =>
+  proxy arch ->
+  [OverrideTemplate (personality sym) sym arch rtp l a]
+unsoundOverrides arch =
+  [ basic_llvm_override $
+      [llvmOvr| i32 @gethostname( i8* , size_t ) |]
+        (\memOps sym args -> Ctx.uncurryAssignment (callGetHostName arch sym memOps) args)
+  ]
+
+callGetHostName ::
+  ( IsSymInterface sym,
+    HasLLVMAnn sym,
+    wptr ~ ArchWidth arch,
+    ArchOk arch,
+    ?lc :: TypeContext
+  ) =>
+  proxy arch ->
+  sym ->
+  GlobalVar Mem ->
+  RegEntry sym (LLVMPointerType wptr) ->
+  RegEntry sym (BVType wptr) ->
+  OverrideSim p sym ext r args ret (RegValue sym (BVType 32))
+callGetHostName _proxy sym mvar (regValue -> ptr) (regValue -> len) =
+  do
+    let hostname = "hostname"
+    let lenLt bv = liftIO (What4.bvSlt sym len =<< What4.bvLit sym ?ptrWidth bv)
+    lenNeg <- lenLt (BV.mkBV ?ptrWidth 0)
+    -- TODO(lb): Panic if ?ptrWidth is like 2 or something crazy
+    lenSmall <- lenLt (BV.mkBV ?ptrWidth (fromIntegral (BS.length hostname)))
+    Override.symbolicBranches
+      emptyRegMap
+      [ ( lenNeg,
+          Override.modifyGlobal mvar $ \_mem ->
+            unimplemented "callGetHostName" Unimplemented.GetHostNameNegativeSize,
+          Nothing
+        ),
+        ( lenSmall,
+          Override.modifyGlobal mvar $ \_mem ->
+            unimplemented "callGetHostName" Unimplemented.GetHostNameSmallSize,
+          Nothing
+        ),
+        -- TODO Check for name size
+        -- Otherwise, return a canned name
+        ( What4.truePred sym,
+          Override.modifyGlobal mvar $ \mem ->
+            liftIO $
+              do
+                let val = LLVMMem.LLVMValString hostname
+                let ty = LLVMMem.llvmValStorableType val
+                mem1 <- LLVMMem.storeRaw sym mem ptr ty noAlignment val
+                bv0' <- What4.bvLit sym (knownNat @32) (BV.mkBV (knownNat @32) 0)
+                return (bv0', mem1),
+          Nothing
+        )
+      ]

--- a/uc-crux-llvm/src/UCCrux/LLVM/Run/Loop.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Run/Loop.hs
@@ -34,7 +34,7 @@ import qualified Lang.Crucible.CFG.Core as Crucible
 import qualified Lang.Crucible.FunctionHandle as Crucible
 
 -- crucible-llvm
-import Lang.Crucible.LLVM.MemModel (MemOptions, withPtrWidth)
+import Lang.Crucible.LLVM.MemModel (withPtrWidth)
 import Lang.Crucible.LLVM.Extension( LLVM )
 import Lang.Crucible.LLVM.Translation (llvmPtrWidth, transContext, ModuleCFGMap, cfgMap)
 
@@ -59,7 +59,7 @@ import           UCCrux.LLVM.Logging (Verbosity(Hi))
 import           UCCrux.LLVM.FullType (MapToCrucibleType)
 import           UCCrux.LLVM.Run.Result (BugfindingResult(..), SomeBugfindingResult(..))
 import qualified UCCrux.LLVM.Run.Result as Result
-import           UCCrux.LLVM.Run.Simulate (runSimulator)
+import           UCCrux.LLVM.Run.Simulate (SimulationOptions(..), runSimulator)
 {- ORMOLU_ENABLE -}
 
 -- | Run the simulator in a loop, creating a 'BugfindingResult'
@@ -72,13 +72,13 @@ bugfindingLoop ::
   FunctionContext m arch argTypes ->
   Crucible.CFG LLVM blocks (MapToCrucibleType arch argTypes) ret ->
   CruxOptions ->
-  MemOptions ->
+  SimulationOptions ->
   Crucible.HandleAllocator ->
   IO (BugfindingResult m arch argTypes)
-bugfindingLoop appCtx modCtx funCtx cfg cruxOpts memOptions halloc =
+bugfindingLoop appCtx modCtx funCtx cfg cruxOpts simOpts halloc =
   do
     let runSim preconds =
-          runSimulator appCtx modCtx funCtx halloc preconds cfg cruxOpts memOptions
+          runSimulator appCtx modCtx funCtx halloc preconds cfg cruxOpts simOpts
 
     -- Loop, learning preconditions and reporting errors
     let loop truePositives constraints precondTags =
@@ -169,7 +169,11 @@ loopOnFunction appCtx modCtx halloc cruxOpts ucOpts fn =
                           funCtx
                           cfg
                           cruxOpts
-                          (memOpts (Config.ucLLVMOptions ucOpts))
+                          ( SimulationOptions
+                              { memOptions = memOpts (Config.ucLLVMOptions ucOpts),
+                                applyUnsoundOverrides = Config.unsoundOverrides ucOpts
+                              }
+                          )
                           halloc
             )
       )

--- a/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
@@ -80,6 +80,7 @@ import           UCCrux.LLVM.Context.Function (FunctionContext, functionName)
 import           UCCrux.LLVM.Context.Module (ModuleContext, llvmModule, moduleTranslation)
 import           UCCrux.LLVM.Errors.Panic (panic)
 import           UCCrux.LLVM.Logging (Verbosity(Hi))
+import           UCCrux.LLVM.Overrides (registerUnsoundOverrides)
 import           UCCrux.LLVM.FullType (MapToCrucibleType)
 import           UCCrux.LLVM.PP (ppRegMap)
 import           UCCrux.LLVM.Setup (setupExecution, SetupResult(SetupResult), SetupAssumption(SetupAssumption))
@@ -186,6 +187,8 @@ simulateLLVM appCtx modCtx funCtx halloc explRef constraints cfg memOptions =
                   -- called from any particular function. Needs some
                   -- benchmarking.
                   registerFunctions (modCtx ^. llvmModule) trans
+                  -- TODO(lb): This should be configurable
+                  registerUnsoundOverrides modCtx (modCtx ^. llvmModule) trans
                   liftIO $ (appCtx ^. log) Hi $ "Running " <> funCtx ^. functionName <> " on arguments..."
                   printed <- ppRegMap modCtx funCtx sym mem args
                   mapM_ (liftIO . (appCtx ^. log) Hi . Text.pack . show) printed

--- a/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
@@ -223,7 +223,7 @@ simulateLLVM appCtx modCtx funCtx halloc explRef constraints cfg memOptions =
                   do
                     -- Helpful for debugging:
                     -- putStrLn "~~~~~~~~~~~"
-                    -- putStrLn (show (ppBB badBehavior))
+                    -- putStrLn (show (LLVMErrors.ppBB badBehavior))
 
                     liftIO $ (appCtx ^. log) Hi ("Explaining error: " <> Text.pack (show (LLVMErrors.explainBB badBehavior)))
                     classifyBadBehavior appCtx modCtx funCtx sym args argAnnotations argShapes badBehavior

--- a/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
@@ -18,7 +18,8 @@ Stability    : provisional
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module UCCrux.LLVM.Run.Simulate
-  ( runSimulator,
+  ( UCCruxSimulationResult (..),
+    runSimulator,
   )
 where
 
@@ -33,11 +34,14 @@ import           Data.Foldable (for_)
 import           Data.IORef
 import           Data.List (isInfixOf)
 import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import           Data.Set (Set)
 import qualified Data.Text as Text
 
 import qualified Prettyprinter as PP
 import qualified Prettyprinter.Render.Text as PP
 
+import           Data.Parameterized.Ctx (Ctx)
 import           Data.Parameterized.Some (Some(Some))
 
 import qualified What4.Interface as What4
@@ -80,9 +84,10 @@ import           UCCrux.LLVM.Context.Function (FunctionContext, functionName)
 import           UCCrux.LLVM.Context.Module (ModuleContext, llvmModule, moduleTranslation)
 import           UCCrux.LLVM.Errors.Panic (panic)
 import           UCCrux.LLVM.Logging (Verbosity(Hi))
-import           UCCrux.LLVM.Overrides (registerUnsoundOverrides)
-import           UCCrux.LLVM.FullType (MapToCrucibleType)
+import           UCCrux.LLVM.Overrides (UnsoundOverrideName, registerUnsoundOverrides)
+import           UCCrux.LLVM.FullType (FullType, MapToCrucibleType)
 import           UCCrux.LLVM.PP (ppRegMap)
+import           UCCrux.LLVM.Run.Unsoundness (Unsoundness(Unsoundness))
 import           UCCrux.LLVM.Setup (setupExecution, SetupResult(SetupResult), SetupAssumption(SetupAssumption))
 import           UCCrux.LLVM.Setup.Monad (ppSetupError)
 {- ORMOLU_ENABLE -}
@@ -94,11 +99,12 @@ simulateLLVM ::
   FunctionContext m arch argTypes ->
   Crucible.HandleAllocator ->
   IORef [Explanation m arch argTypes] ->
+  IORef (Set UnsoundOverrideName) ->
   Constraints m argTypes ->
   Crucible.CFG LLVM blocks (MapToCrucibleType arch argTypes) ret ->
   MemOptions ->
   Crux.SimulatorCallback
-simulateLLVM appCtx modCtx funCtx halloc explRef constraints cfg memOptions =
+simulateLLVM appCtx modCtx funCtx halloc explRef unsoundOverrideRef constraints cfg memOptions =
   Crux.SimulatorCallback $ \sym _maybeOnline ->
     do
       let trans = modCtx ^. moduleTranslation
@@ -187,8 +193,7 @@ simulateLLVM appCtx modCtx funCtx halloc explRef constraints cfg memOptions =
                   -- called from any particular function. Needs some
                   -- benchmarking.
                   registerFunctions (modCtx ^. llvmModule) trans
-                  -- TODO(lb): This should be configurable
-                  registerUnsoundOverrides modCtx (modCtx ^. llvmModule) trans
+                  registerUnsoundOverrides modCtx (modCtx ^. llvmModule) trans unsoundOverrideRef
                   liftIO $ (appCtx ^. log) Hi $ "Running " <> funCtx ^. functionName <> " on arguments..."
                   printed <- ppRegMap modCtx funCtx sym mem args
                   mapM_ (liftIO . (appCtx ^. log) Hi . Text.pack . show) printed
@@ -232,6 +237,13 @@ simulateLLVM appCtx modCtx funCtx halloc explRef constraints cfg memOptions =
 
       return (Crux.RunnableState initSt, explainFailure)
 
+-- NOTE(lb): The explicit kind signature here is necessary for GHC 8.6
+-- compatibility.
+data UCCruxSimulationResult m arch (argTypes :: Ctx (FullType m)) = UCCruxSimulationResult
+  { unsoundness :: Unsoundness,
+    explanations :: [Explanation m arch argTypes]
+  }
+
 runSimulator ::
   ( ?outputConfig :: OutputConfig,
     ArchOk arch
@@ -244,10 +256,11 @@ runSimulator ::
   Crucible.CFG LLVM blocks (MapToCrucibleType arch argTypes) ret ->
   CruxOptions ->
   MemOptions ->
-  IO [Explanation m arch argTypes]
+  IO (UCCruxSimulationResult m arch argTypes)
 runSimulator appCtx modCtx funCtx halloc preconditions cfg cruxOpts memOptions =
   do
     explRef <- newIORef []
+    unsoundOverrideRef <- newIORef Set.empty
     cruxResult <-
       Crux.runSimulator
         cruxOpts
@@ -257,11 +270,14 @@ runSimulator appCtx modCtx funCtx halloc preconditions cfg cruxOpts memOptions =
             funCtx
             halloc
             explRef
+            unsoundOverrideRef
             preconditions
             cfg
             memOptions
         )
-    case cruxResult of
-      Crux.CruxSimulationResult Crux.ProgramIncomplete _ ->
-        pure [ExUncertain (UTimeout (funCtx ^. functionName))]
-      _ -> readIORef explRef
+    unsoundness' <- Unsoundness <$> readIORef unsoundOverrideRef
+    UCCruxSimulationResult unsoundness'
+      <$> case cruxResult of
+        Crux.CruxSimulationResult Crux.ProgramIncomplete _ ->
+          pure [ExUncertain (UTimeout (funCtx ^. functionName))]
+        _ -> readIORef explRef

--- a/uc-crux-llvm/src/UCCrux/LLVM/Run/Unsoundness.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Run/Unsoundness.hs
@@ -1,0 +1,62 @@
+{-
+Module       : UCCrux.LLVM.Run.Unsoundness
+Description  : Tracking sources of unsoundness
+Copyright    : (c) Galois, Inc 2021
+License      : BSD3
+Maintainer   : Langston Barrett <langston@galois.com>
+Stability    : provisional
+-}
+{-# LANGUAGE DeriveFunctor #-}
+
+module UCCrux.LLVM.Run.Unsoundness
+  ( Unsoundness (..),
+    WithUnsoundness (..),
+    ppUnsoundness,
+  )
+where
+
+{- ORMOLU_DISABLE -}
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import           Data.Void (Void)
+
+import           Prettyprinter (Doc)
+import qualified Prettyprinter as PP
+
+import           UCCrux.LLVM.Overrides (UnsoundOverrideName(getUnsoundOverrideName))
+{- ORMOLU_ENABLE -}
+
+-- | Track sources of unsoundness
+data WithUnsoundness a = WithUnsoundness
+  { unsoundness :: Unsoundness,
+    possiblyUnsoundValue :: a
+  }
+  deriving (Eq, Functor, Ord, Show)
+
+data Unsoundness = Unsoundness
+  { unsoundOverridesUsed :: Set UnsoundOverrideName
+  }
+  deriving (Eq, Ord, Show)
+
+ppUnsoundness :: Unsoundness -> Doc Void
+ppUnsoundness u =
+  PP.nest 2 $
+    PP.vcat $
+      PP.pretty
+        "The following unsound overrides (built-in functions) were used:" :
+      map
+        ((PP.pretty "-" PP.<+>) . PP.pretty . getUnsoundOverrideName)
+        (Set.toList (unsoundOverridesUsed u))
+
+instance Semigroup Unsoundness where
+  u1 <> u2 =
+    Unsoundness
+      { unsoundOverridesUsed =
+          unsoundOverridesUsed u1 <> unsoundOverridesUsed u2
+      }
+
+instance Monoid Unsoundness where
+  mempty =
+    Unsoundness
+      { unsoundOverridesUsed = Set.empty
+      }

--- a/uc-crux-llvm/test/Test.hs
+++ b/uc-crux-llvm/test/Test.hs
@@ -121,12 +121,7 @@ findBugs llvmModule file fns =
           Crux.loadOptions outCfg "uc-crux-llvm" "0.1" conf $ \(cruxOpts, ucOpts) ->
             do
               let cruxOpts' = cruxOpts {Crux.inputFiles = [testDir </> file]}
-              let ucOpts' =
-                    ucOpts
-                      { Config.entryPoints = fns,
-                        -- TODO(lb): This should be configurable per-test
-                        Config.unsoundOverrides = True
-                      }
+              let ucOpts' = ucOpts {Config.entryPoints = fns}
               (appCtx, cruxOpts'', ucOpts'') <- Config.processUCCruxLLVMOptions (cruxOpts', ucOpts')
               path <-
                 if isRealFile

--- a/uc-crux-llvm/test/Test.hs
+++ b/uc-crux-llvm/test/Test.hs
@@ -349,6 +349,10 @@ inFileTests =
         ("write_to_null.c", [("write_to_null", hasBugs)]),
         ("branch.c", [("branch", isSafe)]),
         ("compare_to_null.c", [("compare_to_null", isSafe)]),
+        -- This override needs refinement; the following should be safe with the
+        -- precondition that the argument pointer is valid.
+        ("getenv_arg.c", [("getenv_arg", isSafe)]),
+        ("getenv_const.c", [("getenv_const", isSafe)]),
         ("gethostname_const_len.c", [("gethostname_const_len", isSafe)]),
         ("id_function_pointer.c", [("id_function_pointer", isSafe)]),
         ("opaque_struct.c", [("opaque_struct", isSafe)]),

--- a/uc-crux-llvm/test/Test.hs
+++ b/uc-crux-llvm/test/Test.hs
@@ -349,6 +349,7 @@ inFileTests =
         ("write_to_null.c", [("write_to_null", hasBugs)]),
         ("branch.c", [("branch", isSafe)]),
         ("compare_to_null.c", [("compare_to_null", isSafe)]),
+        ("gethostname_const_len.c", [("gethostname_const_len", isSafe)]),
         ("id_function_pointer.c", [("id_function_pointer", isSafe)]),
         ("opaque_struct.c", [("opaque_struct", isSafe)]),
         ("print.c", [("print", isSafe)]),
@@ -365,6 +366,7 @@ inFileTests =
         ("free_dict.c", [("free_dict", isSafeWithPreconditions DidHitBounds)]),
         ("free_dict_kv.c", [("free_dict_kv", isSafeWithPreconditions DidHitBounds)]),
         ("free_linked_list.c", [("free_linked_list", isSafeWithPreconditions DidHitBounds)]),
+        ("gethostname_arg_ptr.c", [("gethostname_arg_ptr", isSafeWithPreconditions DidntHitBounds)]),
         ("linked_list_sum.c", [("linked_list_sum", isSafeWithPreconditions DidHitBounds)]),
         ("lots_of_loops.c", [("lots_of_loops", isSafeWithPreconditions DidHitBounds)]),
         ("memset_const_len.c", [("memset_const_len", isSafeWithPreconditions DidntHitBounds)]),
@@ -979,5 +981,14 @@ main =
         isUnimplemented "id_varargs_function_pointer.c" "id_varargs_function_pointer", -- goal: isSafe
         -- Strangely, this compiles to a function that takes a variable-arity
         -- function as an argument?
-        isUnimplemented "set_errno.c" "set_errno" -- goal: ???
+        isUnimplemented "set_errno.c" "set_errno", -- goal: ???
+        isUnimplemented
+          "gethostname_neg_len.c"
+          "gethostname_neg_len", -- goal: ???
+        isUnimplemented
+          "gethostname_arg_ptr_len.c"
+          "gethostname_arg_ptr_len", -- goal: ???
+        isUnimplemented
+          "gethostname_arg_len.c"
+          "gethostname_arg_len" -- goal: ???
       ]

--- a/uc-crux-llvm/test/Test.hs
+++ b/uc-crux-llvm/test/Test.hs
@@ -121,7 +121,12 @@ findBugs llvmModule file fns =
           Crux.loadOptions outCfg "uc-crux-llvm" "0.1" conf $ \(cruxOpts, ucOpts) ->
             do
               let cruxOpts' = cruxOpts {Crux.inputFiles = [testDir </> file]}
-              let ucOpts' = ucOpts {Config.entryPoints = fns}
+              let ucOpts' =
+                    ucOpts
+                      { Config.entryPoints = fns,
+                        -- TODO(lb): This should be configurable per-test
+                        Config.unsoundOverrides = True
+                      }
               (appCtx, cruxOpts'', ucOpts'') <- Config.processUCCruxLLVMOptions (cruxOpts', ucOpts')
               path <-
                 if isRealFile

--- a/uc-crux-llvm/test/programs/getenv_arg.c
+++ b/uc-crux-llvm/test/programs/getenv_arg.c
@@ -1,0 +1,2 @@
+#include <stdlib.h>
+char *getenv_arg(char *var) { return getenv(var); }

--- a/uc-crux-llvm/test/programs/getenv_const.c
+++ b/uc-crux-llvm/test/programs/getenv_const.c
@@ -1,0 +1,2 @@
+#include <stdlib.h>
+char *getenv_const() { return getenv("SOME_VARIABLE"); }

--- a/uc-crux-llvm/test/programs/gethostname_arg_len.c
+++ b/uc-crux-llvm/test/programs/gethostname_arg_len.c
@@ -1,0 +1,6 @@
+#include <unistd.h>
+char *gethostname_arg_len(int len) {
+  char *buf = malloc(64);
+  gethostname(buf, len);
+  return buf;
+}

--- a/uc-crux-llvm/test/programs/gethostname_arg_ptr.c
+++ b/uc-crux-llvm/test/programs/gethostname_arg_ptr.c
@@ -1,0 +1,5 @@
+#include <unistd.h>
+char *gethostname_arg_ptr(char *buf) {
+  gethostname(buf, 64);
+  return buf;
+}

--- a/uc-crux-llvm/test/programs/gethostname_arg_ptr_len.c
+++ b/uc-crux-llvm/test/programs/gethostname_arg_ptr_len.c
@@ -1,0 +1,5 @@
+#include <unistd.h>
+char *gethostname_arg_ptr_len(char *buf, int len) {
+  gethostname(buf, len);
+  return buf;
+}

--- a/uc-crux-llvm/test/programs/gethostname_const_len.c
+++ b/uc-crux-llvm/test/programs/gethostname_const_len.c
@@ -1,0 +1,6 @@
+#include <unistd.h>
+char *gethostname_const_len() {
+  char *buf = malloc(64);
+  gethostname(buf, 64);
+  return buf;
+}

--- a/uc-crux-llvm/test/programs/gethostname_neg_len.c
+++ b/uc-crux-llvm/test/programs/gethostname_neg_len.c
@@ -1,0 +1,6 @@
+#include <unistd.h>
+char *gethostname_neg_len() {
+  char *buf = malloc(64);
+  gethostname(buf, -1);
+  return buf;
+}

--- a/uc-crux-llvm/uc-crux-llvm.cabal
+++ b/uc-crux-llvm/uc-crux-llvm.cabal
@@ -42,6 +42,7 @@ library
     UCCrux.LLVM.FullType.Type
     UCCrux.LLVM.Logging
     UCCrux.LLVM.Main
+    UCCrux.LLVM.Overrides
     UCCrux.LLVM.PP
     UCCrux.LLVM.Run.Explore
     UCCrux.LLVM.Run.Loop
@@ -56,6 +57,7 @@ library
     async,
     base >= 4.8 && < 4.15,
     bv-sized,
+    bytestring,
     config-schema,
     containers,
     crucible,

--- a/uc-crux-llvm/uc-crux-llvm.cabal
+++ b/uc-crux-llvm/uc-crux-llvm.cabal
@@ -48,6 +48,7 @@ library
     UCCrux.LLVM.Run.Loop
     UCCrux.LLVM.Run.Result
     UCCrux.LLVM.Run.Simulate
+    UCCrux.LLVM.Run.Unsoundness
     UCCrux.LLVM.Setup
     UCCrux.LLVM.Setup.Monad
     UCCrux.LLVM.Shape


### PR DESCRIPTION
These overrides aren't suitable for verification, but they can help achieve higher coverage for finding bugs with `uc-crux-llvm`. The behavior without them is to just bail unconditionally when calls to these functions (and many others) are encountered.