### PR TITLE
crux-mir translation and library changes for Cryptol support

### DIFF
--- a/crux-mir/lib/crucible/cryptol.rs
+++ b/crux-mir/lib/crucible/cryptol.rs
@@ -1,3 +1,5 @@
+use core::cell::UnsafeCell;
+
 /// Load a Cryptol definition.  `module_path` must be the path to a Cryptol module file, and `name`
 /// must be an identifier defined within that module.  The type parameter `F` must be a function
 /// pointer type matching the type of the Cryptol definition.  For example, if the Cryptol
@@ -5,4 +7,64 @@
 /// u8`, or some similar combination.
 pub fn load<F>(module_path: &str, name: &str) -> F {
     unimplemented!("cryptol::load")
+}
+
+
+#[doc(hidden)]
+pub struct SimpleOnce<T>(UnsafeCell<Option<T>>);
+
+unsafe impl<T: Sync> Sync for SimpleOnce<T> {}
+
+impl<T> SimpleOnce<T> {
+    pub const fn new() -> SimpleOnce<T> {
+        SimpleOnce(UnsafeCell::new(None))
+    }
+}
+
+impl<T: Sync> SimpleOnce<T> {
+    pub fn get_or_init<F: FnOnce() -> T>(&self, f: F) -> &T {
+        unsafe {
+            let ptr = self.0.get();
+            if let Some(ref val) = *ptr {
+                val
+            } else {
+                *ptr = Some(f());
+                (*ptr).as_ref().unwrap()
+            }
+        }
+    }
+}
+
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! cryptol_function_name {
+    ($custom_name:expr, $ident:ident) => { $custom_name };
+    ($ident:ident) => { stringify!($ident) };
+}
+
+#[macro_export]
+macro_rules! cryptol {
+    (
+        path $path:expr;
+
+        $(
+            $pub_:vis fn $name:ident
+                ( $($arg_name:ident : $arg_ty:ty),* )
+                $( -> $ret_ty:ty )?
+                $(= $cryptol_name:expr)?
+                ; )*
+    ) => {
+        $(
+            $pub_ fn $name($($arg_name: $arg_ty),*) $(-> $ret_ty)? {
+                static FUNC: $crate::cryptol::SimpleOnce<fn($($arg_ty),*) $(-> $ret_ty)?> =
+                    $crate::cryptol::SimpleOnce::new();
+                let func = FUNC.get_or_init(|| $crate::cryptol::load(
+                    $path,
+                    $crate::cryptol_function_name!($($cryptol_name,)? $name),
+                ));
+                func($($arg_name),*)
+            }
+        )*
+    };
 }

--- a/crux-mir/lib/crucible/cryptol.rs
+++ b/crux-mir/lib/crucible/cryptol.rs
@@ -54,3 +54,9 @@ macro_rules! cryptol {
         )*
     };
 }
+
+/// Convert all what4 expressions within `x` to saw-core and back.  The resulting expressions will
+/// be equivalent but not necessarily identical.
+pub fn munge<T>(x: T) -> T {
+    x
+}

--- a/crux-mir/lib/crucible/cryptol.rs
+++ b/crux-mir/lib/crucible/cryptol.rs
@@ -1,0 +1,8 @@
+/// Load a Cryptol definition.  `module_path` must be the path to a Cryptol module file, and `name`
+/// must be an identifier defined within that module.  The type parameter `F` must be a function
+/// pointer type matching the type of the Cryptol definition.  For example, if the Cryptol
+/// definition has type `[8] -> [8] -> [8]`, then `F` must be `fn(u8, u8) -> u8`, `fn(i8, i8) ->
+/// u8`, or some similar combination.
+pub fn load<F>(module_path: &str, name: &str) -> F {
+    unimplemented!("cryptol::load")
+}

--- a/crux-mir/lib/crucible/lib.rs
+++ b/crux-mir/lib/crucible/lib.rs
@@ -128,6 +128,11 @@ pub fn override_<F, G>(f: F, g: G) {
     unimplemented!("crucible::override_");
 }
 
