### PR TITLE
uc-crux-llvm: Improve type translation

### DIFF
--- a/uc-crux-llvm/.hlint.yaml
+++ b/uc-crux-llvm/.hlint.yaml
@@ -69,4 +69,5 @@
     within:
       - "UCCrux.LLVM.Cursor"
       - "UCCrux.LLVM.FullType.Type"
+      - "UCCrux.LLVM.FullType.VarArgs"
       - "UCCrux.LLVM.Shape"

--- a/uc-crux-llvm/src/UCCrux/LLVM/Classify.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Classify.hs
@@ -67,8 +67,8 @@ import           Lang.Crucible.LLVM.MemType (memTypeSize)
 import           UCCrux.LLVM.Classify.Poison
 import           UCCrux.LLVM.Classify.Types
 import           UCCrux.LLVM.Context.App (AppContext, log)
-import           UCCrux.LLVM.Context.Module (ModuleContext, dataLayout)
-import           UCCrux.LLVM.Context.Function (FunctionContext, argumentNames, moduleTypes)
+import           UCCrux.LLVM.Context.Module (ModuleContext, dataLayout, moduleTypes)
+import           UCCrux.LLVM.Context.Function (FunctionContext, argumentNames)
 import           UCCrux.LLVM.Constraints
 import           UCCrux.LLVM.Cursor (ppCursor, Selector(..), SomeInSelector(SomeInSelector))
 import           UCCrux.LLVM.FullType (FullType(FTPtr), MapToCrucibleType, FullTypeRepr(..), PartTypeRepr, ModuleTypes, asFullType)
@@ -167,7 +167,7 @@ classifyBadBehavior ::
     ShowF (What4.SymAnnotation sym)
   ) =>
   AppContext ->
-  ModuleContext arch ->
+  ModuleContext m arch ->
   FunctionContext m arch argTypes ->
   sym ->
   -- | Function arguments
@@ -632,7 +632,7 @@ classifyBadBehavior appCtx modCtx funCtx sym (Crucible.RegMap _args) annotations
       PartTypeRepr m ft ->
       Int
     elemsFromOffset' =
-      elemsFromOffset (modCtx ^. dataLayout) (funCtx ^. moduleTypes)
+      elemsFromOffset (modCtx ^. dataLayout) (modCtx ^. moduleTypes)
 
     handleFreeUnallocated :: LLVMPtr.LLVMPtr sym w -> f (Maybe (Explanation m arch argTypes))
     handleFreeUnallocated ptr =

--- a/uc-crux-llvm/src/UCCrux/LLVM/Context/Module.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Context/Module.hs
@@ -6,53 +6,179 @@ License      : BSD3
 Maintainer   : Langston Barrett <langston@galois.com>
 Stability    : provisional
 -}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module UCCrux.LLVM.Context.Module
   ( ModuleContext,
+    SomeModuleContext (..),
     moduleFilePath,
     makeModuleContext,
     llvmModule,
+    moduleTypes,
     moduleTranslation,
     dataLayout,
     withTypeContext,
+
+    -- * Looking up CFGs
+    CFGWithTypes (..),
+    findFun,
   )
 where
 
 {- ORMOLU_DISABLE -}
-import           Control.Lens ((^.), Simple, Getter, Lens, lens, to)
+import           Control.Lens ((^.), Simple, Getter, Lens, lens, to, at)
+import           Control.Monad (when)
+import           Data.Proxy (Proxy(Proxy))
+import           Data.Type.Equality ((:~:)(Refl), testEquality)
 
-import           Text.LLVM (Module)
+import           Text.LLVM (Module, Symbol(Symbol))
+
+import qualified Data.Parameterized.Context as Ctx
+import           Data.Parameterized.Some (Some(Some))
+
+import qualified Lang.Crucible.CFG.Core as Crucible
+import qualified Lang.Crucible.Types as CrucibleTypes hiding ((::>))
 
 import           Lang.Crucible.LLVM.DataLayout (DataLayout)
+import           Lang.Crucible.LLVM.Extension (LLVM)
 import           Lang.Crucible.LLVM.Translation (ModuleTranslation)
 import qualified Lang.Crucible.LLVM.Translation as LLVMTrans
 import           Lang.Crucible.LLVM.TypeContext (TypeContext, llvmDataLayout)
+
+import           Crux.LLVM.Overrides (ArchOk)
+
+import           UCCrux.LLVM.Errors.Panic (panic)
+import           UCCrux.LLVM.Errors.Unimplemented (unimplemented)
+import qualified UCCrux.LLVM.Errors.Unimplemented as Unimplemented
+import           UCCrux.LLVM.FullType.CrucibleType (DeclTypes, TranslatedTypes(..), TypeTranslationError, FunctionTypes(..), MatchingAssign(..), translateModuleDefines, testCompatibility, lookupDeclTypes)
+import           UCCrux.LLVM.FullType.Type (FullTypeRepr, ModuleTypes, MapToCrucibleType)
+import           UCCrux.LLVM.FullType.ReturnType (ReturnType(..), ReturnTypeToCrucibleType)
+import           UCCrux.LLVM.FullType.VarArgs (VarArgsRepr, varArgsReprToBool)
 {- ORMOLU_ENABLE -}
 
-data ModuleContext arch = ModuleContext
+-- | The @m@ type parameter represents a specific LLVM module
+data ModuleContext m arch = ModuleContext
   { _moduleFilePath :: FilePath,
     _llvmModule :: Module,
+    _moduleTypes :: ModuleTypes m,
+    _declTypes :: DeclTypes m arch,
     _moduleTranslation :: ModuleTranslation arch
   }
 
