### PR TITLE
uc-crux-llvm: Two more test programs

### DIFF
--- a/uc-crux-llvm/test/Test.hs
+++ b/uc-crux-llvm/test/Test.hs
@@ -467,6 +467,8 @@ inFileTests =
         ("oob_read_heap.c", [("oob_read_heap", isUnclassified)]), -- goal: hasBugs
         ("oob_read_stack.c", [("oob_read_stack", isUnclassified)]), -- goal: hasBugs
         ("read_extern_global_unsized_array.c", [("read_extern_global_unsized_array", isUnclassified)]), -- goal: isSafeWithPreconditions
+        ("read_global_neg_offset.c", [("read_global_neg_offset", isUnclassified)]), -- goal: hasBugs
+        ("read_global_neg_offset_strlen.c", [("read_global_neg_offset_strlen", isUnclassified)]), -- goal: hasBugs
         ("signed_add_wrap_concrete.c", [("signed_add_wrap_concrete", isUnclassified)]), -- goal: hasBugs
         ("signed_mul_wrap_concrete.c", [("signed_mul_wrap_concrete", isUnclassified)]), -- goal: hasBugs
         ("signed_sub_wrap_concrete.c", [("signed_sub_wrap_concrete", isUnclassified)]), -- goal: hasBugs

--- a/uc-crux-llvm/test/programs/read_global_neg_offset.c
+++ b/uc-crux-llvm/test/programs/read_global_neg_offset.c
@@ -1,0 +1,5 @@
+int glob = 0;
+int *minus_1(int *ptr) __attribute__((noinline)) { return ptr - 1; }
+int read_global_neg_offset() {
+  return *minus_1(&glob);
+}

--- a/uc-crux-llvm/test/programs/read_global_neg_offset_strlen.c
+++ b/uc-crux-llvm/test/programs/read_global_neg_offset_strlen.c
@@ -1,0 +1,5 @@
+#include <string.h>
+char str[] = "str";
+int read_global_neg_offset_strlen() {
+  return strlen(str - 1);
+}


### PR DESCRIPTION
These programs involve reading from negative offsets from (the beginnings of) global allocations, which is undefined.