### PR TITLE
uc-crux-llvm: Detect uninitialized heap reads

### DIFF
--- a/uc-crux-llvm/README.md
+++ b/uc-crux-llvm/README.md
@@ -279,6 +279,7 @@ Uncertain results:
       - [ ] `free` called on non-argument pointer with non-zero offset
       - [ ] Write of `const` memory
       - [ ] Illegal (un)signed wrap when both operands are concrete
+      - [x] Uninitialized stack reads
       - [x] Concretely null pointer dereference
     - [ ] Missing preconditions:
       - [ ] Signed wrap with integers from arguments

--- a/uc-crux-llvm/src/UCCrux/LLVM/Classify/Types.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Classify/Types.hs
@@ -73,6 +73,7 @@ data TruePositiveTag
   | TagSRemByConcreteZero
   | TagReadNonPointer
   | TagWriteNonPointer
+  | TagReadUninitializedStack
   deriving (Eq, Ord)
 
 data TruePositive
@@ -84,6 +85,7 @@ data TruePositive
   | SRemByConcreteZero
   | ReadNonPointer
   | WriteNonPointer
+  | ReadUninitializedStack !String -- program location
 
 truePositiveTag :: TruePositive -> TruePositiveTag
 truePositiveTag =
@@ -96,6 +98,7 @@ truePositiveTag =
     SRemByConcreteZero {} -> TagSRemByConcreteZero
     ReadNonPointer {} -> TagReadNonPointer
     WriteNonPointer {} -> TagWriteNonPointer
+    ReadUninitializedStack {} -> TagReadUninitializedStack
 
 ppTruePositiveTag :: TruePositiveTag -> Text
 ppTruePositiveTag =
@@ -108,6 +111,7 @@ ppTruePositiveTag =
     TagSRemByConcreteZero -> "Signed remainder with a concretely zero divisor"
     TagReadNonPointer -> "Read from an integer that concretely wasn't a pointer"
     TagWriteNonPointer -> "Write from an integer that concretely wasn't a pointer"
+    TagReadUninitializedStack -> "Read from uninitialized stack allocation"
 
 ppTruePositive :: TruePositive -> Text
 ppTruePositive =

--- a/uc-crux-llvm/src/UCCrux/LLVM/Classify/Types.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Classify/Types.hs
@@ -74,6 +74,7 @@ data TruePositiveTag
   | TagReadNonPointer
   | TagWriteNonPointer
   | TagReadUninitializedStack
+  | TagReadUninitializedHeap
   deriving (Eq, Ord)
 
 data TruePositive
@@ -86,6 +87,7 @@ data TruePositive
   | ReadNonPointer
   | WriteNonPointer
   | ReadUninitializedStack !String -- program location
+  | ReadUninitializedHeap !String -- program location
 
 truePositiveTag :: TruePositive -> TruePositiveTag
 truePositiveTag =
@@ -99,6 +101,7 @@ truePositiveTag =
     ReadNonPointer {} -> TagReadNonPointer
     WriteNonPointer {} -> TagWriteNonPointer
     ReadUninitializedStack {} -> TagReadUninitializedStack
+    ReadUninitializedHeap {} -> TagReadUninitializedHeap
 
 ppTruePositiveTag :: TruePositiveTag -> Text
 ppTruePositiveTag =
@@ -112,6 +115,7 @@ ppTruePositiveTag =
     TagReadNonPointer -> "Read from an integer that concretely wasn't a pointer"
     TagWriteNonPointer -> "Write from an integer that concretely wasn't a pointer"
     TagReadUninitializedStack -> "Read from uninitialized stack allocation"
+    TagReadUninitializedHeap -> "Read from uninitialized heap allocation"
 
 ppTruePositive :: TruePositive -> Text
 ppTruePositive =

--- a/uc-crux-llvm/src/UCCrux/LLVM/Setup/Monad.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Setup/Monad.hs
@@ -38,6 +38,7 @@ module UCCrux.LLVM.Setup.Monad
     storableType,
     sizeInBytes,
     sizeBv,
