### PR TITLE
uc-crux-llvm: Detect bad float casts and frees of non-pointers

### DIFF
--- a/uc-crux-llvm/src/UCCrux/LLVM/Classify/Types.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Classify/Types.hs
@@ -73,6 +73,7 @@ data TruePositiveTag
   | TagSRemByConcreteZero
   | TagReadNonPointer
   | TagWriteNonPointer
+  | TagFreeNonPointer
   | TagReadUninitializedStack
   | TagReadUninitializedHeap
   | TagCallNonFunctionPointer
@@ -88,6 +89,7 @@ data TruePositive
   | SRemByConcreteZero
   | ReadNonPointer
   | WriteNonPointer
+  | FreeNonPointer
   | ReadUninitializedStack !String -- program location
   | ReadUninitializedHeap !String -- program location
   | CallNonFunctionPointer !String -- program location of allocation
@@ -104,6 +106,7 @@ truePositiveTag =
     SRemByConcreteZero {} -> TagSRemByConcreteZero
     ReadNonPointer {} -> TagReadNonPointer
     WriteNonPointer {} -> TagWriteNonPointer
+    FreeNonPointer {} -> TagFreeNonPointer
     ReadUninitializedStack {} -> TagReadUninitializedStack
     ReadUninitializedHeap {} -> TagReadUninitializedHeap
     CallNonFunctionPointer {} -> TagCallNonFunctionPointer
@@ -120,6 +123,7 @@ ppTruePositiveTag =
     TagSRemByConcreteZero -> "Signed remainder with a concretely zero divisor"
     TagReadNonPointer -> "Read from data that concretely wasn't a pointer"
     TagWriteNonPointer -> "Write to data that concretely wasn't a pointer"
+    TagFreeNonPointer -> "`free` called on data that concretely wasn't a pointer"
     TagReadUninitializedStack -> "Read from uninitialized stack allocation"
     TagReadUninitializedHeap -> "Read from uninitialized heap allocation"
     TagCallNonFunctionPointer -> "Called a pointer that wasn't a function pointer"

--- a/uc-crux-llvm/src/UCCrux/LLVM/Classify/Types.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Classify/Types.hs
@@ -76,6 +76,7 @@ data TruePositiveTag
   | TagReadUninitializedStack
   | TagReadUninitializedHeap
   | TagCallNonFunctionPointer
+  | TagFloatToPointer
   deriving (Eq, Ord)
 
 data TruePositive
@@ -90,6 +91,7 @@ data TruePositive
   | ReadUninitializedStack !String -- program location
   | ReadUninitializedHeap !String -- program location
   | CallNonFunctionPointer !String -- program location of allocation
+  | FloatToPointer
 
 truePositiveTag :: TruePositive -> TruePositiveTag
 truePositiveTag =
@@ -105,6 +107,7 @@ truePositiveTag =
     ReadUninitializedStack {} -> TagReadUninitializedStack
     ReadUninitializedHeap {} -> TagReadUninitializedHeap
     CallNonFunctionPointer {} -> TagCallNonFunctionPointer
+    FloatToPointer {} -> TagFloatToPointer
 
 ppTruePositiveTag :: TruePositiveTag -> Text
 ppTruePositiveTag =
@@ -115,11 +118,12 @@ ppTruePositiveTag =
     TagSDivByConcreteZero -> "Signed division with a concretely zero divisor"
     TagURemByConcreteZero -> "Unsigned remainder with a concretely zero divisor"
     TagSRemByConcreteZero -> "Signed remainder with a concretely zero divisor"
-    TagReadNonPointer -> "Read from an integer that concretely wasn't a pointer"
-    TagWriteNonPointer -> "Write from an integer that concretely wasn't a pointer"
+    TagReadNonPointer -> "Read from data that concretely wasn't a pointer"
+    TagWriteNonPointer -> "Write to data that concretely wasn't a pointer"
     TagReadUninitializedStack -> "Read from uninitialized stack allocation"
     TagReadUninitializedHeap -> "Read from uninitialized heap allocation"
     TagCallNonFunctionPointer -> "Called a pointer that wasn't a function pointer"
