### PR TITLE
Sequences

### DIFF
--- a/crucible-syntax/README.txt
+++ b/crucible-syntax/README.txt
@@ -79,8 +79,17 @@ first may be relaxed.
 
 Types
 
-t ::= 'Any' | 'Unit' | 'Bool' | 'Nat' | 'Real' | 'ComplexReal' | 'Char' | 'String'
-    | '(' 'Vector' t ')' | '(' 'BitVector' n ')' | '(' '->' t ... t ')' 
+si ::= 'Unicode' | 'Char16' | 'Char8'
+
+fi ::= 'Half' | 'Float' | 'Double' | 'Quad'
+     | 'X86_80' | 'DoubleDouble'
+
+t ::= 'Any' | 'Unit' | 'Bool' | 'Nat' | 'Integer' | 'Real'
+    | 'ComplexReal' | 'Char' | '(' 'String' si ')'
+    | '(' 'FP' fi ')' | '(' 'BitVector' n ')'
+    | '(' '->' t ... t ')' | '(' 'Maybe' t ')'
+    | '(' 'Sequence' t ')' | '(' 'Vector' t ')' | '(' 'Ref' t ')'
+    | '(' 'Struct' t ... t ')' | '(' 'Variant' t ... t ')'
 
 
 Expressions

--- a/crucible-syntax/src/Lang/Crucible/Syntax/Atoms.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Atoms.hs
@@ -50,7 +50,7 @@ data Keyword = Defun | DefBlock | DefGlobal
              | Just_ | Nothing_ | FromJust
              | Inj | Proj
              | AnyT | UnitT | BoolT | NatT | IntegerT | RealT | ComplexRealT | CharT | StringT
-             | BitvectorT | VectorT | FPT | FunT | MaybeT | VariantT | RefT
+             | BitvectorT | VectorT | FPT | FunT | MaybeT | VariantT | StructT | RefT
              | Half_ | Float_ | Double_ | Quad_ | X86_80_ | DoubleDouble_
              | Unicode_ | Char8_ | Char16_
              | The
@@ -64,6 +64,7 @@ data Keyword = Defun | DefBlock | DefGlobal
              | ToAny | FromAny
              | VectorLit_ | VectorReplicate_ | VectorIsEmpty_ | VectorSize_
              | VectorGetEntry_ | VectorSetEntry_ | VectorCons_
+             | MkStruct_ | GetField_ | SetField_
              | Deref | Ref | EmptyRef
              | Jump_ | Return_ | Branch_ | MaybeBranch_ | TailCall_ | Error_ | Output_ | Case
              | Print_ | PrintLn_
@@ -133,6 +134,7 @@ keywords =
   , ("->", FunT)
   , ("Maybe", MaybeT)
   , ("Variant", VariantT)
+  , ("Struct", StructT)
 
     -- string sorts
   , ("Unicode", Unicode_)
@@ -181,6 +183,11 @@ keywords =
     -- Variants
   , ("inj", Inj)
   , ("proj", Proj)
+
+    -- Structs
+  , ("struct", MkStruct_)
+  , ("get-field", GetField_)
+  , ("set-field", SetField_)
 
     -- Maybe
   , ("just" , Just_)

--- a/crucible-syntax/src/Lang/Crucible/Syntax/Atoms.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Atoms.hs
@@ -19,7 +19,6 @@ import Control.Applicative
 import Data.Char
 import Data.Functor
 import Data.Ratio
-import Data.Semigroup ( (<>) )
 import Data.Text (Text)
 import qualified Data.Text as T
 
@@ -50,7 +49,7 @@ data Keyword = Defun | DefBlock | DefGlobal
              | Just_ | Nothing_ | FromJust
              | Inj | Proj
              | AnyT | UnitT | BoolT | NatT | IntegerT | RealT | ComplexRealT | CharT | StringT
-             | BitvectorT | VectorT | FPT | FunT | MaybeT | VariantT | StructT | RefT
+             | BitvectorT | VectorT | SequenceT | FPT | FunT | MaybeT | VariantT | StructT | RefT
              | Half_ | Float_ | Double_ | Quad_ | X86_80_ | DoubleDouble_
              | Unicode_ | Char8_ | Char16_
              | The
@@ -65,6 +64,9 @@ data Keyword = Defun | DefBlock | DefGlobal
              | VectorLit_ | VectorReplicate_ | VectorIsEmpty_ | VectorSize_
              | VectorGetEntry_ | VectorSetEntry_ | VectorCons_
              | MkStruct_ | GetField_ | SetField_
+             | SequenceNil_ | SequenceCons_ | SequenceAppend_
+             | SequenceIsNil_ | SequenceLength_
+             | SequenceHead_ | SequenceTail_ | SequenceUncons_
              | Deref | Ref | EmptyRef
              | Jump_ | Return_ | Branch_ | MaybeBranch_ | TailCall_ | Error_ | Output_ | Case
              | Print_ | PrintLn_
@@ -131,6 +133,7 @@ keywords =
   , ("String" , StringT)
   , ("Bitvector" , BitvectorT)
   , ("Vector", VectorT)
+  , ("Sequence", SequenceT)
   , ("->", FunT)
   , ("Maybe", MaybeT)
   , ("Variant", VariantT)
@@ -202,6 +205,16 @@ keywords =
   , ("vector-get", VectorGetEntry_)
   , ("vector-set", VectorSetEntry_)
   , ("vector-cons", VectorCons_)
+
+    -- Sequences
+  , ("seq-nil", SequenceNil_)
+  , ("seq-cons", SequenceCons_)
+  , ("seq-append", SequenceAppend_)
+  , ("seq-nil?", SequenceIsNil_)
+  , ("seq-length", SequenceLength_)
+  , ("seq-head", SequenceHead_)
+  , ("seq-tail", SequenceTail_)
+  , ("seq-uncons", SequenceUncons_)
 
     -- strings
   , ("show", Show)

