### PR TITLE
Modifications to eliminate partial fields and incomplete patterns.

### DIFF
--- a/.github/workflows/crux-llvm-build.yml
+++ b/.github/workflows/crux-llvm-build.yml
@@ -63,7 +63,7 @@ jobs:
 
       - uses: cachix/install-nix-action@v12
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
+          nix_path: nixpkgs=channel:nixos-20.09
       - uses: actions/cache@v2
         name: Cache cabal store
         with:

--- a/.github/workflows/crux-llvm-build.yml
+++ b/.github/workflows/crux-llvm-build.yml
@@ -87,6 +87,7 @@ jobs:
 
       - name: Package's Cabal/GHC compatibility
         shell: bash
+        if: runner.os == 'Linux'
         # Using setup will use the cabal library installed with GHC
         # instead of the cabal library of the Cabal-install tool to
         # verify the cabal file is compatible with the associated

--- a/.github/workflows/crux-mir-build.yml
+++ b/.github/workflows/crux-mir-build.yml
@@ -83,6 +83,7 @@ jobs:
 
       - name: Package's Cabal/GHC compatibility
         shell: bash
+        if: runner.os == 'Linux'
         # Using setup will use the cabal library installed with GHC
         # instead of the cabal library of the Cabal-install tool to
         # verify the cabal file is compatible with the associated

--- a/.github/workflows/crux-mir-build.yml
+++ b/.github/workflows/crux-mir-build.yml
@@ -51,7 +51,7 @@ jobs:
 
       - uses: cachix/install-nix-action@v12
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
+          nix_path: nixpkgs=channel:nixos-20.09
 
       - name: Install latest Rust nightly
         uses: actions-rs/toolchain@v1

--- a/crucible-llvm/crucible-llvm.cabal
+++ b/crucible-llvm/crucible-llvm.cabal
@@ -18,6 +18,7 @@ common bldflags
                -Werror=incomplete-patterns
                -Werror=missing-methods
                -Werror=overlapping-patterns
+               -Wpartial-fields
   ghc-prof-options: -O2 -fprof-auto-top
   default-language: Haskell2010
 

--- a/crucible-llvm/crucible-llvm.cabal
+++ b/crucible-llvm/crucible-llvm.cabal
@@ -19,6 +19,7 @@ common bldflags
                -Werror=missing-methods
                -Werror=overlapping-patterns
                -Wpartial-fields
+               -Wincomplete-uni-patterns
   ghc-prof-options: -O2 -fprof-auto-top
   default-language: Haskell2010
 

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Common.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Common.hs
@@ -58,7 +58,7 @@ import Data.Vector (Vector)
 import qualified Data.Vector as V
 import Numeric.Natural
 
-import Lang.Crucible.Panic
+import Lang.Crucible.Panic ( panic )
 import Lang.Crucible.LLVM.Bytes
 import Lang.Crucible.LLVM.MemModel.Type
 
@@ -566,7 +566,10 @@ symbolicValueLoad pref tp bnd v (LinearLoadStoreOffsetDiff stride delta) =
   MuxTable Store Load suffixTable loadFail
   where
     lsz = typeEnd 0 tp
-    Just stp = viewType v
+    stp = case viewType v of
+            Just x -> x
+            Nothing -> panic "crucible-llvm:symbolicValueLoad"
+                       [ "Unable obtain type of stored value ValueView" ]
 
     -- The prefix table represents cases where the load pointer occurs strictly before the
     -- write pointer, so that the end of the load may be partially satisfied by this write.

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Printf.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Printf.hs
@@ -93,7 +93,10 @@ data PrintfConversionType
 
 data PrintfDirective
   = StringDirective BS.ByteString
