### PR TITLE
uc-crux-llvm: Skip execution of declared (not defined) functions

### DIFF
--- a/crucible/src/Lang/Crucible/FunctionHandle.hs
+++ b/crucible/src/Lang/Crucible/FunctionHandle.hs
@@ -35,6 +35,7 @@ module Lang.Crucible.FunctionHandle
   , insertHandleMap
   , lookupHandleMap
   , searchHandleMap
+  , handleMapToHandles
     -- * Reference cells
   , RefCell
   , freshRefCell
@@ -231,3 +232,7 @@ searchHandleMap nm fnTyRepr (FnHandleMap m) =
       case testEquality (handleType h) fnTyRepr of
         Just Refl -> Just (h,x)
         Nothing -> Nothing
+
+handleMapToHandles :: FnHandleMap f -> [SomeHandle]
+handleMapToHandles (FnHandleMap m) =
+  map (\(Some (HandleElt handle _)) -> SomeHandle handle) (MapF.elems m)

--- a/uc-crux-llvm/src/UCCrux/LLVM/Errors/Unimplemented.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Errors/Unimplemented.hs
@@ -22,6 +22,8 @@ where
 
 {- ORMOLU_DISABLE -}
 import Control.Exception (SomeException, try, displayException)
+import Data.Text (Text)
+import qualified Data.Text as Text
 import Panic hiding (panic)
 import qualified Panic
 {- ORMOLU_ENABLE -}
@@ -39,7 +41,8 @@ data Unimplemented
   | GetHostNameNegativeSize
   | GetHostNameSmallSize
   | NonEmptyUnboundedSizeArrays
-  deriving (Bounded, Enum, Eq, Ord)
+  | NonVoidUndefinedFunc Text
+  deriving (Eq, Ord)
 
 ppUnimplemented :: Unimplemented -> String
 ppUnimplemented =
@@ -56,6 +59,8 @@ ppUnimplemented =
     GetHostNameNegativeSize -> "`gethostname` called with a negative length"
     GetHostNameSmallSize -> "`gethostname` called with a small length"
     NonEmptyUnboundedSizeArrays -> "Generating arrays with unbounded size"
+    NonVoidUndefinedFunc func ->
+      "Non-void function without a definition: " ++ Text.unpack func
 
 instance PanicComponent Unimplemented where
   panicComponentName _ = "uc-crux-llvm"

