### PR TITLE
Use `Paths_*` for version numbers in `--version` output

### DIFF
--- a/crucible-concurrency/crucible-concurrency.cabal
+++ b/crucible-concurrency/crucible-concurrency.cabal
@@ -53,6 +53,8 @@ library
 
 executable cruces
   main-is:             crucibles/Main.hs
+  other-modules:       Paths_crucible_concurrency
+  autogen-modules:     Paths_crucible_concurrency
   -- other-extensions:
   build-depends:       base >=4.7 && < 5
                      , crucible

--- a/crucible-concurrency/crucibles/Main.hs
+++ b/crucible-concurrency/crucibles/Main.hs
@@ -15,6 +15,7 @@ import           System.IO
 
 import qualified Crux
 import Cruces.CrucesMain
+import Paths_crucible_concurrency (version)
 
 main :: IO ()
-main = Crux.loadOptions Crux.defaultOutputConfig "cruces" "0.1" cruciblesConfig $ run
+main = Crux.loadOptions Crux.defaultOutputConfig "cruces" version cruciblesConfig $ run

--- a/crucible-go/crucible-go.cabal
+++ b/crucible-go/crucible-go.cabal
@@ -8,12 +8,14 @@ maintainer:          abagnall@galois.com
 copyright:           (c) 2020 Galois Inc
 category:            Language
 build-type:          Simple
-cabal-version:       >=1.10
+cabal-version:       2.0
 
 executable crux-go
 
   hs-source-dirs: tool
   main-is: Main.hs
+  other-modules: Paths_crucible_go
+  autogen-modules: Paths_crucible_go
 
   build-depends:
     base >= 4 && < 5,

--- a/crucible-go/tool/Main.hs
+++ b/crucible-go/tool/Main.hs
@@ -20,6 +20,7 @@ import qualified Crux.Types   as Crux
 import Language.Go.Parser
 import Lang.Crucible.Go.Simulate (setupCrucibleGoCrux)
 import Lang.Crucible.Go.Types
+import Paths_crucible_go (version)
 
 -- | A simulator context
 type SimCtxt sym = SimContext (Crux.Model sym) sym Go
@@ -63,7 +64,7 @@ simulateGo copts _opts = Crux.SimulatorCallback $ \sym _maybeOnline -> do
 -- | Entry point, parse command line options
 main :: IO ()
 main =
