### PR TITLE
crux-llvm code re-arrangement

### DIFF
--- a/.github/workflows/crux-mir-build.yml
+++ b/.github/workflows/crux-mir-build.yml
@@ -16,7 +16,7 @@ on:
 # (symptom: "No suitable image found ... unknown file type, first
 # eight bytes: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00")
 env:
-  CACHE_VERSION: 3
+  CACHE_VERSION: 4
 
 jobs:
   outputs:

--- a/.github/workflows/crux-mir-build.yml
+++ b/.github/workflows/crux-mir-build.yml
@@ -12,7 +12,7 @@ on:
 # (e.g. cabal complains it can't find a valid version of the "happy"
 # tool).
 env:
-  CACHE_VERSION: 1
+  CACHE_VERSION: 2
 
 jobs:
   outputs:

--- a/crucible-llvm/src/Lang/Crucible/LLVM.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM.hs
@@ -16,6 +16,7 @@
 module Lang.Crucible.LLVM
   ( LLVM
   , registerModuleFn
+  , llvmGlobalsToCtx
   , llvmGlobals
   , register_llvm_overrides
   , llvmExtensionImpl
@@ -35,7 +36,7 @@ import           Lang.Crucible.LLVM.Extension (ArchWidth)
 import           Lang.Crucible.LLVM.Intrinsics
 import           Lang.Crucible.LLVM.MemModel
                    ( llvmStatementExec, HasPtrWidth, HasLLVMAnn, MemOptions, MemImpl
-                   , bindLLVMFunPtr
+                   , bindLLVMFunPtr, Mem
                    )
 import           Lang.Crucible.LLVM.Translation.Monad
 import           Lang.Crucible.Simulator.ExecutionTree
@@ -63,12 +64,17 @@ registerModuleFn llvm_ctx (decl, AnyCFG cfg) = do
   writeGlobal mvar mem'
 
 
-llvmGlobals
+llvmGlobalsToCtx
    :: LLVMContext arch
    -> MemImpl sym
    -> SymGlobalState sym
-llvmGlobals ctx mem = emptyGlobals & insertGlobal var mem
-  where var = llvmMemVar $ ctx
+llvmGlobalsToCtx = llvmGlobals . llvmMemVar
+
+llvmGlobals
+   :: GlobalVar Mem
+   -> MemImpl sym
+   -> SymGlobalState sym
+llvmGlobals memVar mem = emptyGlobals & insertGlobal memVar mem
 
 llvmExtensionImpl ::
   (HasLLVMAnn sym) =>

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
@@ -520,9 +520,10 @@ evalStmt sym = eval
        liftIO $ doPtrSubtract sym mem x y
 
 
-mkMemVar :: HandleAllocator
+mkMemVar :: Text
+         -> HandleAllocator
          -> IO (GlobalVar Mem)
-mkMemVar halloc = freshGlobalVar halloc "llvm_memory" knownRepr
+mkMemVar memName halloc = freshGlobalVar halloc memName knownRepr
 
 
 -- | For now, the core message should be on the first line, with details

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation.hs
@@ -388,10 +388,11 @@ transDefine halloc ctx d = do
 -- if we want to support dynamic loading.
 translateModule :: (?laxArith :: Bool, ?optLoopMerge :: Bool)
                 => HandleAllocator -- ^ Generator for nonces.
+                -> GlobalVar Mem   -- ^ Memory model to associate with this context
                 -> L.Module        -- ^ Module to translate
                 -> IO (Some ModuleTranslation)
-translateModule halloc m = do
-  Some ctx <- mkLLVMContext halloc m
+translateModule halloc mvar m = do
+  Some ctx <- mkLLVMContext mvar m
   let nonceGen = haCounter halloc
   llvmPtrWidth ctx $ \wptr -> withPtrWidth wptr $
     do pairs <- mapM (transDefine halloc ctx) (L.modDefines m)

--- a/crucible-llvm/test/MemSetup.hs
+++ b/crucible-llvm/test/MemSetup.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -61,7 +62,8 @@ withLLVMCtx mod' action =
         sym <- CBS.newSimpleBackend CBS.FloatRealRepr nonceGen
         let ?laxArith = False
         let ?optLoopMerge = False
-        Some (LLVMTr.ModuleTranslation _ ctx _ _) <- LLVMTr.translateModule halloc mod'
+        memVar <- LLVMM.mkMemVar "test_llvm_memory" halloc
+        Some (LLVMTr.ModuleTranslation _ ctx _ _) <- LLVMTr.translateModule halloc memVar mod'
         case LLVMTr.llvmArch ctx            of { LLVME.X86Repr width ->
         case assertLeq (knownNat @1)  width of { LeqProof      ->
         case assertLeq (knownNat @16) width of { LeqProof      -> do

--- a/crucible-llvm/test/Tests.hs
+++ b/crucible-llvm/test/Tests.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE ImplicitParams   #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LambdaCase       #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -44,6 +45,7 @@ import           System.FilePath ( (-<.>), splitExtension, splitFileName )
 import qualified System.Process as Proc
 
 -- Modules being tested
+import           Lang.Crucible.LLVM.MemModel ( mkMemVar )
 import           Lang.Crucible.LLVM.MemType
 import           Lang.Crucible.LLVM.Translation
 
@@ -220,7 +222,8 @@ testBuildTranslation srcPath llvmTransTests =
       trans = do halloc <- newHandleAllocator
                  let ?laxArith = False
                  let ?optLoopMerge = False
-                 translateModule halloc =<<
+                 memVar <- mkMemVar "buildTranslation_test_llvm_memory" halloc
+                 translateModule halloc memVar =<<
                    (fromRight (error "parsing was already verified") <$> parseLLVM bcPath)
 
       translate_bitcode =

--- a/crux-llvm/src/Crux/LLVM/Simulate.hs
+++ b/crux-llvm/src/Crux/LLVM/Simulate.hs
@@ -150,24 +150,24 @@ setupFileSim halloc llvm_file llvmOpts sym _maybeOnline =
 
      prepped <- prepLLVMModule llvmOpts halloc sym llvm_file memVar
 
-     let globSt = llvmGlobals memVar (p_mem prepped)
+     let globSt = llvmGlobals memVar (prepMem prepped)
 
      return $ Crux.RunnableState $
        InitialState simctx globSt defaultAbortHandler UnitRepr $
        runOverrideSim UnitRepr $
-       do Some trans <- return $ p_someTrans prepped
+       do Some trans <- return $ prepSomeTrans prepped
           llvmPtrWidth (trans ^. transContext) $ \ptrW ->
             withPtrWidth ptrW $
-            do registerFunctions (p_llvmMod prepped) trans
+            do registerFunctions (prepLLVMMod prepped) trans
                checkFun (entryPoint llvmOpts) (cfgMap trans)
 
 
 
 
-data PreppedLLVM sym = PreppedLLVM { p_llvmMod :: LLVM.Module
-                                   , p_someTrans :: Some ModuleTranslation
-                                   , p_memVar :: GlobalVar Mem
-                                   , p_mem :: MemImpl sym
+data PreppedLLVM sym = PreppedLLVM { prepLLVMMod :: LLVM.Module
+                                   , prepSomeTrans :: Some ModuleTranslation
+                                   , prepMemVar :: GlobalVar Mem
+                                   , prepMem :: MemImpl sym
                                    }
 
 -- | Given an LLVM Bitcode file, and a GlobalVar memory, translate the

--- a/crux-llvm/src/Crux/LLVM/Simulate.hs
+++ b/crux-llvm/src/Crux/LLVM/Simulate.hs
@@ -218,9 +218,13 @@ checkFun nm mp =
 memMetrics :: forall p sym ext
              . GlobalVar Mem
             -> Map.Map Text (Metric p sym ext)
-memMetrics memVar = Map.fromList [ ("LLVM.Mem.allocs", allocs)
-                                 , ("LLVM.Mem.writes", writes)
-                                 ]
+memMetrics memVar = Map.fromList
+                    -- Note: These map keys are used by profile.js in
+                    -- https://github.com/GaloisInc/sympro-ui and must
+                    -- match the names there.
+                    [ ("LLVM.allocs", allocs)
+                    , ("LLVM.writes", writes)
+                    ]
   where
     allocs = Metric $ measureMemBy memAllocCount
     writes = Metric $ measureMemBy memWriteCount

--- a/crux-llvm/src/Crux/LLVM/Simulate.hs
+++ b/crux-llvm/src/Crux/LLVM/Simulate.hs
@@ -27,6 +27,7 @@ import qualified Text.LLVM as LLVM
 import Prettyprinter
 
 -- what4
+import qualified What4.Expr.Builder as WEB
 
 -- crucible
 import Lang.Crucible.Backend
@@ -123,9 +124,44 @@ registerFunctions llvm_module mtrans =
      mapM_ (registerModuleFn llvm_ctx) $ Map.elems $ cfgMap mtrans
 
 simulateLLVMFile :: FilePath -> LLVMOptions -> Crux.SimulatorCallback
-simulateLLVMFile llvm_file llvmOpts = Crux.SimulatorCallback $ \sym _maybeOnline ->
+simulateLLVMFile llvm_file llvmOpts = do
+  Crux.SimulatorCallback $ \sym _maybeOnline -> do
+    halloc <- newHandleAllocator
+    bbMapRef <- newIORef (Map.empty :: LLVMAnnMap sym)
+    let ?recordLLVMAnnotation = \an bb -> modifyIORef bbMapRef (Map.insert an bb)
+    runnableState <- setupFileSim halloc llvm_file llvmOpts sym maybeOnline
+
+    -- arbitrary, we should probabl make this limit configurable
+    let detailLimit = 10
+
+    let explainFailure evalFn gl =
+          do bb <- readIORef bbMapRef
+             ex <- explainCex sym bb evalFn >>= \f -> f (gl ^. labeledPred)
+             let details = case ex of
+                             NoExplanation -> mempty
+                             DisjOfFailures xs ->
+                               case map ppBB xs of
+                                 []  -> mempty
+                                 [x] -> indent 2 x
+                                 xs' | length xs' <= detailLimit
+                                       -> "All of the following conditions failed:" <> line <> indent 2 (vcat xs')
+                                     | otherwise
+                                       -> "All of the following conditions failed (and other conditions have been elided to reduce output): "
+                                          <> line <> indent 2 (vcat (take detailLimit xs'))
+
+             return $ vcat [ ppSimError (gl^.labeledPredMsg), details ]
+
+setupFileSim :: Logs
+             => IsSymInterface sym
+             => sym ~ WEB.ExprBuilder t st fs
+             => HasLLVMAnn sym
+             => HandleAllocator
+             -> FilePath
+             -> LLVMOptions
+             -> sym -> Maybe (Crux.SomeOnlineSolver sym)
+             -> IO (Crux.RunnableState sym)
+setupFileSim halloc llvm_file llvmOpts sym _maybeOnline =
   do llvm_mod   <- parseLLVM llvm_file
-     halloc     <- newHandleAllocator
      let ?laxArith = laxArithmetic llvmOpts
      let ?optLoopMerge = loopMerge llvmOpts
      memVar <- mkMemVar "crux:llvm_memory" halloc
@@ -135,44 +171,21 @@ simulateLLVMFile llvm_file llvmOpts = Crux.SimulatorCallback $ \sym _maybeOnline
      llvmPtrWidth llvmCtxt $ \ptrW ->
        withPtrWidth ptrW $
          do liftIO $ say "Crux" $ unwords ["Using pointer width:", show ptrW]
-            bbMapRef <- newIORef (Map.empty :: LLVMAnnMap sym)
             let ?lc = llvmCtxt^.llvmTypeCtx
-            -- shrug... some weird interaction between do notation and implicit parameters here...
-            -- not sure why I have to let/in this expression...
-            let ?recordLLVMAnnotation = \an bb -> modifyIORef bbMapRef (Map.insert an bb) in
-              do let simctx = (setupSimCtxt halloc sym (memOpts llvmOpts) memVar)
-                                { printHandle = view outputHandle ?outputConfig }
-                 mem <- populateAllGlobals sym (globalInitMap trans)
-                           =<< initializeAllMemory sym llvmCtxt llvm_mod
+            do let simctx = (setupSimCtxt halloc sym (memOpts llvmOpts) memVar)
+                            { printHandle = view outputHandle ?outputConfig }
+               mem <- populateAllGlobals sym (globalInitMap trans)
+                      =<< initializeAllMemory sym llvmCtxt llvm_mod
 
-                 let globSt = llvmGlobals llvmCtxt mem
+               let globSt = llvmGlobals llvmCtxt mem
 
-                 let initSt = InitialState simctx globSt defaultAbortHandler UnitRepr $
-                          runOverrideSim UnitRepr $
+               let initSt = InitialState simctx globSt defaultAbortHandler UnitRepr $
+                            runOverrideSim UnitRepr $
                             do registerFunctions llvm_mod trans
                                checkFun (entryPoint llvmOpts) (cfgMap trans)
 
-                 -- arbitrary, we should probabl make this limit configurable
-                 let detailLimit = 10
 
-                 let explainFailure evalFn gl =
-                       do bb <- readIORef bbMapRef
-                          ex <- explainCex sym bb evalFn >>= \f -> f (gl ^. labeledPred)
-                          let details = case ex of
-                                NoExplanation -> mempty
-                                DisjOfFailures xs ->
-                                  case map ppBB xs of
-                                    []  -> mempty
-                                    [x] -> indent 2 x
-                                    xs' | length xs' <= detailLimit
-                                        -> "All of the following conditions failed:" <> line <> indent 2 (vcat xs')
-                                        | otherwise
-                                        -> "All of the following conditions failed (and other conditions have been elided to reduce output): "
-                                               <> line <> indent 2 (vcat (take detailLimit xs'))
-
-                          return $ vcat [ ppSimError (gl^.labeledPredMsg), details ]
-
-                 return (Crux.RunnableState initSt, explainFailure)
+               return (Crux.RunnableState initSt, explainFailure)
 
 
 checkFun ::

--- a/crux-llvm/src/Crux/LLVM/Simulate.hs
+++ b/crux-llvm/src/Crux/LLVM/Simulate.hs
@@ -51,7 +51,7 @@ import Lang.Crucible.LLVM(llvmExtensionImpl, llvmGlobals, registerModuleFn )
 import Lang.Crucible.LLVM.Globals
         ( initializeAllMemory, populateAllGlobals )
 import Lang.Crucible.LLVM.MemModel
-        ( MemImpl, withPtrWidth, memAllocCount, memWriteCount
+        ( MemImpl, mkMemVar, withPtrWidth, memAllocCount, memWriteCount
         , MemOptions(..), HasLLVMAnn, LLVMAnnMap
         , explainCex, CexExplanation(..)
         )
@@ -130,7 +130,8 @@ simulateLLVMFile llvm_file llvmOpts = Crux.SimulatorCallback $ \sym _maybeOnline
      halloc     <- newHandleAllocator
      let ?laxArith = laxArithmetic llvmOpts
      let ?optLoopMerge = loopMerge llvmOpts
-     Some trans <- translateModule halloc llvm_mod
+     memVar <- mkMemVar "crux:llvm_memory" halloc
+     Some trans <- translateModule halloc memVar llvm_mod
      let llvmCtxt = trans ^. transContext
 
      llvmPtrWidth llvmCtxt $ \ptrW ->

--- a/uc-crux-llvm/src/UCCrux/LLVM/Main.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Main.hs
@@ -128,7 +128,7 @@ translateLLVMModule ::
   FilePath ->
   L.Module ->
   IO SomeModuleContext'
-translateLLVMModule ucOpts halloc memvar moduleFilePath llvmMod =
+translateLLVMModule ucOpts halloc memVar moduleFilePath llvmMod =
   do
     let llvmOpts = Config.ucLLVMOptions ucOpts
     Some trans <-

--- a/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
@@ -56,10 +56,10 @@ import qualified Lang.Crucible.Simulator as Crucible
 import qualified Lang.Crucible.Types as CrucibleTypes
 
 -- crucible-llvm
-import           Lang.Crucible.LLVM (llvmGlobals)
+import           Lang.Crucible.LLVM (llvmGlobalsToCtx)
 import qualified Lang.Crucible.LLVM.Errors as LLVMErrors
 import           Lang.Crucible.LLVM.MemModel (MemOptions,  LLVMAnnMap)
-import           Lang.Crucible.LLVM.Translation (transContext, llvmTypeCtx)
+import           Lang.Crucible.LLVM.Translation (transContext, llvmMemVar, llvmTypeCtx)
 
 import           Lang.Crucible.LLVM.MemModel.Partial (BoolAnn(BoolAnn))
 import           Lang.Crucible.LLVM.Extension (LLVM)
@@ -113,7 +113,7 @@ simulateLLVM appCtx modCtx funCtx halloc explRef unsoundOverrideRef constraints 
       let ?lc = llvmCtxt ^. llvmTypeCtx
       let ?recordLLVMAnnotation = \an bb -> modifyIORef bbMapRef (Map.insert an bb)
       let simctx =
-            (setupSimCtxt halloc sym memOptions llvmCtxt)
+            (setupSimCtxt halloc sym memOptions (llvmMemVar llvmCtxt))
               { Crucible.printHandle = view outputHandle ?outputConfig
               }
 
@@ -178,7 +178,7 @@ simulateLLVM appCtx modCtx funCtx halloc explRef unsoundOverrideRef constraints 
                 Right value -> pure value
         )
 
-      let globSt = llvmGlobals llvmCtxt mem
+      let globSt = llvmGlobalsToCtx llvmCtxt mem
       let initSt =
             Crucible.InitialState simctx globSt Crucible.defaultAbortHandler CrucibleTypes.UnitRepr $
               Crucible.runOverrideSim CrucibleTypes.UnitRepr $

--- a/uc-crux-llvm/test/Test.hs
+++ b/uc-crux-llvm/test/Test.hs
@@ -69,6 +69,8 @@ import           Data.Parameterized.Some (Some(..))
 
 import           Lang.Crucible.FunctionHandle (newHandleAllocator)
 
+import           Lang.Crucible.LLVM.MemModel (mkMemVar)
+
 import qualified Crux
 import           Crux.LLVM.Compile (genBitCode)
 import           Crux.LLVM.Config (clangOpts)
@@ -160,10 +162,11 @@ findBugs llvmModule file fns =
         --   )
         let ?outputConfig = outCfg
         halloc <- newHandleAllocator
+        memVar <- mkMemVar "uc-crux-llvm:test_llvm_memory" halloc
         Some modCtx <-
           case llvmModule of
-            Just lMod -> translateLLVMModule ucOpts halloc path lMod
-            Nothing -> translateFile ucOpts halloc path
+            Just lMod -> translateLLVMModule ucOpts halloc memVar path lMod
+            Nothing -> translateFile ucOpts halloc memVar path
         loopOnFunctions appCtx modCtx halloc cruxOpts ucOpts
 
 inFile :: FilePath -> [(String, String -> Result.SomeBugfindingResult -> IO ())] -> TT.TestTree

--- a/uc-crux-llvm/uc-crux-llvm.cabal
+++ b/uc-crux-llvm/uc-crux-llvm.cabal
@@ -122,6 +122,7 @@ test-suite uc-crux-llvm-test
                 base             >= 4.7,
                 containers,
                 crucible,
+                crucible-llvm,
                 crux,
                 crux-llvm,
                 filepath,


### PR DESCRIPTION
This PR generally provides some code re-arrangement to split out some useful functionality into independent functions and make other entry points available for external re-use (e.g. Polyglot will make use of these).

The changes are generally described as:
* [crucible-llvm] `mkMemVar` now takes a name for the memory region instead of using a hard-coded internal name
* The `GlobalVar Mem` obtained from `mkMemVar` is now passed explicitly where needed instead of bundling it into llvm module translation and needing to extract it from the `LLVMContext`
  * [crucible-llvm] `translateModule` is now passed the `memVar` instead of allocating it internally.
  * [crucible-llvm] `setupSimCtxt` is passed the `memVar`, not the `llvmCtxt`.
  * [crux-llvm] `llvmMetrics` is renamed to `memMetrics` and is passed the `memVar`, not the `llvmCtxt`.
* [crux-llvm] the `simulateLLVMFile` sequence is re-arranged, and subsections are split out into new functions (allowing external re-use of these functions for other setup arrangements):
   1. Memory and handle initialization happens first, independent of the LLVM file Module handling
   2. a new `setupFileSim` function provides the simulation's `InitialState` setup after invoking `prepLLVMModule` (see next item).
   3. a new `prepLLVMModule` provides LLVM file parsing and translation into Crucible IR, returning a `PreppedLLVM` structure with the resulting components needed by other initialization functions.
   4. the default annotation failure explanation is extracted to the new `explainFailure` function (and the new `Explainer` type alias is created for referencing the explanation function for crucible.