--- a/crucible-syntax/src/Lang/Crucible/Syntax/ExprParse.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/ExprParse.hs
@@ -66,7 +66,6 @@ module Lang.Crucible.Syntax.ExprParse
 
 import Control.Applicative
 import Control.Lens hiding (List, cons, backwards)
-import Control.Monad (ap)
 import Control.Monad.Reader
 import qualified Control.Monad.State.Strict as Strict
 import qualified Control.Monad.State.Lazy as Lazy
@@ -79,7 +78,6 @@ import Data.Foldable as Foldable
 import Data.List
 import qualified Data.List.NonEmpty as NE
 import Data.List.NonEmpty (NonEmpty(..))
-import Data.Semigroup (Semigroup(..))
 import Data.String
 import Data.Text (Text)
 import qualified Data.Text as T

--- a/crucible-syntax/src/Lang/Crucible/Syntax/Overrides.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Overrides.hs
@@ -28,7 +28,6 @@ import Lang.Crucible.Backend
 import Lang.Crucible.Types
 import Lang.Crucible.FunctionHandle
 import Lang.Crucible.Simulator
-import Lang.Crucible.Simulator.SimError (ppSimError)
 
 
 setupOverrides ::

--- a/crucible-syntax/src/Lang/Crucible/Syntax/Prog.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Prog.hs
@@ -106,13 +106,13 @@ simulateProgram fn theInput outh profh opts setup =
                 case find isMain cs of
                   Just (ACFG Ctx.Empty retType mn) ->
                     do let mainHdl = cfgHandle mn
-                       let fnBindings = fnBindingsFromList
+                       let fns = fnBindingsFromList
                              [ case toSSA g of
                                  C.SomeCFG ssa ->
                                    FnBinding (cfgHandle g) (UseCFG ssa (postdomInfo ssa))
                              | ACFG _ _ g <- cs
                              ]
-                       let simCtx = initSimContext sym emptyIntrinsicTypes ha outh fnBindings emptyExtensionImpl ()
+                       let simCtx = initSimContext sym emptyIntrinsicTypes ha outh fns emptyExtensionImpl ()
                        let simSt  = InitialState simCtx emptyGlobals defaultAbortHandler retType $
                                       runOverrideSim retType $
                                         do mapM_ (registerFnBinding . fst) ovrs

--- a/crucible-syntax/src/Lang/Crucible/Syntax/SExpr.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/SExpr.hs
@@ -27,7 +27,6 @@ module Lang.Crucible.Syntax.SExpr
   ) where
 
 import Data.Char (isDigit, isLetter)
-import Data.Semigroup (Semigroup(..))
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Void