-moduleFilePath :: Simple Lens (ModuleContext arch) FilePath
+moduleFilePath :: Simple Lens (ModuleContext m arch) FilePath
 moduleFilePath = lens _moduleFilePath (\s v -> s {_moduleFilePath = v})
 
-llvmModule :: Simple Lens (ModuleContext arch) Module
+llvmModule :: Simple Lens (ModuleContext m arch) Module
 llvmModule = lens _llvmModule (\s v -> s {_llvmModule = v})
 
-moduleTranslation :: Simple Lens (ModuleContext arch) (ModuleTranslation arch)
+moduleTypes :: Simple Lens (ModuleContext m arch) (ModuleTypes m)
+moduleTypes = lens _moduleTypes (\s v -> s {_moduleTypes = v})
+
+declTypes :: Simple Lens (ModuleContext m arch) (DeclTypes m arch)
+declTypes = lens _declTypes (\s v -> s {_declTypes = v})
+
+moduleTranslation :: Simple Lens (ModuleContext m arch) (ModuleTranslation arch)
 moduleTranslation = lens _moduleTranslation (\s v -> s {_moduleTranslation = v})
 
-dataLayout :: Getter (ModuleContext arch) DataLayout
+dataLayout :: Getter (ModuleContext m arch) DataLayout
 dataLayout = moduleTranslation . LLVMTrans.transContext . LLVMTrans.llvmTypeCtx . to llvmDataLayout
 
-withTypeContext :: ModuleContext arch -> ((?lc :: TypeContext) => a) -> a
+withTypeContext :: ModuleContext m arch -> ((?lc :: TypeContext) => a) -> a
 withTypeContext context computation =
   let ?lc = context ^. moduleTranslation . LLVMTrans.transContext . LLVMTrans.llvmTypeCtx
    in computation
 
