### PR TITLE
uc-crux-llvm: Detect calls to non-function pointers

### DIFF
--- a/uc-crux-llvm/README.md
+++ b/uc-crux-llvm/README.md
@@ -273,13 +273,13 @@ Uncertain results:
   - [ ] Develop heuristics for more types of errors
     - [ ] True positives:
       - [ ] Out-of-bounds reads/writes at concrete offsets
+      - [x] Calls to non-function pointers
       - [x] Division by zero
       - [x] Mod by zero
-      - [ ] Use before initialization of non-argument allocation
+      - [x] Use before initialization of non-argument allocation
       - [ ] `free` called on non-argument pointer with non-zero offset
       - [ ] Write of `const` memory
       - [ ] Illegal (un)signed wrap when both operands are concrete
-      - [x] Uninitialized stack reads
       - [x] Concretely null pointer dereference
     - [ ] Missing preconditions:
       - [ ] Signed wrap with integers from arguments

--- a/uc-crux-llvm/src/UCCrux/LLVM/Classify.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Classify.hs
@@ -573,7 +573,7 @@ classifyBadBehavior appCtx modCtx funCtx sym (Crucible.RegMap _args) annotations
                   _ -> unclass appCtx badBehavior
     LLVMErrors.BBMemoryError
       ( MemError.MemoryError
-          (MemError.MemLoadHandleOp _type _str ptr _)
+          (MemError.MemLoadHandleOp _type _str ptr mem)
           (MemError.BadFunctionPointer _msg)
         ) ->
         case getPtrOffsetAnn ptr of
@@ -591,7 +591,38 @@ classifyBadBehavior appCtx modCtx funCtx sym (Crucible.RegMap _args) annotations
                       "(" <> Text.pack (show (LLVMPtr.ppPtr ptr)) <> ")"
                     ]
               unfixed appCtx tag
-          _ -> unclass appCtx badBehavior
+          _ ->
+            liftIO (allocInfoFromPtr mem ptr)
+              >>= \case
+                Just (G.AllocInfo G.StackAlloc _sz _mut _align loc) ->
+                  do
+                    when (loc == mallocLocation) $
+                      panic "classify" ["Setup allocated something on the stack?"]
+                    let tag = TagCallNonFunctionPointer
+                    liftIO $
+                      (appCtx ^. log) Hi $
+                        Text.unwords
+                          [ "Diagnosis:",
+                            ppTruePositiveTag tag,
+                            "at",
+                            Text.pack loc
+                          ]
+                    return $ ExTruePositive (CallNonFunctionPointer loc)
+                Just (G.AllocInfo G.HeapAlloc _sz _mut _align loc) ->
+                  if loc == mallocLocation
+                    then unclass appCtx badBehavior
+                    else do
+                      let tag = TagCallNonFunctionPointer
+                      liftIO $
+                        (appCtx ^. log) Hi $
+                          Text.unwords
+                            [ "Diagnosis:",
+                              ppTruePositiveTag tag,
+                              "at",
+                              Text.pack loc
+                            ]
+                      return $ ExTruePositive (CallNonFunctionPointer loc)
+                _ -> unclass appCtx badBehavior
     _ -> unclass appCtx badBehavior
   where
     getTermAnn ::

--- a/uc-crux-llvm/src/UCCrux/LLVM/Classify/Types.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Classify/Types.hs
@@ -75,6 +75,7 @@ data TruePositiveTag
   | TagWriteNonPointer
   | TagReadUninitializedStack
   | TagReadUninitializedHeap
+  | TagCallNonFunctionPointer
   deriving (Eq, Ord)
 
 data TruePositive
@@ -88,6 +89,7 @@ data TruePositive
   | WriteNonPointer
   | ReadUninitializedStack !String -- program location
   | ReadUninitializedHeap !String -- program location
+  | CallNonFunctionPointer !String -- program location of allocation
 
 truePositiveTag :: TruePositive -> TruePositiveTag
 truePositiveTag =
@@ -102,6 +104,7 @@ truePositiveTag =
     WriteNonPointer {} -> TagWriteNonPointer
     ReadUninitializedStack {} -> TagReadUninitializedStack
     ReadUninitializedHeap {} -> TagReadUninitializedHeap
+    CallNonFunctionPointer {} -> TagCallNonFunctionPointer
 
 ppTruePositiveTag :: TruePositiveTag -> Text
 ppTruePositiveTag =
@@ -116,6 +119,7 @@ ppTruePositiveTag =
     TagWriteNonPointer -> "Write from an integer that concretely wasn't a pointer"
     TagReadUninitializedStack -> "Read from uninitialized stack allocation"
     TagReadUninitializedHeap -> "Read from uninitialized heap allocation"
+    TagCallNonFunctionPointer -> "Called a pointer that wasn't a function pointer"
 
 ppTruePositive :: TruePositive -> Text
 ppTruePositive =

--- a/uc-crux-llvm/src/UCCrux/LLVM/Classify/Types.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Classify/Types.hs
@@ -124,9 +124,15 @@ ppTruePositiveTag =
 ppTruePositive :: TruePositive -> Text
 ppTruePositive =
   \case
-    ConcretelyFailingAssert loc ->
-      "Concretely failing call to assert() at " <> Text.pack (show loc)
+    pos@(ConcretelyFailingAssert loc) -> withProgLoc pos loc
+    pos@(ReadUninitializedStack loc) -> withLoc pos loc
+    pos@(ReadUninitializedHeap loc) -> withLoc pos loc
+    pos@(CallNonFunctionPointer loc) -> withLoc pos loc
     tp -> ppTruePositiveTag (truePositiveTag tp)
+  where
+    withLoc pos loc =
+      ppTruePositiveTag (truePositiveTag pos) <> " at " <> Text.pack loc
+    withProgLoc pos loc = withLoc pos (show loc)
 
 -- | All of the preconditions that we can deduce. We know how to detect and fix
 -- these issues.

--- a/uc-crux-llvm/test/Test.hs
+++ b/uc-crux-llvm/test/Test.hs
@@ -359,6 +359,7 @@ inFileTests =
       (uncurry inFile)
       [ ("assert_false.c", [("assert_false", hasBugs)]),
         ("assert_arg_eq.c", [("assert_arg_eq", hasBugs)]), -- goal: hasFailedAssert
+        ("call_non_function_pointer.c", [("call_non_function_pointer", hasBugs)]),
         ("double_free.c", [("double_free", hasBugs)]),
         ("uninitialized_heap.c", [("uninitialized_heap", hasBugs)]),
         ("uninitialized_stack.c", [("uninitialized_stack", hasBugs)]),

--- a/uc-crux-llvm/test/programs/call_non_function_pointer.c
+++ b/uc-crux-llvm/test/programs/call_non_function_pointer.c
@@ -1,0 +1,11 @@
+#include <stddef.h>
+#include <string.h>
+typedef int (*fun_ptr_t)(void);
+int call_function_pointer(fun_ptr_t fun_ptr) __attribute__((noinline)) {
+  return fun_ptr();
+}
+int call_non_function_pointer(char x) {
+  size_t arr[8];
+  memset(arr, x, 8);
+  return call_function_pointer((fun_ptr_t)arr);
+}


### PR DESCRIPTION
The second commit also has a bit of refactoring along the lines suggested in the review of the original `uc-crux-llvm` PR.