### PR TITLE
Refactor `IsSymInterface` (attempt 1)

### DIFF
--- a/crucible-concurrency/crucibles/Main.hs
+++ b/crucible-concurrency/crucibles/Main.hs
@@ -9,9 +9,9 @@
 {-# LANGUAGE ImplicitParams #-}
 module Main where
 
-import qualified Data.Text.IO as T
-import qualified Options.Applicative.Simple as Opts
-import           System.IO
+--import qualified Data.Text.IO as T
+--import qualified Options.Applicative.Simple as Opts
+--import           System.IO
 
 import qualified Crux
 import Cruces.CrucesMain

--- a/crucible-concurrency/src/Crucibles/Explore.hs
+++ b/crucible-concurrency/src/Crucibles/Explore.hs
@@ -554,7 +554,7 @@ returnFinishedResult mres =
          do sym <- use (stateContext.ctxSymInterface)
             loc <- liftIO $ getCurrentProgramLoc sym
             let simerr = SimError loc "<deadlock>"
-            let err = LabeledPred (falsePred sym) simerr
+            let err = LabeledPred (falsePred sym) (AssertionReason False simerr)
             liftIO $ addProofObligation sym err
             s <- get
             liftIO $

--- a/crucible-go/src/Lang/Crucible/Go/Overrides.hs
+++ b/crucible-go/src/Lang/Crucible/Go/Overrides.hs
@@ -111,9 +111,10 @@ do_assert = do
   sym <- C.getSymInterface
   RegMap (Empty :> mgs :> file :> b) <- C.getOverrideArgs
   loc <- liftIO $ W4.getCurrentProgramLoc sym
-  liftIO $ addDurableAssertion sym (LabeledPred (regValue b)
-                                    (C.SimError loc $ C.AssertFailureSimError
-                                     "assertion_failure" ""))
+  liftIO $ addAssertion sym (LabeledPred (regValue b)
+                             (AssertionReason True -- N.B. durable assertion
+                              (C.SimError loc $ C.AssertFailureSimError
+                                     "assertion_failure" "")))
   return Ctx.empty
 
 go_overrides :: (IsSymInterface sym, 1 <= w)

--- a/crucible-llvm/crucible-llvm.cabal
+++ b/crucible-llvm/crucible-llvm.cabal
@@ -95,6 +95,7 @@ library
     Lang.Crucible.LLVM.Intrinsics.LLVM
     Lang.Crucible.LLVM.MemModel.Common
     Lang.Crucible.LLVM.MemModel.MemLog
+    Lang.Crucible.LLVM.MemModel.Monad
     Lang.Crucible.LLVM.MemModel.Options
     Lang.Crucible.LLVM.MemModel.Type
     Lang.Crucible.LLVM.MemModel.Value

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Errors/MemoryError.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Errors/MemoryError.hs
@@ -22,6 +22,7 @@ module Lang.Crucible.LLVM.Errors.MemoryError
 , details
 , ppMemoryError
 , MemoryOp(..)
+, descMemoryOp
 , ppMemoryOp
 , MemoryErrorReason(..)
 , ppMemoryErrorReason
@@ -87,6 +88,16 @@ ppGSym :: Maybe String -> [Doc ann]
 ppGSym Nothing = []
 ppGSym (Just nm) = [ "Global symbol", viaShow nm ]
 
+-- | A short description of a memory operation
+descMemoryOp :: MemoryOp sym w -> String
+descMemoryOp MemLoadOp{}       = "memory load"
+descMemoryOp MemStoreOp{}      = "memory store"
+descMemoryOp MemStoreBytesOp{} = "memory byte array store"
+descMemoryOp MemCopyOp{}       = "memory copy"
+descMemoryOp MemLoadHandleOp{} = "function handle load"
+descMemoryOp MemInvalidateOp{} = "memory invalidation"
+
+-- | A detailed description of a memory operation
 ppMemoryOp :: IsExpr (SymExpr sym) => MemoryOp sym w -> Doc ann
 ppMemoryOp (MemLoadOp tp gsym ptr mem)  =
   vsep [ "Performing overall load at type:" <+> ppType tp

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
@@ -440,7 +440,7 @@ evalStmt sym = eval
              do p <- Partial.annotateME sym mop (BadFunctionPointer doc) (falsePred sym)
                 loc <- getCurrentProgramLoc sym
                 let err = SimError loc (AssertFailureSimError "Failed to load function handle" (show doc))
-                addProofObligation sym (LabeledPred p err)
+                addProofObligation sym (LabeledPred p (AssertionReason False err))
                 abortExecBecause $ AssumedFalse $ AssumingNoError err
 
            Right (VarargsFnHandle h) ->

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Monad.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Monad.hs
@@ -1,0 +1,137 @@
+------------------------------------------------------------------------
+-- |
+-- Module           : Lang.Crucible.LLVM.MemModel.Monad
+-- Description      : Monad for organizing memory model operations
+-- Copyright        : (c) Galois, Inc 2021
+-- License          : BSD3
+-- Maintainer       : Rob Dockins <rdockins@galois.com>
+-- Stability        : provisional
+--
+------------------------------------------------------------------------
+
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StrictData #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Lang.Crucible.LLVM.MemModel.Monad
+( MM
+, runMM
+, overrideMM
+, MMAssertReason(..)
+, MMAssertion
+, annotateMMPred
+, mmFailedAssertion
+, mmAssert
+, mmAssertUndefined
+, mmAssertMemError
+) where
+
+import           Control.Lens ( (^.), to )
+import           Control.Monad.Trans
+import           Control.Monad.Trans.Except
+import           Control.Monad.Trans.Writer
+
+import           Lang.Crucible.Backend
+import           Lang.Crucible.Simulator.RegValue
+import           Lang.Crucible.Simulator.SimError
+import qualified Lang.Crucible.Simulator.OverrideSim as OSim
+import           Lang.Crucible.LLVM.Errors
+import qualified Lang.Crucible.LLVM.Errors.MemoryError as ME
+import qualified Lang.Crucible.LLVM.Errors.UndefinedBehavior as UB
+import           Lang.Crucible.LLVM.MemModel.Partial
+
+import           What4.Interface
+import           What4.ProgramLoc
+
+type MMAssertion sym = LabeledPred (Pred sym) (MMAssertReason sym)
+
+data MMAssertReason sym
+  = MMAssertError SimErrorReason
+  | MMAssertMemError (MemoryError sym)
+  | MMAssertUB (UB.UndefinedBehavior (RegValue' sym))
+
+newtype MM sym a = MM (WriterT [MMAssertion sym] (ExceptT (MMAssertReason sym) IO) a)
+  deriving (Applicative, Functor, Monad, MonadIO)
+
+runMM :: MM sym a -> IO (Either (MMAssertReason sym) (a, [MMAssertion sym]))
+runMM (MM m) = runExceptT (runWriterT m)
+
+overrideMM :: (IsExprBuilder sym, HasLLVMAnn sym) => MM sym a -> OSim.OverrideSim p sym ext rtp args res a
+overrideMM mm =
+  do sym <- OSim.getSymInterface
+     loc <- liftIO (getCurrentProgramLoc sym)
+     liftIO (runMM mm) >>= \case
+       Left rsn ->
+         do a <- liftIO (annotateMMPred sym loc (falsePred sym) rsn)
+            OSim.overrideAssertions [a]
+            OSim.overrideAbort
+              (AssumedFalse (AssumingNoError (a ^. labeledPredMsg . to assertionSimError)))
+
+       Right (x, asserts) ->
+         do asserts' <- liftIO (mapM (annotateMMAssert sym loc) asserts)
+            OSim.overrideAssertions asserts'
+            return x
+
+annotateMMAssert :: (IsExprBuilder sym, HasLLVMAnn sym) =>
+  sym ->
+  ProgramLoc ->
+  MMAssertion sym ->
+  IO (Assertion sym)
+annotateMMAssert sym loc (LabeledPred p rsn) = annotateMMPred sym loc p rsn
+
+annotateMMPred :: (IsExprBuilder sym, HasLLVMAnn sym) =>
+  sym ->
+  ProgramLoc ->
+  Pred sym ->
+  MMAssertReason sym ->
+  IO (Assertion sym)
+annotateMMPred _ loc p (MMAssertError err) =
+  return (LabeledPred p (AssertionReason False (SimError loc err)))
+  
+annotateMMPred sym loc p (MMAssertMemError merr@(MemoryError mop _)) =
+  do (n, p') <- annotateTerm sym p
+     ?recordLLVMAnnotation (BoolAnn n) (BBMemoryError merr)
+     let msg = "Error performing " ++ ME.descMemoryOp mop
+     let err = AssertFailureSimError msg ""
+     return (LabeledPred p' (AssertionReason False (SimError loc err)))
+
+annotateMMPred sym loc p (MMAssertUB ub) =
+  do (n, p') <- annotateTerm sym p
+     ?recordLLVMAnnotation (BoolAnn n) (BBUndefinedBehavior ub)
+     let err = AssertFailureSimError "Undefined behavior encountered" (show (UB.explain ub))
+     return (LabeledPred p' (AssertionReason False (SimError loc err)))
+
+
+mmFailedAssertion :: MMAssertReason sym -> MM sym a
+mmFailedAssertion rsn = MM (lift (throwE rsn))
+
+mmAssert :: IsExprBuilder sym => Pred sym -> MMAssertReason sym -> MM sym ()
+mmAssert p rsn
+  | Just False <- asConstantPred p = mmFailedAssertion rsn
+  | otherwise = MM (tell [LabeledPred p rsn])
+
+mmAssertUndefined :: IsExprBuilder sym => Pred sym -> UB.UndefinedBehavior (RegValue' sym) -> MM sym ()
+mmAssertUndefined p ub = mmAssert p (MMAssertUB ub)
+
+mmAssertMemError :: (IsExprBuilder sym, 1 <= w) =>
+  Pred sym ->
+  ME.MemoryOp sym w ->
+  ME.MemoryErrorReason sym w ->
+  MM sym ()
+mmAssertMemError p mop rsn = mmAssert p (MMAssertMemError (MemoryError mop rsn))

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Partial.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Partial.hs
@@ -331,7 +331,7 @@ assertSafe sym (Err p) = do
   do let rsn = AssertFailureSimError "Error during memory load" ""
      loc <- getCurrentProgramLoc sym
      let err = SimError loc rsn
-     addProofObligation sym (LabeledPred p err)
+     addProofObligation sym (LabeledPred p (AssertionReason False err))
      abortExecBecause $ AssumedFalse $ AssumingNoError err
 
 

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Pointer.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Pointer.hs
@@ -74,6 +74,7 @@ module Lang.Crucible.LLVM.MemModel.Pointer
   ) where
 
 import           Control.Monad (guard)
+import           Control.Monad.Trans (lift)
 import           Data.Map (Map)
 import qualified Data.Map as Map (lookup)
 import           Numeric.Natural
@@ -126,7 +127,7 @@ data SomePointer sym = forall w. (1 <= w) => SomePointer !(LLVMPtr sym w)
 instance (IsSymInterface sym) => IntrinsicClass sym "LLVM_pointer" where
   type Intrinsic sym "LLVM_pointer" ctx = LLVMPointerImpl sym ctx
 
-  muxIntrinsic sym _iTypes _nm (Ctx.Empty Ctx.:> (BVRepr _w)) = muxLLVMPtr sym
+  muxIntrinsic sym _iTypes _nm (Ctx.Empty Ctx.:> (BVRepr _w)) = \c x y -> lift (muxLLVMPtr sym c x y)
   muxIntrinsic _ _ nm ctx = typeError nm ctx
 
 -- | Alternative to the 'LLVMPointer' pattern synonym, this function can be used as a view

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Monad.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Monad.hs
@@ -68,7 +68,6 @@ import           Lang.Crucible.LLVM.MemType
 import           Lang.Crucible.LLVM.Translation.Types
 import           Lang.Crucible.LLVM.TypeContext
 
-import           Lang.Crucible.FunctionHandle
 import           Lang.Crucible.Types
 
 ------------------------------------------------------------------------

--- a/crucible-syntax/src/Lang/Crucible/Syntax/Overrides.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Overrides.hs
@@ -56,7 +56,8 @@ proveObligations =
             gl <- notPred sym ((proofGoal o)^.labeledPred)
             let logData = defaultLogData { logCallbackVerbose = \_ -> hPutStrLn h
                                          , logReason = "assertion proof" }
+            let msg = show $ ppSimError $ assertionSimError $ (proofGoal o)^.labeledPredMsg
             runZ3InOverride sym logData (asms ++ [gl]) $ \case
-              Unsat{}  -> hPutStrLn h $ unlines ["Proof Succeeded!", show $ ppSimError $ (proofGoal o)^.labeledPredMsg]
-              Sat _mdl -> hPutStrLn h $ unlines ["Proof failed!", show $ ppSimError $ (proofGoal o)^.labeledPredMsg]
-              Unknown  -> hPutStrLn h $ unlines ["Proof inconclusive!", show $ ppSimError $ (proofGoal o)^.labeledPredMsg]
+              Unsat{}  -> hPutStrLn h $ unlines ["Proof Succeeded!", msg]
+              Sat _mdl -> hPutStrLn h $ unlines ["Proof failed!", msg]
+              Unknown  -> hPutStrLn h $ unlines ["Proof inconclusive!", msg]

--- a/crucible-wasm/src/Lang/Crucible/Wasm/Memory.hs
+++ b/crucible-wasm/src/Lang/Crucible/Wasm/Memory.hs
@@ -12,6 +12,7 @@
 
 module Lang.Crucible.Wasm.Memory where
 
+import Control.Monad.Trans( lift )
 import Data.Bits
 import qualified Data.BitVector.Sized as BV
 import qualified Data.ByteString.Lazy as LBS
@@ -266,8 +267,8 @@ instance IsSymInterface sym => IntrinsicClass sym "Wasm_Mem" where
   muxIntrinsic sym _ _nm _ctx p mem1 mem2 =
     do let WasmMemImpl heap1 sz1 mx1 = mem1
        let WasmMemImpl heap2 sz2 mx2 = mem2
-       sz <- bvIte sym p sz1 sz2
-       mx <- bvIte sym p mx1 mx2
+       sz <- lift (bvIte sym p sz1 sz2)
+       mx <- lift (bvIte sym p mx1 mx2)
        return $ WasmMemImpl (G.mergeMem p heap1 heap2) sz mx
 
   pushBranchIntrinsic _sym _iTypes _nm _ctx mem =

--- a/crucible/src/Lang/Crucible/Backend/Online.hs
+++ b/crucible/src/Lang/Crucible/Backend/Online.hs
@@ -110,7 +110,6 @@ import qualified What4.Solver.Z3 as Z3
 import           Lang.Crucible.Backend
 import           Lang.Crucible.Backend.AssumptionStack as AS
 import qualified Lang.Crucible.Backend.ProofGoals as PG
-import           Lang.Crucible.Simulator.SimError
 
 data UnsatFeatures
   = NoUnsatFeatures
@@ -305,7 +304,7 @@ data SolverState scope solver =
 -- It contains the current assertions and program location.
 data OnlineBackendState solver userState scope = OnlineBackendState
   { assumptionStack ::
-      !(AssumptionStack (B.BoolExpr scope) AssumptionReason SimError)
+      !(AssumptionStack (B.BoolExpr scope) AssumptionReason AssertionReason)
       -- ^ Number of times we have pushed
   , solverProc :: !(IORef (SolverState scope solver))
     -- ^ The solver process, if any.
@@ -337,7 +336,7 @@ initialOnlineBackendState gen feats ust =
 
 getAssumptionStack ::
   OnlineBackendUserSt scope solver userSt fs ->
-  IO (AssumptionStack (B.BoolExpr scope) AssumptionReason SimError)
+  IO (AssumptionStack (B.BoolExpr scope) AssumptionReason AssertionReason)
 getAssumptionStack sym = pure (assumptionStack (B.sbUserState sym))
 
 
@@ -371,7 +370,7 @@ resetSolverProcess' st = do
 
 restoreSolverState ::
   OnlineSolver solver =>
-  AS.LabeledGoalCollector (B.BoolExpr scope) AssumptionReason SimError ->
+  AS.LabeledGoalCollector (B.BoolExpr scope) AssumptionReason AssertionReason ->
   OnlineBackendState solver userSt scope ->
   IO ()
 restoreSolverState gc st =

--- a/crucible/src/Lang/Crucible/Backend/Simple.hs
+++ b/crucible/src/Lang/Crucible/Backend/Simple.hs
@@ -40,7 +40,6 @@ import qualified What4.Expr.Builder as B
 
 import qualified Lang.Crucible.Backend.AssumptionStack as AS
 import           Lang.Crucible.Backend
-import           Lang.Crucible.Simulator.SimError
 
 type SimpleBackend t fs = B.ExprBuilder t SimpleBackendState fs
 
@@ -51,7 +50,7 @@ type SimpleBackend t fs = B.ExprBuilder t SimpleBackendState fs
 -- It contains the current assertion stack.
 
 newtype SimpleBackendState t
-      = SimpleBackendState { sbAssumptionStack :: AssumptionStack (B.BoolExpr t) AssumptionReason SimError }
+      = SimpleBackendState { sbAssumptionStack :: AssumptionStack (B.BoolExpr t) AssumptionReason AssertionReason }
 
 -- | Returns an initial execution state.
 initialSimpleBackendState :: NonceGenerator IO t -> IO (SimpleBackendState t)
@@ -69,7 +68,7 @@ newSimpleBackend floatMode gen =
      extendConfig backendOptions (getConfiguration sym)
      return sym
 
-getAssumptionStack :: SimpleBackend t fs -> IO (AssumptionStack (B.BoolExpr t) AssumptionReason SimError)
+getAssumptionStack :: SimpleBackend t fs -> IO (AssumptionStack (B.BoolExpr t) AssumptionReason AssertionReason)
 getAssumptionStack sym = pure (sbAssumptionStack (B.sbUserState sym))
 
 instance IsBoolSolver (SimpleBackend t fs) where

--- a/crucible/src/Lang/Crucible/Simulator/BoundedExec.hs
+++ b/crucible/src/Lang/Crucible/Simulator/BoundedExec.hs
@@ -32,6 +32,7 @@ module Lang.Crucible.Simulator.BoundedExec
 
 import           Control.Lens ( (^.), to, (&), (%~), (.~) )
 import           Control.Monad ( when )
+import           Control.Monad.Trans ( lift )
 import           Data.IORef
 import           Data.Map (Map)
 import qualified Data.Map as Map
@@ -110,7 +111,7 @@ incrementBoundCount cs depth =
 instance IntrinsicClass sym "BoundedExecFrameData" where
   type Intrinsic sym "BoundedExecFrameData" ctx = [Either FunctionName FrameBoundData]
 
-  muxIntrinsic _sym _iTypes _nm _ _p fd1 fd2 = combineFrameBoundData fd1 fd2
+  muxIntrinsic _sym _iTypes _nm _ _p fd1 fd2 = lift (combineFrameBoundData fd1 fd2)
 
 mergeCounts :: Seq Word64 -> Seq Word64 -> Seq Word64
 mergeCounts cx cy =

--- a/crucible/src/Lang/Crucible/Simulator/BoundedExec.hs
+++ b/crucible/src/Lang/Crucible/Simulator/BoundedExec.hs
@@ -258,7 +258,8 @@ boundedExecFeature getLoopBounds generateSideConditions =
          do let msg = "reached maximum number of loop iterations (" ++ show n ++ ")"
             let loc = st^.stateCrucibleFrame.to frameProgramLoc
             let err = SimError loc (ResourceExhausted msg)
-            when generateSideConditions (addProofObligation sym (LabeledPred (falsePred sym) err))
+            let rsn = AssertionReason False err
+            when generateSideConditions (addProofObligation sym (LabeledPred (falsePred sym) rsn))
             return (ExecutionFeatureNewState (AbortState (AssumedFalse (AssumingNoError err)) st'))
        Nothing -> return (ExecutionFeatureModifiedState (ControlTransferState res st'))
 

--- a/crucible/src/Lang/Crucible/Simulator/BoundedRecursion.hs
+++ b/crucible/src/Lang/Crucible/Simulator/BoundedRecursion.hs
@@ -120,7 +120,8 @@ boundedRecursionFeature getRecursionBound generateSideConditions =
                    do loc <- getCurrentProgramLoc sym
                       let msg = ("reached maximum number of recursive calls to function " ++ show h ++ " (" ++ show b ++ ")")
                       let err = SimError loc (ResourceExhausted msg)
-                      when generateSideConditions (addProofObligation sym (LabeledPred (falsePred sym) err))
+                      let rsn = AssertionReason False err
+                      when generateSideConditions (addProofObligation sym (LabeledPred (falsePred sym) rsn))
                       return (ExecutionFeatureNewState (AbortState (AssumedFalse (AssumingNoError err)) st))
                  _ ->
                    do let x'  = Map.insert h v x

--- a/crucible/src/Lang/Crucible/Simulator/CallFrame.hs
+++ b/crucible/src/Lang/Crucible/Simulator/CallFrame.hs
@@ -228,7 +228,7 @@ extendFrame tp v s f = f { _frameRegs = assignReg tp v (_frameRegs f)
 mergeCallFrame :: IsSymInterface sym
                => sym
                -> IntrinsicTypes sym
-               -> MuxFn (Pred sym) (CallFrame sym ext blocks ret args)
+               -> MuxFn' (Pred sym) (CallFrame sym ext blocks ret args)
 mergeCallFrame s iteFns p xcf ycf = do
   r <- mergeRegs s iteFns p (_frameRegs xcf) (_frameRegs ycf)
   return $ xcf { _frameRegs = r }

--- a/crucible/src/Lang/Crucible/Simulator/EvalStmt.hs
+++ b/crucible/src/Lang/Crucible/Simulator/EvalStmt.hs
@@ -324,7 +324,7 @@ stepStmt verb stmt rest =
                          Just (UnicodeLiteral txt) -> AssertFailureSimError (Text.unpack txt) ""
                          _ -> AssertFailureSimError "Symbolic message" (show (printSymExpr msg))
             loc <- liftIO (getCurrentProgramLoc sym)
-            let asrt = SimError loc err
+            let asrt = AssertionReason False (SimError loc err) -- TODO? Should these assertions be durable?
             let cont = continueWith (stateCrucibleFrame  . frameStmts .~ rest)
             ReaderT (return . AssertState [LabeledPred c asrt] cont)
 
@@ -503,7 +503,7 @@ dispatchExecState getVerb exst kresult k =
     AssertState asserts next st ->
       k (performAsserts asserts >>= \case
            Nothing  -> next
-           Just rsn -> ReaderT (runAbortHandler (AssumedFalse (AssumingNoError rsn))))
+           Just rsn -> ReaderT (runAbortHandler (AssumedFalse (assertToAssume rsn))))
         st
 
     AssumeState assumes next st ->

--- a/crucible/src/Lang/Crucible/Simulator/Intrinsics.hs
+++ b/crucible/src/Lang/Crucible/Simulator/Intrinsics.hs
@@ -34,6 +34,8 @@ module Lang.Crucible.Simulator.Intrinsics
   , typeError
   ) where
 
+import           Control.Monad.Trans.Maybe
+
 import           Data.Kind
 import qualified Data.Parameterized.Map as MapF
 import           Data.Parameterized.SymbolRepr
@@ -100,7 +102,7 @@ class IntrinsicClass (sym :: Type) (nm :: GHC.TypeLits.Symbol) where
                -> Pred sym
                -> Intrinsic sym nm ctx
                -> Intrinsic sym nm ctx
-               -> IO (Intrinsic sym nm ctx)
+               -> MaybeT IO (Intrinsic sym nm ctx)
 
 -- | Sometimes it is convenient to provide a 'CrucibleType' as the type
 -- argument to 'Intrinsic', rather than the symbol and context. If you

--- a/crucible/src/Lang/Crucible/Simulator/Operations.hs
+++ b/crucible/src/Lang/Crucible/Simulator/Operations.hs
@@ -431,7 +431,7 @@ runErrorHandler msg st =
    in ctxSolverProof ctx $
       do loc <- getCurrentProgramLoc sym
          let err = SimError loc msg
-         let obl = LabeledPred (falsePred sym) err
+         let obl = LabeledPred (falsePred sym) (AssertionReason False err)
          let rsn = AssumedFalse (AssumingNoError err)
          return (AssertState [obl] (ReaderT (return . AbortState rsn)) st)
 
@@ -818,7 +818,7 @@ handleSimReturn fnName vfv return_value =
 performAsserts ::
   IsSymInterface sym =>
   [Assertion sym] ->
-  ReaderT (SimState p sym ext r f a) IO (Maybe SimError)
+  ReaderT (SimState p sym ext r f a) IO (Maybe AssertionReason)
 performAsserts asserts
   | Just ast <- filterAsserts asserts =
       do sym <- view stateSymInterface

--- a/crucible/src/Lang/Crucible/Simulator/OverrideSim.hs
+++ b/crucible/src/Lang/Crucible/Simulator/OverrideSim.hs
@@ -497,7 +497,7 @@ overrideAssert p rsn =
   Sim $ StateContT $ \c st ->
      do let sym = st^.stateSymInterface
         loc <- getCurrentProgramLoc sym
-        let err = SimError loc rsn
+        let err = AssertionReason False (SimError loc rsn)
         return (AssertState [LabeledPred p err] (ReaderT (c ())) st)
 
 overrideAssertions :: [Assertion sym] -> OverrideSim p sym ext rtp args res ()

--- a/crucible/src/Lang/Crucible/Simulator/SimError.hs
+++ b/crucible/src/Lang/Crucible/Simulator/SimError.hs
@@ -25,9 +25,12 @@ module Lang.Crucible.Simulator.SimError (
   ) where
 
 import Control.Exception
+import Data.Parameterized.Some
 import Data.String
 import Data.Typeable
 import Prettyprinter
+
+import Lang.Crucible.Types ( TypeRepr )
 
 import What4.ProgramLoc
 
@@ -38,6 +41,7 @@ import What4.ProgramLoc
 data SimErrorReason
    = GenericSimError !String
    | Unsupported !String -- ^ We can't do that (yet?)
+   | MuxFailure (Some TypeRepr) -- ^ could not mux values at the given type
    | ReadBeforeWriteSimError !String -- FIXME? include relevant data instead of a string?
    | AssertFailureSimError !String !String
      -- ^ An assertion failed. The first parameter is a short
@@ -60,6 +64,7 @@ simErrorReasonMsg (Unsupported msg) = "Unsupported feature: " ++ msg
 simErrorReasonMsg (ReadBeforeWriteSimError msg) = msg
 simErrorReasonMsg (AssertFailureSimError msg _) = msg
 simErrorReasonMsg (ResourceExhausted msg) = "Resource exhausted: " ++ msg
+simErrorReasonMsg (MuxFailure (Some tp)) = "Could not mux values at type: " ++ show tp
 
 simErrorDetailsMsg :: SimErrorReason -> String
 simErrorDetailsMsg (AssertFailureSimError _ msg) = msg

--- a/crux-llvm/src/Crux/LLVM/Compile.hs
+++ b/crux-llvm/src/Crux/LLVM/Compile.hs
@@ -73,7 +73,7 @@ getClang = attempt (map inPath clangs)
                        Right a -> return a
 
 runClang :: Logs => CruxOptions -> LLVMOptions -> [String] -> IO ()
-runClang cruxOpts llvmOpts params =
+runClang _cruxOpts llvmOpts params =
   do let clang = clangBin llvmOpts
          allParams = clangOpts llvmOpts ++ params
      say Noisily "CLANG" $ T.unwords (T.pack <$> (clang : map show allParams))

--- a/crux-llvm/src/Crux/LLVM/Simulate.hs
+++ b/crux-llvm/src/Crux/LLVM/Simulate.hs
@@ -273,4 +273,4 @@ explainFailure sym bbMapRef evalFn gl =
                                    <+> "failed conditions]"
                               else "Total failed conditions:" <+> pretty xs'l
                    in nest 2 $ vcat $ msg1 : xs'' <> [msg2]
-     return $ vcat [ ppSimError (gl^. labeledPredMsg), details ]
+     return $ vcat [ ppSimError (assertionSimError (gl^. labeledPredMsg)), details ]

--- a/crux/src/Crux.hs
+++ b/crux/src/Crux.hs
@@ -107,7 +107,7 @@ data RunnableState sym where
 -- simulation error.
 
 type Explainer sym t ann = Maybe (GroundEvalFn t)
-                           -> LPred sym SimError
+                           -> LPred sym AssertionReason
                            -> IO (Doc ann)
 
 -- | Individual crux tools will generally call the @runSimulator@ combinator
@@ -578,8 +578,8 @@ type ProverCallback sym =
     CruxOptions ->
     SimCtxt personality sym ext ->
     Explainer sym t Void ->
-    Maybe (Goals (LPred sym AssumptionReason) (LPred sym SimError)) ->
-    IO (ProcessedGoals, Maybe (Goals (LPred sym AssumptionReason) (LPred sym SimError, ProofResult (Either (LPred sym AssumptionReason) (LPred sym SimError)))))
+    Maybe (Goals (LPred sym AssumptionReason) (LPred sym AssertionReason)) ->
+    IO (ProcessedGoals, Maybe (Goals (LPred sym AssumptionReason) (LPred sym AssertionReason, ProofResult (Either (LPred sym AssumptionReason) (LPred sym AssertionReason)))))
 
 
 -- | Core invocation of the symbolic execution engine

--- a/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
@@ -231,7 +231,7 @@ simulateLLVM appCtx modCtx funCtx halloc explRef skipOverrideRef unsoundOverride
                       panic "simulateLLVM" ["Unexplained error: no error for annotation."]
                     Nothing ->
                       modifyIORef explRef . (:) $
-                        case gl ^. Crucible.labeledPredMsg . to Crucible.simErrorReason of
+                        case gl ^. Crucible.labeledPredMsg . to Crucible.assertionSimError . to Crucible.simErrorReason of
                           Crucible.ResourceExhausted msg ->
                             ExExhaustedBounds msg
                           Crucible.AssertFailureSimError msg _ ->
@@ -240,9 +240,9 @@ simulateLLVM appCtx modCtx funCtx halloc explRef skipOverrideRef unsoundOverride
                                 classifyAssertion
                                   sym
                                   (gl ^. Crucible.labeledPred)
-                                  (gl ^. Crucible.labeledPredMsg . to Crucible.simErrorLoc)
-                              else ExUncertain (UMissingAnnotation (gl ^. Crucible.labeledPredMsg))
-                          _ -> ExUncertain (UMissingAnnotation (gl ^. Crucible.labeledPredMsg))
+                                  (gl ^. Crucible.labeledPredMsg . to Crucible.assertionSimError . to Crucible.simErrorLoc)
+                              else ExUncertain (UMissingAnnotation (gl ^. Crucible.labeledPredMsg . to Crucible.assertionSimError))
+                          _ -> ExUncertain (UMissingAnnotation (gl ^. Crucible.labeledPredMsg . to Crucible.assertionSimError))
                 Just badBehavior ->
                   do
                     -- Helpful for debugging:
@@ -258,7 +258,7 @@ simulateLLVM appCtx modCtx funCtx halloc explRef skipOverrideRef unsoundOverride
                       funCtx
                       sym
                       skipped
-                      (gl ^. Crucible.labeledPredMsg)
+                      (gl ^. Crucible.labeledPredMsg . to Crucible.assertionSimError)
                       args
                       (Map.union argAnnotations retAnns)
                       argShapes


### PR DESCRIPTION
The goal of this refactoring is to address #763. To do this, we need to ensure that we only add assertions or assumptions to the logical program state via program states that can be observed by execution features.  Ultimately, we may remove the `IsBoolSolver` interface altogether.

To do this, we need to refactor the handling of errors, assertions, and assumptions so that they are always done in a context that can properly step the simulator abstract machine.