### PR TITLE
uc-crux-llvm: Configurable hard timeout and parallelism for exploration mode

### DIFF
--- a/uc-crux-llvm/src/UCCrux/LLVM/Config.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Config.hs
@@ -35,8 +35,10 @@ data UCCruxLLVMOptions = UCCruxLLVMOptions
   { ucLLVMOptions :: LLVMOptions,
     doExplore :: Bool,
     reExplore :: Bool,
-    entryPoints :: [String],
     exploreBudget :: Int,
+    exploreTimeout :: Int,
+    exploreParallel :: Bool,
+    entryPoints :: [String],
     skipFunctions :: [String],
     verbosity :: Int
   }
@@ -85,15 +87,25 @@ ucCruxLLVMConfig = do
               False
               "Re-explore functions that have already been explored (i.e., have logs)"
             <*> Crux.section
-              "entry-points"
-              (Crux.listSpec Crux.stringSpec)
-              []
-              "Comma-separated list of functions to examine."
-            <*> Crux.section
               "explore-budget"
               Crux.numSpec
               8
               "Budget for exploration mode"
+            <*> Crux.section
+              "explore-timeout"
+              Crux.numSpec
+              5
+              "Hard timeout for exploration of a single function (seconds)"
+            <*> Crux.section
+              "explore-parallel"
+              Crux.yesOrNoSpec
+              False
+              "Explore different functions in parallel"
+            <*> Crux.section
+              "entry-points"
+              (Crux.listSpec Crux.stringSpec)
+              []
+              "Comma-separated list of functions to examine."
             <*> Crux.section
               "skip-functions"
               (Crux.listSpec Crux.stringSpec)
@@ -157,15 +169,6 @@ ucCruxLLVMConfig = do
                          opts {verbosity = v},
                  Crux.Option
                    []
-                   ["explore-budget"]
-                   "Budget for exploration mode"
-                   $ Crux.ReqArg
-                     "INT"
-                     $ Crux.parsePosNum
-                       "INT"
-                       $ \v opts -> opts {exploreBudget = v},
-                 Crux.Option
-                   []
                    ["skip-functions"]
                    "List of functions to skip during exploration"
                    $ Crux.ReqArg "FUN" $
@@ -181,6 +184,30 @@ ucCruxLLVMConfig = do
                    ["re-explore"]
                    "Re-explore functions that have already been explored (i.e., have logs)"
                    $ Crux.NoArg $
-                     \opts -> Right opts {reExplore = True}
+                     \opts -> Right opts {reExplore = True},
+                 Crux.Option
+                   []
+                   ["explore-budget"]
+                   "Budget for exploration mode"
+                   $ Crux.ReqArg
+                     "INT"
+                     $ Crux.parsePosNum
+                       "INT"
+                       $ \v opts -> opts {exploreBudget = v},
+                 Crux.Option
+                   []
+                   ["explore-timeout"]
+                   "Hard timeout for exploration of a single function (seconds)"
+                   $ Crux.ReqArg
+                     "INT"
+                     $ Crux.parsePosNum
+                       "INT"
+                       $ \v opts -> opts {exploreTimeout = v},
+                 Crux.Option
+                   []
+                   ["explore-parallel"]
+                   "Explore different functions in parallel"
+                   $ Crux.NoArg $
+                     \opts -> Right opts {exploreParallel = True}
                ]
       }

--- a/uc-crux-llvm/src/UCCrux/LLVM/Config.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Config.hs
@@ -20,6 +20,8 @@ import           Control.Applicative ((<|>))
 import           Control.Monad (when)
 import           Data.Functor ((<&>))
 import           Data.Word (Word64)
+import           Data.Text (Text)
+import qualified Data.Text as Text
 import           System.Exit (die)
 
 import qualified Crux.Config as Crux
@@ -68,6 +70,30 @@ processUCCruxLLVMOptions (initCOpts, initUCOpts) =
         )
     pure (appCtx, finalCOpts, initUCOpts {ucLLVMOptions = finalLLOpts})
 