-makeModuleContext :: FilePath -> Module -> ModuleTranslation arch -> ModuleContext arch
-makeModuleContext = ModuleContext
+makeModuleContext ::
+  ArchOk arch =>
+  FilePath ->
+  Module ->
+  ModuleTranslation arch ->
+  Either TypeTranslationError (SomeModuleContext arch)
+makeModuleContext path llvmMod trans =
+  let ?lc = trans ^. LLVMTrans.transContext . LLVMTrans.llvmTypeCtx
+   in case translateModuleDefines llvmMod trans of
+        Left err -> Left err
+        Right (TranslatedTypes modTypes decTypes) ->
+          Right $
+            SomeModuleContext $
+              ModuleContext path llvmMod modTypes decTypes trans
+
+-- ------------------------------------------------------------------------------
+-- Looking up CFGs
+
+data CFGWithTypes m arch = forall argTypes ret blocks.
+  CFGWithTypes
+  { cfgWithTypes ::
+      Crucible.CFG
+        LLVM
+        blocks
+        (MapToCrucibleType arch argTypes)
+        (ReturnTypeToCrucibleType arch ret),
+    cfgArgFullTypes :: Ctx.Assignment (FullTypeRepr m) argTypes,
+    cfgRetFullType :: ReturnType m ret,
+    cfgIsVarArgs :: Some VarArgsRepr
+  }
+
+data SomeModuleContext arch
+  = forall m. SomeModuleContext (ModuleContext m arch)
+
+-- | This function has a lot of calls to @panic@, these are all justified by the
+-- invariant on 'DeclTypes' (namely that it contains types for declarations in
+-- the module specified by the @m@ type parameter), and the invariant on
+-- 'ModuleContext' that the @moduleTypes@ and @declTypes@ correspond to the
+-- @moduleTranslation@.
+findFun ::
+  forall m arch.
+  ArchOk arch =>
+  ModuleContext m arch ->
+  String ->
+  Maybe (CFGWithTypes m arch)
+findFun modCtx name =
+  do
+    FunctionTypes (MatchingAssign argFTys argCTys) retTy (Some varArgs) <-
+      modCtx ^. declTypes . to (lookupDeclTypes (Symbol name))
+    (_decl, Crucible.AnyCFG cfg) <-
+      modCtx ^. moduleTranslation . to LLVMTrans.cfgMap . at (Symbol name)
+
+    when (varArgsReprToBool varArgs) $
+      unimplemented "findFun" Unimplemented.VarArgsFunction
+
+    case testEquality (Crucible.cfgArgTypes cfg) argCTys of
+      Nothing -> panic "findFunc" ["Mismatched argument types"]
+      Just Refl ->
+        Just $
+          case Crucible.cfgReturnType cfg of
+            CrucibleTypes.UnitRepr ->
+              case retTy of
+                Just (Some _) ->
+                  panic
+                    "findFun"
+                    [ unwords
+                        [ "Extra return type: Crucible function type was void",
+                          "but the translated type was not."
+                        ]
+                    ]
+                Nothing ->
+                  CFGWithTypes
+                    { cfgWithTypes = cfg,
+                      cfgArgFullTypes = argFTys,
+                      cfgRetFullType = Void,
+                      cfgIsVarArgs = Some varArgs
+                    }
+            cRetTy ->
+              case retTy of
+                Nothing -> panic "findFun" ["Missing return type"]
+                Just (Some retTy') ->
+                  case testCompatibility (Proxy :: Proxy arch) retTy' cRetTy of
+                    Just Refl ->
+                      CFGWithTypes
+                        { cfgWithTypes = cfg,
+                          cfgArgFullTypes = argFTys,
+                          cfgRetFullType = NonVoid retTy',
+                          cfgIsVarArgs = Some varArgs
+                        }
+                    Nothing -> panic "findFun" ["Bad return type"]

--- a/uc-crux-llvm/src/UCCrux/LLVM/Cursor.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Cursor.hs
@@ -62,7 +62,7 @@ import           UCCrux.LLVM.FullType.Type (FullType(..), FullTypeRepr(..), Modu
 -- The type variables are:
 --
 -- * @m@: The LLVM module where the 'FullType' being pointed into originates,
---   see also the comment on 'UCCrux.LLVM.FullType.CrucibleType.SomeAssign'.
+--   see also the comment on 'UCCrux.LLVM.FullType.CrucibleType.TranslatedTypes'.
 -- * @inTy@: This is the \"outermost\" type, the type being pointed into.
 -- * @atTy@: This is the \"innermost\" type, the type being pointed at.
 data Cursor m (inTy :: FullType m) (atTy :: FullType m) where

--- a/uc-crux-llvm/src/UCCrux/LLVM/Errors/Unimplemented.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Errors/Unimplemented.hs
@@ -30,7 +30,6 @@ import qualified Panic
 
 data Unimplemented
   = VarArgsFunction
-  | VarArgsFunctionType
   | VoidType
   | OpaqueType
   | UnsupportedType
@@ -49,7 +48,6 @@ ppUnimplemented :: Unimplemented -> String
 ppUnimplemented =
   \case
     VarArgsFunction -> "Exploring variable-arity functions"
-    VarArgsFunctionType -> "Variable-arity function (pointer) types in globals or arguments"
     VoidType -> "Void types in globals or arguments"
     OpaqueType -> "Opaque (undefined) types in globals or arguments"
     UnsupportedType -> "Unsupported types in globals or arguments"

--- a/uc-crux-llvm/src/UCCrux/LLVM/FullType/CrucibleType.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/FullType/CrucibleType.hs
@@ -19,13 +19,23 @@ Stability        : provisional
 module UCCrux.LLVM.FullType.CrucibleType
   ( toCrucibleType,
 
+    -- * Translation
+    FunctionTypes (..),
+    MatchingAssign (..),
+    DeclTypes,
+    TranslatedTypes (..),
+    TypeTranslationError (..),
+    translateModuleDefines,
+    ppTypeTranslationError,
+    lookupDeclTypes,
+
     -- * Assignments
-    SomeAssign (..),
     SomeIndex (..),
-    assignmentToFullType,
     SomeAssign' (..),
     assignmentToCrucibleType,
     assignmentToCrucibleTypeA,
+    testCompatibility,
+    testCompatibilityAssign,
     translateIndex,
     generateM,
     generate,
@@ -35,12 +45,17 @@ where
 {- ORMOLU_DISABLE -}
 import           Prelude hiding (unzip)
 
+import           Control.Monad (unless)
+import           Control.Monad.Except (ExceptT, runExceptT, throwError, withExceptT)
+import           Control.Monad.State (State, runState)
 import           Data.Coerce (coerce)
 import           Data.Functor ((<&>))
-import           Data.Functor.Const (Const(Const, getConst))
+import           Data.Functor.Const (Const(Const))
 import           Data.Functor.Identity (Identity(Identity, runIdentity))
 import           Data.Functor.Product (Product(Pair))
-import           Control.Monad.State (runStateT)
+import           Data.Proxy (Proxy(Proxy))
+import           Data.Map (Map)
+import qualified Data.Map as Map
 
 import qualified Text.LLVM.AST as L
 
@@ -48,15 +63,19 @@ import qualified Data.Parameterized.Context as Ctx
 import           Data.Parameterized.NatRepr
 import           Data.Parameterized.Some (Some(Some))
 
+import qualified Lang.Crucible.CFG.Core as Crucible
 import qualified Lang.Crucible.Types as CrucibleTypes hiding ((::>))
 
 import qualified Lang.Crucible.LLVM.MemModel as LLVMMem
-import           Lang.Crucible.LLVM.MemType (MemType(..))
+import           Lang.Crucible.LLVM.MemType (fdArgTypes, fdRetType, fdVarArgs)
+import           Lang.Crucible.LLVM.Translation (ModuleTranslation)
+import qualified Lang.Crucible.LLVM.Translation as LLVMTrans
 import           Lang.Crucible.LLVM.TypeContext (TypeContext)
 
 import           Crux.LLVM.Overrides (ArchOk)
 import           UCCrux.LLVM.Errors.Panic (panic)
 import           UCCrux.LLVM.FullType.Type
+import           UCCrux.LLVM.FullType.VarArgs (VarArgsRepr, boolToVarArgsRepr)
 {- ORMOLU_ENABLE -}
 
 -- | c.f. @llvmTypeToRepr@
@@ -68,10 +87,10 @@ toCrucibleType ::
 toCrucibleType proxy =
   \case
     FTIntRepr natRepr -> LLVMMem.LLVMPointerRepr natRepr
-    FTPtrRepr _ -> LLVMMem.LLVMPointerRepr ?ptrWidth
-    FTVoidFuncPtrRepr _argTypeReprs -> LLVMMem.LLVMPointerRepr ?ptrWidth
-    FTNonVoidFuncPtrRepr _retTypeRepr _argTypeReprs -> LLVMMem.LLVMPointerRepr ?ptrWidth
-    FTOpaquePtrRepr _aliasName -> LLVMMem.LLVMPointerRepr ?ptrWidth
+    FTPtrRepr {} -> LLVMMem.LLVMPointerRepr ?ptrWidth
+    FTVoidFuncPtrRepr {} -> LLVMMem.LLVMPointerRepr ?ptrWidth
+    FTNonVoidFuncPtrRepr {} -> LLVMMem.LLVMPointerRepr ?ptrWidth
+    FTOpaquePtrRepr {} -> LLVMMem.LLVMPointerRepr ?ptrWidth
     FTFloatRepr floatInfo -> CrucibleTypes.FloatRepr floatInfo
     FTArrayRepr _natRepr fullTypeRepr ->
       CrucibleTypes.VectorRepr (toCrucibleType proxy fullTypeRepr)
@@ -81,56 +100,169 @@ toCrucibleType proxy =
       case assignmentToCrucibleType proxy typeReprs of
         SomeAssign' ctReprs Refl _ -> CrucibleTypes.StructRepr ctReprs
 
+data FunctionTypes m arch = FunctionTypes
+  { ftArgTypes :: MatchingAssign m arch,
+    ftRetType :: Maybe (Some (FullTypeRepr m)),
+    ftIsVarArgs :: Some VarArgsRepr
+  }
+
+data MatchingAssign m arch = forall fullTypes crucibleTypes.
+  MapToCrucibleType arch fullTypes ~ crucibleTypes =>
+  MatchingAssign
+  { maFullTypes :: Ctx.Assignment (FullTypeRepr m) fullTypes,
+    maCrucibleTypes :: Ctx.Assignment CrucibleTypes.TypeRepr crucibleTypes
+  }
+
+-- | Constructor not exported to enforce the invariant that a 'DeclTypes' holds
+-- a 'FunctionTypes' for every LLVM function in the corresponding module
+-- indicated by the @m@ parameter.
+newtype DeclTypes m arch = DeclTypes {_getDeclTypes :: Map L.Symbol (FunctionTypes m arch)}
+
+lookupDeclTypes :: L.Symbol -> DeclTypes m arch -> Maybe (FunctionTypes m arch)
+lookupDeclTypes symb (DeclTypes mp) = Map.lookup symb mp
+
 -- | The existential quantification over @m@ here makes the @FullType@ API safe.
 -- You can only intermingle 'FullTypeRepr' from the same LLVM module, and by
 -- construction, the 'ModuleTypes' contains a 'FullTypeRepr' for every type
--- that\'s (transitively) mentioned in any of the types in the 'Ctx.Assignment'.
+-- that\'s (transitively) mentioned in any of the types in the 'DeclTypes'.
 -- Thus, you can avoid partiality when looking up type aliases in the
 -- 'ModuleTypes', they're guaranteed to be present and translated.
 --
 -- See 'UCCrux.LLVM.FullType.MemType.asFullType' for where partiality is
 -- avoided. Since this function is ubiquitous, this is a big win.
-data SomeAssign arch crucibleTypes = forall m fullTypes.
-  SomeAssign
-  { saFullTypes :: Ctx.Assignment (FullTypeRepr m) fullTypes,
-    saModuleTypes :: ModuleTypes m,
-    saProof :: MapToCrucibleType arch fullTypes :~: crucibleTypes
+data TranslatedTypes arch = forall m.
+  TranslatedTypes
+  { translatedModuleTypes :: ModuleTypes m,
+    translatedDeclTypes :: DeclTypes m arch
   }
 
--- | Convert from a 'Ctx.Assignment' of 'CrucibleTypes.TypeRepr' to a
--- 'Ctx.Assignment' of 'FullTypeRepr', together with a proof of the
--- correspondence of the two assignments via 'MapToCrucibleType'.
-assignmentToFullType ::
-  forall proxy arch crucibleTypes.
+data TypeTranslationError
+  = -- | Couldn't find CFG in translated module
+    NoCFG !L.Symbol
+  | -- | Couldn't lift types in declaration to 'MemType'
+    BadLift !String
+  | -- | Wrong number of arguments after lifting declaration
+    BadLiftArgs !L.Symbol
+  | FullTypeTranslation L.Ident
+
+ppTypeTranslationError :: TypeTranslationError -> String
+ppTypeTranslationError =
+  \case
+    NoCFG (L.Symbol name) -> "Couldn't find definition of function " <> name
+    BadLift name -> "Couldn't lift argument/return types to MemTypes for " <> name
+    BadLiftArgs (L.Symbol name) ->
+      "Wrong number of arguments after lifting declaration of " <> name
+    FullTypeTranslation (L.Ident ident) ->
+      "Couldn't find or couldn't translate type: " <> ident
+
+translateModuleDefines ::
+  forall arch.
   ( ?lc :: TypeContext,
     ArchOk arch
   ) =>
-  proxy arch ->
-  Ctx.Assignment CrucibleTypes.TypeRepr crucibleTypes ->
-  Ctx.Assignment (Const MemType) crucibleTypes ->
-  Either L.Ident (SomeAssign arch crucibleTypes)
-assignmentToFullType proxy crucibleTypes memTypes =
+  L.Module ->
+  ModuleTranslation arch ->
+  Either TypeTranslationError (TranslatedTypes arch)
+translateModuleDefines llvmModule trans =
   case makeModuleTypes ?lc of
-    Some moduleTypes ->
+    Some initialModuleTypes ->
+      let (maybeResult, modTypes) =
+            runState
+              ( runExceptT
+                  ( mapM
+                      (translateDecl . LLVMTrans.declareFromDefine)
+                      (L.modDefines llvmModule)
+                  )
+              )
+              initialModuleTypes
+       in TranslatedTypes modTypes . DeclTypes . Map.fromList <$> maybeResult
+  where
+    translateDecl ::
+      L.Declare ->
+      ExceptT
+        TypeTranslationError
+        (State (ModuleTypes m))
+        (L.Symbol, FunctionTypes m arch)
+    translateDecl decl =
       do
-        (Some fullTypes, moduleTypes') <-
-          runStateT
-            ( Ctx.generateSomeM
-                (Ctx.sizeInt (Ctx.size crucibleTypes))
-                ( \idx ->
-                    case Ctx.intIndex idx (Ctx.size crucibleTypes) of
-                      Nothing -> panic "Impossible" ["Mismatched context size"]
-                      Just (Some idx') ->
-                        do
-                          Some fullTypeRepr <-
-                            toFullTypeM (getConst (memTypes Ctx.! idx'))
-                          pure $ Some fullTypeRepr
-                )
+        liftedDecl <-
+          case LLVMTrans.liftDeclare decl of
+            Left err -> throwError (BadLift err)
+            Right d -> pure d
+        Crucible.AnyCFG cfg <-
+          case Map.lookup (L.decName decl) (LLVMTrans.cfgMap trans) of
+            Just (_, anyCfg) -> pure anyCfg
+            Nothing -> throwError (NoCFG (L.decName decl))
+        let crucibleTypes = Crucible.cfgArgTypes cfg
+        let memTypes = fdArgTypes liftedDecl
+        let isVarArgs = fdVarArgs liftedDecl
+        -- Do the MemTypes agree with the Crucible types on the number of
+        -- arguments? (Note that a variadic function has an "extra" argument
+        -- after being translated to a CFG, hence the "+1")
+        let matchedNumArgTypes =
+              let numCrucibleTypes = Ctx.sizeInt (Ctx.size crucibleTypes)
+               in length memTypes == numCrucibleTypes
+                    || ( isVarArgs
+                           && length memTypes + 1 == numCrucibleTypes
+                       )
+
+        unless matchedNumArgTypes (throwError (BadLiftArgs (L.decName decl)))
+        Some fullTypes <-
+          Ctx.generateSomeM
+            ( Ctx.sizeInt (Ctx.size crucibleTypes)
+                - if isVarArgs
+                  then 1
+                  else 0
             )
-            moduleTypes
-        case testCompatibilityAssign proxy fullTypes crucibleTypes of
-          Just Refl -> Right (SomeAssign fullTypes moduleTypes' Refl)
-          Nothing -> panic "Impossible" []
+            ( \idx ->
+                do
+                  -- NOTE(lb): The indexing here is safe because of the "unless
+                  -- matchedNumArgTypes" just above.
+                  Some fullTypeRepr <-
+                    withExceptT FullTypeTranslation $
+                      toFullTypeM (memTypes !! idx)
+                  pure $ Some fullTypeRepr
+            )
+        retType <-
+          traverse
+            (withExceptT FullTypeTranslation . toFullTypeM)
+            (fdRetType liftedDecl)
+        Some crucibleTypes' <-
+          pure $
+            if isVarArgs
+              then removeVarArgsRepr crucibleTypes
+              else Some crucibleTypes
+        case testCompatibilityAssign (Proxy :: Proxy arch) fullTypes crucibleTypes' of
+          Just Refl ->
+            pure
+              ( L.decName decl,
+                FunctionTypes
+                  { ftArgTypes = MatchingAssign fullTypes crucibleTypes',
+                    ftRetType = retType,
+                    ftIsVarArgs = boolToVarArgsRepr isVarArgs
+                  }
+              )
+          Nothing ->
+            panic
+              "Impossible"
+              ["(toCrucibleType . toFullTypeM) should be the identity function"]
+
+    removeVarArgsRepr ::
+      Ctx.Assignment CrucibleTypes.TypeRepr ctx ->
+      Some (Ctx.Assignment CrucibleTypes.TypeRepr)
+    removeVarArgsRepr crucibleTypes =
+      case Ctx.viewAssign crucibleTypes of
+        Ctx.AssignEmpty ->
+          panic
+            "translateModuleDefines"
+            ["varargs function with no arguments"]
+        Ctx.AssignExtend rest vaRepr ->
+          case testEquality vaRepr LLVMTrans.varArgsRepr of
+            Just Refl -> Some rest
+            Nothing ->
+              panic
+                "translateModuleDefines"
+                ["varargs function with no varargs repr"]
 
 data SomeAssign' arch m fullTypes f = forall crucibleTypes.
   SomeAssign'

--- a/uc-crux-llvm/src/UCCrux/LLVM/FullType/ReturnType.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/FullType/ReturnType.hs
@@ -1,0 +1,38 @@
+{-
+Module           : UCCrux.LLVM.FullType.ReturnType
+Description      : TODO
+Copyright        : (c) Galois, Inc 2021
+License          : BSD3
+Maintainer       : Langston Barrett <langston@galois.com>
+Stability        : provisional
+
+By having a separate notion of \"return type\", 'FullType' doesn't need to have
+a \"void\" constructor, which avoids some de-normalization/partiality
+elsewhere.
+-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module UCCrux.LLVM.FullType.ReturnType
+  ( ReturnType (..),
+    ReturnTypeToCrucibleType,
+  )
+where
+
+{- ORMOLU_DISABLE -}
+import           Data.Kind (Type)
+
+import qualified Lang.Crucible.Types as CrucibleTypes hiding ((::>))
+
+import           UCCrux.LLVM.FullType.Type
+{- ORMOLU_ENABLE -}
+
+data ReturnType (m :: Type) (ft :: Maybe (FullType m)) where
+  Void :: ReturnType m 'Nothing
+  NonVoid :: FullTypeRepr m ft -> ReturnType m ('Just ft)
+
+type family ReturnTypeToCrucibleType arch (ft :: Maybe (FullType m)) where
+  ReturnTypeToCrucibleType arch 'Nothing = CrucibleTypes.UnitType
+  ReturnTypeToCrucibleType arch ('Just ft) = ToCrucibleType arch ft

--- a/uc-crux-llvm/src/UCCrux/LLVM/FullType/VarArgs.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/FullType/VarArgs.hs
@@ -1,0 +1,62 @@
+{-
+Module           : UCCrux.LLVM.FullType.VarArgs
+Description      : Type-level indication of whether a function is variadic
+Copyright        : (c) Galois, Inc 2021
+License          : BSD3
+Maintainer       : Langston Barrett <langston@galois.com>
+Stability        : provisional
+-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module UCCrux.LLVM.FullType.VarArgs
+  ( type IsVarArgs (..),
+    VarArgsRepr (..),
+    boolToVarArgsRepr,
+    varArgsReprToBool,
+  )
+where
+
+{- ORMOLU_DISABLE -}
+import           Data.Type.Equality (TestEquality(testEquality))
+
+import           Data.Parameterized.Classes (OrdF(compareF))
+import           Data.Parameterized.Some (Some(Some))
+import qualified Data.Parameterized.TH.GADT as U
+{- ORMOLU_ENABLE -}
+
+-- | Type level only.
+data IsVarArgs
+  = IsVarArgs
+  | NotVarArgs
+
+data VarArgsRepr (varArgs :: IsVarArgs) where
+  IsVarArgsRepr :: VarArgsRepr 'IsVarArgs
+  NotVarArgsRepr :: VarArgsRepr 'NotVarArgs
+
+boolToVarArgsRepr :: Bool -> Some VarArgsRepr
+boolToVarArgsRepr True = Some IsVarArgsRepr
+boolToVarArgsRepr False = Some NotVarArgsRepr
+
+varArgsReprToBool :: VarArgsRepr varArgs -> Bool
+varArgsReprToBool IsVarArgsRepr = True
+varArgsReprToBool NotVarArgsRepr = False
+
+-- ------------------------------------------------------------------------------
+-- Instances
+
+$(return [])
+
+instance TestEquality VarArgsRepr where
+  testEquality = $(U.structuralTypeEquality [t|VarArgsRepr|] [])
+
+instance OrdF VarArgsRepr where
+  compareF = $(U.structuralTypeOrd [t|VarArgsRepr|] [])

--- a/uc-crux-llvm/src/UCCrux/LLVM/Run/Explore.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Run/Explore.hs
@@ -66,7 +66,7 @@ exploreOne ::
     ArchOk arch
   ) =>
   AppContext ->
-  ModuleContext arch ->
+  ModuleContext m arch ->
   CruxOptions ->
   UCCruxLLVMOptions ->
   Crucible.HandleAllocator ->
@@ -117,7 +117,7 @@ explore ::
     ArchOk arch
   ) =>
   AppContext ->
-  ModuleContext arch ->
+  ModuleContext m arch ->
   CruxOptions ->
   UCCruxLLVMOptions ->
   Crucible.HandleAllocator ->

--- a/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
@@ -99,7 +99,7 @@ import           UCCrux.LLVM.Setup.Monad (ppSetupError)
 simulateLLVM ::
   ArchOk arch =>
   AppContext ->
-  ModuleContext arch ->
+  ModuleContext m arch ->
   FunctionContext m arch argTypes ->
   Crucible.HandleAllocator ->
   IORef [Explanation m arch argTypes] ->
@@ -265,7 +265,7 @@ runSimulator ::
     ArchOk arch
   ) =>
   AppContext ->
-  ModuleContext arch ->
+  ModuleContext m arch ->
   FunctionContext m arch argTypes ->
   Crucible.HandleAllocator ->
   Constraints m argTypes ->

--- a/uc-crux-llvm/src/UCCrux/LLVM/Setup.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Setup.hs
@@ -64,8 +64,8 @@ import qualified Lang.Crucible.LLVM.Translation as LLVMTrans
 import           Crux.LLVM.Overrides (ArchOk)
 
 import           UCCrux.LLVM.Context.App (AppContext)
-import           UCCrux.LLVM.Context.Function (FunctionContext, argumentCrucibleTypes, argumentFullTypes, moduleTypes)
-import           UCCrux.LLVM.Context.Module (ModuleContext, moduleTranslation, withTypeContext, llvmModule)
+import           UCCrux.LLVM.Context.Function (FunctionContext, argumentCrucibleTypes, argumentFullTypes)
+import           UCCrux.LLVM.Context.Module (ModuleContext, moduleTranslation, withTypeContext, llvmModule, moduleTypes)
 import           UCCrux.LLVM.Errors.Panic (panic)
 import           UCCrux.LLVM.Errors.Unimplemented (unimplemented)
 import qualified UCCrux.LLVM.Errors.Unimplemented as Unimplemented
@@ -353,6 +353,7 @@ generateArgs ::
     ArchOk arch
   ) =>
   AppContext ->
+  ModuleContext m arch ->
   FunctionContext m arch argTypes ->
   sym ->
   Ctx.Assignment (ConstrainedShape m) argTypes ->
@@ -364,7 +365,7 @@ generateArgs ::
     ( Ctx.Assignment (Shape m (SymValue sym arch)) argTypes,
       Crucible.RegMap sym (MapToCrucibleType arch argTypes)
     )
-generateArgs _appCtx funCtx sym argSpecs =
+generateArgs _appCtx modCtx funCtx sym argSpecs =
   do
     let argTypesRepr = funCtx ^. argumentCrucibleTypes
     shapes <-
@@ -374,7 +375,7 @@ generateArgs _appCtx funCtx sym argSpecs =
             let ft = funCtx ^. argumentFullTypes . ixF' index
              in generate
                   sym
-                  (funCtx ^. moduleTypes)
+                  (modCtx ^. moduleTypes)
                   ft
                   (SelectArgument index (Here ft))
                   (argSpecs Ctx.! index)
@@ -408,7 +409,7 @@ setupExecution ::
     MonadIO f
   ) =>
   AppContext ->
-  ModuleContext arch ->
+  ModuleContext m arch ->
   FunctionContext m arch argTypes ->
   sym ->
   -- | Constraints and memory layouts of each argument
@@ -435,4 +436,4 @@ setupExecution appCtx modCtx funCtx sym argSpecs = do
       liftIO $
         LLVMGlobals.populateAllGlobals sym (LLVMTrans.globalInitMap moduleTrans)
           =<< LLVMGlobals.initializeAllMemory sym llvmCtxt (modCtx ^. llvmModule)
-  runSetup modCtx mem (generateArgs appCtx funCtx sym argSpecs)
+  runSetup modCtx mem (generateArgs appCtx modCtx funCtx sym argSpecs)

--- a/uc-crux-llvm/src/UCCrux/LLVM/Setup/Monad.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Setup/Monad.hs
@@ -142,7 +142,7 @@ newtype Setup m arch sym (argTypes :: Ctx (FullType m)) a
       ( ExceptT
           (SetupError m arch argTypes)
           ( RWST
-              (ModuleContext arch)
+              (ModuleContext m arch)
               [SetupAssumption m sym]
               (SetupState m arch sym argTypes)
               IO
@@ -155,7 +155,7 @@ deriving instance MonadError (SetupError m arch argTypes) (Setup m arch sym argT
 
 deriving instance MonadState (SetupState m arch sym argTypes) (Setup m arch sym argTypes)
 
-deriving instance MonadReader (ModuleContext arch) (Setup m arch sym argTypes)
+deriving instance MonadReader (ModuleContext m arch) (Setup m arch sym argTypes)
 
 deriving instance MonadWriter [SetupAssumption m sym] (Setup m arch sym argTypes)
 
@@ -185,7 +185,7 @@ data SetupResult m arch sym (argTypes :: Ctx (FullType m)) = SetupResult
 
 runSetup ::
   MonadIO f =>
-  ModuleContext arch ->
+  ModuleContext m arch ->
   LLVMMem.MemImpl sym ->
   Setup m arch sym argTypes a ->
   f (Either (SetupError m arch argTypes) (SetupResult m arch sym argTypes, a))

--- a/uc-crux-llvm/src/UCCrux/LLVM/Shape.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Shape.hs
@@ -105,8 +105,8 @@ data Shape (m :: Type) (tag :: FullType m -> Type) (ft :: FullType m) where
   -- | Function pointers don't have any sub-shapes because they aren't data
   -- pointers and can't be dereferenced.
   ShapeFuncPtr ::
-    tag ('FTFuncPtr ret args) ->
-    Shape m tag ('FTFuncPtr ret args)
+    tag ('FTFuncPtr varArgs ret args) ->
+    Shape m tag ('FTFuncPtr varArgs ret args)
   -- | Opaque pointers don't have any sub-shapes because they can't be
   -- dereferenced.
   ShapeOpaquePtr ::

--- a/uc-crux-llvm/test/Test.hs
+++ b/uc-crux-llvm/test/Test.hs
@@ -65,7 +65,6 @@ import qualified Text.LLVM.AST as L
 
 import qualified Data.Parameterized.Context as Ctx
 import           Data.Parameterized.NatRepr (NatRepr, knownNat)
-import           Data.Parameterized.Some (Some(..))
 
 import           Lang.Crucible.FunctionHandle (newHandleAllocator)
 
@@ -75,7 +74,7 @@ import           Crux.LLVM.Config (clangOpts)
 
 -- Code being tested
 import qualified UCCrux.LLVM.Config as Config
-import           UCCrux.LLVM.Main (loopOnFunctions, translateFile, translateLLVMModule)
+import           UCCrux.LLVM.Main (SomeModuleContext'(..), loopOnFunctions, translateFile, translateLLVMModule)
 import           UCCrux.LLVM.Errors.Unimplemented (catchUnimplemented)
 import           UCCrux.LLVM.Cursor (Cursor(..))
 import           UCCrux.LLVM.Classify.Types (partitionUncertainty)
@@ -161,7 +160,7 @@ findBugs llvmModule file fns =
         --   )
         let ?outputConfig = outCfg
         halloc <- newHandleAllocator
-        Some modCtx <-
+        SomeModuleContext' modCtx <-
           case llvmModule of
             Just lMod -> translateLLVMModule ucOpts halloc path lMod
             Nothing -> translateFile ucOpts halloc path
@@ -303,6 +302,25 @@ isUnclassified fn (Result.SomeBugfindingResult result) =
           Text.unpack (Result.printFunctionSummary (Result.summary result))
         ]
 
+isUnfixed :: String -> Result.SomeBugfindingResult -> IO ()
+isUnfixed fn (Result.SomeBugfindingResult result) =
+  do
+    let (missingAnn, failedAssert, unimpl, unclass, unfixed, unfixable, timeouts) =
+          partitionUncertainty (Result.uncertainResults result)
+    [] TH.@=? map show missingAnn
+    [] TH.@=? map show failedAssert
+    [] TH.@=? map show unimpl
+    [] TH.@=? map show unclass
+    [] TH.@=? map show unfixable
+    [] TH.@=? map show timeouts
+    0 < length unfixed
+      TH.@? unwords
+        [ "Expected",
+          fn,
+          "to be unfixed but the result was:\n",
+          Text.unpack (Result.printFunctionSummary (Result.summary result))
+        ]
+
 hasMissingAnn :: String -> Result.SomeBugfindingResult -> IO ()
 hasMissingAnn fn (Result.SomeBugfindingResult result) =
   do
@@ -372,6 +390,7 @@ inFileTests =
         ("getenv_const.c", [("getenv_const", isSafe (unsoundOverride "getenv"))]),
         ("gethostname_const_len.c", [("gethostname_const_len", isSafe (unsoundOverride "gethostname"))]),
         ("id_function_pointer.c", [("id_function_pointer", isSafe mempty)]),
+        ("id_varargs_function_pointer.c", [("id_varargs_function_pointer", isSafe mempty)]),
         ("opaque_struct.c", [("opaque_struct", isSafe mempty)]),
         ("print.c", [("print", isSafe mempty)]),
         ("read_global.c", [("read_global", isSafe mempty)]),
@@ -431,9 +450,14 @@ inFileTests =
         ("deref_arg_arg_index.c", [("deref_arg_arg_index", hasMissingAnn)]),
         -- This one could use an override. Currently fails because it's
         -- skipped, and so unreachable code gets reached.
-        ("do_exit.c", [("do_exit", hasMissingAnn)]) -- goal: isSafe
+        ("do_exit.c", [("do_exit", hasMissingAnn)]), -- goal: isSafe
         -- TODO: https://github.com/GaloisInc/crucible/issues/651
         -- , isSafeWithPreconditions "do_strlen.c" "do_strlen" False
+        ("call_function_pointer.c", [("call_function_pointer", isUnfixed)]), -- goal: ???
+        ("call_varargs_function_pointer.c", [("call_varargs_function_pointer", isUnfixed)]), -- goal: ???
+        -- Strangely, this compiles to a function that takes a variable-arity
+        -- function as an argument?
+        ("set_errno.c", [("set_errno", isUnfixed)]) -- goal: ???
 
         -- TODO: Not sure if Crux can do C++?
         -- , isSafe "cxxbasic.cpp" "cxxbasic"
@@ -1000,9 +1024,6 @@ main =
       "uc-crux-llvm"
       [ inFileTests,
         moduleTests,
-        isUnimplemented "call_function_pointer.c" "call_function_pointer", -- goal: ???
-        isUnimplemented "call_varargs_function_pointer.c" "call_varargs_function_pointer", -- goal: ???
-        isUnimplemented "id_varargs_function_pointer.c" "id_varargs_function_pointer", -- goal: isSafe
         isUnimplemented "do_fork.c" "do_fork", -- goal: ???
         isUnimplemented "do_recv.c" "do_recv",
         isUnimplemented "do_strdup.c" "do_strdup", -- goal: isSafe
@@ -1010,12 +1031,6 @@ main =
         isUnimplemented "do_strncmp.c" "do_strncmp", -- goal: isSafe
         isUnimplemented "extern_non_void_function.c" "extern_non_void_function", -- goal: isSafeWithPreconditions
         isUnimplemented "read_errno.c" "read_errno", -- goal: isSafe
-
-        -- Strangely, this compiles to a function that takes a variable-arity
-        -- function as an argument?
-        isUnimplemented
-          "set_errno.c"
-          "set_errno", -- goal: ???
         isUnimplemented
           "gethostname_neg_len.c"
           "gethostname_neg_len", -- goal: ???

--- a/uc-crux-llvm/uc-crux-llvm.cabal
+++ b/uc-crux-llvm/uc-crux-llvm.cabal
@@ -46,6 +46,8 @@ library
     UCCrux.LLVM.FullType.CrucibleType
     UCCrux.LLVM.FullType.MemType
     UCCrux.LLVM.FullType.Type
+    UCCrux.LLVM.FullType.ReturnType
+    UCCrux.LLVM.FullType.VarArgs
     UCCrux.LLVM.Logging
     UCCrux.LLVM.Main
     UCCrux.LLVM.Overrides.Skip


### PR DESCRIPTION
This is based on #707, which is only held up due to some CI difficulties.

Previously, the declaration for each function was separately translated into `FullType`s, now all declarations are done at once. This has a few benefits:

- Efficiency: there's no duplicated work when exploring multiple functions
- Parsimony: The ModuleTypes abstraction applies best at the module level
- Functionality: The big feature introduced here is `findFun`/`CFGWithTypes`: the `FullType`s for a declaration can be looked up in the `ModuleContext`. One spot this will be useful is in generating return values from skipped functions.

Additionally, this patch introduces support for variable-arity function types. This was necessary because the default is now to translate *all* function types in a module, which would fail on any module with a varargs function if these weren't supported.