--- a/crucible-syntax/test-data/parser-tests/structs.cbl
+++ b/crucible-syntax/test-data/parser-tests/structs.cbl
@@ -1,0 +1,12 @@
+(defun @structs ((x (Struct Bool Integer))) (Struct Unit Nat Bool)
+  (start st:
+    (let b (get-field 0 x))
+    (let i (get-field 1 x))
+
+    (let r1 (struct () (the Nat 5) b))
+    (let r2 (set-field r1 1 42))
+    (let r3 (set-field r2 2 #f))
+
+    (return r3)
+  )
+)

--- a/crucible-syntax/test-data/parser-tests/structs.out.good
+++ b/crucible-syntax/test-data/parser-tests/structs.out.good
@@ -1,0 +1,35 @@
+(defun
+   @structs
+   ((x (Struct Bool Integer)))
+   (Struct Unit Nat Bool)
+   (start st:
+      (let b (get-field 0 x))
+      (let i (get-field 1 x))
+      (let r1 (struct () (the Nat 5) b))
+      (let r2 (set-field r1 1 42))
+      (let r3 (set-field r2 2 #f))
+      (return r3)))
+
+structs
+%0
+  % 3:12
+  $1 = getStruct($0, 0, BoolRepr)
+  % 4:12
+  $2 = getStruct($0, 1, IntegerRepr)
+  % 6:13
+  $3 = emptyApp()
+  % 6:13
+  $4 = natLit(5)
+  % 6:13
+  $5 = mkStruct([UnitRepr, NatRepr, BoolRepr], [$3, $4, $1])
+  % 7:13
+  $6 = natLit(42)
+  % 7:13
+  $7 = setStruct([UnitRepr, NatRepr, BoolRepr], $5, 1, $6)
+  % 8:13
+  $8 = boolLit(False)
+  % 8:13
+  $9 = setStruct([UnitRepr, NatRepr, BoolRepr], $7, 2, $8)
+  % 10:5
+  return $9
+  % no postdom

--- a/crucible-syntax/test-data/simulator-tests/seq-test1.cbl
+++ b/crucible-syntax/test-data/simulator-tests/seq-test1.cbl
@@ -1,0 +1,32 @@
+(defun @main () Unit
+  (start start:
+    (let n (the (Sequence Nat) seq-nil))
+    (assert! (seq-nil? n) "nil test")
+    (assert! (equal? 0 (seq-length n)) "nil length test")
+
+    (let s1 (seq-cons 5 n))
+
+    (assert! (not (seq-nil? s1)) "cons test")
+    (assert! (equal? 1 (seq-length s1)) "cons length test")
+
+    (let v (from-just (seq-head s1) "head s1"))
+    (let t (from-just (seq-tail s1) "tail s1"))
+    (let u (from-just (seq-uncons s1) "uncons s1"))
+
+    (let v2 (get-field 0 u))
+    (let t2 (get-field 1 u))
+
+    (assert! (equal? 5 v) "head value test")
+    (assert! (equal? v v2) "head equal test")
+    (assert! (seq-nil? t) "tail nil test")
+    (assert! (seq-nil? t2) "uncons tail nil test")
+
+    (let s2 (seq-append s1 (seq-cons 42 (seq-nil Nat))))
+    (assert! (equal? 2 (seq-length s2)) "append length")
+    (assert! (not (seq-nil? s2)) "append non-nil")
+
+    (let v3 (from-just (seq-head (from-just (seq-tail s2) "cdr s2")) "cadr s2"))
+    (assert! (equal? 42 v3) "cadr s2 test")
+
+    (return ()))
+)

--- a/crucible-syntax/test-data/simulator-tests/seq-test1.out.good
+++ b/crucible-syntax/test-data/simulator-tests/seq-test1.out.good
@@ -1,0 +1,4 @@
+==== Begin Simulation ====
+
+==== Finish Simulation ====
+==== No proof obligations ====

--- a/crucible-syntax/test-data/simulator-tests/seq-test2.cbl
+++ b/crucible-syntax/test-data/simulator-tests/seq-test2.cbl
@@ -1,0 +1,47 @@
+(defun @main () Unit
+  (registers
+    ($s (Sequence Integer))
+  )
+
+  (start start:
+    (set-register! $s seq-nil)
+    (let b (fresh Bool))
+    (let x (fresh Integer))
+    (let y (fresh Integer))
+    (let z (fresh Integer))
+    (branch b l1: l2:))
+
+  (defblock l1:
+    (set-register! $s (seq-cons x (seq-cons y $s)))
+    (jump l3:)
+  )
+
+  (defblock l2:
+    (set-register! $s (seq-cons z $s))
+    (jump l3:)
+  )
+
+  (defblock l3:
+    (assert! (<= 1 (seq-length $s)) "length test")
+    (let u (from-just (seq-uncons $s) "uncons"))
+
+    (let v (if b x z))
+    (assert! (equal? v (get-field 0 u)) "head check")
+    (assert! (equal? (seq-nil? (get-field 1 u)) (not b)) "tail check")
+
+    (let mu2 (seq-uncons (get-field 1 u)))
+    (maybe-branch mu2 j: n:))
+
+  (defblock (j: u2 (Struct Integer (Sequence Integer)))
+    (let v2 (get-field 0 u2))
+    (let t2 (get-field 1 u2))
+    (assert! b "tail 2 condition check")
+    (assert! (equal? y v2) "tail 2 value test")
+    (assert! (seq-nil? t2) "tail 2 nil test")
+    (return ())
+  )
+
+  (defblock n:
+    (assert! (not b) "tail 2 none check")
+    (return ()))
+)

--- a/crucible-syntax/test-data/simulator-tests/seq-test2.out.good
+++ b/crucible-syntax/test-data/simulator-tests/seq-test2.out.good
@@ -1,0 +1,26 @@
+==== Begin Simulation ====
+
+==== Finish Simulation ====
+==== Proof obligations ====
+
+Prove:
+  test-data/simulator-tests/seq-test2.cbl:29:5: error: in main
+  head check
+  eq (ite cb@0:b cx@1:i cz@3:i) (ite cb@0:b cx@1:i cz@3:i)
+PROVED
+Assuming:
+* The branch in main from test-data/simulator-tests/seq-test2.cbl:33:5 to test-data/simulator-tests/seq-test2.cbl:36:13
+    cb@0:b
+Prove:
+  test-data/simulator-tests/seq-test2.cbl:38:5: error: in main
+  tail 2 condition check
+  cb@0:b
+PROVED
+Assuming:
+* The branch in main from test-data/simulator-tests/seq-test2.cbl:33:5 to test-data/simulator-tests/seq-test2.cbl:45:14
+    not cb@0:b
+Prove:
+  test-data/simulator-tests/seq-test2.cbl:45:5: error: in main
+  tail 2 none check
+  not cb@0:b
+PROVED

--- a/crucible-syntax/test-data/simulator-tests/seq-test3.cbl
+++ b/crucible-syntax/test-data/simulator-tests/seq-test3.cbl
@@ -1,0 +1,106 @@
+(defun @main () Unit
+  (registers
+    ($s1 (Sequence Integer))
+    ($s2 (Sequence Integer))
+  )
+
+  (start start:
+    (set-register! $s1 (seq-cons 42 seq-nil))
+    (set-register! $s2 seq-nil)
+
+    (let b1 (fresh Bool))
+    (let b2 (fresh Bool))
+    (let x (fresh Integer))
+    (let y (fresh Integer))
+    (let z (fresh Integer))
+    (let w (fresh Integer))
+
+    (branch b1 l1: l2:))
+
+  (defblock l1:
+    (set-register! $s1 (seq-cons x $s1))
+    (jump l3:)
+  )
+
+  (defblock l2:
+    (set-register! $s1 (seq-cons y $s1))
+    (jump l3:)
+  )
+
+  (defblock l3:
+    (branch b2 l4: l5:)
+  )
+
+
+  (defblock l4:
+    (set-register! $s2 (seq-cons z $s2))
+    (jump l6:)
+  )
+
+  (defblock l5:
+    (set-register! $s2 (seq-cons w $s2))
+    (jump l6:)
+  )
+
+  (defblock l6:
+    (let s (seq-append $s1 $s2))
+
+    (let _0 (funcall @eqseq s
+      (seq-cons (if b1 x y) (seq-cons 42 (seq-cons (if b2 z w) (seq-nil Integer))))))
+
+    (let u1 (from-just (seq-uncons s) "uncons 1"))
+    (let v1 (get-field 0 u1))
+    (let t1 (get-field 1 u1))
+
+    (let v1alt (from-just (seq-head s) "head 1"))
+    (assert! (equal? v1 v1alt) "head 1 eq check")
+    (assert! (equal? v1 (if b1 x y)) "head 1 check")
+
+    (let t1alt (from-just (seq-tail s) "tail 1"))
+    (let _1 (funcall @eqseq t1 t1alt))
+    (let _2 (funcall @eqseq t1 (seq-cons 42 (seq-cons (if b2 z w) (seq-nil Integer)))))
+
+    (let u2 (from-just (seq-uncons t1) "uncons 2"))
+    (let v2 (get-field 0 u2))
+    (let t2 (get-field 1 u2))
+
+    (let v2alt (from-just (seq-head t1) "head 2"))
+    (assert! (equal? v2 v2alt) "head 2 eq check")
+    (assert! (equal? v2 42) "head 2 check")
+
+    (let t2alt (from-just (seq-tail t1) "tail 2"))
+    (let _3 (funcall @eqseq t2 t2alt))
+    (let _4 (funcall @eqseq t2 (seq-cons (if b2 z w) (seq-nil Integer))))
+
+    (return ())
+  )
+)
+
+(defun @eqseq ( (xs (Sequence Integer)) (ys (Sequence Integer)) ) Unit
+  (registers
+    ($xs (Sequence Integer))
+    ($ys (Sequence Integer)))
+
+  (start st:
+    (set-register! $xs xs)
+    (set-register! $ys ys)
+    (jump loop:))
+
+  (defblock loop:
+    (maybe-branch (seq-uncons $xs) xsj: xsn:)
+  )
+
+  (defblock (xsj: uxs (Struct Integer (Sequence Integer)))
+    (let uys (from-just (seq-uncons $ys) "sequence length mismatch!"))
+    (assert! (equal? (get-field 0 uxs) (get-field 0 uys)) "value mismatch!")
+
+    (set-register! $xs (get-field 1 uxs))
+    (set-register! $ys (get-field 1 uys))
+    (jump loop:)
+  )
+
+  (defblock xsn:
+    (assert! (seq-nil? $ys) "sequence length mismatch!")
+    (return ())
+  )
+)

--- a/crucible-syntax/test-data/simulator-tests/seq-test3.out.good
+++ b/crucible-syntax/test-data/simulator-tests/seq-test3.out.good
@@ -1,0 +1,52 @@
+==== Begin Simulation ====
+
+==== Finish Simulation ====
+==== Proof obligations ====
+Assuming:
+Prove:
+  test-data/simulator-tests/seq-test3.cbl:95:5: error: in eqseq
+  value mismatch!
+  eq (ite cb1@0:b cx@2:i cy@3:i) (ite cb1@0:b cx@2:i cy@3:i)
+PROVED
+Assuming:
+Prove:
+  test-data/simulator-tests/seq-test3.cbl:95:5: error: in eqseq
+  value mismatch!
+  eq (ite cb2@1:b cz@4:i cw@5:i) (ite cb2@1:b cz@4:i cw@5:i)
+PROVED
+Assuming:
+Prove:
+  test-data/simulator-tests/seq-test3.cbl:56:5: error: in main
+  head 1 eq check
+  eq (ite cb1@0:b cx@2:i cy@3:i) (ite cb1@0:b cx@2:i cy@3:i)
+PROVED
+Assuming:
+Prove:
+  test-data/simulator-tests/seq-test3.cbl:57:5: error: in main
+  head 1 check
+  eq (ite cb1@0:b cx@2:i cy@3:i) (ite cb1@0:b cx@2:i cy@3:i)
+PROVED
+Assuming:
+Prove:
+  test-data/simulator-tests/seq-test3.cbl:95:5: error: in eqseq
+  value mismatch!
+  eq (ite cb2@1:b cz@4:i cw@5:i) (ite cb2@1:b cz@4:i cw@5:i)
+PROVED
+Assuming:
+Prove:
+  test-data/simulator-tests/seq-test3.cbl:95:5: error: in eqseq
+  value mismatch!
+  eq (ite cb2@1:b cz@4:i cw@5:i) (ite cb2@1:b cz@4:i cw@5:i)
+PROVED
+Assuming:
+Prove:
+  test-data/simulator-tests/seq-test3.cbl:95:5: error: in eqseq
+  value mismatch!
+  eq (ite cb2@1:b cz@4:i cw@5:i) (ite cb2@1:b cz@4:i cw@5:i)
+PROVED
+Assuming:
+Prove:
+  test-data/simulator-tests/seq-test3.cbl:95:5: error: in eqseq
+  value mismatch!
+  eq (ite cb2@1:b cz@4:i cw@5:i) (ite cb2@1:b cz@4:i cw@5:i)
+PROVED

--- a/crucible/crucible.cabal
+++ b/crucible/crucible.cabal
@@ -110,6 +110,7 @@ library
     Lang.Crucible.Simulator.RegMap
     Lang.Crucible.Simulator.RegValue
     Lang.Crucible.Simulator.SimError
+    Lang.Crucible.Simulator.SymSequence
     Lang.Crucible.Syntax
     Lang.Crucible.Types
     Lang.Crucible.Vector

--- a/crucible/src/Lang/Crucible/CFG/Expr.hs
+++ b/crucible/src/Lang/Crucible/CFG/Expr.hs
@@ -488,6 +488,50 @@ data App (ext :: Type) (f :: CrucibleType -> Type) (tp :: CrucibleType) where
                 -> App ext f (UnrollType nm ctx)
 
   ----------------------------------------------------------------------
+  -- Sequences
+
+  -- Create an empty sequence
+  SequenceNil :: !(TypeRepr tp) -> App ext f (SequenceType tp)
+
+  -- Add a new value to the front of a sequence
+  SequenceCons :: !(TypeRepr tp)
+               -> !(f tp)
+               -> !(f (SequenceType tp))
+               -> App ext f (SequenceType tp)
+
+  -- Append two sequences
+  SequenceAppend :: !(TypeRepr tp)
+                 -> !(f (SequenceType tp))
+                 -> !(f (SequenceType tp))
+                 -> App ext f (SequenceType tp)
+
+  -- Test if a sequence is nil
+  SequenceIsNil :: !(TypeRepr tp)
+                -> !(f (SequenceType tp))
+                -> App ext f BoolType
+
+  -- Return the length of a sequence
+  SequenceLength :: !(TypeRepr tp)
+                 -> !(f (SequenceType tp))
+                 -> App ext f NatType
+
+  -- Return the head of a sesquence, if it is non-nil.
+  SequenceHead :: !(TypeRepr tp)
+               -> !(f (SequenceType tp))
+               -> App ext f (MaybeType tp)
+
+  -- Return the tail of a sequence, if it is non-nil.
+  SequenceTail :: !(TypeRepr tp)
+               -> !(f (SequenceType tp))
+               -> App ext f (MaybeType (SequenceType tp))
+
+  -- Deconstruct a sequence.  Return nothing if nil,
+  -- return the head and tail if non-nil.
+  SequenceUncons :: !(TypeRepr tp)
+                 -> !(f (SequenceType tp))
+                 -> App ext f (MaybeType (StructType (EmptyCtx ::> tp ::> SequenceType tp)))
+
+  ----------------------------------------------------------------------
   -- Vector
 
   -- Vector literal.
@@ -1172,6 +1216,18 @@ instance TypeApp (ExprExtension ext) => TypeApp (App ext) where
     VectorGetEntry  tp _ _   -> tp
     VectorSetEntry  tp _ _ _ -> VectorRepr tp
     VectorCons      tp _ _   -> VectorRepr tp
+
+    ----------------------------------------------------------------------
+    -- Sequence
+    SequenceNil tpr -> SequenceRepr tpr
+    SequenceCons tpr _ _ -> SequenceRepr tpr
+    SequenceAppend tpr _ _ -> SequenceRepr tpr
+    SequenceIsNil _ _ -> knownRepr
+    SequenceHead tpr _ -> MaybeRepr tpr
+    SequenceUncons tpr _ ->
+      MaybeRepr (StructRepr (Ctx.Empty Ctx.:> tpr Ctx.:> SequenceRepr tpr))
+    SequenceLength{} -> knownRepr
+    SequenceTail tpr _ -> MaybeRepr (SequenceRepr tpr)
 
     ----------------------------------------------------------------------
     -- SymbolicArrayType

--- a/crucible/src/Lang/Crucible/Simulator/RegMap.hs
+++ b/crucible/src/Lang/Crucible/Simulator/RegMap.hs
@@ -233,6 +233,7 @@ muxRegForType s itefns p =
 
      MaybeRepr r          -> mergePartExpr s (muxRegForType s itefns r)
      VectorRepr r         -> muxVector s (muxRegForType s itefns r)
+     SequenceRepr _r      -> muxSymSequence s
      StringMapRepr r      -> muxStringMap s (muxRegForType s itefns r)
      SymbolicArrayRepr{}         -> arrayIte s
      SymbolicStructRepr{}        -> structIte s

--- a/crucible/src/Lang/Crucible/Simulator/RegValue.hs
+++ b/crucible/src/Lang/Crucible/Simulator/RegValue.hs
@@ -25,8 +25,6 @@ module Lang.Crucible.Simulator.RegValue
   ( RegValue
   , CanMux(..)
   , RegValue'(..)
-  , VariantBranch(..)
-  , injectVariant
   , MuxFn
 
     -- * Register values
@@ -34,6 +32,10 @@ module Lang.Crucible.Simulator.RegValue
   , FnVal(..)
   , fnValType
   , RolledType(..)
+  , SymSequence(..)
+
+  , VariantBranch(..)
+  , injectVariant
 
     -- * Value mux functions
   , ValMuxFn
@@ -44,6 +46,7 @@ module Lang.Crucible.Simulator.RegValue
   , muxStruct
   , muxVariant
   , muxVector
+  , muxSymSequence
   , muxHandle
   ) where
 
@@ -70,6 +73,7 @@ import           What4.WordMap
 import           Lang.Crucible.FunctionHandle
 import           Lang.Crucible.Simulator.Intrinsics
 import           Lang.Crucible.Simulator.SimError
+import           Lang.Crucible.Simulator.SymSequence
 import           Lang.Crucible.Types
 import           Lang.Crucible.Utils.MuxTree
 import           Lang.Crucible.Backend
@@ -87,6 +91,7 @@ type family RegValue (sym :: Type) (tp :: CrucibleType) :: Type where
   RegValue sym (FunctionHandleType a r) = FnVal sym a r
   RegValue sym (MaybeType tp) = PartExpr (Pred sym) (RegValue sym tp)
   RegValue sym (VectorType tp) = V.Vector (RegValue sym tp)
+  RegValue sym (SequenceType tp) = SymSequence sym (RegValue sym tp)
   RegValue sym (StructType ctx) = Ctx.Assignment (RegValue' sym) ctx
   RegValue sym (VariantType ctx) = Ctx.Assignment (VariantBranch sym) ctx
   RegValue sym (ReferenceType tp) = MuxTree sym (RefCell tp)

--- a/crucible/src/Lang/Crucible/Simulator/SymSequence.hs
+++ b/crucible/src/Lang/Crucible/Simulator/SymSequence.hs
@@ -1,0 +1,302 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Lang.Crucible.Simulator.SymSequence
+( SymSequence(..)
+, nilSymSequence
+, consSymSequence
+, appendSymSequence
+, muxSymSequence
+, isNilSymSequence
+, lengthSymSequence
+, headSymSequence
+, tailSymSequence
+, unconsSymSequence
+) where
+
+import           Data.Functor.Const
+import           Data.Kind (Type)
+import           Data.IORef
+import           Data.Maybe (isJust)
+import           Data.Parameterized.Nonce
+import qualified Data.Parameterized.Map as MapF
+
+import           Lang.Crucible.Types
+import           What4.Interface
+import           What4.Partial
+
+------------------------------------------------------------------------
+-- SymSequence
+
+data SymSequence sym a where
+  SymSequenceNil :: SymSequence sym a
+  SymSequenceCons ::
+    Nonce GlobalNonceGenerator a ->
+    a ->
+    SymSequence sym a ->
+    SymSequence sym a
+
+  SymSequenceAppend ::
+    Nonce GlobalNonceGenerator a ->
+    SymSequence sym a ->
+    SymSequence sym a ->
+    SymSequence sym a
+
+  SymSequenceMerge ::
+    Nonce GlobalNonceGenerator a ->
+    Pred sym ->
+    SymSequence sym a ->
+    SymSequence sym a ->
+    SymSequence sym a
+
+instance Eq (SymSequence sym a) where
+  SymSequenceNil == SymSequenceNil = True
+  (SymSequenceCons n1 _ _) == (SymSequenceCons n2 _ _) =
+    isJust (testEquality n1 n2)
+  (SymSequenceMerge n1 _ _ _) == (SymSequenceMerge n2 _ _ _) =
+    isJust (testEquality n1 n2)
+  (SymSequenceAppend n1 _ _) == (SymSequenceAppend n2 _ _) =
+    isJust (testEquality n1 n2)
+  _ == _ = False
+
+muxSymSequence :: IsExprBuilder sym =>
+  sym ->
+  Pred sym ->
+  SymSequence sym a ->
+  SymSequence sym a ->
+  IO (SymSequence sym a)
+muxSymSequence _sym p x y
+  | x == y = pure x
+  | otherwise =
+      do n <- freshNonce globalNonceGenerator
+         pure (SymSequenceMerge n p x y)
+
+newtype SeqCache (f :: Type -> Type)
+  = SeqCache (IORef (MapF.MapF (Nonce GlobalNonceGenerator) f))
+
+newSeqCache :: IO (SeqCache f)
+newSeqCache = SeqCache <$> newIORef MapF.empty
+
+symSequenceNonce :: SymSequence sym a -> Maybe (Nonce GlobalNonceGenerator a)
+symSequenceNonce SymSequenceNil = Nothing
+symSequenceNonce (SymSequenceCons n _ _ ) = Just n
+symSequenceNonce (SymSequenceAppend n _ _) = Just n
+symSequenceNonce (SymSequenceMerge n _ _ _) = Just n
+
+evalWithFreshCache ::
+  ((SymSequence sym a -> IO (f a)) -> SymSequence sym a -> IO (f a)) ->
+  (SymSequence sym a -> IO (f a))
+evalWithFreshCache fn s =
+  do c <- newSeqCache
+     evalWithCache c fn s
+
+evalWithCache ::
+  SeqCache f ->
+  ((SymSequence sym a -> IO (f a)) -> SymSequence sym a -> IO (f a)) ->
+  (SymSequence sym a -> IO (f a))
+evalWithCache (SeqCache ref) fn = loop
+  where
+    loop s
+      | Just n <- symSequenceNonce s =
+          (MapF.lookup n <$> readIORef ref) >>= \case
+            Just v -> pure v
+            Nothing ->
+              do v <- fn loop s
+                 modifyIORef ref (MapF.insert n v)
+                 pure v
+
+      | otherwise = fn loop s
+
+nilSymSequence :: sym -> IO (SymSequence sym a)
+nilSymSequence _sym = pure SymSequenceNil
+
+consSymSequence ::
+  sym ->
+  a ->
+  SymSequence sym a ->
+  IO (SymSequence sym a)
+consSymSequence _sym x xs =
+  do n <- freshNonce globalNonceGenerator
+     pure (SymSequenceCons n x xs)
+
+appendSymSequence ::
+  sym ->
+  SymSequence sym a ->
+  SymSequence sym a ->
+  IO (SymSequence sym a)
+
+-- special cases, nil is the unit for append
+appendSymSequence _ xs SymSequenceNil = pure xs
+appendSymSequence _ SymSequenceNil ys = pure ys
+-- special case, append of a singleton is cons
+appendSymSequence sym (SymSequenceCons _ v SymSequenceNil) xs =
+  consSymSequence sym v xs
+appendSymSequence _sym xs ys =
+  do n <- freshNonce globalNonceGenerator
+     pure (SymSequenceAppend n xs ys)
+
+
+isNilSymSequence :: forall sym a.
+  IsExprBuilder sym =>
+  sym ->
+  SymSequence sym a ->
+  IO (Pred sym)
+isNilSymSequence sym = \s -> getConst <$> evalWithFreshCache f s
+  where
+   f :: (SymSequence sym tp -> IO (Const (Pred sym) tp)) -> (SymSequence sym tp -> IO (Const (Pred sym) tp))
+   f _loop SymSequenceNil{}  = pure (Const (truePred sym))
+   f _loop SymSequenceCons{} = pure (Const (falsePred sym))
+   f loop (SymSequenceAppend _ xs ys) =
+     do px <- getConst <$> loop xs
+        Const <$> itePredM sym px (getConst <$> loop ys) (pure (falsePred sym))
+   f loop (SymSequenceMerge _ p xs ys) =
+     Const <$> itePredM sym p (getConst <$> loop xs) (getConst <$> loop ys)
+
+
+lengthSymSequence :: forall sym a.
+  IsExprBuilder sym =>
+  sym ->
+  SymSequence sym a ->
+  IO (SymNat sym)
+lengthSymSequence sym = \s -> getConst <$> evalWithFreshCache f s
+  where
+   f :: (SymSequence sym a -> IO (Const (SymNat sym) a)) -> (SymSequence sym a -> IO (Const (SymNat sym) a))
+   f _loop SymSequenceNil = Const <$> natLit sym 0
+   f loop (SymSequenceCons _ _ tl) =
+     do x <- getConst <$> loop tl
+        one <- natLit sym 1
+        Const <$> natAdd sym one x
+   f loop (SymSequenceMerge _ p xs ys) =
+     do x <- getConst <$> loop xs
+        y <- getConst <$> loop ys
+        Const <$> natIte sym p x y
+   f loop (SymSequenceAppend _ xs ys) =
+     do x <- getConst <$> loop xs
+        y <- getConst <$> loop ys
+        Const <$> natAdd sym x y
+
+
+newtype SeqHead sym a = SeqHead { getSeqHead :: PartExpr (Pred sym) a }
+
+headSymSequence :: forall sym a.
+  IsExprBuilder sym =>
+  sym ->
+  (Pred sym -> a -> a -> IO a) ->
+  SymSequence sym a ->
+  IO (PartExpr (Pred sym) a)
+headSymSequence sym mux = \s -> getSeqHead <$> evalWithFreshCache f s
+  where
+   f' :: Pred sym -> a -> a -> PartialT sym IO a
+   f' c x y = PartialT (\_ p -> PE p <$> mux c x y)
+
+   f :: (SymSequence sym a -> IO (SeqHead sym a)) -> (SymSequence sym a -> IO (SeqHead sym a))
+   f _loop SymSequenceNil = pure (SeqHead Unassigned)
+   f _loop (SymSequenceCons _ v _) = pure (SeqHead (justPartExpr sym v))
+   f loop (SymSequenceMerge _ p xs ys) =
+     do mhx <- getSeqHead <$> loop xs
+        mhy <- getSeqHead <$> loop ys
+        SeqHead <$> mergePartial sym f' p mhx mhy
+
+   f loop (SymSequenceAppend _ xs ys) =
+     loop xs >>= \case
+       SeqHead Unassigned -> loop ys
+       SeqHead (PE px hx)
+         | Just True <- asConstantPred px -> pure (SeqHead (PE px hx))
+         | otherwise ->
+             loop ys >>= \case
+               SeqHead Unassigned -> pure (SeqHead (PE px hx))
+               SeqHead (PE py hy) ->
+                 do p <- orPred sym px py
+                    SeqHead <$> runPartialT sym p (f' px hx hy)
+
+newtype SeqUncons sym a =
+  SeqUncons
+  { getSeqUncons :: PartExpr (Pred sym) (a, SymSequence sym a)
+  }
+
+unconsSymSequence :: forall sym a.
+  IsExprBuilder sym =>
+  sym ->
+  (Pred sym -> a -> a -> IO a) ->
+  SymSequence sym a ->
+  IO (PartExpr (Pred sym) (a, SymSequence sym a))
+unconsSymSequence sym mux = \s -> getSeqUncons <$> evalWithFreshCache f s
+  where
+   f' :: Pred sym ->
+         (a, SymSequence sym a) ->
+         (a, SymSequence sym a) ->
+         PartialT sym IO (a, SymSequence sym a)
+   f' c x y = PartialT $ \_ p -> PE p <$> 
+                    do h  <- mux c (fst x) (fst y)
+                       tl <- muxSymSequence sym c (snd x) (snd y)
+                       pure (h, tl)
+
+   f :: (SymSequence sym a -> IO (SeqUncons sym a)) -> (SymSequence sym a -> IO (SeqUncons sym a))
+   f _loop SymSequenceNil = pure (SeqUncons Unassigned)
+   f _loop (SymSequenceCons _ v tl) = pure (SeqUncons (justPartExpr sym (v, tl)))
+   f loop (SymSequenceMerge _ p xs ys) =
+     do ux <- getSeqUncons <$> loop xs
+        uy <- getSeqUncons <$> loop ys
+        SeqUncons <$> mergePartial sym f' p ux uy
+
+   f loop (SymSequenceAppend _ xs ys) =
+     loop xs >>= \case
+       SeqUncons Unassigned -> loop ys
+       SeqUncons (PE px ux)
+         | Just True <- asConstantPred px ->
+             do t <- appendSymSequence sym (snd ux) ys
+                pure (SeqUncons (PE px (fst ux, t)))
+
+         | otherwise ->
+             loop ys >>= \case
+               SeqUncons Unassigned -> pure (SeqUncons (PE px ux))
+               SeqUncons (PE py uy) ->
+                 do p <- orPred sym px py
+                    t <- appendSymSequence sym (snd ux) ys
+                    let ux' = (fst ux, t)
+                    SeqUncons <$> runPartialT sym p (f' px ux' uy)
+
+newtype SeqTail sym tp =
+  SeqTail
+  { getSeqTail :: PartExpr (Pred sym) (SymSequence sym tp) }
+
+tailSymSequence :: forall sym a.
+  IsExprBuilder sym =>
+  sym ->
+  SymSequence sym a ->
+  IO (PartExpr (Pred sym) (SymSequence sym a))
+tailSymSequence sym = \s -> getSeqTail <$> evalWithFreshCache f s
+  where
+   f' :: Pred sym ->
+         SymSequence sym a ->
+         SymSequence sym a ->
+         PartialT sym IO (SymSequence sym a)
+   f' c x y = PartialT $ \_ p -> PE p <$> muxSymSequence sym c x y
+
+   f :: (SymSequence sym a -> IO (SeqTail sym a)) -> (SymSequence sym a -> IO (SeqTail sym a))
+   f _loop SymSequenceNil = pure (SeqTail Unassigned)
+   f _loop (SymSequenceCons _ _v tl) = pure (SeqTail (justPartExpr sym tl))
+   f loop (SymSequenceMerge _ p xs ys) =
+     do tx <- getSeqTail <$> loop xs
+        ty <- getSeqTail <$> loop ys
+        SeqTail <$> mergePartial sym f' p tx ty
+   f loop (SymSequenceAppend _ xs ys) =
+     loop xs >>= \case
+       SeqTail Unassigned -> loop ys
+       SeqTail (PE px tx)
+         | Just True <- asConstantPred px ->
+             do t <- appendSymSequence sym tx ys
+                pure (SeqTail (PE px t))
+
+         | otherwise ->
+             loop ys >>= \case
+               SeqTail Unassigned -> pure (SeqTail (PE px tx))
+               SeqTail (PE py ty) ->
+                 do p <- orPred sym px py
+                    t <- appendSymSequence sym tx ys
+                    SeqTail <$> runPartialT sym p (f' px t ty)

--- a/crucible/src/Lang/Crucible/Types.hs
+++ b/crucible/src/Lang/Crucible/Types.hs
@@ -64,6 +64,7 @@ module Lang.Crucible.Types
   , RecursiveType
   , IntrinsicType
   , VectorType
+  , SequenceType
   , StructType
   , VariantType
   , ReferenceType
@@ -165,8 +166,17 @@ data CrucibleType where
 
    -- The Maybe type lifted into crucible expressions
    MaybeType :: CrucibleType -> CrucibleType
-   -- A finite (one-dimensional) sequence of values
+
+   -- A finite (one-dimensional) sequence of values.  Vectors are
+   -- optimized for random-access indexing and updating.  Vectors
+   -- of different lengths may not be combined at join points.
    VectorType :: CrucibleType -> CrucibleType
+
+   -- Sequences of values, represented as linked lists of cons cells.  Sequences
+   -- only allow access to the front. Unlike Vectors, sequences of
+   -- different lengths may be combined at join points.
+   SequenceType :: CrucibleType -> CrucibleType
+
    -- A structure is an aggregate type consisting of a sequence of values.
    -- The type of each value is known statically.
    StructType :: Ctx CrucibleType -> CrucibleType
@@ -183,7 +193,7 @@ data CrucibleType where
    WordMapType :: Nat -> BaseType -> CrucibleType
 
    -- Named recursive types, named by the given symbol.  To use recursive types
-   -- you must provide an instances of the IsRecursiveType class that gives
+   -- you must provide an instance of the IsRecursiveType class that gives
    -- the unfolding of this recursive type.  The RollRecursive and UnrollRecursive
    -- operations witness the isomorphism between a recursive type and its one-step
    -- unrolling.  Similar to Haskell's newtype, recursive types do not necessarily
@@ -191,11 +201,13 @@ data CrucibleType where
    -- is simply a new named type which is isomorphic to its definition.
    RecursiveType :: Symbol -> Ctx CrucibleType -> CrucibleType
 
-   -- Named intrinsic types.  Intrinsic types are a way to extend the crucible
-   -- type system after-the-fact and add new type implementations.
-   -- Core crucible provides no operations on intrinsic types; they must be provided
-   -- as built-in override functions.  See the `IntrinsicClass` typeclass
-   -- and the `Intrinsic` type family defined in "Lang.Crucible.Simulator.Intrinsics".
+   -- Named intrinsic types.  Intrinsic types are a way to extend the
+   -- crucible type system after-the-fact and add new type
+   -- implementations.  Core crucible provides no operations on
+   -- intrinsic types; they must be provided as built-in override
+   -- functions, or via the language extension mechanism.  See the
+   -- `IntrinsicClass` typeclass and the `Intrinsic` type family
+   -- defined in "Lang.Crucible.Simulator.Intrinsics".
    --
    -- The context of crucible types are type arguments to the intrinsic type.
    IntrinsicType :: Symbol -> Ctx CrucibleType -> CrucibleType
@@ -273,8 +285,15 @@ type NatType       = 'NatType       -- ^ @:: 'CrucibleType'@.
 -- | A variant is a disjoint union of the types listed in the context.
 type VariantType   = 'VariantType   -- ^ @:: 'Ctx' 'CrucibleType' -> 'CrucibleType'@.
 
--- | A finite (one-dimensional) sequence of values.
+-- | A finite (one-dimensional) sequence of values.  Vectors are
+-- optimized for random-access indexing and updating.  Vectors
+-- of different lengths may not be combined at join points.
 type VectorType    = 'VectorType    -- ^ @:: 'CrucibleType' -> 'CrucibleType'@.
+
+-- | Sequences of values, represented as linked lists of cons cells.  Sequences
+-- only allow access to the front. Unlike Vectors, sequences of
+-- different lengths may be combined at join points.
+type SequenceType  = 'SequenceType  -- ^ @:: 'CrucibleType' -> 'CrucibleType'@.
 
 -- | A finite map from bitvector values to the given Crucible type.
 -- The 'Nat' index gives the width of the bitvector values used to
@@ -354,11 +373,12 @@ data TypeRepr (tp::CrucibleType) where
                       -> !(TypeRepr ret)
                       -> TypeRepr (FunctionHandleType ctx ret)
 
-   MaybeRepr   :: !(TypeRepr tp) -> TypeRepr (MaybeType   tp)
-   VectorRepr  :: !(TypeRepr tp) -> TypeRepr (VectorType  tp)
-   StructRepr  :: !(CtxRepr ctx) -> TypeRepr (StructType  ctx)
+   MaybeRepr   :: !(TypeRepr tp) -> TypeRepr (MaybeType tp)
+   SequenceRepr:: !(TypeRepr tp) -> TypeRepr (SequenceType tp)
+   VectorRepr  :: !(TypeRepr tp) -> TypeRepr (VectorType tp)
+   StructRepr  :: !(CtxRepr ctx) -> TypeRepr (StructType ctx)
    VariantRepr :: !(CtxRepr ctx) -> TypeRepr (VariantType ctx)
-   ReferenceRepr :: TypeRepr a -> TypeRepr (ReferenceType a)
+   ReferenceRepr :: !(TypeRepr a) -> TypeRepr (ReferenceType a)
 
    WordMapRepr :: (1 <= n)
                => !(NatRepr n)
@@ -417,6 +437,9 @@ instance KnownRepr FloatPrecisionRepr ps => KnownRepr TypeRepr (IEEEFloatType ps
 
 instance KnownRepr TypeRepr tp => KnownRepr TypeRepr (VectorType tp) where
   knownRepr = VectorRepr knownRepr
+
+instance KnownRepr TypeRepr tp => KnownRepr TypeRepr (SequenceType tp) where
+  knownRepr = SequenceRepr knownRepr
 
 instance KnownRepr TypeRepr tp => KnownRepr TypeRepr (MaybeType tp) where
   knownRepr = MaybeRepr knownRepr


### PR DESCRIPTION
Add a new `Sequence` type to crucible.

This will be used to implement the event log needed to close #587.  It may also prove helpful when we eventualy refactor the LLVM memory model.