### PR TITLE
crucible-jvm: Add permission bit for writability to each instance field and array.

### DIFF
--- a/crucible-jvm/src/Lang/Crucible/JVM/Overrides.hs
+++ b/crucible-jvm/src/Lang/Crucible/JVM/Overrides.hs
@@ -432,8 +432,8 @@ instance Concretize JVMArrayType where
 instance Concretize JVMInstanceType where
   type Concrete JVMInstanceType = (Map Text (Maybe CValue), CClass)
   concretize (C.RV x) = do
-    let (C.RV sm)  = x Ctx.! Ctx.i1of2
-    let cls' = x Ctx.! Ctx.i2of2
+    let (C.RV sm) = x Ctx.! Ctx.i1of3
+    let cls' = x Ctx.! Ctx.i3of3
     (sm1 :: Map Text (Maybe CValue)) <-
       traverse (\mv -> foldr (\a b -> (concretize @JVMValueType . C.RV) a) (return Nothing) mv) sm
     (cc  :: Maybe CClass) <- concretize @JVMClassType cls'

--- a/crucible-jvm/src/Lang/Crucible/JVM/Overrides.hs
+++ b/crucible-jvm/src/Lang/Crucible/JVM/Overrides.hs
@@ -424,7 +424,7 @@ instance Concretize JVMRefType where
 instance Concretize JVMArrayType where
   type Concrete JVMArrayType = Vector (Maybe CValue)
   concretize (C.RV x) = do
-    let (C.RV vec) = x Ctx.! Ctx.i2of3
+    let (C.RV vec) = x Ctx.! Ctx.i2of4
     vm <- V.mapM (concretize @JVMValueType . C.RV) vec
     return (Just vm)
 

--- a/crucible-jvm/src/Lang/Crucible/JVM/Types.hs
+++ b/crucible-jvm/src/Lang/Crucible/JVM/Types.hs
@@ -164,10 +164,16 @@ type JVMRefType    = MaybeType (ReferenceType JVMObjectType)
 
 -- ** Objects and Arrays
 
--- | A class instance contains a table of fields
--- and an (immutable) pointer to the class (object).
+-- | A class instance contains a table of fields, a write permission
+-- bit for each field, and an (immutable) pointer to the class
+-- (object).
 type JVMInstanceType =
-  StructType (EmptyCtx ::> StringMapType JVMValueType ::> JVMClassType)
+  StructType (
+    EmptyCtx
+    ::> StringMapType JVMValueType
+    ::> StringMapType UnitType
+    ::> JVMClassType
+  )
 
 -- | An array value is a length, a vector of values,
 -- and an element type.

--- a/crucible-jvm/src/Lang/Crucible/JVM/Types.hs
+++ b/crucible-jvm/src/Lang/Crucible/JVM/Types.hs
@@ -175,10 +175,16 @@ type JVMInstanceType =
     ::> JVMClassType
   )
 
--- | An array value is a length, a vector of values,
--- and an element type.
+-- | An array value is a length, a vector of values, a vector of write
+-- permission bits, and an element type.
 type JVMArrayType =
-  StructType (EmptyCtx ::> JVMIntType ::> VectorType JVMValueType ::> JVMTypeRepType)
+  StructType (
+    EmptyCtx
+    ::> JVMIntType
+    ::> VectorType JVMValueType
+    ::> VectorType BoolType
+    ::> JVMTypeRepType
+  )
 
 -- | An object is either a class instance or an array.
 type JVMObjectImpl =


### PR DESCRIPTION
The field permission bit is asserted on every `putfield` instruction. The array permission bit is asserted on every `astore` instruction.

This PR builds on top of #733. It will be used to address GaloisInc/saw-script#900.