### PR TITLE
crucible-llvm: Only consult default address space for pointer size

### DIFF
--- a/crucible-llvm/doc/limitations.md
+++ b/crucible-llvm/doc/limitations.md
@@ -1,0 +1,16 @@
+`crucible-llvm` limitations
+---------------------------
+
+Address space limitations
+=========================
+
+`crucible-llvm` currently assumes that all code uses the default address space
+`0`. LLVM's data layout is permitted to declare multiple address spaces with
+differing pointer sizes, however. For instance, LLVM 10 and later will
+[reserve address spaces 270 through 272](https://reviews.llvm.org/D64931) in
+X86 data layouts for the purpose of implementing mixed pointer sizes.
+`crucible-llvm`, on the other hand, currently assumes that all pointers in a
+given program are the same size, so it is unlikely that `crucible-llvm` would
+work on code that uses differently sized address spaces. In practice,
+`crucible-llvm` will only look at the part of the data layout which specifies
+the default address space when determining what size pointers should be.

--- a/crux-llvm/test-data/golden/T737.c
+++ b/crux-llvm/test-data/golden/T737.c
@@ -1,0 +1,19 @@
+int N = 10;
+
+int main() {
+  int i;
+  int j = 0;
+  int a[N];
+
+  for (i = 0; i < N; i++) {
+    a[i] = 0;
+  }
+
+  for (i = 0; i < N; i++){
+    if (a[i] == 0) {
+      j++;
+    }
+  }
+
+  return 0;
+}

--- a/crux-llvm/test-data/golden/T737.config
+++ b/crux-llvm/test-data/golden/T737.config
@@ -1,0 +1,2 @@
+ub-sanitizers: [ "signed-integer-overflow" ]
+target-architecture: "i386-unknown-linux-elf"

--- a/crux-llvm/test-data/golden/T737.good
+++ b/crux-llvm/test-data/golden/T737.good
@@ -1,0 +1,1 @@
+[Crux] Overall status: Valid.


### PR DESCRIPTION
LLVM 10 and later reserve multiple address spaces (with different sizes!) in the data layout. Since `crucible-llvm` is only equipped to deal with a single pointer size throughout a program at the moment, we now deal with this by only using the default address space in the data layout to determine what the pointer size will be. This means that any programs that actually _use_ multiple address spaces of different pointer sizes are unlikely to work in `crucible-llvm`, but we do not aim to support such programs yet.

While I was in town, I took the liberty of documenting the assumptions that `crucible-llvm` makes with respect to address spaces in `crucible-llvm/doc/limitations.md`.

Fixes #737.