### PR TITLE
uc-crux-llvm: Fix panic on int-to-pointer casts

### DIFF
--- a/.github/workflows/crux-mir-build.yml
+++ b/.github/workflows/crux-mir-build.yml
@@ -16,7 +16,7 @@ on:
 # (symptom: "No suitable image found ... unknown file type, first
 # eight bytes: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00")
 env:
-  CACHE_VERSION: 2
+  CACHE_VERSION: 3
 
 jobs:
   outputs:

--- a/uc-crux-llvm/src/UCCrux/LLVM/Errors/Unimplemented.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Errors/Unimplemented.hs
@@ -42,6 +42,7 @@ data Unimplemented
   | GetHostNameSmallSize
   | NonEmptyUnboundedSizeArrays
   | NonVoidUndefinedFunc Text
+  | CastIntegerToPointer
   deriving (Eq, Ord)
 
 ppUnimplemented :: Unimplemented -> String
@@ -61,6 +62,7 @@ ppUnimplemented =
     NonEmptyUnboundedSizeArrays -> "Generating arrays with unbounded size"
     NonVoidUndefinedFunc func ->
       "Non-void function without a definition: " ++ Text.unpack func
+    CastIntegerToPointer -> "Value of integer type treated as/cast to a pointer"
 
 instance PanicComponent Unimplemented where
   panicComponentName _ = "uc-crux-llvm"

--- a/uc-crux-llvm/src/UCCrux/LLVM/FullType/Type.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/FullType/Type.hs
@@ -427,10 +427,13 @@ asFullType mts ptRepr =
   case asFullType' mts ptRepr of
     Right ok -> ok
     Left _err ->
-      -- See comment on 'UCCrux.LLVM.FullType.CrucibleType.SomeAssign'.
-      panic
-        "asFullType"
-        ["Impossible: couldn't find definition for type alias"]
+      case ptRepr of
+        PTAliasRepr (Const (L.Ident name)) ->
+          -- See comment on 'UCCrux.LLVM.FullType.CrucibleType.SomeAssign'.
+          panic
+            "asFullType"
+            ["Impossible: couldn't find definition for type alias: " <> name]
+        _ -> panic "asFullType" ["Impossible case"]
 
 -- ------------------------------------------------------------------------------
 -- Instances

--- a/uc-crux-llvm/test/Test.hs
+++ b/uc-crux-llvm/test/Test.hs
@@ -407,9 +407,11 @@ inFileTests =
         -- nonzero size, but it actually requires the input pointer to point to
         -- an *array of structs*.
         ("unsized_array.c", [("unsized_array", isSafeWithPreconditions mempty DidntHitBounds)]),
+        ("deref_func_ptr.c", [("deref_func_ptr", isUnclassified)]), -- goal: hasBugs
         ("do_getchar.c", [("do_getchar", isUnclassified)]), -- goal: isSafe
         ("free_with_offset.c", [("free_with_offset", isUnclassified)]), -- goal: hasBugs
         ("memset_arg_len.c", [("memset_arg_len", isUnclassified)]), -- goal: isSafeWP
+        ("memset_func_ptr.c", [("memset_func_ptr", isUnclassified)]), -- goal: hasBugs
         ("nested_structs.c", [("nested_structs", isUnclassified)]), -- goal: ???
         ("oob_read_heap.c", [("oob_read_heap", isUnclassified)]), -- goal: hasBugs
         ("oob_read_stack.c", [("oob_read_stack", isUnclassified)]), -- goal: hasBugs
@@ -421,6 +423,7 @@ inFileTests =
         --
         --
         -- TODO(lb): Fix upstream? Missing annotations just seems like a bug.
+        ("cast_void_pointer.c", [("cast_void_pointer", hasMissingAnn)]),
         ("compare_ptr_to_int.c", [("compare_ptr_to_int", hasMissingAnn)]), -- goal: hasBugs
         ("compare_ptrs_different_heap_allocs.c", [("compare_ptrs_different_heap_allocs", hasMissingAnn)]), -- goal: hasBugs
         ("compare_ptrs_different_stack_allocs.c", [("compare_ptrs_different_stack_allocs", hasMissingAnn)]), -- goal: hasBugs
@@ -1019,6 +1022,12 @@ main =
         isUnimplemented
           "gethostname_arg_ptr_len.c"
           "gethostname_arg_ptr_len", -- goal: ???
+        isUnimplemented
+          "cast_int_to_pointer_dereference.c"
+          "cast_int_to_pointer_dereference", -- goal: isSafeWithPreconditions
+        isUnimplemented
+          "cast_int_to_pointer_memset.c"
+          "cast_int_to_pointer_memset", -- goal: isSafeWithPreconditions
         isUnimplemented
           "gethostname_arg_len.c"
           "gethostname_arg_len" -- goal: ???

--- a/uc-crux-llvm/test/programs/cast_int_to_pointer_dereference.c
+++ b/uc-crux-llvm/test/programs/cast_int_to_pointer_dereference.c
@@ -1,0 +1,2 @@
+#include <stdint.h>
+int cast_int_to_pointer_dereference(uintptr_t ptr) { return *((int *)(void *)ptr); }

--- a/uc-crux-llvm/test/programs/cast_int_to_pointer_memset.c
+++ b/uc-crux-llvm/test/programs/cast_int_to_pointer_memset.c
@@ -1,0 +1,5 @@
+#include <stdint.h>
+#include <string.h>
+int cast_int_to_pointer_memset(uintptr_t ptr) {
+  return memset((char *)(void *)ptr, 0, 8);
+}

--- a/uc-crux-llvm/test/programs/cast_void_pointer.c
+++ b/uc-crux-llvm/test/programs/cast_void_pointer.c
@@ -1,0 +1,1 @@
+int cast_void_pointer(void* ptr) { return *((int *)ptr); }

--- a/uc-crux-llvm/test/programs/deref_func_ptr.c
+++ b/uc-crux-llvm/test/programs/deref_func_ptr.c
@@ -1,0 +1,2 @@
+int deref_arg(void *ptr) __attribute__((noinline)) { return *(int*)ptr; }
+int deref_func_ptr() { return deref_arg((void *)(&deref_arg)); }

--- a/uc-crux-llvm/test/programs/memset_func_ptr.c
+++ b/uc-crux-llvm/test/programs/memset_func_ptr.c
@@ -1,0 +1,3 @@
+#include <string.h>
+int do_memset(void *ptr) __attribute__((noinline)) { memset(ptr, 0, 8); }
+int memset_func_ptr() { return do_memset((void *)(&do_memset)); }


### PR DESCRIPTION
This mostly defers the work by treating these as unimplemented/not yet supported, but adds some test cases as well to exhibit the behavior.

Fixes #711.