+exploreDoc :: Text
+exploreDoc = "Run in exploration mode"
+
+reExploreDoc :: Text
+reExploreDoc = "Re-explore functions that have already been explored (i.e., have logs)"
+
+exploreBudgetDoc :: Text
+exploreBudgetDoc = "Budget for exploration mode (number of functions)"
+
+exploreTimeoutDoc :: Text
+exploreTimeoutDoc = "Hard timeout for exploration of a single function (seconds)"
+
+exploreParallelDoc :: Text
+exploreParallelDoc = "Explore different functions in parallel"
+
+entryPointsDoc :: Text
+entryPointsDoc = "Comma-separated list of functions to examine."
+
+skipDoc :: Text
+skipDoc = "List of functions to skip during exploration"
+
+verbDoc :: Text
+verbDoc = "Verbosity of logging. (0: minimal, 1: informational, 2: debug)"
+
 ucCruxLLVMConfig :: IO (Crux.Config UCCruxLLVMOptions)
 ucCruxLLVMConfig = do
   llvmOpts <- llvmCruxConfig
@@ -76,46 +102,14 @@ ucCruxLLVMConfig = do
       { Crux.cfgFile =
           UCCruxLLVMOptions
             <$> Crux.cfgFile llvmOpts
-            <*> Crux.section
-              "explore"
-              Crux.yesOrNoSpec
-              False
-              "Run in exploration mode"
-            <*> Crux.section
-              "re-explore"
-              Crux.yesOrNoSpec
-              False
-              "Re-explore functions that have already been explored (i.e., have logs)"
-            <*> Crux.section
-              "explore-budget"
-              Crux.numSpec
-              8
-              "Budget for exploration mode"
-            <*> Crux.section
-              "explore-timeout"
-              Crux.numSpec
-              5
-              "Hard timeout for exploration of a single function (seconds)"
-            <*> Crux.section
-              "explore-parallel"
-              Crux.yesOrNoSpec
-              False
-              "Explore different functions in parallel"
-            <*> Crux.section
-              "entry-points"
-              (Crux.listSpec Crux.stringSpec)
-              []
-              "Comma-separated list of functions to examine."
-            <*> Crux.section
-              "skip-functions"
-              (Crux.listSpec Crux.stringSpec)
-              []
-              "List of functions to skip during exploration"
-            <*> Crux.section
-              "verbosity"
-              Crux.numSpec
-              0
-              "Verbosity of logging. (0: minimal, 1: informational, 2: debug)",
+            <*> Crux.section "explore" Crux.yesOrNoSpec False exploreDoc
+            <*> Crux.section "re-explore" Crux.yesOrNoSpec False reExploreDoc
+            <*> Crux.section "explore-budget" Crux.numSpec 8 exploreBudgetDoc
+            <*> Crux.section "explore-timeout" Crux.numSpec 5 exploreTimeoutDoc
+            <*> Crux.section "explore-parallel" Crux.yesOrNoSpec False exploreParallelDoc
+            <*> Crux.section "entry-points" (Crux.listSpec Crux.stringSpec) [] entryPointsDoc
+            <*> Crux.section "skip-functions" (Crux.listSpec Crux.stringSpec) [] skipDoc
+            <*> Crux.section "verbosity" Crux.numSpec 0 verbDoc,
         Crux.cfgEnv =
           map
             ( \envDescr ->
@@ -154,41 +148,20 @@ ucCruxLLVMConfig = do
             (Crux.cfgCmdLineFlag llvmOpts)
             ++ [ Crux.Option
                    []
-                   ["entry-points"]
-                   "List of functions to examine."
-                   $ Crux.ReqArg "FUN" $
-                     \v opts -> Right opts {entryPoints = v : entryPoints opts},
-                 Crux.Option
-                   ['v']
-                   ["verbosity"]
-                   "Verbosity of logging. (0: minimal, 1: informational, 2: debug)"
-                   $ Crux.ReqArg "LEVEL" $
-                     Crux.parsePosNum
-                       "LEVEL"
-                       $ \v opts ->
-                         opts {verbosity = v},
-                 Crux.Option
-                   []
-                   ["skip-functions"]
-                   "List of functions to skip during exploration"
-                   $ Crux.ReqArg "FUN" $
-                     \v opts -> Right opts {skipFunctions = v : skipFunctions opts},
-                 Crux.Option
-                   []
                    ["explore"]
-                   "Run in exploration mode"
+                   (Text.unpack exploreDoc)
                    $ Crux.NoArg $
                      \opts -> Right opts {doExplore = True},
                  Crux.Option
                    []
                    ["re-explore"]
-                   "Re-explore functions that have already been explored (i.e., have logs)"
+                   (Text.unpack reExploreDoc)
                    $ Crux.NoArg $
                      \opts -> Right opts {reExplore = True},
                  Crux.Option
                    []
                    ["explore-budget"]
-                   "Budget for exploration mode"
+                   (Text.unpack exploreBudgetDoc)
                    $ Crux.ReqArg
                      "INT"
                      $ Crux.parsePosNum
@@ -197,7 +170,7 @@ ucCruxLLVMConfig = do
                  Crux.Option
                    []
                    ["explore-timeout"]
-                   "Hard timeout for exploration of a single function (seconds)"
+                   (Text.unpack exploreTimeoutDoc)
                    $ Crux.ReqArg
                      "INT"
                      $ Crux.parsePosNum
@@ -206,8 +179,29 @@ ucCruxLLVMConfig = do
                  Crux.Option
                    []
                    ["explore-parallel"]
-                   "Explore different functions in parallel"
+                   (Text.unpack exploreParallelDoc)
                    $ Crux.NoArg $
-                     \opts -> Right opts {exploreParallel = True}
+                     \opts -> Right opts {exploreParallel = True},
+                 Crux.Option
+                   []
+                   ["entry-points"]
+                   (Text.unpack entryPointsDoc)
+                   $ Crux.ReqArg "FUN" $
+                     \v opts -> Right opts {entryPoints = v : entryPoints opts},
+                 Crux.Option
+                   []
+                   ["skip-functions"]
+                   (Text.unpack skipDoc)
+                   $ Crux.ReqArg "FUN" $
+                     \v opts -> Right opts {skipFunctions = v : skipFunctions opts},
+                 Crux.Option
+                   ['v']
+                   ["verbosity"]
+                   (Text.unpack verbDoc)
+                   $ Crux.ReqArg "LEVEL" $
+                     Crux.parsePosNum
+                       "LEVEL"
+                       $ \v opts ->
+                         opts {verbosity = v}
                ]
       }

--- a/uc-crux-llvm/src/UCCrux/LLVM/Run/Explore.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Run/Explore.hs
@@ -20,7 +20,8 @@ import           Prelude hiding (log, writeFile)
 
 import           Control.Lens ((.~))
 import           Control.Concurrent (threadDelay )
-import           Control.Concurrent.Async (race, mapConcurrently)
+import           Control.Concurrent.Async (race)
+import           Control.Scheduler (Comp(Par), traverseConcurrently)
 import           Control.Exception (displayException)
 import           Control.Lens ((^.))
 import           Data.Function ((&))
@@ -138,7 +139,8 @@ explore appCtx modCtx cruxOpts ucOpts halloc =
     stats <-
       if Config.exploreParallel ucOpts
         then
-          mapConcurrently
+          traverseConcurrently
+            Par
             (doExplore (appCtx & log .~ (\_ _ -> pure ())))
             funcsToExplore
         else for funcsToExplore (doExplore appCtx)

--- a/uc-crux-llvm/src/UCCrux/LLVM/Setup.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Setup.hs
@@ -108,7 +108,7 @@ constrainHere sym _selector constraint fullTypeRepr regEntry@(Crucible.RegEntry 
           )
   where
     assumeOne :: W4I.Pred sym -> Setup m arch sym argTypes (Crucible.RegEntry sym (ToCrucibleType arch atTy))
-    assumeOne pred = assume constraint pred >> pure regEntry
+    assumeOne predicate = assume constraint predicate >> pure regEntry
     interpretOp ::
       forall w. 1 <= w => L.ICmpOp -> W4I.SymBV sym w -> W4I.SymBV sym w -> IO (W4I.Pred sym)
     interpretOp =

--- a/uc-crux-llvm/uc-crux-llvm.cabal
+++ b/uc-crux-llvm/uc-crux-llvm.cabal
@@ -53,6 +53,7 @@ library
     UCCrux.LLVM.Stats
 
   build-depends:
+    async,
     base >= 4.8 && < 4.15,
     bv-sized,
     config-schema,

--- a/uc-crux-llvm/uc-crux-llvm.cabal
+++ b/uc-crux-llvm/uc-crux-llvm.cabal
@@ -71,6 +71,7 @@ library
     panic,
     parameterized-utils,
     prettyprinter >= 1.7.0,
+    scheduler,
     semigroupoids,
     simple-get-opt,
     text,
@@ -86,6 +87,10 @@ executable uc-crux-llvm
   build-depends:
     base >= 4.8 && < 4.15,
     uc-crux-llvm
+
+  ghc-options: -threaded
+               -rtsopts
+               "-with-rtsopts=-N"
 
   main-is: Main.hs
 


### PR DESCRIPTION
These features help it scale to bigger codebases. The hard timeout is helpful for things like the strlen override (#689), or just generally being robust to nontermination/slowness bugs in Crucible/solvers.