+    TagFloatToPointer -> "Treated float as pointer"
 
 ppTruePositive :: TruePositive -> Text
 ppTruePositive =

--- a/uc-crux-llvm/test/Test.hs
+++ b/uc-crux-llvm/test/Test.hs
@@ -366,6 +366,7 @@ inFileTests =
         ("assert_arg_eq.c", [("assert_arg_eq", hasBugs)]), -- goal: hasFailedAssert
         ("call_non_function_pointer.c", [("call_non_function_pointer", hasBugs)]),
         ("cast_float_to_pointer_deref.c", [("cast_float_to_pointer_deref", hasBugs)]),
+        ("cast_float_to_pointer_free.c", [("cast_float_to_pointer_free", hasBugs)]),
         ("cast_float_to_pointer_write.c", [("cast_float_to_pointer_write", hasBugs)]),
         ("double_free.c", [("double_free", hasBugs)]),
         ("uninitialized_heap.c", [("uninitialized_heap", hasBugs)]),

--- a/uc-crux-llvm/test/programs/cast_float_to_pointer.c
+++ b/uc-crux-llvm/test/programs/cast_float_to_pointer.c
@@ -1,0 +1,7 @@
+#include <stdint.h>
+uintptr_t cast_float_to_uintptr_t(float f) __attribute__((noinline)) {
+  return (uintptr_t)f;
+}
+void *cast_float_to_pointer(float x) {
+  return (void *)cast_float_to_uintptr_t(x);
+}

--- a/uc-crux-llvm/test/programs/cast_float_to_pointer_deref.c
+++ b/uc-crux-llvm/test/programs/cast_float_to_pointer_deref.c
@@ -1,0 +1,7 @@
+#include <stdint.h>
+uintptr_t cast_float_to_uintptr_t(float f) __attribute__((noinline)) {
+  return (uintptr_t)f;
+}
+int cast_float_to_pointer_deref(float x) {
+  return *(int *)(void *)cast_float_to_uintptr_t(x);
+}

--- a/uc-crux-llvm/test/programs/cast_float_to_pointer_free.c
+++ b/uc-crux-llvm/test/programs/cast_float_to_pointer_free.c
@@ -1,0 +1,8 @@
+#include <stdint.h>
+#include <stdlib.h>
+uintptr_t cast_float_to_uintptr_t(float f) __attribute__((noinline)) {
+  return (uintptr_t)f;
+}
+void cast_float_to_pointer_free(float x) {
+  free((void *)cast_float_to_uintptr_t(x));
+}

--- a/uc-crux-llvm/test/programs/cast_float_to_pointer_write.c
+++ b/uc-crux-llvm/test/programs/cast_float_to_pointer_write.c
@@ -1,0 +1,7 @@
+#include <stdint.h>
+uintptr_t cast_float_to_uintptr_t(float f) __attribute__((noinline)) {
+  return (uintptr_t)f;
+}
+int cast_float_to_pointer_write(float x) {
+  *(int *)(void *)cast_float_to_uintptr_t(x) = 5;
+}

--- a/uc-crux-llvm/test/programs/cast_pointer_to_float.c
+++ b/uc-crux-llvm/test/programs/cast_pointer_to_float.c
@@ -1,0 +1,9 @@
+#include <stdint.h>
+#include <stdlib.h>
+float cast_uintptr_t_to_float(uintptr_t ptr) __attribute__((noinline)) {
+  return (float)ptr;
+}
+float cast_pointer_to_float(int x) {
+  int *ptr = malloc(x*sizeof(int));
+  return (uintptr_t)cast_uintptr_t_to_float(ptr);
+}

--- a/uc-crux-llvm/test/programs/free_integer.c
+++ b/uc-crux-llvm/test/programs/free_integer.c
@@ -1,0 +1,3 @@
+#include <stdlib.h>
+void do_free(void *ptr) { free(ptr); }
+void free_integer(float x) { do_free((void *)x); }


### PR DESCRIPTION
While these are two seemingly unrelated classes of bugs, the mechanisms for catching them were overlapping.