### PR TITLE
Allow CRUCIBLE clang_flags in source to affect crux-llvm compilation.

### DIFF
--- a/crux-llvm/crux-llvm.cabal
+++ b/crux-llvm/crux-llvm.cabal
@@ -88,6 +88,7 @@ library
     bv-sized,
     config-schema,
     data-binary-ieee754,
+    logict,
     llvm-pretty,
     llvm-pretty-bc-parser,
     mtl,

--- a/crux-llvm/src/Crux/LLVM/Compile.hs
+++ b/crux-llvm/src/Crux/LLVM/Compile.hs
@@ -6,34 +6,30 @@
 {-# LANGUAGE TypeOperators #-}
 module Crux.LLVM.Compile where
 
-import Control.Exception
-  ( SomeException(..), try, displayException )
-import Control.Monad
-  ( unless, when, forM_ )
+import           Control.Exception ( SomeException(..), try, displayException )
+import           Control.Monad ( unless, when, forM_ )
 import qualified Data.Foldable as Fold
-import Data.List
-  ( intercalate, isSuffixOf )
+import           Data.List ( intercalate, isSuffixOf )
 import qualified Data.Parameterized.Map as MapF
-import System.Directory
-  ( doesFileExist, removeFile, createDirectoryIfMissing, copyFile )
-import System.Exit
-  ( ExitCode(..) )
-import System.FilePath
-  ( takeExtension, (</>), takeDirectory, takeFileName, (-<.>) )
-import System.Process
-  ( readProcess, readProcessWithExitCode )
+import           System.Directory ( doesFileExist, removeFile
+                                  , createDirectoryIfMissing, copyFile )
+import           System.Exit ( ExitCode(..) )
+import           System.FilePath ( takeExtension, (</>), (-<.>)
+                                 , takeDirectory, takeFileName )
+import           System.Process ( readProcess, readProcessWithExitCode )
 
-import What4.Interface
-import What4.ProgramLoc
+import           What4.Interface
+import           What4.ProgramLoc
 
-import Lang.Crucible.Simulator.SimError
+import           Lang.Crucible.Simulator.SimError
 
-import Crux
+import           Crux
 import qualified Crux.Config.Common as CC
-import Crux.Model( toDouble, showBVLiteral, showFloatLiteral, showDoubleLiteral )
-import Crux.Types
+import           Crux.Model ( toDouble, showBVLiteral, showFloatLiteral
+                            , showDoubleLiteral )
+import           Crux.Types
 
-import Crux.LLVM.Config
+import           Crux.LLVM.Config
 
 
 isCPlusPlus :: FilePath -> Bool

--- a/crux-llvm/test-data/golden/gcd-test-clang-flags.c
+++ b/crux-llvm/test-data/golden/gcd-test-clang-flags.c
@@ -1,0 +1,41 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <crucible.h>
+/* CRUCIBLE clang_flags: -m64 -DTEST_FLAGS -Wall */
+// CRUX CLANG_FLAGS: -Dmore_FLAGS -pthread
+
+// This test exercises the path satisfiability option.
+//
+// The ouput should indicate that we only recursively call
+// `gdc` up to depth = 12, which is the worst case for
+// this algorithm on 8-bits.
+//
+// Without path-sat this should still terminate, but it
+// takes 255 recursive calls instead for the bitvector
+// abstract domain to determine the loop must terminate.
+uint8_t gcd(uint32_t depth, uint8_t a, uint8_t b) {
+  printf("depth = %u\n", depth);
+  if(b == 0)
+    return a;
+  return gcd(depth+1, b, a%b);
+}
+
+
+int main ( )
+{
+  uint8_t a = crucible_uint8_t( "a" );
+  uint8_t b = crucible_uint8_t( "b" );
+
+#ifdef TEST_FLAGS
+  printf("Starting gcd\n");
+#endif
+
+  uint8_t x = gcd( 0, a, b);
+
+#ifdef more_FLAGS
+  printf("Ended gcd run\n");
+#endif
+
+  printf( "%d\n", x );
+  return 0;
+}

--- a/crux-llvm/test-data/golden/gcd-test-clang-flags.config
+++ b/crux-llvm/test-data/golden/gcd-test-clang-flags.config
@@ -1,0 +1,1 @@
+path-sat: yes

--- a/crux-llvm/test-data/golden/gcd-test-clang-flags.good
+++ b/crux-llvm/test-data/golden/gcd-test-clang-flags.good
@@ -1,0 +1,17 @@
+Starting gcd
+depth = 0
+depth = 1
+depth = 2
+depth = 3
+depth = 4
+depth = 5
+depth = 6
+depth = 7
+depth = 8
+depth = 9
+depth = 10
+depth = 11
+depth = 12
+Ended gcd run
+????
+[Crux] Overall status: Valid.


### PR DESCRIPTION
The source file can embed a comment of the form `/* CRUCIBLE clang_flags: .... */` (or in C++ single-line comment syntax) and the ellipsized portion will be added to the flags pass to `clang` for compilation.