+    mallocLocation,
     malloc,
     store,
   )
@@ -332,6 +333,13 @@ sizeBv ::
 sizeBv _proxy sym ftRepr size =
   liftIO . What4.bvLit sym ?ptrWidth . mkBV ?ptrWidth =<< sizeInBytes ftRepr size
 
+-- | This is exposed so that classification can check if a given allocation was
+-- generated during setup or during execution. A slightly heavier-weight
+-- alternative would be to keep track of the set of allocations made in the
+-- state.
+mallocLocation :: String
+mallocLocation = "uc-crux-llvm bugfinding auto-setup"
+
 malloc ::
   forall m sym arch argTypes inTy atTy.
   ( Crucible.IsSymInterface sym,
@@ -365,7 +373,7 @@ malloc sym fullTypeRepr selector size =
                     sym
                     LLVMMem.HeapAlloc -- TODO(lb): Change based on arg/global
                     LLVMMem.Mutable -- TODO(lb): Change based on arg/global
-                    "crux-llvm bugfinding auto-setup"
+                    mallocLocation
                     mem
                     sz
                     (maxAlignment dl) -- TODO is this OK?

--- a/uc-crux-llvm/test/Test.hs
+++ b/uc-crux-llvm/test/Test.hs
@@ -354,6 +354,7 @@ inFileTests =
       [ ("assert_false.c", [("assert_false", hasBugs)]),
         ("assert_arg_eq.c", [("assert_arg_eq", hasBugs)]), -- goal: hasFailedAssert
         ("double_free.c", [("double_free", hasBugs)]),
+        ("uninitialized_heap.c", [("uninitialized_heap", hasBugs)]),
         ("uninitialized_stack.c", [("uninitialized_stack", hasBugs)]),
         ("write_to_null.c", [("write_to_null", hasBugs)]),
         ("branch.c", [("branch", isSafe mempty)]),

--- a/uc-crux-llvm/test/Test.hs
+++ b/uc-crux-llvm/test/Test.hs
@@ -354,6 +354,7 @@ inFileTests =
       [ ("assert_false.c", [("assert_false", hasBugs)]),
         ("assert_arg_eq.c", [("assert_arg_eq", hasBugs)]), -- goal: hasFailedAssert
         ("double_free.c", [("double_free", hasBugs)]),
+        ("uninitialized_stack.c", [("uninitialized_stack", hasBugs)]),
         ("write_to_null.c", [("write_to_null", hasBugs)]),
         ("branch.c", [("branch", isSafe mempty)]),
         ("compare_to_null.c", [("compare_to_null", isSafe mempty)]),
@@ -409,7 +410,6 @@ inFileTests =
         ("signed_add_wrap_concrete.c", [("signed_add_wrap_concrete", isUnclassified)]), -- goal: hasBugs
         ("signed_mul_wrap_concrete.c", [("signed_mul_wrap_concrete", isUnclassified)]), -- goal: hasBugs
         ("signed_sub_wrap_concrete.c", [("signed_sub_wrap_concrete", isUnclassified)]), -- goal: hasBugs
-        ("uninitialized_stack.c", [("uninitialized_stack", isUnclassified)]), -- goal: hasBugs
         ("write_const_global.c", [("write_const_global", isUnclassified)]), -- goal: hasBugs
         ("use_after_free.c", [("use_after_free", isUnclassified)]), -- goal: hasBugs
         --

--- a/uc-crux-llvm/test/programs/uninitialized_heap.c
+++ b/uc-crux-llvm/test/programs/uninitialized_heap.c
@@ -1,0 +1,6 @@
+#include <stdlib.h>
+int dereferences_argument(int *ptr) __attribute__((noinline)) { return *ptr; }
+int uninitialized_heap() {
+  int *x = malloc(sizeof(int));
+  return dereferences_argument(x);
+}


### PR DESCRIPTION
This is based on top of #713 to avoid merge conflicts, will rebase when that one is merged.