-  | ConversionDirective
+  | ConversionDirective ConversionDirective
+ deriving (Eq,Ord,Show)
+
+data ConversionDirective = Conversion
     { printfAccessField :: Maybe Int
     , printfFlags     :: Set PrintfFlag
     , printfMinWidth  :: Int
@@ -329,7 +332,7 @@ executeDirectives ops = go id 0 0
        let len'  = len + length s
        let fstr' = fstr . (s ++)
        go fstr' len' fld xs
-   go fstr !len !fld (d@ConversionDirective{}:xs) =
+   go fstr !len !fld (ConversionDirective d:xs) =
        let fld' = fromMaybe (fld+1) (printfAccessField d) in
        case printfType d of
          Conversion_Integer fmt -> do
@@ -396,7 +399,7 @@ parseConversion = do
   prec  <- option 0 (char '.' >> decimal)
   len   <- parseLenModifier
   typ   <- parseConversionType
-  return ConversionDirective
+  return $ ConversionDirective $ Conversion
          { printfAccessField = field
          , printfFlags       = flags
          , printfMinWidth    = width

--- a/crucible/crucible.cabal
+++ b/crucible/crucible.cabal
@@ -25,7 +25,11 @@ flag unsafe-operations
   Default: True
 
 common bldflags
-  ghc-options: -Wall -Werror=incomplete-patterns -Werror=missing-methods -Werror=overlapping-patterns
+  ghc-options: -Wall
+               -Werror=incomplete-patterns
+               -Werror=missing-methods
+               -Werror=overlapping-patterns
+               -Wpartial-fields
   ghc-prof-options: -O2 -fprof-auto-top
   default-language: Haskell2010
 

--- a/crucible/crucible.cabal
+++ b/crucible/crucible.cabal
@@ -30,6 +30,7 @@ common bldflags
                -Werror=missing-methods
                -Werror=overlapping-patterns
                -Wpartial-fields
+               -Wincomplete-uni-patterns
   ghc-prof-options: -O2 -fprof-auto-top
   default-language: Haskell2010
 

--- a/crucible/src/Lang/Crucible/Analysis/Fixpoint.hs
+++ b/crucible/src/Lang/Crucible/Analysis/Fixpoint.hs
@@ -726,7 +726,7 @@ wtoIteration mWiden dom interp cfg = loop (cfgWeakTopologicalOrdering cfg)
       let blk = getBlock bid (cfgBlockMap cfg)
       _ <- transfer dom interp (cfgReturnType cfg) blk assignment
       loop rest
-    loop (SCC { wtoHead = hbid, wtoComps = comps } : rest) = do
+    loop (SCC (SCCData { wtoHead = hbid, wtoComps = comps }) : rest) = do
       processSCC hbid comps 0
       loop rest
 

--- a/crucible/src/Lang/Crucible/Analysis/Postdom.hs
+++ b/crucible/src/Lang/Crucible/Analysis/Postdom.hs
@@ -89,7 +89,9 @@ postdomMap m breakpointIds = r
           [ (pd_id, mapMaybe f l)
           | (pd,_:l)  <- G.dom g 0
           , pd > 0
-          , let Just pd_id = Map.lookup pd idMap
+          -- Get the post dominator blkID, using a total version of:
+          --    let Just pd_id = Map.lookup pd idMap
+          , pd_id <- snd <$> (filter ((pd ==) . fst) $ Map.toList idMap)
           ]
 
 postdomAssignment :: forall ext blocks ret

--- a/crucible/src/Lang/Crucible/Analysis/Postdom.hs
+++ b/crucible/src/Lang/Crucible/Analysis/Postdom.hs
@@ -91,7 +91,7 @@ postdomMap m breakpointIds = r
           , pd > 0
           -- Get the post dominator blkID, using a total version of:
           --    let Just pd_id = Map.lookup pd idMap
-          , pd_id <- snd <$> (filter ((pd ==) . fst) $ Map.toList idMap)
+          , pd_id <- catMaybes [ Map.lookup pd idMap ]
           ]
 
 postdomAssignment :: forall ext blocks ret

--- a/crucible/src/Lang/Crucible/Simulator/BoundedExec.hs
+++ b/crucible/src/Lang/Crucible/Simulator/BoundedExec.hs
@@ -86,9 +86,9 @@ buildWTOMap = snd . go 0 0 Map.empty
  go !x !d m (Vertex (Some bid) : cs) =
     let m' = Map.insert (Ctx.indexVal (blockIDIndex bid)) (x,d) m
      in go (x+1) d m' cs
- go !x !d m (SCC (Some hd) subcs : cs) =
-    let m'  = Map.insert (Ctx.indexVal (blockIDIndex hd)) (x,d+1) m
-        (x',m'') = go (x+1) (d+1) m' subcs
+ go !x !d m (SCC scc : cs) =
+    let m'  = viewSome (\hd -> Map.insert (Ctx.indexVal (blockIDIndex hd)) (x,d+1) m) (wtoHead scc)
+        (x',m'') = go (x+1) (d+1) m' $ wtoComps scc
      in go x' d m'' cs
 
 

--- a/crucible/test/absint/WTO.hs
+++ b/crucible/test/absint/WTO.hs
@@ -70,9 +70,9 @@ indexContainingComponentHeads cs = St.execState (mapM_ (go []) cs) M.empty
     go heads c =
       case c of
         Vertex v -> St.modify' $ M.insert v (S.fromList heads)
-        SCC { wtoHead = h
-            , wtoComps = cs'
-            } -> do
+        SCC (SCCData { wtoHead = h
+                     , wtoComps = cs'
+                     }) -> do
           let heads' = h : heads
           St.modify' $ M.insert h (S.fromList heads')
           mapM_ (go heads') cs'

--- a/crux/crux.cabal
+++ b/crux/crux.cabal
@@ -78,7 +78,13 @@ library
    Crux.UI.Jquery,
    Crux.UI.IndexHtml
 
-  ghc-options: -Wall -Wcompat -Werror=incomplete-patterns -Werror=missing-methods -Werror=overlapping-patterns
+  ghc-options: -Wall
+               -Wcompat
+               -Werror=incomplete-patterns
+               -Werror=missing-methods
+               -Werror=overlapping-patterns
+               -Wpartial-fields
+               -Wincomplete-uni-patterns
   ghc-prof-options: -O2
   default-language: Haskell2010
 


### PR DESCRIPTION
Individual commit comments describe the various changes, but the overall is to avoid using record fields with multi-constructor ADT types and eliminate partial and/or irrefutable pattern matches.

The first commit synchronizes crucible with PR 111 in the what4 repository (the identically named branch).