### PR TITLE
crux: add output-for-ide option

### DIFF
--- a/crux-llvm/svcomp/Main.hs
+++ b/crux-llvm/svcomp/Main.hs
@@ -310,6 +310,7 @@ evaluateSingleTask writeHdl jsonHdl cruxOpts llvmOpts bsRoot num task inpBCFile 
       let cruxOpts' = cruxOpts { outDir = taskRoot, inputFiles = inputs }
 
       let ?outputConfig = OutputConfig False writeHdl writeHdl False
+      let ?outputForIDE = False
 
       mres <- try $
                do res <- Crux.runSimulator cruxOpts' (simulateLLVMFile inpBCFile llvmOpts)

--- a/crux/src/Crux/Config/Common.hs
+++ b/crux/src/Crux/Config/Common.hs
@@ -147,6 +147,10 @@ data CruxOptions = CruxOptions
 
   , printFailures            :: Bool
     -- ^ Print errors regarding failed verification goals
+
+  , outputForIDE :: Bool
+    -- ^ Whether to format the output to be machine-readable
+
   }
 
 
@@ -279,6 +283,10 @@ cruxOptions = Config
             "If true, stop attempting to prove goals as soon as one of them is disproved"
 
           onlineProblemFeatures <- pure noFeatures
+
+          outputForIDE <-
+            section "output-for-ide" yesOrNoSpec False
+            "Format the output to be machine-readable"
 
           pure CruxOptions { .. }
 
@@ -422,6 +430,11 @@ cruxOptions = Config
          ++ " i.e. one of [real|ieee|uninterpreted|default]. "
          ++ "Default representation is solver specific: [cvc4|yices]=>real, z3=>ieee.")
         $ ReqArg "FPREP" $ \v opts -> Right opts { floatMode = map toLower v }
+
+      , Option [] ["output-for-ide"]
+        ("Format the output to be machine-readable")
+        $ NoArg $ \opts -> Right opts { outputForIDE = True }
+
       ]
   }
 


### PR DESCRIPTION
For vscode-crux-llvm, we need a way of communicating relevant information to
the client process.  Most of Crux's current output is directed at a human user.
This adds the possibility of having machine-readable output instead.

Open questions (could be solved now or later):
- Do we want to still output the human-relevant bits in `outputForIDE` mode?
- Should we have a more robust scheme for indicating the beginning and end of each output?

Open question to resolve before merging:
- Is the current output flushing greedy enough for the IDE? (I'll figure this out, but the PR can be reviewed either way)