-  Crux.loadOptions Crux.defaultOutputConfig "crux-go" "0.1" cruxGoConfig $
+  Crux.loadOptions Crux.defaultOutputConfig "crux-go" version cruxGoConfig $
     \(cruxOpts, goOpts) ->
       exitWith =<< Crux.postprocessSimResult cruxOpts =<<
         Crux.runSimulator (cruxOpts { Crux.outDir = "report"

--- a/crucible-jvm/crucible-jvm.cabal
+++ b/crucible-jvm/crucible-jvm.cabal
@@ -6,7 +6,7 @@ Maintainer:    huffman@galois.com, sweirich@galois.com
 License:       BSD3
 License-file:  LICENSE
 Build-type:    Simple
-Cabal-version: >= 1.10
+Cabal-version: 2.0
 Category:      Language
 Synopsis:      Support for translating and executing JVM code in Crucible
 
@@ -14,6 +14,8 @@ executable crucible-jvm
 
   hs-source-dirs: tool
   main-is: Main.hs
+  other-modules: Paths_crucible_jvm
+  autogen-modules: Paths_crucible_jvm
 
   build-depends:
     base >= 4 && < 5,

--- a/crucible-jvm/tool/Main.hs
+++ b/crucible-jvm/tool/Main.hs
@@ -85,6 +85,7 @@ import           Lang.JVM.JavaTools
 
 import           Lang.Crucible.JVM.Simulate (setupCrucibleJVMCrux)
 import           Lang.Crucible.JVM.Types
+import           Paths_crucible_jvm (version)
 
 -- executable
 
@@ -201,7 +202,7 @@ simulateJVM copts opts = Crux.SimulatorCallback $ \sym _maybeOnline -> do
 -- | Entry point, parse command line options
 main :: IO ()
 main =
-  Crux.loadOptions Crux.defaultOutputConfig "crux-jvm" "0.1" cruxJVMConfig $
+  Crux.loadOptions Crux.defaultOutputConfig "crux-jvm" version cruxJVMConfig $
     \(cruxOpts, jvmOpts) -> do
       jvmOpts' <- processJVMOptions jvmOpts
       exitWith =<< Crux.postprocessSimResult cruxOpts =<<

--- a/crucible-wasm/crucible-wasm.cabal
+++ b/crucible-wasm/crucible-wasm.cabal
@@ -6,7 +6,7 @@ Maintainer:    rdockins@galois.com
 License:       BSD3
 License-file:  LICENSE
 Build-type:    Simple
-Cabal-version: >= 1.10
+Cabal-version: 2.0
 Category:      Language
 Synopsis:      Support for translating and executing WebAssembly code in Crucible
 
@@ -14,6 +14,8 @@ executable crucible-wasm
 
   hs-source-dirs: tool
   main-is: Main.hs
+  other-modules: Paths_crucible_wasm
+  autogen-modules: Paths_crucible_wasm
 
   build-depends:
     base >= 4 && < 5,

--- a/crucible-wasm/tool/Main.hs
+++ b/crucible-wasm/tool/Main.hs
@@ -20,6 +20,7 @@ import qualified Crux.Types as Crux
 import qualified Language.Wasm as Wasm
 
 import Lang.Crucible.Wasm
+import Paths_crucible_wasm (version)
 
 data WasmOptions = WasmOptions
 
@@ -65,7 +66,7 @@ simulateWasm cruxOpts _wasmOpts = Crux.SimulatorCallback $ \sym _mOnline ->
 
 main :: IO ()
 main =
-  Crux.loadOptions Crux.defaultOutputConfig "crux-wasm" "0.1" cruxWasmConfig
+  Crux.loadOptions Crux.defaultOutputConfig "crux-wasm" version cruxWasmConfig
    \(cruxOpts, wasmOpts) ->
        do res <- Crux.runSimulator cruxOpts (simulateWasm cruxOpts wasmOpts)
           exitWith =<< Crux.postprocessSimResult cruxOpts res

--- a/crux-llvm/src/CruxLLVMMain.hs
+++ b/crux-llvm/src/CruxLLVMMain.hs
@@ -21,6 +21,7 @@ import Crux.Config.Common(CruxOptions(..))
 import Crux.LLVM.Config
 import Crux.LLVM.Compile
 import Crux.LLVM.Simulate
+import Paths_crux_llvm (version)
 
 
 mainWithOutputTo :: Handle -> IO ExitCode
@@ -29,7 +30,7 @@ mainWithOutputTo h = mainWithOutputConfig (OutputConfig False h h False)
 mainWithOutputConfig :: OutputConfig -> IO ExitCode
 mainWithOutputConfig outCfg = do
   cfg <- llvmCruxConfig
-  Crux.loadOptions outCfg "crux-llvm" "0.1" cfg $ \initOpts ->
+  Crux.loadOptions outCfg "crux-llvm" version cfg $ \initOpts ->
     do (cruxOpts, llvmOpts) <- processLLVMOptions initOpts
        bcFile <- genBitCode cruxOpts llvmOpts
        res <- Crux.runSimulator cruxOpts (simulateLLVMFile bcFile llvmOpts)

--- a/crux-llvm/svcomp/Main.hs
+++ b/crux-llvm/svcomp/Main.hs
@@ -51,12 +51,13 @@ import Crux.LLVM.Config
 import Crux.LLVM.Compile
 import Crux.LLVM.Simulate
 import CruxLLVMMain( processLLVMOptions )
+import Paths_crux_llvm (version)
 
 main :: IO ()
 main = do
   cfg <- llvmCruxConfig
   let opts = Crux.cfgJoin cfg svcompOptions
-  Crux.loadOptions defaultOutputConfig "crux-llvm-svcomp" "0.1" opts $ \(co0,(lo0,svOpts)) ->
+  Crux.loadOptions defaultOutputConfig "crux-llvm-svcomp" version opts $ \(co0,(lo0,svOpts)) ->
     do (cruxOpts, llvmOpts) <- processLLVMOptions (co0{ outDir = "results" </> "SVCOMP" },lo0)
        bss <- loadSVCOMPBenchmarks cruxOpts
        let taskMap = deduplicateTasks bss

--- a/crux-mir/crux-mir.cabal
+++ b/crux-mir/crux-mir.cabal
@@ -14,7 +14,7 @@ maintainer:          spernsteiner@galois.com
 copyright:           2017-2020 Galois, Inc.
 category:            Web
 build-type:          Simple
-cabal-version:       >=1.10
+cabal-version:       2.0
 extra-source-files:  README.md
 
 library
@@ -73,6 +73,8 @@ library
                    Mir.TransTy
                    Mir.Trans
                    Mir.TransCustom
+  other-modules: Paths_crux_mir
+  autogen-modules: Paths_crux_mir
 
 
 executable crux-mir

--- a/crux-mir/src/Mir/Language.hs
+++ b/crux-mir/src/Mir/Language.hs
@@ -102,6 +102,7 @@ import           Mir.Generate (generateMIR, translateMIR)
 import           Mir.Trans (transStatics)
 import           Mir.TransTy
 import           Mir.Concurrency
+import           Paths_crux_mir (version)
 
 main :: IO ()
 main = mainWithOutputConfig defaultOutputConfig noExtraOverrides >>= exitWith
@@ -115,7 +116,7 @@ mainWithOutputTo h bindExtra = mainWithOutputConfig (OutputConfig False h h Fals
 
 mainWithOutputConfig :: OutputConfig -> BindExtraOverridesFn -> IO ExitCode
 mainWithOutputConfig outCfg bindExtra =
-    Crux.loadOptions outCfg "crux-mir" "0.1" mirConfig $ runTestsWithExtraOverrides bindExtra
+    Crux.loadOptions outCfg "crux-mir" version mirConfig $ runTestsWithExtraOverrides bindExtra
 
 type BindExtraOverridesFn = forall sym p t st fs args ret blocks rtp a r.
     (C.IsSymInterface sym, sym ~ W4.ExprBuilder t st fs, HasModel p) =>

--- a/crux/crux.cabal
+++ b/crux/crux.cabal
@@ -17,8 +17,8 @@ Description:
   verification, usually by embedding verification specifications in
   the source language.
 
-library 
-        
+library
+
   build-depends:
     base >= 4 && < 5,
     aig,
@@ -77,6 +77,10 @@ library
   other-modules:
    Crux.UI.Jquery,
    Crux.UI.IndexHtml
+   Paths_crux
+
+  autogen-modules:
+   Paths_crux
 
   ghc-options: -Wall
                -Wcompat

--- a/crux/src/Crux.hs
+++ b/crux/src/Crux.hs
@@ -36,6 +36,8 @@ import Data.Proxy ( Proxy(..) )
 import qualified Data.Sequence as Seq
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
+import qualified Data.Version as Version (showVersion)
+import Data.Version (Version)
 import Data.Void
 import Control.Monad(when)
 import Prettyprinter
@@ -144,7 +146,7 @@ postprocessSimResult opts res =
 loadOptions ::
   OutputConfig ->
   Text {- ^ Name -} ->
-  Text {- ^ Version -}->
+  Version ->
   Config opts ->
   (Logs => (CruxOptions, opts) -> IO a) ->
   IO a
@@ -177,9 +179,9 @@ showHelp nm cfg = do
   let opts = LayoutOptions $ AvailablePerLine outWidth 0.98
   outputLn (TL.unpack $ PR.renderLazy $ layoutPretty opts (configDocs nm cfg))
 
-showVersion :: Logs => Text -> Text -> IO ()
+showVersion :: Logs => Text -> Version -> IO ()
 showVersion nm ver =
-  outputLn $ "crux version: " <> Crux.version <> ", " <> Text.unpack nm <> " version: " <> Text.unpack ver
+  outputLn $ "crux version: " <> Crux.version <> ", " <> Text.unpack nm <> " version: " <> Version.showVersion ver
 
 
 --------------------------------------------------------------------------------
@@ -629,7 +631,7 @@ printFailedGoals opts (CruxSimulationResult _cmpl allGls)
   where
   printFailed (AtLoc _ _ gls) = printFailed gls
   printFailed (Branch gls1 gls2) = printFailed gls1 >> printFailed gls2
-  printFailed (Goal _asmps _goal _trivial (Proved _)) = return () 
+  printFailed (Goal _asmps _goal _trivial (Proved _)) = return ()
   printFailed (Goal _asmps (err, _msg) _trivial (NotProved ex mdl))
     | skipIncompleteReports opts
     , SimError _ (ResourceExhausted _) <- err

--- a/crux/src/Crux/Version.hs
+++ b/crux/src/Crux/Version.hs
@@ -1,6 +1,9 @@
 module Crux.Version where
 
+import Data.Version (showVersion)
+import qualified Paths_crux (version)
+
 version :: String
-version = "0.1"
+version = showVersion Paths_crux.version
 
 

--- a/uc-crux-llvm/src/UCCrux/LLVM/Main.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Main.hs
@@ -70,6 +70,7 @@ import Crux.LLVM.Config
 import Crux.LLVM.Compile (genBitCode)
 import Crux.LLVM.Simulate (parseLLVM)
 
+import           Paths_uc_crux_llvm (version)
 import qualified UCCrux.LLVM.Config as Config
 import           UCCrux.LLVM.Config (UCCruxLLVMOptions)
 import           UCCrux.LLVM.Context.App (AppContext)
@@ -89,7 +90,7 @@ mainWithOutputConfig :: OutputConfig -> IO ExitCode
 mainWithOutputConfig outCfg =
   do
     conf <- Config.ucCruxLLVMConfig
-    Crux.loadOptions outCfg "uc-crux-llvm" "0.1" conf $ \opts ->
+    Crux.loadOptions outCfg "uc-crux-llvm" version conf $ \opts ->
       do
         (appCtx, cruxOpts, ucOpts) <- Config.processUCCruxLLVMOptions opts
         path <- genBitCode cruxOpts (Config.ucLLVMOptions ucOpts)

--- a/uc-crux-llvm/test/Test.hs
+++ b/uc-crux-llvm/test/Test.hs
@@ -75,6 +75,7 @@ import           Crux.LLVM.Compile (genBitCode)
 import           Crux.LLVM.Config (clangOpts)
 
 -- Code being tested
+import           Paths_uc_crux_llvm (version)
 import qualified UCCrux.LLVM.Config as Config
 import           UCCrux.LLVM.Main (SomeModuleContext'(..), loopOnFunctions, translateFile, translateLLVMModule)
 import           UCCrux.LLVM.Errors.Unimplemented (catchUnimplemented)
@@ -123,7 +124,7 @@ findBugs llvmModule file fns =
         let outCfg = Crux.OutputConfig False h h True
         conf <- Config.ucCruxLLVMConfig
         (appCtx, path, cruxOpts, ucOpts) <-
-          Crux.loadOptions outCfg "uc-crux-llvm" "0.1" conf $ \(cruxOpts, ucOpts) ->
+          Crux.loadOptions outCfg "uc-crux-llvm" version conf $ \(cruxOpts, ucOpts) ->
             do
               -- With Yices, cast_float_to_pointer_write.c hangs
               let cruxOpts' =

--- a/uc-crux-llvm/uc-crux-llvm.cabal
+++ b/uc-crux-llvm/uc-crux-llvm.cabal
@@ -64,6 +64,12 @@ library
     UCCrux.LLVM.Shape
     UCCrux.LLVM.Stats
 
+  other-modules:
+    Paths_uc_crux_llvm
+
+  autogen-modules:
+    Paths_uc_crux_llvm
+
   build-depends:
     async,
     base >= 4.8 && < 4.15,
@@ -121,6 +127,8 @@ test-suite uc-crux-llvm-test
   hs-source-dirs: test
 
   main-is: Test.hs
+  other-modules: Paths_uc_crux_llvm
+  autogen-modules: Paths_uc_crux_llvm
 
   build-depends:
                 base             >= 4.7,


### PR DESCRIPTION
This avoids needing to hardcode the version numbers used in `.cabal` files as strings. Fixes #750.