--- a/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Skip.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Skip.hs
@@ -1,0 +1,136 @@
+{-
+Module       : UCCrux.LLVM.Overrides.Skip
+Description  : Unsound overrides for skipping execution of functions
+Copyright    : (c) Galois, Inc 2021
+License      : BSD3
+Maintainer   : Langston Barrett <langston@galois.com>
+Stability    : provisional
+-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+
+module UCCrux.LLVM.Overrides.Skip
+  ( SkipOverrideName (..),
+    unsoundSkipOverrides,
+  )
+where
+
+{- ORMOLU_DISABLE -}
+import           Control.Lens ((^.), use)
+import           Control.Monad.IO.Class (liftIO)
+import           Data.IORef (IORef, modifyIORef)
+import           Data.Maybe (mapMaybe)
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import           Data.Text (Text)
+import qualified Data.Text as Text
+
+import qualified Text.LLVM.AST as L
+
+-- what4
+import           What4.FunctionName (functionName)
+
+-- crucible
+import           Lang.Crucible.Backend (IsSymInterface)
+import           Lang.Crucible.FunctionHandle (SomeHandle(..), handleMapToHandles, handleName)
+import           Lang.Crucible.Simulator.ExecutionTree (functionBindings, stateContext, fnBindings)
+import qualified Lang.Crucible.Types as CrucibleTypes
+
+-- crucible-llvm
+import           Lang.Crucible.LLVM.Extension (LLVM)
+import           Lang.Crucible.LLVM.MemModel (HasLLVMAnn)
+import           Lang.Crucible.LLVM.Translation (ModuleTranslation, transContext, llvmTypeCtx, llvmDeclToFunHandleRepr')
+import           Lang.Crucible.LLVM.TypeContext (TypeContext)
+import           Lang.Crucible.LLVM.Intrinsics (OverrideTemplate(..), LLVMOverride(..), basic_llvm_override)
+
+import           Crux.Types (OverM, Model, HasModel)
+
+-- crux-llvm
+import           Crux.LLVM.Overrides (ArchOk)
+
+-- uc-crux-llvm
+import           UCCrux.LLVM.Errors.Unimplemented (unimplemented)
+import qualified UCCrux.LLVM.Errors.Unimplemented as Unimplemented
+{- ORMOLU_ENABLE -}
+
+newtype SkipOverrideName = SkipOverrideName {getSkipOverrideName :: Text}
+  deriving (Eq, Ord, Show)
+
+declName :: L.Declare -> Text
+declName decl =
+  let L.Symbol name = L.decName decl
+   in Text.pack name
+
+-- | Additional overrides that are useful for bugfinding, but not for
+-- verification. They skip execution of the specified functions.
+--
+-- Mostly useful for functions that are declared but not defined.
+--
+-- Note that this won't register overrides for functions that already have
+-- associated CFGs, like if you already registered a normal override for `free`
+-- or similar.
+unsoundSkipOverrides ::
+  ( IsSymInterface sym,
+    HasLLVMAnn sym,
+    ArchOk arch,
+    ?lc :: TypeContext,
+    HasModel personality
+  ) =>
+  proxy arch ->
+  ModuleTranslation arch ->
+  IORef (Set SkipOverrideName) ->
+  [L.Declare] ->
+  OverM Model sym LLVM [OverrideTemplate (personality sym) sym arch rtp l a]
+unsoundSkipOverrides proxy mtrans usedRef decls =
+  do
+    let llvmCtx = mtrans ^. transContext
+    let ?lc = llvmCtx ^. llvmTypeCtx
+    binds <- use (stateContext . functionBindings)
+    let alreadyDefined =
+          Set.fromList $
+            map
+              (\(SomeHandle hand) -> functionName (handleName hand))
+              (handleMapToHandles (fnBindings binds))
+    pure $
+      mapMaybe
+        (createSkipOverride proxy usedRef)
+        (filter ((`Set.notMember` alreadyDefined) . declName) decls)
+
+-- TODO(lb): Currently only works for void functions, should be extended to
+-- handle non-void functions.
+createSkipOverride ::
+  ( IsSymInterface sym,
+    HasLLVMAnn sym,
+    ArchOk arch,
+    ?lc :: TypeContext,
+    HasModel personality
+  ) =>
+  proxy arch ->
+  IORef (Set SkipOverrideName) ->
+  L.Declare ->
+  Maybe (OverrideTemplate (personality sym) sym arch rtp l a)
+createSkipOverride _proxy usedRef decl =
+  llvmDeclToFunHandleRepr' decl $ \args ret ->
+    Just $
+      basic_llvm_override $
+        LLVMOverride
+          { llvmOverride_declare = decl,
+            llvmOverride_args = args,
+            llvmOverride_ret = ret,
+            llvmOverride_def =
+              \_memOps _sym _args ->
+                do
+                  let name = declName decl
+                  liftIO $
+                    modifyIORef usedRef (Set.insert (SkipOverrideName name))
+                  case ret of
+                    CrucibleTypes.UnitRepr -> pure ()
+                    _ ->
+                      unimplemented
+                        "createSkipOverride"
+                        (Unimplemented.NonVoidUndefinedFunc name)
+          }

--- a/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
@@ -38,6 +38,8 @@ import qualified Data.Set as Set
 import           Data.Set (Set)
 import qualified Data.Text as Text
 
+import qualified Text.LLVM.AST as L
+
 import qualified Prettyprinter as PP
 import qualified Prettyprinter.Render.Text as PP
 
@@ -58,6 +60,7 @@ import qualified Lang.Crucible.Types as CrucibleTypes
 -- crucible-llvm
 import           Lang.Crucible.LLVM (llvmGlobals)
 import qualified Lang.Crucible.LLVM.Errors as LLVMErrors
+import           Lang.Crucible.LLVM.Intrinsics (register_llvm_overrides)
 import           Lang.Crucible.LLVM.MemModel (MemOptions,  LLVMAnnMap)
 import           Lang.Crucible.LLVM.Translation (transContext, llvmTypeCtx)
 
@@ -84,7 +87,8 @@ import           UCCrux.LLVM.Context.Function (FunctionContext, functionName)
 import           UCCrux.LLVM.Context.Module (ModuleContext, llvmModule, moduleTranslation)
 import           UCCrux.LLVM.Errors.Panic (panic)
 import           UCCrux.LLVM.Logging (Verbosity(Hi))
-import           UCCrux.LLVM.Overrides (UnsoundOverrideName, registerUnsoundOverrides)
+import           UCCrux.LLVM.Overrides.Skip (SkipOverrideName, unsoundSkipOverrides)
+import           UCCrux.LLVM.Overrides.Unsound (UnsoundOverrideName, unsoundOverrides)
 import           UCCrux.LLVM.FullType (FullType, MapToCrucibleType)
 import           UCCrux.LLVM.PP (ppRegMap)
 import           UCCrux.LLVM.Run.Unsoundness (Unsoundness(Unsoundness))
@@ -99,12 +103,13 @@ simulateLLVM ::
   FunctionContext m arch argTypes ->
   Crucible.HandleAllocator ->
   IORef [Explanation m arch argTypes] ->
+  IORef (Set SkipOverrideName) ->
   IORef (Set UnsoundOverrideName) ->
   Constraints m argTypes ->
   Crucible.CFG LLVM blocks (MapToCrucibleType arch argTypes) ret ->
   MemOptions ->
   Crux.SimulatorCallback
-simulateLLVM appCtx modCtx funCtx halloc explRef unsoundOverrideRef constraints cfg memOptions =
+simulateLLVM appCtx modCtx funCtx halloc explRef skipOverrideRef unsoundOverrideRef constraints cfg memOptions =
   Crux.SimulatorCallback $ \sym _maybeOnline ->
     do
       let trans = modCtx ^. moduleTranslation
@@ -193,7 +198,18 @@ simulateLLVM appCtx modCtx funCtx halloc explRef unsoundOverrideRef constraints 
                   -- called from any particular function. Needs some
                   -- benchmarking.
                   registerFunctions (modCtx ^. llvmModule) trans
-                  registerUnsoundOverrides modCtx (modCtx ^. llvmModule) trans unsoundOverrideRef
+                  let uOverrides = unsoundOverrides trans unsoundOverrideRef
+                  sOverrides <-
+                    unsoundSkipOverrides
+                      modCtx
+                      trans
+                      skipOverrideRef
+                      (L.modDeclares (modCtx ^. llvmModule))
+                  register_llvm_overrides
+                    (modCtx ^. llvmModule)
+                    []
+                    (uOverrides ++ sOverrides)
+                    llvmCtxt
                   liftIO $ (appCtx ^. log) Hi $ "Running " <> funCtx ^. functionName <> " on arguments..."
                   printed <- ppRegMap modCtx funCtx sym mem args
                   mapM_ (liftIO . (appCtx ^. log) Hi . Text.pack . show) printed
@@ -260,6 +276,7 @@ runSimulator ::
 runSimulator appCtx modCtx funCtx halloc preconditions cfg cruxOpts memOptions =
   do
     explRef <- newIORef []
+    skipOverrideRef <- newIORef Set.empty
     unsoundOverrideRef <- newIORef Set.empty
     cruxResult <-
       Crux.runSimulator
@@ -270,12 +287,16 @@ runSimulator appCtx modCtx funCtx halloc preconditions cfg cruxOpts memOptions =
             funCtx
             halloc
             explRef
+            skipOverrideRef
             unsoundOverrideRef
             preconditions
             cfg
             memOptions
         )
-    unsoundness' <- Unsoundness <$> readIORef unsoundOverrideRef
+    unsoundness' <-
+      Unsoundness
+        <$> readIORef unsoundOverrideRef
+          <*> readIORef skipOverrideRef
     UCCruxSimulationResult unsoundness'
       <$> case cruxResult of
         Crux.CruxSimulationResult Crux.ProgramIncomplete _ ->

--- a/uc-crux-llvm/test/programs/extern_non_void_function.c
+++ b/uc-crux-llvm/test/programs/extern_non_void_function.c
@@ -1,0 +1,5 @@
+extern int do_stuff(int x);
+
+int extern_non_void_function(int x) {
+  do_stuff(x);
+}

--- a/uc-crux-llvm/test/programs/extern_void_function.c
+++ b/uc-crux-llvm/test/programs/extern_void_function.c
@@ -1,0 +1,5 @@
+extern void do_stuff(int x);
+
+void extern_void_function(int x) {
+  do_stuff(x);
+}

--- a/uc-crux-llvm/uc-crux-llvm.cabal
+++ b/uc-crux-llvm/uc-crux-llvm.cabal
@@ -48,7 +48,8 @@ library
     UCCrux.LLVM.FullType.Type
     UCCrux.LLVM.Logging
     UCCrux.LLVM.Main
-    UCCrux.LLVM.Overrides
+    UCCrux.LLVM.Overrides.Skip
+    UCCrux.LLVM.Overrides.Unsound
     UCCrux.LLVM.PP
     UCCrux.LLVM.Run.Explore
     UCCrux.LLVM.Run.Loop


### PR DESCRIPTION
The goal here is more coverage, at the expense of soundness/safety guarantees. Unsoundness is tracked and reported to the user.