### PR TITLE
Make crucible:helper-tests compile with tasty-hspec-1.1.7 (#739)

### DIFF
--- a/crucible/crucible.cabal
+++ b/crucible/crucible.cabal
@@ -157,6 +157,7 @@ test-suite helper-tests
   main-is: Main.hs
   build-depends: base,
                  containers,
+                 hspec >= 2.5,
                  mtl,
                  crucible,
                  what4,

--- a/crucible/test/helpers/Main.hs
+++ b/crucible/test/helpers/Main.hs
@@ -3,8 +3,9 @@ module Main where
 
 import Data.List (isInfixOf)
 
-import qualified Test.Tasty as T
-import Test.Tasty.Hspec
+import Test.Hspec
+import Test.Tasty
+import Test.Tasty.Hspec (testSpec)
 
 import Lang.Crucible.Panic
 
@@ -12,15 +13,15 @@ import qualified Panic as P
 
 main :: IO ()
 main =
-  T.defaultMain =<< panicTests
+  defaultMain =<< panicTests
 
-panicTests :: IO T.TestTree
+panicTests :: IO TestTree
 panicTests =
   do t <- testSpec "Panicking throws an exception" $
           describe "panic" $
           it "should throw an exception with the right details" $
           shouldThrow (panic "Oh no!" ["line 1", "line 2"]) acceptableExn
-     pure $ T.testGroup "panic" [ t ]
+     pure $ testGroup "panic" [ t ]
   where
     acceptableExn :: P.Panic Crucible -> Bool
     acceptableExn e =


### PR DESCRIPTION
`tasty-hspec-1.1.7` no longer re-exports `Test.Hspec` from `hspec`. In order to make `crucible`'s `helper-tests` work with all versions of `tasty-hspec`, this patch adds a `Test.Hspec` import. This also uses explicit imports from `Test.Tasty.Hspec` to ensure that there are no warnings when built with older versions of `tasty-hspec`.

Fixes #739.