+/// Print a what4 expression to stderr.  `T` must have a primitive/base type for its Crucible
+/// representation.
+pub fn dump_what4<T>(desc: &str, x: T) {
+}
+
 // Some older test cases still use these functions.
 #[deprecated(note = "call i8::symbolic instead")]
 pub fn crucible_i8(name: &'static str) -> i8 { Symbolic::symbolic(name) }

--- a/crux-mir/lib/crucible/lib.rs
+++ b/crux-mir/lib/crucible/lib.rs
@@ -123,6 +123,11 @@ pub fn concretize<T>(x: T) -> T {
     x
 }
 
+/// Install `g` as an override for `f`.
+pub fn override_<F, G>(f: F, g: G) {
+    unimplemented!("crucible::override_");
+}
+
 // Some older test cases still use these functions.
 #[deprecated(note = "call i8::symbolic instead")]
 pub fn crucible_i8(name: &'static str) -> i8 { Symbolic::symbolic(name) }

--- a/crux-mir/lib/crucible/lib.rs
+++ b/crux-mir/lib/crucible/lib.rs
@@ -4,6 +4,7 @@
 #![feature(unboxed_closures)]
 
 pub mod bitvector;
+pub mod cryptol;
 pub mod method_spec;
 pub mod sym_bytes;
 pub mod symbolic;

--- a/crux-mir/lib/libcore/cell.rs
+++ b/crux-mir/lib/libcore/cell.rs
@@ -1636,16 +1636,10 @@ impl<T: ?Sized> UnsafeCell<T> {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_stable(feature = "const_unsafecell_get", since = "1.32.0")]
     pub const fn get(&self) -> *mut T {
-        // Crux: We wrap the body of this function in an inner function to give us a unique name to
-        // override.  An override on `core::cell::{{impl}}::get` would match both `UnsafeCell::get`
-        // and `Cell::get`, but there is only one `core::cell::{{impl}}::get::crucible_hook`.
-        const fn crucible_hook<T: ?Sized>(this: &UnsafeCell<T>) -> *mut T {
-            // We can just cast the pointer from `UnsafeCell<T>` to `T` because of
-            // #[repr(transparent)]. This exploits libstd's special status, there is
-            // no guarantee for user code that this will work in future versions of the compiler!
-            this as *const UnsafeCell<T> as *const T as *mut T
-        }
-        crucible_hook(self)
+        // We can just cast the pointer from `UnsafeCell<T>` to `T` because of
+        // #[repr(transparent)]. This exploits libstd's special status, there is
+        // no guarantee for user code that this will work in future versions of the compiler!
+        self as *const UnsafeCell<T> as *const T as *mut T
     }
 
     /// Gets a mutable pointer to the wrapped value.

--- a/crux-mir/src/Mir/GenericOps.hs
+++ b/crux-mir/src/Mir/GenericOps.hs
@@ -64,7 +64,7 @@ class GenericOps a where
 -- generated `PartialEq` impls use `Rvalue::Discriminant` and compare the
 -- result to the constants from the enum definition.
 adtIndices :: Adt -> Collection -> [Integer]
-adtIndices (Adt _aname _kind vars _ _) col = go 0 vars
+adtIndices (Adt _aname _kind vars _ _ _ _) col = go 0 vars
   where
     go _ [] = []
     go lastExplicit (v : vs) =

--- a/crux-mir/src/Mir/Intrinsics.hs
+++ b/crux-mir/src/Mir/Intrinsics.hs
@@ -98,7 +98,7 @@ import           Lang.Crucible.Simulator.RegValue
 import           Lang.Crucible.Simulator.RegMap
 import           Lang.Crucible.Simulator.SimError
 
-import           Crux.Types (Model)
+import           Crux.Types (HasModel)
 
 import           What4.Concrete (ConcreteVal(..), concreteType)
 import           What4.Interface
@@ -1947,16 +1947,18 @@ class MethodSpecImpl sym ms where
     -- | Pretty-print the MethodSpec, returning the result as a Rust string
     -- (`&str`).
     msPrettyPrint ::
-        forall rtp args ret.
+        forall p rtp args ret.
+        (HasModel p) =>
         ms ->
-        OverrideSim (Model sym) sym MIR rtp args ret (RegValue sym (MirSlice (BVType 8)))
+        OverrideSim (p sym) sym MIR rtp args ret (RegValue sym (MirSlice (BVType 8)))
 
     -- | Enable the MethodSpec for use as an override for the remainder of the
     -- current test.
     msEnable ::
-        forall rtp args ret.
+        forall p rtp args ret.
+        (HasModel p) =>
         ms ->
-        OverrideSim (Model sym) sym MIR rtp args ret ()
+        OverrideSim (p sym) sym MIR rtp args ret ()
 
 data MethodSpec sym = forall ms. MethodSpecImpl sym ms => MethodSpec {
     msData :: ms,
@@ -1985,21 +1987,26 @@ instance IsSymInterface sym => IntrinsicClass sym MethodSpecSymbol where
 
 
 class MethodSpecBuilderImpl sym msb where
-    msbAddArg :: forall rtp args ret tp.
+    msbAddArg :: forall p rtp args ret tp.
+        (HasModel p) =>
         TypeRepr tp -> MirReferenceMux sym tp -> msb ->
-        OverrideSim (Model sym) sym MIR rtp args ret msb
-    msbSetReturn :: forall rtp args ret tp.
+        OverrideSim (p sym) sym MIR rtp args ret msb
+    msbSetReturn :: forall p rtp args ret tp.
+        (HasModel p) =>
         TypeRepr tp -> MirReferenceMux sym tp -> msb ->
-        OverrideSim (Model sym) sym MIR rtp args ret msb
-    msbGatherAssumes :: forall rtp args ret.
+        OverrideSim (p sym) sym MIR rtp args ret msb
+    msbGatherAssumes :: forall p rtp args ret.
+        (HasModel p) =>
         msb ->
-        OverrideSim (Model sym) sym MIR rtp args ret msb
-    msbGatherAsserts :: forall rtp args ret.
+        OverrideSim (p sym) sym MIR rtp args ret msb
+    msbGatherAsserts :: forall p rtp args ret.
+        (HasModel p) =>
         msb ->
-        OverrideSim (Model sym) sym MIR rtp args ret msb
-    msbFinish :: forall rtp args ret.
+        OverrideSim (p sym) sym MIR rtp args ret msb
+    msbFinish :: forall p rtp args ret.
+        (HasModel p) =>
         msb ->
-        OverrideSim (Model sym) sym MIR rtp args ret (MethodSpec sym)
+        OverrideSim (p sym) sym MIR rtp args ret (MethodSpec sym)
 
 data MethodSpecBuilder sym = forall msb. MethodSpecBuilderImpl sym msb => MethodSpecBuilder msb
 

--- a/crux-mir/src/Mir/JSON.hs
+++ b/crux-mir/src/Mir/JSON.hs
@@ -141,6 +141,8 @@ instance FromJSON Adt where
         <$> v .: "name"
         <*> v .: "kind"
         <*> v .: "variants"
+        <*> v .: "size"
+        <*> v .: "repr_transparent"
         <*> v .: "orig_def_id"
         <*> v .: "orig_substs"
 

--- a/crux-mir/src/Mir/Language.hs
+++ b/crux-mir/src/Mir/Language.hs
@@ -551,7 +551,7 @@ showRegEntry col mty (C.RegEntry tp rv) =
 
     -- Tagged union type
     (TyAdt name _ _, C.AnyRepr)
-      | Just adt <- List.find (\(Adt n _ _ _ _) -> name == n) (col^.adts) -> do
+      | Just adt <- List.find (\(Adt n _ _ _ _ _ _) -> name == n) (col^.adts) -> do
         optParts <- case adt^.adtkind of
             Struct -> do
                 let var = onlyVariant adt

--- a/crux-mir/src/Mir/Language.hs
+++ b/crux-mir/src/Mir/Language.hs
@@ -555,12 +555,12 @@ showRegEntry col mty (C.RegEntry tp rv) =
         optParts <- case adt^.adtkind of
             Struct -> do
                 let var = onlyVariant adt
-                C.Some fctx <- return $ variantFields' var
+                C.Some fctx <- return $ variantFields' col var
                 let ctx = fieldCtxType fctx
                 let fields = unpackAnyValue rv (C.StructRepr ctx)
                 return $ Right (var, readFields fctx fields)
             Enum -> do
-                C.Some vctx <- return $ enumVariants adt
+                C.Some vctx <- return $ enumVariants col adt
                 let enumVal = unpackAnyValue rv (RustEnumRepr vctx)
                 -- Note we don't look at the discriminant here, because mapping
                 -- a discriminant value to a variant index is somewhat complex.
@@ -570,7 +570,7 @@ showRegEntry col mty (C.RegEntry tp rv) =
                         let i = Ctx.indexVal idx
                         let var = fromMaybe (error "bad index from findVariant?") $
                                 adt ^? adtvariants . ix i
-                        C.Some fctx <- return $ variantFields' var
+                        C.Some fctx <- return $ variantFields' col var
                         Refl <- failIfNotEqual tpr (C.StructRepr $ fieldCtxType fctx)
                             ("when printing enum type " ++ show name)
                         return $ Right (var, readFields fctx fields)

--- a/crux-mir/src/Mir/Language.hs
+++ b/crux-mir/src/Mir/Language.hs
@@ -24,6 +24,7 @@ module Mir.Language (
     runTestsWithExtraOverrides,
     BindExtraOverridesFn,
     noExtraOverrides,
+    orOverride,
     MIROptions(..),
     defaultMirOptions,
 ) where
@@ -127,6 +128,14 @@ type BindExtraOverridesFn = forall sym p t st fs args ret blocks rtp a r.
 
 noExtraOverrides :: BindExtraOverridesFn
 noExtraOverrides _ _ _ _ = Nothing
+
+orOverride ::
+    BindExtraOverridesFn -> BindExtraOverridesFn -> BindExtraOverridesFn
+orOverride f g symOnline cs name cfg =
+    case f symOnline cs name cfg of
+        Just x -> Just x
+        Nothing -> g symOnline cs name cfg
+
 
 -- | This closes over the Crucible 'personality' parameter, allowing us to select between
 -- normal execution over Models and concurrent exeuctions that use an Exploration

--- a/crux-mir/src/Mir/Mir.hs
+++ b/crux-mir/src/Mir/Mir.hs
@@ -177,6 +177,8 @@ data Adt = Adt
     { _adtname :: DefId
     , _adtkind :: AdtKind
     , _adtvariants :: [Variant]
+    , _adtSize :: Int
+    , _adtReprTransparent :: Bool
     , _adtOrigDefId :: DefId
     , _adtOrigSubsts :: Substs
     }
@@ -576,8 +578,8 @@ fromIntegerLit (Isize i) = i
 
 -- Get the only variant of a struct or union ADT.
 onlyVariant :: Adt -> Variant
-onlyVariant (Adt _ _ [v] _ _) = v
-onlyVariant (Adt name kind _ _ _) = error $
+onlyVariant (Adt _ _ [v] _ _ _ _) = v
+onlyVariant (Adt name kind _ _ _ _ _) = error $
     "expected " ++ show kind ++ " " ++ show name ++ " to have only one variant"
 
 

--- a/crux-mir/src/Mir/Overrides.hs
+++ b/crux-mir/src/Mir/Overrides.hs
@@ -89,8 +89,6 @@ import Mir.Generator (CollectionState, collection, handleMap, MirHandle(..))
 import Mir.Intrinsics
 import qualified Mir.Mir as M
 
-import Debug.Trace
-
 
 getString :: forall sym rtp args ret p. (IsSymInterface sym) =>
     RegValue sym (MirSlice (BVType 8)) ->
@@ -440,7 +438,7 @@ bindFn symOnline cs name cfg
         str <- getString strRef >>= \x -> case x of
             Just x -> return x
             Nothing -> fail $ "dump_what4: desc string must be concrete"
-        traceM $ Text.unpack str ++ " = " ++ show (printSymExpr expr)
+        liftIO $ putStrLn $ Text.unpack str ++ " = " ++ show (printSymExpr expr)
 
 
 bindFn _symOnline _cs fn cfg =

--- a/crux-mir/src/Mir/Overrides.hs
+++ b/crux-mir/src/Mir/Overrides.hs
@@ -11,7 +11,7 @@
 {-# Language PartialTypeSignatures #-}
 {-# Language FlexibleContexts #-}
 
-module Mir.Overrides (bindFn) where
+module Mir.Overrides (bindFn, getString) where
 
 import Control.Lens ((^.), (%=), (.=), use)
 import Control.Monad

--- a/crux-mir/src/Mir/PP.hs
+++ b/crux-mir/src/Mir/PP.hs
@@ -91,7 +91,8 @@ instance Pretty Ty where
     pretty (TyInterned s) = pretty s
 
 instance Pretty Adt where
-   pretty (Adt nm kind vs origName origSubsts) =
+   pretty (Adt nm kind vs _size reprTransparent origName origSubsts) =
+    (if reprTransparent then pretty "#[repr(transparent)]" else mempty) <+>
     pretty kind <+> pretty nm <> brackets (pretty origName <+> pretty origSubsts)
         <> tupled (map pretty vs)
 
@@ -197,7 +198,7 @@ instance Pretty Rvalue where
     pretty (RAdtAg a) = pretty a
 
 instance Pretty AdtAg where
-  pretty (AdtAg (Adt nm _kind _vs _ _) i ops _) = pretty_fn3 "AdtAg" nm i ops
+  pretty (AdtAg (Adt nm _kind _vs _ _ _ _) i ops _) = pretty_fn3 "AdtAg" nm i ops
 
 
 instance Pretty Terminator where

--- a/crux-mir/src/Mir/Trans.hs
+++ b/crux-mir/src/Mir/Trans.hs
@@ -560,39 +560,18 @@ transCheckedBinOp op a b = do
 -- Nullary ops in rust are used for resource allocation, so are not interpreted
 transNullaryOp ::  M.NullOp -> M.Ty -> MirGenerator h s ret (MirExp s)
 transNullaryOp M.Box ty = do
-    -- Look up `Box<ty>`
-    let boxDefId = M.textId "alloc::boxed::Box"
-    let boxSubsts = Substs [ty]
-    candidates <- use $ cs . collection . adtsOrig . at boxDefId
-    let found = filter (\a -> a ^. adtOrigSubsts == boxSubsts) (Maybe.fromMaybe [] candidates)
-    boxTy <- case found of
-        [adt] -> return $ M.TyAdt (adt ^. adtname) boxDefId boxSubsts
-        _ -> mirFail $ "expected exactly one monomorphization of Box<" ++ show ty ++
-            ">, but got " ++ show found
-    mkBox boxTy
-  where
-    -- A `Box<T>` looks much like `*mut T`, but with a few wrapper structs in
-    -- the way.  We recursively traverse those structs until we find the
-    -- pointer field, then construct the `MirReference`.
-    mkBox (M.TyRawPtr ty' _) = do
-        Some tpr <- tyToReprM ty'
-        ptr <- newMirRef tpr
-        maybeInitVal <- initialValue ty'
-        case maybeInitVal of
-            Just (MirExp tpr' initVal) -> do
-                Refl <- testEqualityOrFail tpr tpr' $
-                    "bad initial value for box: expected " ++ show tpr ++ " but got " ++ show tpr'
-                writeMirRef ptr initVal
-            Nothing -> return ()
-        return $ MirExp (MirReferenceRepr tpr) ptr
-    mkBox ty@(M.TyAdt aname _ _) = do
-        adt <- findAdt aname
-        when (adt ^. adtkind /= Struct) $ mirFail $
-            "mkBox not yet implemented for non-struct type " ++ show ty
-        let v = Maybe.fromJust $ adt ^? adtvariants . ix 0
-        vals <- mapM (\f -> mkBox $ f ^. fty) (v ^. vfields)
-        buildStruct adt vals
-    mkBox ty = mirFail $ "unsupported type in mkBox: " ++ show ty
+    -- Box<T> has special translation to ensure that its representation is just
+    -- an ordinary pointer.
+    Some tpr <- tyToReprM ty
+    ptr <- newMirRef tpr
+    maybeInitVal <- initialValue ty
+    case maybeInitVal of
+        Just (MirExp tpr' initVal) -> do
+            Refl <- testEqualityOrFail tpr tpr' $
+                "bad initial value for box: expected " ++ show tpr ++ " but got " ++ show tpr'
+            writeMirRef ptr initVal
+        Nothing -> return ()
+    return $ MirExp (MirReferenceRepr tpr) ptr
 transNullaryOp M.SizeOf _ = do
     -- TODO: return the actual size, once mir-json exports size/layout info
     return $ MirExp UsizeRepr $ R.App $ usizeLit 1
@@ -647,7 +626,8 @@ extendSignedBV (MirExp tp e) w =
 
 
 evalCast' :: HasCallStack => M.CastKind -> M.Ty -> MirExp s -> M.Ty -> MirGenerator h s ret (MirExp s)
-evalCast' ck ty1 e ty2  =
+evalCast' ck ty1 e ty2  = do
+    col <- use $ cs . collection
     case (ck, ty1, ty2) of
       (M.Misc,a,b) | a == b -> return e
 
@@ -780,10 +760,6 @@ evalCast' ck ty1 e ty2  =
       (M.MutToConstPointer, M.TyRawPtr ty1 M.Mut, M.TyRawPtr ty2 M.Immut)
          | ty1 == ty2 -> return e
 
-      -- Arbitrary *mut<->*const conversions can be done via Misc cast
-      (M.Misc, M.TyRawPtr ty1 _, M.TyRawPtr ty2 _)
-         | ty1 == ty2 -> return e
-
       -- Integer-to-pointer casts.  Pointer-to-integer casts are not yet
       -- supported.
       (M.Misc, M.TyInt _, M.TyRawPtr ty _)
@@ -816,6 +792,13 @@ evalCast' ck ty1 e ty2  =
       (M.Misc, M.TyRawPtr M.TyStr m1, M.TyRawPtr (M.TySlice (M.TyUint M.B8)) m2)
         | m1 == m2 -> return e
 
+      -- Arbitrary pointer-to-pointer casts are allowed as long as the pointee
+      -- has the same Crucible representation.  This is similar to calling
+      -- `transmute`.
+      (M.Misc, M.TyRawPtr ty1 _, M.TyRawPtr ty2 _)
+         | ty1 == ty2 -> return e
+         | tyToRepr col ty1 == tyToRepr col ty2 -> return e
+
       (M.ReifyFnPointer, M.TyFnDef defId, M.TyFnPtr sig@(M.FnSig args ret _ _))
          -> do mhand <- lookupFunction defId
                case mhand of
@@ -845,13 +828,23 @@ evalCast' ck ty1 e ty2  =
     -- Implementation of the "coerce unsized" operation.  If `Foo<T>:
     -- CoerceUnsized<Foo<U>>`, then this operation is enabled for converting
     -- `Foo<T>` to `Foo<U>`.  The actual operation consists of disassembling
-    -- teh struct, coercing any raw pointers inside, and putting it back
+    -- the struct, coercing any raw pointers inside, and putting it back
     -- together again.
     coerceUnsized :: HasCallStack =>
         M.AdtName -> M.AdtName -> MirExp s -> MirGenerator h s ret (MirExp s)
     coerceUnsized an1 an2 e = do
+        col <- use $ cs . collection
         adt1 <- findAdt an1
         adt2 <- findAdt an2
+        case (reprTransparentFieldTy col adt1, reprTransparentFieldTy col adt2) of
+            (Just ty1, Just ty2) -> evalCast' M.Unsize ty1 e ty2
+            (Nothing, Nothing) -> coerceUnsizedNormal adt1 adt2 e
+            _ -> mirFail $ "impossible: coerceUnsized: one of " ++ show (an1, an2) ++
+                " is repr(transparent) and the other is not?"
+
+    coerceUnsizedNormal :: HasCallStack =>
+        M.Adt -> M.Adt -> MirExp s -> MirGenerator h s ret (MirExp s)
+    coerceUnsizedNormal adt1 adt2 e = do
         when (adt1 ^. adtkind /= Struct || adt2 ^. adtkind /= Struct) $ mirFail $
             "coerceUnsized not yet implemented for non-struct types: " ++ show (an1, an2)
         let v1 = Maybe.fromJust $ adt1 ^? adtvariants . ix 0
@@ -864,6 +857,9 @@ evalCast' ck ty1 e ty2  =
             val <- getStructField adt1 i e
             evalCast' M.Unsize (f1 ^. fty) val (f2 ^. fty)
         buildStruct adt2 vals'
+      where
+        an1 = adt1 ^. adtname
+        an2 = adt2 ^. adtname
 
 
 evalCast :: HasCallStack => M.CastKind -> M.Operand -> M.Ty -> MirGenerator h s ret (MirExp s)
@@ -979,41 +975,12 @@ evalPlace (M.LProj lv proj) = do
     pl <- evalPlace lv
     evalPlaceProj (M.typeOf lv) pl proj
 
--- Recursively traverse the structure of a `Box<ty>` to find the raw pointer
--- inside.  See `mkBox` for more explanation of the structure of `Box`.
-getBoxPointer :: HasCallStack => M.Ty -> MirExp s -> MirGenerator h s ret (MirExp s)
-getBoxPointer ty e = do
-    ptr <- go ty e
-    case ptr of
-        Just x -> return x
-        Nothing -> mirFail $ "failed to find pointer within " ++ show ty
-  where
-    go :: M.Ty -> MirExp s -> MirGenerator h s ret (Maybe (MirExp s))
-    go (M.TyRawPtr _ _) e = return $ Just e
-    go ty@(M.TyAdt aname _ _) e = do
-        adt <- findAdt aname
-        when (adt ^. adtkind /= Struct) $ mirFail $
-            "getBoxPointer not yet implemented for non-struct type " ++ show ty
-        let v = Maybe.fromJust $ adt ^? adtvariants . ix 0
-        ptrs <- forM (zip [0..] (v ^. vfields)) $ \(i, f) -> do
-            val <- getStructField adt i e
-            go (f ^. fty) val
-        case Maybe.mapMaybe id ptrs of
-            [] -> return Nothing
-            [x] -> return $ Just x
-            _ -> mirFail $ "expected exactly one pointer within " ++ show ty ++
-                ", but got " ++ show ptrs
-    go ty _ = mirFail $ "unsupported type in getBoxPointer: " ++ show ty
-
 evalPlaceProj :: HasCallStack => M.Ty -> MirPlace s -> M.PlaceElem -> MirGenerator h s ret (MirPlace s)
 evalPlaceProj ty pl@(MirPlace tpr ref NoMeta) M.Deref = do
     case ty of
         M.TyRef t _ -> doRef t
         M.TyRawPtr t _ -> doRef t
-        CTyBox _ -> do
-            box <- readMirRef tpr ref
-            ptr <- getBoxPointer ty (MirExp tpr box)
-            derefExp ptr
+        CTyBox t -> doRef t
         _ -> mirFail $ "deref not supported on " ++ show ty
   where
     doRef (M.TySlice _) | MirSliceRepr tpr' <- tpr = doSlice tpr' ref
@@ -1028,9 +995,30 @@ evalPlaceProj ty pl@(MirPlace tpr ref NoMeta) M.Deref = do
         let len = getSliceLen slice
         return $ MirPlace tpr' ptr (SliceMeta len)
 
-evalPlaceProj ty (MirPlace tpr ref NoMeta) (M.PField idx _mirTy) = case ty of
+evalPlaceProj ty pl@(MirPlace tpr ref NoMeta) (M.PField idx _mirTy) = do
+  col <- use $ cs . collection
+  case ty of
     CTyMaybeUninit _ -> do
         return $ MirPlace tpr ref NoMeta
+
+    ty | Just adt <- tyAdtDef col ty, Just tIdx <- findReprTransparentField col adt ->
+        if idx == tIdx then
+            -- The field's low-level representation is identical to the struct
+            -- itself, due to repr(transparent).
+            return pl
+        else do
+            -- Since `findReprTransparentField` returned `Just`, we know that
+            -- fields aside from `tIdx` must be zero-sized, and thus contain no
+            -- actual data.  So we can return a dummy reference here.
+            fieldTy <- case adt ^? M.adtvariants . ix 0 . M.vfields . ix idx . M.fty of
+                Just x -> return x
+                Nothing -> mirFail $ "impossible: accessed out of range field " ++
+                    show idx ++ " of " ++ show adt ++ "?"
+            MirExp tpr' e <- initialValue fieldTy >>= \x -> case x of
+                Just x -> return x
+                Nothing -> mirFail $ "failed to produce dummy value of type " ++ show fieldTy
+            ref <- constMirRef tpr' e
+            return $ MirPlace tpr' ref NoMeta
 
     M.TyAdt nm _ _ -> do
         adt <- findAdt nm
@@ -1134,9 +1122,12 @@ doAssign lv (MirExp tpr val) = do
 
 transStatement :: HasCallStack => M.Statement -> MirGenerator h s ret ()
 transStatement (M.Assign lv rv pos) = do
-  setPosition pos
-  re <- evalRval rv
-  doAssignCoerce lv (M.typeOf rv) re
+  col <- use $ cs . collection
+  -- Skip writes to zero-sized fields, as they are effectively no-ops.
+  when (not $ isZeroSized col $ typeOf lv) $ do
+    setPosition pos
+    re <- evalRval rv
+    doAssignCoerce lv (M.typeOf rv) re
 transStatement (M.StorageLive lv) = return ()
 transStatement (M.StorageDead lv) = return ()
 transStatement (M.SetDiscriminant lv i) = do
@@ -1607,12 +1598,11 @@ initialValue (M.TyClosure tys) = do
     mexps <- mapM initialValue tys
     col <- use $ cs . collection
     return $ Just $ buildTupleMaybe col tys mexps
-initialValue (CTyMaybeUninit t) = do
-    adt <- findAdtInst (M.textId "core::mem::manually_drop::ManuallyDrop") (Substs [t])
-    initialValue $ M.TyAdt (adt ^. adtname) (adt ^. adtOrigDefId) (adt ^. adtOrigSubsts)
 initialValue (M.TyAdt nm _ _) = do
     adt <- findAdt nm
+    col <- use $ cs . collection
     case adt ^. adtkind of
+        _ | Just ty <- reprTransparentFieldTy col adt -> initialValue ty
         Struct -> do
             let var = M.onlyVariant adt
             fldExps <- mapM initField (var^.M.vfields)

--- a/crux-mir/src/Mir/TransCustom.hs
+++ b/crux-mir/src/Mir/TransCustom.hs
@@ -100,6 +100,8 @@ customOpDefs = Map.fromList $ [
                          , saturating_sub
                          , ctlz
                          , ctlz_nonzero
+                         , rotate_left
+                         , rotate_right
                          , size_of
                          , min_align_of
                          , intrinsics_assume
@@ -820,6 +822,22 @@ ctlz_nonzero :: (ExplodedDefId, CustomRHS)
 ctlz_nonzero =
     ( ["core","intrinsics", "", "ctlz_nonzero"]
     , ctlz_impl "ctlz_nonzero" Nothing )
+
+rotate_left :: (ExplodedDefId, CustomRHS)
+rotate_left = ( ["core","intrinsics", "", "rotate_left"],
+  \_substs -> Just $ CustomOp $ \_ ops -> case ops of
+    [MirExp (C.BVRepr w) eVal, MirExp (C.BVRepr w') eAmt]
+      | Just Refl <- testEquality w w' -> do
+        return $ MirExp (C.BVRepr w) $ R.App $ E.BVRol w eVal eAmt
+    _ -> mirFail $ "invalid arguments for rotate_left")
+
+rotate_right :: (ExplodedDefId, CustomRHS)
+rotate_right = ( ["core","intrinsics", "", "rotate_right"],
+  \_substs -> Just $ CustomOp $ \_ ops -> case ops of
+    [MirExp (C.BVRepr w) eVal, MirExp (C.BVRepr w') eAmt]
+      | Just Refl <- testEquality w w' -> do
+        return $ MirExp (C.BVRepr w) $ R.App $ E.BVRor w eVal eAmt
+    _ -> mirFail $ "invalid arguments for rotate_right")
 
 
 ---------------------------------------------------------------------------------------

--- a/crux-mir/test/conc_eval/struct/repr_transparent.rs
+++ b/crux-mir/test/conc_eval/struct/repr_transparent.rs
@@ -1,0 +1,37 @@
+use std::mem;
+
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(transparent)]
+struct S((), [i32; 2], ());
+
+
+#[cfg_attr(crux, crux_test)]
+fn crux_test() -> i32 {
+    let x = [3_i32; 2];
+    // Construct repr(transparent) struct
+    let s = S((), x, ());
+    // Access field of repr(transparent) struct
+    let y = s.1;
+    assert!(x == y);
+
+    // Transmute to and from repr(transparent)
+    let s2: S = unsafe { mem::transmute(x) };
+    assert!(s == s2);
+    let y2: [i32; 2] = unsafe { mem::transmute(s2) };
+    assert!(y == y2);
+
+    // Cast raw pointers to and from repr(transparent)
+    let p1: *const [i32; 2] = &s as *const S as *const [i32; 2];
+    let p2: *const [i32; 2] = &x as *const [i32; 2];
+    unsafe {
+        assert!(*p1 == *p2);
+        assert!(*(p1 as *const S) == *(p2 as *const S));
+    }
+
+    s.1[0] + x[0]
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/conc_eval/struct/repr_transparent_const.rs
+++ b/crux-mir/test/conc_eval/struct/repr_transparent_const.rs
@@ -1,0 +1,12 @@
+use std::num::Wrapping;
+
+static W: Wrapping<i32> = Wrapping(123);
+
+#[cfg_attr(crux, crux_test)]
+fn crux_test() -> i32 {
+    (W + Wrapping(1)).0
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/symb_eval/concretize/assert.good
+++ b/crux-mir/test/symb_eval/concretize/assert.good
@@ -3,7 +3,7 @@ test assert/3a1fbbbh::crux_test[0]: returned 1, FAILED
 failures:
 
 ---- assert/3a1fbbbh::crux_test[0] counterexamples ----
-Failure for ./lib/crucible/lib.rs:46:17: 46:82 !test/symb_eval/concretize/assert.rs:10:5: 10:82: error: in assert/3a1fbbbh::crux_test[0]
+Failure for ./lib/crucible/lib.rs:47:17: 47:82 !test/symb_eval/concretize/assert.rs:10:5: 10:82: error: in assert/3a1fbbbh::crux_test[0]
 MIR assertion at test/symb_eval/concretize/assert.rs:10:5:
 	100 + 157 == 1
 Failure for test/symb_eval/concretize/assert.rs:11:16: 11:17: error: in assert/3a1fbbbh::crux_test[0]

--- a/crux-mir/test/symb_eval/crux/early_fail.good
+++ b/crux-mir/test/symb_eval/crux/early_fail.good
@@ -8,7 +8,7 @@ Failure for internal: error: in early_fail/3a1fbbbh::fail1[0]
 panicking::begin_panic, called from early_fail/3a1fbbbh::fail1[0]
 
 ---- early_fail/3a1fbbbh::fail2[0] counterexamples ----
-Failure for ./lib/crucible/lib.rs:36:41: 36:58 !test/symb_eval/crux/early_fail.rs:17:5: 17:30: error: in early_fail/3a1fbbbh::fail2[0]
+Failure for ./lib/crucible/lib.rs:37:41: 37:58 !test/symb_eval/crux/early_fail.rs:17:5: 17:30: error: in early_fail/3a1fbbbh::fail2[0]
 MIR assertion at test/symb_eval/crux/early_fail.rs:17:5:
 	x == 0
 

--- a/crux-mir/test/symb_eval/crux/fail_return.good
+++ b/crux-mir/test/symb_eval/crux/fail_return.good
@@ -6,14 +6,14 @@ failures:
 ---- fail_return/3a1fbbbh::fail1[0] counterexamples ----
 Failure for test/symb_eval/crux/fail_return.rs:8:22: 8:27: error: in fail_return/3a1fbbbh::fail1[0]
 attempt to add with overflow
-Failure for ./lib/crucible/lib.rs:36:41: 36:58 !test/symb_eval/crux/fail_return.rs:8:5: 8:33: error: in fail_return/3a1fbbbh::fail1[0]
+Failure for ./lib/crucible/lib.rs:37:41: 37:58 !test/symb_eval/crux/fail_return.rs:8:5: 8:33: error: in fail_return/3a1fbbbh::fail1[0]
 MIR assertion at test/symb_eval/crux/fail_return.rs:8:5:
 	x + 1 > x
 
 ---- fail_return/3a1fbbbh::fail2[0] counterexamples ----
 Failure for test/symb_eval/crux/fail_return.rs:15:22: 15:27: error: in fail_return/3a1fbbbh::fail2[0]
 attempt to add with overflow
-Failure for ./lib/crucible/lib.rs:36:41: 36:58 !test/symb_eval/crux/fail_return.rs:15:5: 15:33: error: in fail_return/3a1fbbbh::fail2[0]
+Failure for ./lib/crucible/lib.rs:37:41: 37:58 !test/symb_eval/crux/fail_return.rs:15:5: 15:33: error: in fail_return/3a1fbbbh::fail2[0]
 MIR assertion at test/symb_eval/crux/fail_return.rs:15:5:
 	x + 1 > x
 

--- a/crux-mir/test/symb_eval/crux/mixed_fail.good
+++ b/crux-mir/test/symb_eval/crux/mixed_fail.good
@@ -8,14 +8,14 @@ failures:
 ---- mixed_fail/3a1fbbbh::fail1[0] counterexamples ----
 Failure for test/symb_eval/crux/mixed_fail.rs:8:22: 8:27: error: in mixed_fail/3a1fbbbh::fail1[0]
 attempt to add with overflow
-Failure for ./lib/crucible/lib.rs:36:41: 36:58 !test/symb_eval/crux/mixed_fail.rs:8:5: 8:33: error: in mixed_fail/3a1fbbbh::fail1[0]
+Failure for ./lib/crucible/lib.rs:37:41: 37:58 !test/symb_eval/crux/mixed_fail.rs:8:5: 8:33: error: in mixed_fail/3a1fbbbh::fail1[0]
 MIR assertion at test/symb_eval/crux/mixed_fail.rs:8:5:
 	x + 1 > x
 
 ---- mixed_fail/3a1fbbbh::fail2[0] counterexamples ----
 Failure for test/symb_eval/crux/mixed_fail.rs:14:22: 14:27: error: in mixed_fail/3a1fbbbh::fail2[0]
 attempt to add with overflow
-Failure for ./lib/crucible/lib.rs:36:41: 36:58 !test/symb_eval/crux/mixed_fail.rs:14:5: 14:33: error: in mixed_fail/3a1fbbbh::fail2[0]
+Failure for ./lib/crucible/lib.rs:37:41: 37:58 !test/symb_eval/crux/mixed_fail.rs:14:5: 14:33: error: in mixed_fail/3a1fbbbh::fail2[0]
 MIR assertion at test/symb_eval/crux/mixed_fail.rs:14:5:
 	x + 2 > x
 

--- a/crux-mir/test/symb_eval/crux/multi.good
+++ b/crux-mir/test/symb_eval/crux/multi.good
@@ -7,7 +7,7 @@ failures:
 ---- multi/3a1fbbbh::fail1[0] counterexamples ----
 Failure for test/symb_eval/crux/multi.rs:8:22: 8:27: error: in multi/3a1fbbbh::fail1[0]
 attempt to add with overflow
-Failure for ./lib/crucible/lib.rs:36:41: 36:58 !test/symb_eval/crux/multi.rs:8:5: 8:33: error: in multi/3a1fbbbh::fail1[0]
+Failure for ./lib/crucible/lib.rs:37:41: 37:58 !test/symb_eval/crux/multi.rs:8:5: 8:33: error: in multi/3a1fbbbh::fail1[0]
 MIR assertion at test/symb_eval/crux/multi.rs:8:5:
 	x + 1 > x
 
@@ -16,7 +16,7 @@ Failure for internal: error: in multi/3a1fbbbh::fail2[0]
 panicking::begin_panic, called from multi/3a1fbbbh::fail2[0]
 
 ---- multi/3a1fbbbh::fail3[0] counterexamples ----
-Failure for ./lib/crucible/lib.rs:36:41: 36:58 !test/symb_eval/crux/multi.rs:20:5: 20:30: error: in multi/3a1fbbbh::assert_zero[0]
+Failure for ./lib/crucible/lib.rs:37:41: 37:58 !test/symb_eval/crux/multi.rs:20:5: 20:30: error: in multi/3a1fbbbh::assert_zero[0]
 MIR assertion at test/symb_eval/crux/multi.rs:20:5:
 	x == 0
 

--- a/crux-mir/test/symb_eval/crypto/bytes.good
+++ b/crux-mir/test/symb_eval/crypto/bytes.good
@@ -3,19 +3,19 @@ test bytes/3a1fbbbh::f[0]: FAILED
 failures:
 
 ---- bytes/3a1fbbbh::f[0] counterexamples ----
-Failure for ./lib/crucible/lib.rs:36:41: 36:58 !test/symb_eval/crypto/bytes.rs:85:7: 85:38: error: in bytes/3a1fbbbh::f[0]
+Failure for ./lib/crucible/lib.rs:37:41: 37:58 !test/symb_eval/crypto/bytes.rs:85:7: 85:38: error: in bytes/3a1fbbbh::f[0]
 MIR assertion at test/symb_eval/crypto/bytes.rs:85:7:
 	a[i] == b[i]
-Failure for ./lib/crucible/lib.rs:36:41: 36:58 !test/symb_eval/crypto/bytes.rs:85:7: 85:38: error: in bytes/3a1fbbbh::f[0]
+Failure for ./lib/crucible/lib.rs:37:41: 37:58 !test/symb_eval/crypto/bytes.rs:85:7: 85:38: error: in bytes/3a1fbbbh::f[0]
 MIR assertion at test/symb_eval/crypto/bytes.rs:85:7:
 	a[i] == b[i]
-Failure for ./lib/crucible/lib.rs:36:41: 36:58 !test/symb_eval/crypto/bytes.rs:85:7: 85:38: error: in bytes/3a1fbbbh::f[0]
+Failure for ./lib/crucible/lib.rs:37:41: 37:58 !test/symb_eval/crypto/bytes.rs:85:7: 85:38: error: in bytes/3a1fbbbh::f[0]
 MIR assertion at test/symb_eval/crypto/bytes.rs:85:7:
 	a[i] == b[i]
-Failure for ./lib/crucible/lib.rs:36:41: 36:58 !test/symb_eval/crypto/bytes.rs:85:7: 85:38: error: in bytes/3a1fbbbh::f[0]
+Failure for ./lib/crucible/lib.rs:37:41: 37:58 !test/symb_eval/crypto/bytes.rs:85:7: 85:38: error: in bytes/3a1fbbbh::f[0]
 MIR assertion at test/symb_eval/crypto/bytes.rs:85:7:
 	a[i] == b[i]
-Failure for ./lib/crucible/lib.rs:36:41: 36:58 !test/symb_eval/crypto/bytes.rs:85:7: 85:38: error: in bytes/3a1fbbbh::f[0]
+Failure for ./lib/crucible/lib.rs:37:41: 37:58 !test/symb_eval/crypto/bytes.rs:85:7: 85:38: error: in bytes/3a1fbbbh::f[0]
 MIR assertion at test/symb_eval/crypto/bytes.rs:85:7:
 	a[i] == b[i]
 

--- a/crux-mir/test/symb_eval/overrides/override2.good
+++ b/crux-mir/test/symb_eval/overrides/override2.good
@@ -3,7 +3,7 @@ test override2/3a1fbbbh::f[0]: FAILED
 failures:
 
 ---- override2/3a1fbbbh::f[0] counterexamples ----
-Failure for ./lib/crucible/lib.rs:36:41: 36:58 !test/symb_eval/overrides/override2.rs:9:5: 9:50: error: in override2/3a1fbbbh::f[0]
+Failure for ./lib/crucible/lib.rs:37:41: 37:58 !test/symb_eval/overrides/override2.rs:9:5: 9:50: error: in override2/3a1fbbbh::f[0]
 MIR assertion at test/symb_eval/overrides/override2.rs:9:5:
 	foo.wrapping_add(1) == foo
 

--- a/crux-mir/test/symb_eval/overrides/override5.good
+++ b/crux-mir/test/symb_eval/overrides/override5.good
@@ -3,7 +3,7 @@ test override5/3a1fbbbh::f[0]: FAILED
 failures:
 
 ---- override5/3a1fbbbh::f[0] counterexamples ----
-Failure for ./lib/crucible/lib.rs:36:41: 36:58 !test/symb_eval/overrides/override5.rs:10:5: 10:48: error: in override5/3a1fbbbh::f[0]
+Failure for ./lib/crucible/lib.rs:37:41: 37:58 !test/symb_eval/overrides/override5.rs:10:5: 10:48: error: in override5/3a1fbbbh::f[0]
 MIR assertion at test/symb_eval/overrides/override5.rs:10:5:
 	foo.wrapping_add(1) != 0
 

--- a/crux-mir/test/symb_eval/overrides/override_rust.good
+++ b/crux-mir/test/symb_eval/overrides/override_rust.good
@@ -1,0 +1,3 @@
+test override_rust/3a1fbbbh::crux_test[0]: ok
+
+[Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/overrides/override_rust.rs
+++ b/crux-mir/test/symb_eval/overrides/override_rust.rs
@@ -1,0 +1,12 @@
+extern crate crucible;
+use crucible::*;
+
+fn f() -> i32 { 1 }
+fn g() -> i32 { 2 }
+
+#[cfg_attr(crux, crux_test)]
+fn crux_test() {
+    crucible_assert!(f() == 1);
+    crucible::override_(f, g);
+    crucible_assert!(f() == 2);
+}

--- a/crux-mir/test/symb_eval/sym_bytes/construct.good
+++ b/crux-mir/test/symb_eval/sym_bytes/construct.good
@@ -3,7 +3,7 @@ test construct/3a1fbbbh::crux_test[0]: returned Symbolic BV, FAILED
 failures:
 
 ---- construct/3a1fbbbh::crux_test[0] counterexamples ----
-Failure for ./lib/crucible/lib.rs:36:41: 36:58 !test/symb_eval/sym_bytes/construct.rs:13:5: 13:36: error: in construct/3a1fbbbh::crux_test[0]
+Failure for ./lib/crucible/lib.rs:37:41: 37:58 !test/symb_eval/sym_bytes/construct.rs:13:5: 13:36: error: in construct/3a1fbbbh::crux_test[0]
 MIR assertion at test/symb_eval/sym_bytes/construct.rs:13:5:
 	sym2[0] == 0
 


### PR DESCRIPTION
This PR contains the `crux-mir` parts of GaloisInc/saw-script#1313, specifically:

* Add the `cryptol!` macro to `lib/crucible`, with placeholders for `cryptol::load` and `cryptol::override_` (to be overridden in `crux-mir-comp`).

* Add placeholder for `munge`, to be overridden in `crux-mir-comp`.

* Add support for `#[repr(transparent)]`.

* Add custom translation for unchecked arithmetic and `rotate_left`/`right` intrinsics.
