### PR TITLE
crucible-jvm: Add permission bit for writability to each static field.

### DIFF
--- a/crucible-jvm/src/Lang/Crucible/JVM/Context.hs
+++ b/crucible-jvm/src/Lang/Crucible/JVM/Context.hs
@@ -22,6 +22,7 @@ import qualified Language.JVM.Parser as J
 -- crucible
 import           Lang.Crucible.CFG.Generator
 import           Lang.Crucible.FunctionHandle
+import           Lang.Crucible.Types
 
 -- crucible-jvm
 import           Lang.Crucible.JVM.Types
@@ -30,7 +31,7 @@ import           Lang.Crucible.JVM.Types
 -- * JVMContext
 
 
-type StaticFieldTable = Map J.FieldId (GlobalVar JVMValueType)
+type StaticFieldTable = Map J.FieldId (GlobalVar JVMValueType, GlobalVar BoolType)
 type MethodHandleTable = Map (J.ClassName, J.MethodKey) JVMHandleInfo
 
 data JVMHandleInfo where
@@ -41,8 +42,9 @@ data JVMHandleInfo where
 data JVMContext = JVMContext
   { methodHandles :: Map (J.ClassName, J.MethodKey) JVMHandleInfo
       -- ^ Map from static and dynamic methods to Crucible function handles.
-  , staticFields :: Map J.FieldId (GlobalVar JVMValueType)
+  , staticFields :: Map J.FieldId (GlobalVar JVMValueType, GlobalVar BoolType)
       -- ^ Map from static field names to Crucible global variables.
+      -- Each static field is paired with a permission bit for writability.
       -- We know about these fields at translation time so we can allocate
       -- global variables to store them.
   , classTable :: Map J.ClassName J.Class

--- a/crucible-jvm/src/Lang/Crucible/JVM/Context.hs
+++ b/crucible-jvm/src/Lang/Crucible/JVM/Context.hs
@@ -31,18 +31,24 @@ import           Lang.Crucible.JVM.Types
 -- * JVMContext
 
 
-type StaticFieldTable = Map J.FieldId (GlobalVar JVMValueType, GlobalVar BoolType)
+type StaticFieldTable = Map J.FieldId StaticFieldInfo
 type MethodHandleTable = Map (J.ClassName, J.MethodKey) JVMHandleInfo
 
 data JVMHandleInfo where
   JVMHandleInfo :: J.MethodKey -> FnHandle init ret -> JVMHandleInfo
+
+data StaticFieldInfo =
+  StaticFieldInfo
+  { staticFieldValue :: GlobalVar JVMValueType
+  , staticFieldWritable :: GlobalVar BoolType
+  }
 
 -- | Contains information about crucible function handles and global variables
 -- that is statically known during the class translation.
 data JVMContext = JVMContext
   { methodHandles :: Map (J.ClassName, J.MethodKey) JVMHandleInfo
       -- ^ Map from static and dynamic methods to Crucible function handles.
-  , staticFields :: Map J.FieldId (GlobalVar JVMValueType, GlobalVar BoolType)
+  , staticFields :: Map J.FieldId StaticFieldInfo
       -- ^ Map from static field names to Crucible global variables.
       -- Each static field is paired with a permission bit for writability.
       -- We know about these fields at translation time so we can allocate

--- a/crucible-jvm/src/Lang/Crucible/JVM/Simulate.hs
+++ b/crucible-jvm/src/Lang/Crucible/JVM/Simulate.hs
@@ -844,9 +844,7 @@ doStaticFieldStore ::
 doStaticFieldStore sym jc globals fid val =
   case Map.lookup fid (staticFields jc) of
     Nothing -> C.addFailedAssertion sym msg
-    Just (gvar, _pvar) ->
-      do putStrLn $ "doStaticFieldStore " ++ fname
-         pure (C.insertGlobal gvar val globals)
+    Just (gvar, _pvar) -> pure (C.insertGlobal gvar val globals)
   where
     fname = J.unClassName (J.fieldIdClass fid) ++ "." ++ J.fieldIdName fid
     msg = C.GenericSimError $ "Static field store: field not found: " ++ fname
@@ -864,9 +862,7 @@ doStaticFieldWritable ::
 doStaticFieldWritable sym jc globals fid val =
   case Map.lookup fid (staticFields jc) of
     Nothing -> C.addFailedAssertion sym msg
-    Just (_gvar, pvar) ->
-      do putStrLn $ "doStaticFieldWritable " ++ fname
-         pure (C.insertGlobal pvar val globals)
+    Just (_gvar, pvar) -> pure (C.insertGlobal pvar val globals)
   where
     fname = J.unClassName (J.fieldIdClass fid) ++ "." ++ J.fieldIdName fid
     msg = C.GenericSimError $ "Static field writable: field not found: " ++ fname

--- a/crucible-jvm/src/Lang/Crucible/JVM/Simulate.hs
+++ b/crucible-jvm/src/Lang/Crucible/JVM/Simulate.hs
@@ -12,6 +12,7 @@ Stability        : provisional
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -343,8 +344,9 @@ declareStaticField halloc c m f = do
   let fn = J.fieldName f
   let fieldId = J.FieldId cn fn (J.fieldType f)
   let str = fn ++ show (J.fieldType f)
-  gvar <- C.freshGlobalVar halloc (globalVarName cn str) (knownRepr :: TypeRepr JVMValueType)
-  pvar <- C.freshGlobalVar halloc (globalVarName cn str) (knownRepr :: TypeRepr BoolType)
+  let varname = globalVarName cn str
+  gvar <- C.freshGlobalVar halloc varname (knownRepr :: TypeRepr JVMValueType)
+  pvar <- C.freshGlobalVar halloc (varname <> ".W") (knownRepr :: TypeRepr BoolType)
   return $ Map.insert fieldId (StaticFieldInfo gvar pvar) m
 
 

--- a/crucible-jvm/src/Lang/Crucible/JVM/Simulate.hs
+++ b/crucible-jvm/src/Lang/Crucible/JVM/Simulate.hs
@@ -926,8 +926,7 @@ doStaticFieldLoad sym jc globals fid =
         Nothing -> C.addFailedAssertion sym msg
         Just v -> pure v
   where
-    fname = J.unClassName (J.fieldIdClass fid) ++ "." ++ J.fieldIdName fid
-    msg = C.GenericSimError $ "Static field load: field not found: " ++ fname
+    msg = C.GenericSimError $ "Static field load: field not found: " ++ ppFieldId fid
 
 -- | Read a value at an index of an array reference.
 doArrayLoad ::

--- a/crucible-jvm/src/Lang/Crucible/JVM/Simulate.hs
+++ b/crucible-jvm/src/Lang/Crucible/JVM/Simulate.hs
@@ -846,8 +846,7 @@ doStaticFieldStore sym jc globals fid val =
     Nothing -> C.addFailedAssertion sym msg
     Just (gvar, _pvar) -> pure (C.insertGlobal gvar val globals)
   where
-    fname = J.unClassName (J.fieldIdClass fid) ++ "." ++ J.fieldIdName fid
-    msg = C.GenericSimError $ "Static field store: field not found: " ++ fname
+    msg = C.GenericSimError $ "Static field store: field not found: " ++ ppFieldId fid
 
 -- | Set the write permission on a static field. The 'FieldId' must
 -- have already been resolved (see §5.4.3.2 of the JVM spec).
@@ -864,8 +863,10 @@ doStaticFieldWritable sym jc globals fid val =
     Nothing -> C.addFailedAssertion sym msg
     Just (_gvar, pvar) -> pure (C.insertGlobal pvar val globals)
   where
-    fname = J.unClassName (J.fieldIdClass fid) ++ "." ++ J.fieldIdName fid
-    msg = C.GenericSimError $ "Static field writable: field not found: " ++ fname
+    msg = C.GenericSimError $ "Static field writable: field not found: " ++ ppFieldId fid
+
+ppFieldId :: J.FieldId -> String
+ppFieldId fid = J.unClassName (J.fieldIdClass fid) ++ "." ++ J.fieldIdName fid
 
 -- | Write a value at an index of an array reference.
 doArrayStore ::

--- a/crucible-jvm/src/Lang/Crucible/JVM/Translation/Class.hs
+++ b/crucible-jvm/src/Lang/Crucible/JVM/Translation/Class.hs
@@ -364,8 +364,8 @@ getStaticFieldValue rawFieldId =
      initializeClass (J.fieldIdClass fieldId)
      ctx <- gets jsContext
      case Map.lookup fieldId (staticFields ctx) of
-       Just (glob, _) ->
-         do r <- readGlobal glob
+       Just info ->
+         do r <- readGlobal (staticFieldValue info)
             fromJVMDynamic ("getstatic " <> fieldIdText fieldId) (J.fieldIdType fieldId) r
        Nothing ->
          jvmFail $ "getstatic: field " ++ show (fieldIdText fieldId) ++ " not found"
@@ -387,11 +387,11 @@ setStaticFieldValue :: J.FieldId -> JVMValue s -> JVMGenerator s ret ()
 setStaticFieldValue fieldId val =
   do ctx <- gets jsContext
      case Map.lookup fieldId (staticFields ctx) of
-       Just (glob, perm) ->
-         do writable <- readGlobal perm
+       Just info ->
+         do writable <- readGlobal (staticFieldWritable info)
             let msg = "putstatic: field " ++ show (fieldIdText fieldId) ++ " not writable"
             assertExpr writable $ fromString msg
-            writeGlobal glob (valueToExpr val)
+            writeGlobal (staticFieldValue info) (valueToExpr val)
        Nothing ->
          jvmFail $ "putstatic: field " ++ show (fieldIdText fieldId) ++ " not found"
 


### PR DESCRIPTION
The permission bit is asserted to be true on every putstatic instruction.

This feature will allow SAW to use method specs that do not explicitly
specify a final value for each static field; by making those fields
read-only, we can be sure that the values did not change, without having
to explicitly check that the final value is equal to the initial value.

This will be used to address GaloisInc/saw-script#1066.