### PR TITLE
uc-crux-llvm: Check programs for "crash equivalence"

### DIFF
--- a/uc-crux-llvm/README.md
+++ b/uc-crux-llvm/README.md
@@ -1,8 +1,12 @@
 # UC-Crux-LLVM
 
 UC-Crux-LLVM is a tool for under-constrained symbolic execution of C programs.
-It can be used to find undefined behavior and failing assertions, or for simple
-functions, to formally verify the absence of such behaviors.
+It can be used to:
+
+- find undefined behavior and failing assertions,
+- verify the absence of undefined behavior and failing assertions,
+- deduce sufficient function preconditions to avoid undefined behavior, and
+- check two versions of a program for crash-equivalence.
 
 **UC-Crux-LLVM is still in development.**
 
@@ -201,6 +205,22 @@ Uncertain results:
   Missing annotations: 1
   Symbolically failing assertions: 1
 ```
+
+### Crash-Equivalence Checking
+
+UC-Crux-LLVM can check two different versions of the same program (or two
+implementations of the same interface) for *crash-equivalence*, meaning
+the two implementations are considered the same unless UC-Crux-LLVM can find a
+bug in one but not the other.
+
+The argument to the `--check-equivalence` flag is a second program to check for
+*crash ordering*, i.e. UC-Crux-LLVM checks that the program passed to
+`--check-equivalence` has *fewer* crashes than the one passed as an argument. If
+the `--strict-crash-equivalence` is also passed to UC-Crux-LLVM, it checks for
+*crash-equivalence*. Crash-ordering is a partial order over programs, and
+crash-equivalence is an equivalence relation. Use `--entry-points` to check
+specific functions, or `--explore` to check all functions from both programs
+that share a name.
 
 ## Roadmap
 

--- a/uc-crux-llvm/src/UCCrux/LLVM/Classify/Types.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Classify/Types.hs
@@ -7,6 +7,9 @@ Maintainer   : Langston Barrett <langston@galois.com>
 Stability    : provisional
 -}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PolyKinds #-}
@@ -14,9 +17,10 @@ Stability    : provisional
 
 module UCCrux.LLVM.Classify.Types
   ( Explanation (..),
+    Located (..),
+    ppLocated,
     partitionExplanations,
     TruePositive (..),
-    LocatedTruePositive (..),
     TruePositiveTag (..),
     truePositiveTag,
     Diagnosis (..),
@@ -26,7 +30,6 @@ module UCCrux.LLVM.Classify.Types
     prescribe,
     ppProgramLoc,
     ppTruePositive,
-    ppLocatedTruePositive,
     ppTruePositiveTag,
     Unclassified (..),
     doc,
@@ -44,6 +47,7 @@ where
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Void (Void)
+import           GHC.Generics (Generic)
 
 import           Prettyprinter (Doc)
 import qualified Prettyprinter as PP
@@ -72,6 +76,19 @@ import           UCCrux.LLVM.Cursor (Where(..))
 import           UCCrux.LLVM.Errors.Unimplemented (Unimplemented)
 import           UCCrux.LLVM.FullType.Type (FullType)
 {- ORMOLU_ENABLE -}
+
+data Located a = Located
+  { location :: !What4.ProgramLoc,
+    locatedValue :: a
+  }
+  deriving (Eq, Ord, Functor, Generic, Show)
+
+ppProgramLoc :: What4.ProgramLoc -> Text
+ppProgramLoc = Text.pack . show . What4.plSourceLoc
+
+ppLocated :: (a -> Text) -> Located a -> Text
+ppLocated ppVal (Located loc val) =
+  Text.unwords [ppVal val, Text.pack "at", ppProgramLoc loc]
 
 data TruePositiveTag
   = TagConcretelyFailingAssert
@@ -106,23 +123,6 @@ data TruePositive
   | FloatToPointer
   | DerefFunctionPointer !L.Symbol -- Name of function
   deriving (Eq, Ord)
-
-data LocatedTruePositive = LocatedTruePositive
-  { truePositive :: !TruePositive,
-    truePositiveLoc :: !What4.ProgramLoc
-  }
-  deriving (Eq, Ord)
-
-ppProgramLoc :: What4.ProgramLoc -> Text
-ppProgramLoc = Text.pack . show . What4.plSourceLoc
-
-ppLocatedTruePositive :: LocatedTruePositive -> Text
-ppLocatedTruePositive (LocatedTruePositive pos loc) =
-  Text.unwords
-    [ ppTruePositive pos,
-      Text.pack "at",
-      ppProgramLoc loc
-    ]
 
 truePositiveTag :: TruePositive -> TruePositiveTag
 truePositiveTag =
@@ -311,48 +311,48 @@ instance Show Unclassified where
 
 -- | Possible sources of uncertainty, these might be true or false positives
 data Uncertainty
-  = UUnclassified !What4.ProgramLoc Unclassified
-  | UUnfixable !What4.ProgramLoc Unfixable
-  | UUnfixed !What4.ProgramLoc Unfixed
+  = UUnclassified Unclassified
+  | UUnfixable Unfixable
+  | UUnfixed Unfixed
   | -- | Simulation, input generation, or classification encountered
     -- unimplemented functionality
     UUnimplemented (Panic Unimplemented)
   | -- | This @Pred@ was not annotated
     UMissingAnnotation Crucible.SimError
   | -- | A user assertion failed, but symbolically
-    UFailedAssert !What4.ProgramLoc
+    UFailedAssert
   | -- | Simulation timed out
     UTimeout !Text
   deriving (Show)
 
 partitionUncertainty ::
-  [Uncertainty] -> ([Crucible.SimError], [What4.ProgramLoc], [Panic Unimplemented], [Unclassified], [Unfixed], [Unfixable], [Text])
+  [Located Uncertainty] -> ([Located Crucible.SimError], [Located ()], [Located (Panic Unimplemented)], [Located Unclassified], [Located Unfixed], [Located Unfixable], [Located Text])
 partitionUncertainty = go [] [] [] [] [] [] []
   where
     go ms fs ns us ufd ufa ts =
       \case
         [] -> (ms, fs, ns, us, ufd, ufa, ts)
-        (UMissingAnnotation err : rest) ->
+        (Located loc (UMissingAnnotation err) : rest) ->
           let (ms', fs', ns', us', ufd', ufa', ts') = go ms fs ns us ufd ufa ts rest
-           in (err : ms', fs', ns', us', ufd', ufa', ts')
-        (UFailedAssert loc : rest) ->
+           in (Located loc err : ms', fs', ns', us', ufd', ufa', ts')
+        (Located loc UFailedAssert : rest) ->
           let (ms', fs', ns', us', ufd', ufa', ts') = go ms fs ns us ufd ufa ts rest
-           in (ms', loc : fs', ns', us', ufd', ufa', ts')
-        (UUnimplemented unin : rest) ->
+           in (ms', Located loc () : fs', ns', us', ufd', ufa', ts')
+        (Located loc (UUnimplemented unin) : rest) ->
           let (ms', fs', ns', us', ufd', ufa', ts') = go ms fs ns us ufd ufa ts rest
-           in (ms', fs', unin : ns', us', ufd', ufa', ts')
-        (UUnclassified _loc unclass : rest) ->
+           in (ms', fs', Located loc unin : ns', us', ufd', ufa', ts')
+        (Located loc (UUnclassified unclass) : rest) ->
           let (ms', fs', ns', us', ufd', ufa', ts') = go ms fs ns us ufd ufa ts rest
-           in (ms', fs', ns', unclass : us', ufd', ufa', ts')
-        (UUnfixed _loc uf : rest) ->
+           in (ms', fs', ns', Located loc unclass : us', ufd', ufa', ts')
+        (Located loc (UUnfixed uf) : rest) ->
           let (ms', fs', ns', us', ufd', ufa', ts') = go ms fs ns us ufd ufa ts rest
-           in (ms', fs', ns', us', uf : ufd', ufa', ts')
-        (UUnfixable _loc uf : rest) ->
+           in (ms', fs', ns', us', Located loc uf : ufd', ufa', ts')
+        (Located loc (UUnfixable uf) : rest) ->
           let (ms', fs', ns', us', ufd', ufa', ts') = go ms fs ns us ufd ufa ts rest
-           in (ms', fs', ns', us', ufd', uf : ufa', ts')
-        (UTimeout fun : rest) ->
+           in (ms', fs', ns', us', ufd', Located loc uf : ufa', ts')
+        (Located loc (UTimeout fun) : rest) ->
           let (ms', fs', ns', us', ufd', ufa', ts') = go ms fs ns us ufd ufa ts rest
-           in (ms', fs', ns', us', ufd', ufa', fun : ts')
+           in (ms', fs', ns', us', ufd', ufa', Located loc fun : ts')
 
 -- | An error is either a true positive, a false positive due to some missing
 -- preconditions, or unknown.
@@ -360,57 +360,53 @@ partitionUncertainty = go [] [] [] [] [] [] []
 -- NOTE(lb): The explicit kind signature here is necessary for GHC 8.8/8.6
 -- compatibility.
 data Explanation m arch (argTypes :: Ctx (FullType m))
-  = ExTruePositive LocatedTruePositive
+  = ExTruePositive TruePositive
   | ExDiagnosis (Diagnosis, [NewConstraint m argTypes])
   | ExUncertain Uncertainty
   | -- | Hit recursion/loop bounds
     ExExhaustedBounds !String
 
 partitionExplanations ::
-  [Explanation m arch types] ->
-  ([LocatedTruePositive], [(Diagnosis, [NewConstraint m types])], [Uncertainty], [String])
+  [Located (Explanation m arch types)] ->
+  ([Located TruePositive], [Located (Diagnosis, [NewConstraint m types])], [Located Uncertainty], [Located String])
 partitionExplanations = go [] [] [] []
   where
     go ts cs ds es =
       \case
         [] -> (ts, cs, ds, es)
-        (ExTruePositive t : xs) ->
+        (Located loc (ExTruePositive t) : xs) ->
           let (ts', cs', ds', es') = go ts cs ds es xs
-           in (t : ts', cs', ds', es')
-        (ExDiagnosis c : xs) ->
+           in (Located loc t : ts', cs', ds', es')
+        (Located loc (ExDiagnosis c) : xs) ->
           let (ts', cs', ds', es') = go ts cs ds es xs
-           in (ts', c : cs', ds', es')
-        (ExUncertain d : xs) ->
+           in (ts', Located loc c : cs', ds', es')
+        (Located loc (ExUncertain d) : xs) ->
           let (ts', cs', ds', es') = go ts cs ds es xs
-           in (ts', cs', d : ds', es')
-        (ExExhaustedBounds e : xs) ->
+           in (ts', cs', Located loc d : ds', es')
+        (Located loc (ExExhaustedBounds e) : xs) ->
           let (ts', cs', ds', es') = go ts cs ds es xs
-           in (ts', cs', ds', e : es')
+           in (ts', cs', ds', Located loc e : es')
 
 ppUncertainty :: Uncertainty -> Text
 ppUncertainty =
   \case
-    UUnclassified errorLoc unclass ->
+    UUnclassified unclass ->
       Text.unlines
         [ "Unclassified error:",
-          unclass ^. doc . to (PP.layoutPretty PP.defaultLayoutOptions) . to PP.renderStrict,
-          "at: " <> ppProgramLoc errorLoc
+          unclass ^. doc . to (PP.layoutPretty PP.defaultLayoutOptions) . to PP.renderStrict
         ]
-    UUnfixable errorLoc unfix ->
+    UUnfixable unfix ->
       Text.unlines
         [ "Unfixable/inactionable error:",
-          ppUnfixable unfix,
-          "at: " <> ppProgramLoc errorLoc
+          ppUnfixable unfix
         ]
-    UUnfixed errorLoc unfix ->
+    UUnfixed unfix ->
       Text.unlines
         [ "Fixable missing precondition, but fix not yet implemented for this error:",
-          ppUnfixed unfix,
-          "at: " <> ppProgramLoc errorLoc
+          ppUnfixed unfix
         ]
     UMissingAnnotation err ->
       "(Internal issue) Missing annotation for error:\n" <> Text.pack (show err)
-    UFailedAssert loc ->
-      "Symbolically failing user assertion at " <> Text.pack (show loc)
+    UFailedAssert -> "Symbolically failing user assertion"
     UUnimplemented pan -> Text.pack (displayException pan)
     UTimeout fun -> Text.pack "Simulation timed out while executing " <> fun

--- a/uc-crux-llvm/src/UCCrux/LLVM/Config.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Config.hs
@@ -35,6 +35,8 @@ import           UCCrux.LLVM.Context.App (AppContext, makeAppContext)
 
 data UCCruxLLVMOptions = UCCruxLLVMOptions
   { ucLLVMOptions :: LLVMOptions,
+    crashEquivalence :: FilePath,
+    crashEquivalenceStrict :: Bool,
     doExplore :: Bool,
     reExplore :: Bool,
     exploreBudget :: Int,
@@ -73,6 +75,12 @@ processUCCruxLLVMOptions (initCOpts, initUCOpts) =
         )
     pure (appCtx, finalCOpts, initUCOpts {ucLLVMOptions = finalLLOpts})
 
+crashEquivalenceDoc :: Text
+crashEquivalenceDoc = "Check crash-equivalence with another LLVM bitcode module"
+
+crashEquivalenceStrictDoc :: Text
+crashEquivalenceStrictDoc = "Check for strict crash equivalence"
+
 exploreDoc :: Text
 exploreDoc = "Run in exploration mode"
 
@@ -105,6 +113,8 @@ ucCruxLLVMConfig = do
       { Crux.cfgFile =
           UCCruxLLVMOptions
             <$> Crux.cfgFile llvmOpts
+            <*> Crux.section "crash-equivalence" Crux.fileSpec "" crashEquivalenceDoc
+            <*> Crux.section "strict-crash-equivalence" Crux.yesOrNoSpec False crashEquivalenceStrictDoc
             <*> Crux.section "explore" Crux.yesOrNoSpec False exploreDoc
             <*> Crux.section "re-explore" Crux.yesOrNoSpec False reExploreDoc
             <*> Crux.section "explore-budget" Crux.numSpec 8 exploreBudgetDoc
@@ -118,6 +128,18 @@ ucCruxLLVMConfig = do
         Crux.cfgCmdLineFlag =
           (Crux.liftOptDescr ucCruxLLVMOptionsToLLVMOptions <$> Crux.cfgCmdLineFlag llvmOpts)
             ++ [ Crux.Option
+                   []
+                   ["crash-equivalence"]
+                   (Text.unpack crashEquivalenceDoc)
+                   $ Crux.ReqArg "LLVMMODULE" $
+                     \v opts -> Right opts {crashEquivalence = v},
+                 Crux.Option
+                   []
+                   ["strict-crash-equivalence"]
+                   (Text.unpack crashEquivalenceStrictDoc)
+                   $ Crux.NoArg $
+                     \opts -> Right opts {crashEquivalenceStrict = True},
+                 Crux.Option
                    []
                    ["explore"]
                    (Text.unpack exploreDoc)

--- a/uc-crux-llvm/src/UCCrux/LLVM/Equivalence.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Equivalence.hs
@@ -1,0 +1,268 @@
+{-
+Module       : UCCrux.LLVM.Equivalence
+Description  : Check traces for crash equivalence or crash ordering.
+Copyright    : (c) Galois, Inc 2021
+License      : BSD3
+Maintainer   : Langston Barrett <langston@galois.com>
+Stability    : provisional
+-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module UCCrux.LLVM.Equivalence
+  ( CrashDiff,
+    NonEmptyCrashDiff,
+    crashDiffNonEmpty,
+    crashDiffIsEmpty,
+    ppCrashDiff,
+    renderCrashDiff,
+    getCrashDiffs,
+    reportDiffs,
+    checkEquiv,
+  )
+where
+
+{- ORMOLU_DISABLE -}
+import           Prelude hiding (log)
+
+import           Control.Lens ((^.))
+import           Control.Monad (when, unless, void)
+import           Data.Foldable (for_, toList)
+import qualified Data.Map.Strict as Map
+import           Data.Maybe (catMaybes, isNothing, maybeToList)
+import           Data.Sequence (Seq)
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import           Data.Text (Text)
+import qualified Data.Text as Text
+import           Data.Void (Void)
+
+import           Prettyprinter (Doc)
+import qualified Prettyprinter as PP
+import qualified Prettyprinter.Render.Text as PP
+
+import qualified What4.ProgramLoc as What4
+
+-- crucible
+import qualified Lang.Crucible.FunctionHandle as Crucible
+
+-- crucible-llvm
+
+-- crux
+import Crux.Config.Common
+import Crux.Log as Crux
+
+ -- local
+import           UCCrux.LLVM.Classify.Types (Located(location, locatedValue), Explanation, partitionExplanations, TruePositive, Unfixed, Unfixable, partitionUncertainty)
+import qualified UCCrux.LLVM.Config as Config
+import           UCCrux.LLVM.Config (UCCruxLLVMOptions)
+import           UCCrux.LLVM.Context.App (AppContext, log)
+import           UCCrux.LLVM.Context.Module (ModuleContext)
+import           UCCrux.LLVM.Logging (Verbosity(Low))
+import           UCCrux.LLVM.Run.Simulate (UCCruxSimulationResult, explanations)
+import           UCCrux.LLVM.Run.Result (SomeBugfindingResult(..))
+import           UCCrux.LLVM.Run.Loop (zipResults)
+{- ORMOLU_ENABLE -}
+
+data CrashDiff = CrashDiff
+  { _bugDiff :: Set (Located TruePositive),
+    -- | Failed assertions
+    _assertionDiff :: Set (Located ()),
+    -- | Unclassified errors
+    _unclassifiedDiff :: Set (Located ()),
+    _unfixedDiff :: Set (Located Unfixed),
+    _unfixableDiff :: Set (Located Unfixable)
+  }
+  deriving (Eq, Ord)
+
+instance Semigroup CrashDiff where
+  CrashDiff s1 s2 s3 s4 s5 <> CrashDiff t1 t2 t3 t4 t5 =
+    CrashDiff (s1 <> t1) (s2 <> t2) (s3 <> t3) (s4 <> t4) (s5 <> t5)
+
+instance Monoid CrashDiff where
+  mempty = CrashDiff Set.empty Set.empty Set.empty Set.empty Set.empty
+
+newtype NonEmptyCrashDiff = NonEmptyCrashDiff CrashDiff
+  deriving (Eq, Ord, Monoid, Semigroup)
+
+crashDiffNonEmpty :: CrashDiff -> Maybe NonEmptyCrashDiff
+crashDiffNonEmpty diff =
+  if diff == mempty
+    then Nothing
+    else Just (NonEmptyCrashDiff diff)
+
+crashDiffIsEmpty :: CrashDiff -> Bool
+crashDiffIsEmpty = isNothing . crashDiffNonEmpty
+
+ppCrashDiff :: CrashDiff -> Doc Void
+ppCrashDiff (CrashDiff posDiff assertDiff unclassDiff unfixedDiff unfixableDiff) =
+  PP.vcat $
+    catMaybes
+      [ printDiff posDiff "Likely bugs at",
+        printDiff assertDiff "Assertion failures at",
+        printDiff unclassDiff "Unclassified errors at",
+        printDiff unfixedDiff "Unfixed errors at",
+        printDiff unfixableDiff "Unfixable errors at"
+      ]
+  where
+    headerWithBullets header lst =
+      PP.nest 2 (PP.vcat (header : map ((PP.pretty ("-" :: Text) PP.<+>) . PP.pretty) lst))
+    printDiff :: Set (Located a) -> Text -> Maybe (Doc Void)
+    printDiff diff header =
+      if Set.null diff
+        then Nothing
+        else
+          Just $
+            headerWithBullets
+              (PP.pretty header)
+              (map (show . What4.plSourceLoc . location) (toList diff))
+
+renderCrashDiff :: CrashDiff -> Text
+renderCrashDiff =
+  PP.renderStrict . PP.layoutPretty PP.defaultLayoutOptions . ppCrashDiff
+
+-- | Compute the \"crash difference\" between two sets of results.
+--
+-- This ignores:
+--
+-- * timeouts,
+-- * errors that are missing annotations, and
+-- * executions that encountered unimplemented features of UC-Crux-LLVM.
+--
+-- The behavior of this function is documented in the README, updates should be
+-- reflected there.
+--
+-- Recall that a total function @f : (A, A) -> Bool@ can be considered a
+-- description of a binary relation on @A@:
+-- @{ (x, y) | x, y : A, f(x, y) is True }@. The function
+-- @\expls1 expls2 -> crashDiffIsEmpty (crashDiff expls1 expls2)@, which has type
+-- @[Located (Explanation ...)] -> [Located (Explanation ...)] -> Bool@, is a
+-- partial order when considered in this way as a binary relation on
+-- @Located (Explanation ...)@ (ignoring type indices). The first set of results
+-- is considered \"less\" than the second when its possible crashes are a subset
+-- of the second\'s.
+crashDiff ::
+  [Located (Explanation m1 arch1 argTypes1)] ->
+  [Located (Explanation m2 arch2 argTypes2)] ->
+  CrashDiff
+crashDiff expls1 expls2 =
+  let (truePositives1, _, uncertain1, _) =
+        partitionExplanations locatedValue (toList expls1)
+      (_, failedAssert1, _, unclass1, unfixed1, unfixable1, _) =
+        partitionUncertainty uncertain1
+      (truePositives2, _, uncertain2, _) =
+        partitionExplanations locatedValue (toList expls2)
+      (_, failedAssert2, _, unclass2, unfixed2, unfixable2, _) =
+        partitionUncertainty uncertain2
+      setDiff a b = Set.fromList a `Set.difference` Set.fromList b
+   in CrashDiff
+        (setDiff truePositives2 truePositives1)
+        (setDiff failedAssert2 failedAssert1)
+        -- NB: 'Unclassified' errors contain 'UndefinedBehavior' and other stuff
+        -- that can't be compared for equality/ordered, so we just order by
+        -- program location.
+        (setDiff (map void unclass2) (map void unclass1))
+        (setDiff unfixed2 unfixed1)
+        (setDiff unfixable2 unfixable1)
+
+computeDiffs ::
+  Seq (UCCruxSimulationResult m1 arch1 argTypes1) ->
+  Seq (UCCruxSimulationResult m2 arch2 argTypes2) ->
+  (CrashDiff, CrashDiff)
+computeDiffs trace1 trace2 =
+  let expls ::
+        forall m arch argTypes.
+        Seq (UCCruxSimulationResult m arch argTypes) ->
+        [Located (Explanation m arch argTypes)]
+
+      expls = concatMap explanations . toList
+      diff12 = crashDiff (expls trace1) (expls trace2)
+      diff21 = crashDiff (expls trace2) (expls trace1)
+   in ( diff12,
+        diff21
+      )
+
+-- | Analyze the functions in the two modules, and return the non-empty diffs where
+-- the modules differed
+getCrashDiffs ::
+  Crux.Logs msgs =>
+  Crux.SupportsCruxLogMessage msgs =>
+  AppContext ->
+  ModuleContext m1 arch1 ->
+  ModuleContext m2 arch2 ->
+  Crucible.HandleAllocator ->
+  CruxOptions ->
+  UCCruxLLVMOptions ->
+  IO ([(String, NonEmptyCrashDiff)], [(String, NonEmptyCrashDiff)])
+getCrashDiffs appCtx modCtx1 modCtx2 halloc cruxOpts ucOpts =
+  do
+    results <- zipResults appCtx modCtx1 modCtx2 halloc cruxOpts ucOpts
+    when (Map.null results) $
+      (appCtx ^. log)
+        Low
+        "Modules have no functions in common! Nothing was compared."
+
+    pure $
+      foldMap
+        ( \(funcName, (SomeBugfindingResult _ trace1, SomeBugfindingResult _ trace2)) ->
+            let (diff12, diff21) = computeDiffs trace1 trace2
+             in ( map (funcName,) (maybeToList (crashDiffNonEmpty diff12)),
+                  map (funcName,) (maybeToList (crashDiffNonEmpty diff21))
+                )
+        )
+        (Map.toList results)
+
+reportDiffs ::
+  AppContext ->
+  [(String, NonEmptyCrashDiff)] ->
+  [(String, NonEmptyCrashDiff)] ->
+  IO ()
+reportDiffs appCtx diffs12 diffs21 =
+  do
+    for_
+      diffs12
+      ( \(funcName, NonEmptyCrashDiff diff12) ->
+          unless (crashDiffIsEmpty diff12) $
+            (appCtx ^. log)
+              Low
+              ( Text.unlines
+                  [ "Version 2 had more/different crashes than version 1 on "
+                      <> Text.pack funcName,
+                    renderCrashDiff diff12
+                  ]
+              )
+      )
+    for_
+      diffs21
+      ( \(funcName, NonEmptyCrashDiff diff21) ->
+          (appCtx ^. log)
+            Low
+            ( Text.unlines
+                [ "Version 1 had more/different crashes than version 2 on "
+                    <> Text.pack funcName,
+                  renderCrashDiff diff21
+                ]
+            )
+      )
+
+checkEquiv ::
+  Crux.Logs msgs =>
+  Crux.SupportsCruxLogMessage msgs =>
+  AppContext ->
+  ModuleContext m1 arch1 ->
+  ModuleContext m2 arch2 ->
+  Crucible.HandleAllocator ->
+  CruxOptions ->
+  UCCruxLLVMOptions ->
+  IO ()
+checkEquiv appCtx modCtx1 modCtx2 halloc cruxOpts ucOpts =
+  do
+    (diffs12, diffs21) <- getCrashDiffs appCtx modCtx1 modCtx2 halloc cruxOpts ucOpts
+    reportDiffs
+      appCtx
+      diffs12
+      (if Config.crashEquivalenceStrict ucOpts then diffs21 else [])

--- a/uc-crux-llvm/src/UCCrux/LLVM/Run/Explore.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Run/Explore.hs
@@ -85,7 +85,7 @@ exploreOne appCtx modCtx cruxOpts ucOpts halloc dir func =
             (Config.exploreTimeout ucOpts * 1000000)
             (loopOnFunction appCtx modCtx halloc cruxOpts ucOpts func)
         case maybeResult of
-          Right (Right (SomeBugfindingResult result)) ->
+          Right (Right (SomeBugfindingResult result _trace)) ->
             do
               writeFile logFilePath (Result.printFunctionSummary (Result.summary result))
               pure (getStats result)

--- a/uc-crux-llvm/src/UCCrux/LLVM/Run/Loop.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Run/Loop.hs
@@ -8,6 +8,7 @@ Stability    : provisional
 -}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module UCCrux.LLVM.Run.Loop
@@ -41,10 +42,10 @@ import Crux.Log as Crux
 import Crux.LLVM.Config (LLVMOptions, throwCError, CError(MissingFun))
 import Crux.LLVM.Overrides
 
-import           UCCrux.LLVM.Classify.Types (partitionExplanations)
+import           UCCrux.LLVM.Classify.Types (Explanation, partitionExplanations)
 import           UCCrux.LLVM.Config (UCCruxLLVMOptions)
 import qualified UCCrux.LLVM.Config as Config
-import           UCCrux.LLVM.Constraints (ppConstraints, emptyConstraints, addConstraint, ppExpansionError)
+import           UCCrux.LLVM.Constraints (Constraints, NewConstraint, ppConstraints, emptyConstraints, addConstraint, ppExpansionError)
 import           UCCrux.LLVM.Context.App (AppContext, log)
 import           UCCrux.LLVM.Context.Function (FunctionContext, argumentFullTypes, makeFunctionContext, functionName, ppFunctionContextError)
 import           UCCrux.LLVM.Context.Module (ModuleContext, moduleTranslation, CFGWithTypes(..), findFun)
@@ -55,10 +56,15 @@ import           UCCrux.LLVM.FullType (MapToCrucibleType)
 import           UCCrux.LLVM.Run.Result (BugfindingResult(..), SomeBugfindingResult(..))
 import qualified UCCrux.LLVM.Run.Result as Result
 import qualified UCCrux.LLVM.Run.Simulate as Sim
+import           UCCrux.LLVM.Run.Unsoundness (Unsoundness)
 {- ORMOLU_ENABLE -}
 
 -- | Run the simulator in a loop, creating a 'BugfindingResult'
+--
+-- Also returns the individual 'UCCruxSimulationResult' results in the order in
+-- which they were encountered.
 bugfindingLoop ::
+  forall m msgs arch argTypes blocks ret.
   ArchOk arch =>
   Crux.Logs msgs =>
   Crux.SupportsCruxLogMessage msgs =>
@@ -76,61 +82,88 @@ bugfindingLoop appCtx modCtx funCtx cfg cruxOpts llvmOpts halloc =
           Sim.runSimulator appCtx modCtx funCtx halloc preconds cfg cruxOpts llvmOpts
 
     -- Loop, learning preconditions and reporting errors
-    let loop truePositives constraints precondTags unsoundness =
+    let loop constraints results unsoundness =
           do
             -- TODO(lb) We basically ignore symbolic assertion failures. Maybe
             -- configurably don't?
             simResult <- runSim constraints
-            let (newTruePositives, newConstraints, newUncertain, newResourceExhausted) =
-                  partitionExplanations (Sim.explanations simResult)
-            let (newPrecondTags, newConstraints') = unzip newConstraints
-            let allConstraints =
-                  foldM
-                    (addConstraint modCtx (funCtx ^. argumentFullTypes))
-                    constraints
-                    (concat newConstraints')
-                    & \case
-                      Left err ->
-                        panic
-                          "bugfindingLoop"
-                          ["Error adding constraints", Text.unpack (ppExpansionError err)]
-                      Right allCs -> allCs
-
-            let allTruePositives = truePositives <> newTruePositives
-            let allPrecondTags = newPrecondTags <> precondTags
+            let newExpls = Sim.explanations simResult
+            let (_, newConstraints, _, _) = partitionExplanations newExpls
+            let (_, newConstraints') = unzip newConstraints
+            let allConstraints = addConstraints constraints (concat newConstraints')
             let allUnsoundness = unsoundness <> Sim.unsoundness simResult
-            let result =
-                  BugfindingResult
-                    newUncertain
-                    allPrecondTags
-                    ( Result.makeFunctionSummary
-                        allConstraints
-                        -- This only needs to look at the latest run because we
-                        -- don't continue if there was any uncertainty
-                        newUncertain
-                        allTruePositives
-                        -- This only needs to look at the latest run because we
-                        -- don't continue if the bounds were hit
-                        ( if null newResourceExhausted
-                            then Result.DidntHitBounds
-                            else Result.DidHitBounds
-                        )
-                        allUnsoundness
-                    )
-            case (null newConstraints, newTruePositives, not (null newUncertain), not (null newResourceExhausted)) of
-              (True, [], False, _) -> pure result
-              (noNewConstraints, _, isUncertain, isExhausted) ->
-                do
-                  if noNewConstraints || isUncertain || isExhausted
-                    then pure result -- We can't really go on
-                    else do
-                      (appCtx ^. log) Hi "New preconditions:"
-                      (appCtx ^. log) Hi $ Text.pack (show (ppConstraints allConstraints))
-                      loop allTruePositives allConstraints allPrecondTags allUnsoundness
+            let allResults = simResult : results
+            if shouldStop newExpls
+              then
+                pure $
+                  makeResult
+                    allConstraints
+                    (concatMap Sim.explanations allResults)
+                    allUnsoundness
+              else do
+                (appCtx ^. log) Hi "New preconditions:"
+                (appCtx ^. log) Hi $ Text.pack (show (ppConstraints allConstraints))
+                loop allConstraints allResults allUnsoundness
 
-    let emptyConstraints' =
-          emptyConstraints (funCtx ^. argumentFullTypes)
-    loop [] emptyConstraints' [] mempty
+    loop (emptyConstraints (funCtx ^. argumentFullTypes)) [] mempty
+  where
+    addConstraints ::
+      Constraints m argTypes ->
+      [NewConstraint m argTypes] ->
+      Constraints m argTypes
+    addConstraints constraints newConstraints =
+      foldM
+        (addConstraint modCtx (funCtx ^. argumentFullTypes))
+        constraints
+        newConstraints
+        & \case
+          Left err ->
+            panic
+              "bugfindingLoop"
+              ["Error adding constraints", Text.unpack (ppExpansionError err)]
+          Right allCs -> allCs
+
+    -- Given these results from simulation, should we continue looping?
+    shouldStop ::
+      [Explanation m arch argTypes] ->
+      Bool
+    shouldStop expls =
+      let (truePositives, constraints, uncertain, resourceExhausted) =
+            partitionExplanations expls
+       in case (null constraints, truePositives, not (null uncertain), not (null resourceExhausted)) of
+            (True, [], False, _) ->
+              -- No new constraints were learned, nor were any bugs found, nor
+              -- was there any uncertain results. The code is conditionally
+              -- safe, we can stop here.
+              True
+            (noNewConstraints, _, isUncertain, isExhausted) ->
+              -- We can't proceed if (1) new input constraints weren't learned,
+              -- (2) uncertainty was encountered, or (3) resource bounds were
+              -- exhausted.
+              noNewConstraints || isUncertain || isExhausted
+
+    makeResult ::
+      Constraints m argTypes ->
+      [Explanation m arch argTypes] ->
+      Unsoundness ->
+      BugfindingResult m arch argTypes
+    makeResult constraints expls unsoundness =
+      let (truePositives, newConstraints, uncertain, resourceExhausted) =
+            partitionExplanations expls
+          (precondTags, _) = unzip newConstraints
+       in BugfindingResult
+            uncertain
+            precondTags
+            ( Result.makeFunctionSummary
+                constraints
+                uncertain
+                truePositives
+                ( if null resourceExhausted
+                    then Result.DidntHitBounds
+                    else Result.DidHitBounds
+                )
+                unsoundness
+            )
 
 loopOnFunction ::
   Crux.Logs msgs =>

--- a/uc-crux-llvm/src/UCCrux/LLVM/Run/Result.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Run/Result.hs
@@ -30,6 +30,7 @@ where
 
 {- ORMOLU_DISABLE -}
 import           Data.List.NonEmpty (NonEmpty((:|)), toList)
+import           Data.Sequence (Seq)
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Void (Void)
@@ -43,6 +44,7 @@ import           Data.Parameterized.Ctx (Ctx)
 import           UCCrux.LLVM.Classify.Types (Located, ppLocated, TruePositive, ppTruePositive, Uncertainty, ppUncertainty, Diagnosis)
 import           UCCrux.LLVM.Constraints (isEmpty, ppConstraints, Constraints(..))
 import           UCCrux.LLVM.FullType.Type (FullType)
+import           UCCrux.LLVM.Run.Simulate (UCCruxSimulationResult)
 import           UCCrux.LLVM.Run.Unsoundness (Unsoundness, ppUnsoundness)
 {- ORMOLU_ENABLE -}
 
@@ -83,7 +85,10 @@ data FunctionSummary m (argTypes :: Ctx (FullType m))
   | AlwaysSafe Unsoundness
 
 data SomeBugfindingResult
-  = forall m arch argTypes. SomeBugfindingResult (BugfindingResult m arch argTypes)
+  = forall m arch argTypes.
+    SomeBugfindingResult
+      (BugfindingResult m arch argTypes)
+      (Seq (UCCruxSimulationResult m arch argTypes))
 
 -- NOTE(lb): The explicit kind signature here is necessary for GHC 8.8/8.6
 -- compatibility.

--- a/uc-crux-llvm/test/Test.hs
+++ b/uc-crux-llvm/test/Test.hs
@@ -48,6 +48,7 @@ a very real bug.
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeOperators #-}
 
 module Main (main) where
@@ -55,6 +56,7 @@ module Main (main) where
 {- ORMOLU_DISABLE -}
 import           Control.Exception ( try )
 import           Data.Aeson (ToJSON)
+import           Control.Monad (unless)
 import           Data.Foldable (for_)
 import qualified Data.Text as Text
 import qualified Data.Map as Map
@@ -66,13 +68,14 @@ import           System.IO (IOMode(WriteMode), withFile)
 
 import qualified Test.Tasty as TT
 import qualified Test.Tasty.HUnit as TH
+import qualified Test.Tasty.QuickCheck as TQ
 
 import qualified Text.LLVM.AST as L
 
 import qualified Data.Parameterized.Context as Ctx
 import           Data.Parameterized.NatRepr (NatRepr, knownNat)
 
-import           Lang.Crucible.FunctionHandle (newHandleAllocator)
+import           Lang.Crucible.FunctionHandle (HandleAllocator, newHandleAllocator)
 
 import           Lang.Crucible.LLVM.MemModel (mkMemVar)
 
@@ -86,6 +89,10 @@ import qualified Crux.LLVM.Log as Log
 import           Paths_uc_crux_llvm (version)
 import qualified UCCrux.LLVM.Config as Config
 import qualified UCCrux.LLVM.Main as Main
+import           UCCrux.LLVM.Main (loopOnFunctions, translateFile, translateLLVMModule)
+import           UCCrux.LLVM.Context.App (AppContext)
+import           UCCrux.LLVM.Context.Module (ModuleContext)
+import           UCCrux.LLVM.Equivalence (NonEmptyCrashDiff, reportDiffs, getCrashDiffs)
 import           UCCrux.LLVM.Errors.Unimplemented (catchUnimplemented)
 import           UCCrux.LLVM.Cursor (Cursor(..))
 import           UCCrux.LLVM.Classify.Types (partitionUncertainty)
@@ -173,13 +180,24 @@ withUCCruxLLVMTestLogging computation =
       ?injectUCCruxLLVMTestLogMessage = LoggingUCCruxLLVMTest
    in computation
 
-findBugs ::
+withOptions ::
   Maybe L.Module ->
   FilePath ->
   [String] ->
-  IO (Map.Map String Result.SomeBugfindingResult)
-findBugs llvmModule file fns =
+  ( forall m arch.
+    Log.Logs UCCruxLLVMTestLogging =>
+    Log.SupportsCruxLogMessage UCCruxLLVMTestLogging =>
+    AppContext ->
+    ModuleContext m arch ->
+    HandleAllocator ->
+    Crux.CruxOptions ->
+    Config.UCCruxLLVMOptions ->
+    IO a
+  ) ->
+  IO a
+withOptions llvmModule file fns k =
   withUCCruxLLVMTestLogging $
+  do
     withFile (testDir </> file <> ".output") WriteMode $ \h ->
       do
         let isRealFile = isNothing llvmModule
@@ -194,7 +212,7 @@ findBugs llvmModule file fns =
                   }
           let ucOpts' = ucOpts {Config.entryPoints = fns}
           (appCtx, cruxOpts'', ucOpts'') <- Config.processUCCruxLLVMOptions (cruxOpts', ucOpts')
-          path <- do
+          path <-
             let uclopts =
                   (Config.ucLLVMOptions ucOpts')
                     { -- NB(lb): The -fno-wrapv here ensures that
@@ -205,7 +223,7 @@ findBugs llvmModule file fns =
                     }
                 complain exc = do
                   sayUCCruxLLVMTest ClangTrouble
-                  Crux.logException exc
+                  Log.logException exc
                   error "aborting"
              in if isRealFile
                 then try (genBitCode cruxOpts'' uclopts) >>= either complain return
@@ -225,9 +243,70 @@ findBugs llvmModule file fns =
           memVar <- mkMemVar "uc-crux-llvm:test_llvm_memory" halloc
           Main.SomeModuleContext' modCtx <-
             case llvmModule of
-              Just lMod -> Main.translateLLVMModule ucOpts'' halloc memVar path lMod
-              Nothing -> Main.translateFile ucOpts'' halloc memVar path
-          Main.loopOnFunctions appCtx modCtx halloc cruxOpts'' ucOpts''
+              Just lMod -> translateLLVMModule ucOpts'' halloc memVar path lMod
+              Nothing -> translateFile ucOpts'' halloc memVar path
+
+          k appCtx modCtx halloc cruxOpts'' ucOpts''
+
+findBugs ::
+  Maybe L.Module ->
+  FilePath ->
+  [String] ->
+  IO (Map.Map String Result.SomeBugfindingResult)
+findBugs llvmModule file fns =
+  withOptions llvmModule file fns $
+    \appCtx modCtx halloc cruxOpts ucOpts ->
+      loopOnFunctions appCtx modCtx halloc cruxOpts ucOpts
+
+getCrashDiff ::
+  FilePath ->
+  L.Module ->
+  FilePath ->
+  L.Module ->
+  IO (AppContext, ([(String, NonEmptyCrashDiff)], [(String, NonEmptyCrashDiff)]))
+getCrashDiff path1 mod1 path2 mod2 =
+  withOptions (Just mod1) path1 ["fake"] $
+    \_ modCtx1 _ _ _ ->
+      withOptions (Just mod2) path2 ["fake"] $
+        \appCtx modCtx2 halloc cruxOpts ucOpts ->
+          let ucOpts' = ucOpts {Config.doExplore = True}
+           in (appCtx,) <$> getCrashDiffs appCtx modCtx1 modCtx2 halloc cruxOpts ucOpts'
+
+checkCrashDiff ::
+  FilePath ->
+  L.Module ->
+  FilePath ->
+  L.Module ->
+  -- | Should the check be for strict equivalence?
+  Bool ->
+  -- | Should the result be inverted?
+  Bool ->
+  TT.TestTree
+checkCrashDiff path1 mod1 path2 mod2 equivalent invert =
+  TH.testCase
+    ( unwords
+        [ path1,
+          if equivalent
+            then "is crash-equivalent to"
+            else "crashes less than",
+          path2
+        ]
+    )
+    $ do
+      (appCtx, (diffs12, diffs21)) <- getCrashDiff path1 mod1 path2 mod2
+      let diffs21' = if equivalent then diffs21 else []
+      reportDiffs appCtx diffs12 diffs21'
+      unless ((if invert then not else id) (null diffs12 && null diffs21')) $
+        TH.assertFailure
+          ( unwords
+              [ "Expected",
+                path1,
+                "and",
+                path2,
+                "to",
+                (if invert then "not " else "") ++ "be crash-equivalent."
+              ]
+          )
 
 inFile :: FilePath -> [(String, String -> Result.SomeBugfindingResult -> IO ())] -> TT.TestTree
 inFile file specs =
@@ -249,7 +328,7 @@ inModule fakePath llvmModule specs =
 
 -- | TODO: Take a list of TruePositiveTag, verify that those are the bugs.
 hasBugs :: String -> Result.SomeBugfindingResult -> IO ()
-hasBugs fn (Result.SomeBugfindingResult result) =
+hasBugs fn (Result.SomeBugfindingResult result _) =
   do
     [] TH.@=? map show (Result.uncertainResults result)
     case Result.summary result of
@@ -257,7 +336,7 @@ hasBugs fn (Result.SomeBugfindingResult result) =
       _ -> TH.assertFailure (unwords ["Expected", fn, "to have bugs"])
 
 isSafe :: Unsoundness -> String -> Result.SomeBugfindingResult -> IO ()
-isSafe unsoundness fn (Result.SomeBugfindingResult result) =
+isSafe unsoundness fn (Result.SomeBugfindingResult result _) =
   do
     [] TH.@=? map show (Result.uncertainResults result)
     case Result.summary result of
@@ -273,7 +352,7 @@ isSafe unsoundness fn (Result.SomeBugfindingResult result) =
           )
 
 isSafeToBounds :: Unsoundness -> String -> Result.SomeBugfindingResult -> IO ()
-isSafeToBounds unsoundness fn (Result.SomeBugfindingResult result) =
+isSafeToBounds unsoundness fn (Result.SomeBugfindingResult result _) =
   do
     [] TH.@=? map show (Result.uncertainResults result)
     case Result.summary result of
@@ -290,7 +369,7 @@ isSafeToBounds unsoundness fn (Result.SomeBugfindingResult result) =
 
 -- | TODO: Take a list of MissingPreconditionTag, check that they match.
 isSafeWithPreconditions :: Unsoundness -> DidHitBounds -> String -> Result.SomeBugfindingResult -> IO ()
-isSafeWithPreconditions unsoundness hitBounds fn (Result.SomeBugfindingResult result) =
+isSafeWithPreconditions unsoundness hitBounds fn (Result.SomeBugfindingResult result _) =
   do
     [] TH.@=? map show (Result.uncertainResults result)
     case Result.summary result of
@@ -309,7 +388,7 @@ isSafeWithPreconditions unsoundness hitBounds fn (Result.SomeBugfindingResult re
           )
 
 _isUnannotated :: String -> Result.SomeBugfindingResult -> IO ()
-_isUnannotated fn (Result.SomeBugfindingResult result) =
+_isUnannotated fn (Result.SomeBugfindingResult result _) =
   do
     let (missingAnn, failedAssert, unimpl, unclass, unfixed, unfixable, timeouts) =
           partitionUncertainty (Result.uncertainResults result)
@@ -328,7 +407,7 @@ _isUnannotated fn (Result.SomeBugfindingResult result) =
         ]
 
 _hasFailedAssert :: String -> Result.SomeBugfindingResult -> IO ()
-_hasFailedAssert fn (Result.SomeBugfindingResult result) =
+_hasFailedAssert fn (Result.SomeBugfindingResult result _) =
   do
     let (missingAnn, failedAssert, unimpl, unclass, unfixed, unfixable, timeouts) =
           partitionUncertainty (Result.uncertainResults result)
@@ -347,7 +426,7 @@ _hasFailedAssert fn (Result.SomeBugfindingResult result) =
         ]
 
 isUnclassified :: String -> Result.SomeBugfindingResult -> IO ()
-isUnclassified fn (Result.SomeBugfindingResult result) =
+isUnclassified fn (Result.SomeBugfindingResult result _) =
   do
     let (missingAnn, failedAssert, unimpl, unclass, unfixed, unfixable, timeouts) =
           partitionUncertainty (Result.uncertainResults result)
@@ -366,7 +445,7 @@ isUnclassified fn (Result.SomeBugfindingResult result) =
         ]
 
 isUnfixed :: String -> Result.SomeBugfindingResult -> IO ()
-isUnfixed fn (Result.SomeBugfindingResult result) =
+isUnfixed fn (Result.SomeBugfindingResult result _) =
   do
     let (missingAnn, failedAssert, unimpl, unclass, unfixed, unfixable, timeouts) =
           partitionUncertainty (Result.uncertainResults result)
@@ -385,7 +464,7 @@ isUnfixed fn (Result.SomeBugfindingResult result) =
         ]
 
 hasMissingAnn :: String -> Result.SomeBugfindingResult -> IO ()
-hasMissingAnn fn (Result.SomeBugfindingResult result) =
+hasMissingAnn fn (Result.SomeBugfindingResult result _) =
   do
     let (missingAnn, failedAssert, unimpl, unclass, unfixed, unfixable, timeouts) =
           partitionUncertainty (Result.uncertainResults result)
@@ -410,7 +489,8 @@ isUnimplemented file fn =
     catchUnimplemented
       ( do
           results <- findBugs Nothing file [fn]
-          Result.SomeBugfindingResult result <- pure $ fromMaybe (error "No result") (Map.lookup fn results)
+          Result.SomeBugfindingResult result _ <-
+            pure $ fromMaybe (error "No result") (Map.lookup fn results)
           let (_unclass, _missingAnn, _failedAssert, unimpl, _unfixed, _unfixable, _timeouts) =
                 partitionUncertainty (Result.uncertainResults result)
           0 < length unimpl
@@ -652,6 +732,432 @@ oneArithRight name ty val op =
         ]
     ]
 
+add1Left :: L.Module
+add1Left = oneArithLeft "add1_left" i32 (L.ValInteger 1) (L.Add False False)
+
+add1NswLeft :: L.Module
+add1NswLeft = oneArithLeft "add1_nsw_left" i32 (L.ValInteger 1) (L.Add False True)
+
+add1NuwLeft :: L.Module
+add1NuwLeft = oneArithLeft "add1_nuw_left" i32 (L.ValInteger 1) (L.Add True False)
+
+addNeg1Left :: L.Module
+addNeg1Left = oneArithLeft "add_neg1_left" i32 (L.ValInteger (-1)) (L.Add False False)
+
+addNeg1NswLeft :: L.Module
+addNeg1NswLeft = oneArithLeft "add_neg1_nsw_left" i32 (L.ValInteger (-1)) (L.Add False True)
+
+addNeg1NuwLeft :: L.Module
+addNeg1NuwLeft = oneArithLeft "add_neg1_nuw_left" i32 (L.ValInteger (-1)) (L.Add True False)
+
+add1FloatLeft :: L.Module
+add1FloatLeft = oneArithLeft "add1_float_left" float (L.ValFloat 1.0) L.FAdd
+
+addNeg1FloatLeft :: L.Module
+addNeg1FloatLeft = oneArithLeft "add_neg1_float_left" float (L.ValFloat (-1.0)) L.FAdd
+
+add1DoubleLeft :: L.Module
+add1DoubleLeft = oneArithLeft "add1_double_left" double (L.ValDouble 1.0) L.FAdd
+
+addNeg1DoubleLeft :: L.Module
+addNeg1DoubleLeft = oneArithLeft "add_neg1_double_left" double (L.ValDouble (-1.0)) L.FAdd
+
+sub1Left :: L.Module
+sub1Left = oneArithLeft "sub1_left" i32 (L.ValInteger 1) (L.Sub False False)
+
+sub1NswLeft :: L.Module
+sub1NswLeft = oneArithLeft "sub1_nsw_left" i32 (L.ValInteger 1) (L.Sub False True)
+
+sub1NuwLeft :: L.Module
+sub1NuwLeft = oneArithLeft "sub1_nuw_left" i32 (L.ValInteger 1) (L.Sub True False)
+
+subNeg1Left :: L.Module
+subNeg1Left = oneArithLeft "sub_neg1_left" i32 (L.ValInteger (-1)) (L.Sub False False)
+
+subNeg1NswLeft :: L.Module
+subNeg1NswLeft = oneArithLeft "sub_neg1_nsw_left" i32 (L.ValInteger (-1)) (L.Sub False True)
+
+subNeg1NuwLeft :: L.Module
+subNeg1NuwLeft = oneArithLeft "sub_neg1_nuw_left" i32 (L.ValInteger (-1)) (L.Sub True False)
+
+sub1FloatLeft :: L.Module
+sub1FloatLeft = oneArithLeft "sub1_float_left" float (L.ValFloat 1.0) L.FSub
+
+subNeg1FloatLeft :: L.Module
+subNeg1FloatLeft = oneArithLeft "sub_neg1_float_left" float (L.ValFloat (-1.0)) L.FSub
+
+sub1DoubleLeft :: L.Module
+sub1DoubleLeft = oneArithLeft "sub1_double_left" double (L.ValDouble 1.0) L.FSub
+
+subNeg1DoubleLeft :: L.Module
+subNeg1DoubleLeft = oneArithLeft "sub_neg1_double_left" double (L.ValDouble (-1.0)) L.FSub
+
+mul0Left :: L.Module
+mul0Left = oneArithLeft "mul0_left" i32 (L.ValInteger 0) (L.Mul True True)
+
+mul1Left :: L.Module
+mul1Left = oneArithLeft "mul1_left" i32 (L.ValInteger 1) (L.Mul False False)
+
+mul1NswLeft :: L.Module
+mul1NswLeft = oneArithLeft "mul1_nsw_left" i32 (L.ValInteger 1) (L.Mul False True)
+
+mul1NuwLeft :: L.Module
+mul1NuwLeft = oneArithLeft "mul1_nuw_left" i32 (L.ValInteger 1) (L.Mul True False)
+
+mulNeg1Left :: L.Module
+mulNeg1Left = oneArithLeft "mul_neg1_left" i32 (L.ValInteger (-1)) (L.Mul False False)
+
+mulNeg1NswLeft :: L.Module
+mulNeg1NswLeft = oneArithLeft "mul_neg1_nsw_left" i32 (L.ValInteger (-1)) (L.Mul False True)
+
+mulNeg1NuwLeft :: L.Module
+mulNeg1NuwLeft = oneArithLeft "mul_neg1_nuw_left" i32 (L.ValInteger (-1)) (L.Mul True False)
+
+udiv0Left :: L.Module
+udiv0Left = oneArithLeft "udiv0_left" i32 (L.ValInteger 0) (L.UDiv False)
+
+udiv1Left :: L.Module
+udiv1Left = oneArithLeft "udiv1_left" i32 (L.ValInteger 1) (L.UDiv False)
+
+udiv1ExactLeft :: L.Module
+udiv1ExactLeft = oneArithLeft "udiv1_exact_left" i32 (L.ValInteger 1) (L.UDiv True)
+
+udiv2Left :: L.Module
+udiv2Left = oneArithLeft "udiv2_left" i32 (L.ValInteger 2) (L.UDiv False)
+
+udiv2ExactLeft :: L.Module
+udiv2ExactLeft = oneArithLeft "udiv2_exact_left" i32 (L.ValInteger 2) (L.UDiv True)
+
+udivNeg1Left :: L.Module
+udivNeg1Left = oneArithLeft "udiv_neg1_left" i32 (L.ValInteger (-1)) (L.UDiv False)
+
+udivNeg1ExactLeft :: L.Module
+udivNeg1ExactLeft = oneArithLeft "udiv_neg1_exact_left" i32 (L.ValInteger (-1)) (L.UDiv True)
+
+sdiv0Left :: L.Module
+sdiv0Left = oneArithLeft "sdiv0_left" i32 (L.ValInteger 0) (L.SDiv False)
+
+sdiv1Left :: L.Module
+sdiv1Left = oneArithLeft "sdiv1_left" i32 (L.ValInteger 1) (L.SDiv False)
+
+sdiv1ExactLeft :: L.Module
+sdiv1ExactLeft = oneArithLeft "sdiv1_exact_left" i32 (L.ValInteger 1) (L.SDiv True)
+
+sdivNeg1Left :: L.Module
+sdivNeg1Left = oneArithLeft "sdiv_neg1_left" i32 (L.ValInteger (-1)) (L.SDiv False)
+
+sdivNeg1ExactLeft :: L.Module
+sdivNeg1ExactLeft = oneArithLeft "sdiv_neg1_exact_left" i32 (L.ValInteger (-1)) (L.SDiv True)
+
+sdiv2Left :: L.Module
+sdiv2Left = oneArithLeft "sdiv2_left" i32 (L.ValInteger 2) (L.SDiv False)
+
+sdiv2ExactLeft :: L.Module
+sdiv2ExactLeft = oneArithLeft "sdiv2_exact_left" i32 (L.ValInteger 2) (L.SDiv True)
+
+sdivNeg2Left :: L.Module
+sdivNeg2Left = oneArithLeft "sdiv_neg2_left" i32 (L.ValInteger (-2)) (L.SDiv False)
+
+sdivNeg2ExactLeft :: L.Module
+sdivNeg2ExactLeft = oneArithLeft "sdiv_neg2_exact_left" i32 (L.ValInteger (-2)) (L.SDiv True)
+
+urem0Left :: L.Module
+urem0Left = oneArithLeft "urem0_left" i32 (L.ValInteger 0) L.URem
+
+urem1Left :: L.Module
+urem1Left = oneArithLeft "urem1_left" i32 (L.ValInteger 1) L.URem
+
+uremNeg1Left :: L.Module
+uremNeg1Left = oneArithLeft "urem_neg1_left" i32 (L.ValInteger (-1)) L.URem
+
+urem2Left :: L.Module
+urem2Left = oneArithLeft "urem2_left" i32 (L.ValInteger 2) L.URem
+
+srem0Left :: L.Module
+srem0Left = oneArithLeft "srem0_left" i32 (L.ValInteger 0) L.SRem
+
+srem1Left :: L.Module
+srem1Left = oneArithLeft "srem1_left" i32 (L.ValInteger 1) L.SRem
+
+sremNeg1Left :: L.Module
+sremNeg1Left = oneArithLeft "srem_neg1_left" i32 (L.ValInteger (-1)) L.SRem
+
+srem2Left :: L.Module
+srem2Left = oneArithLeft "srem2_left" i32 (L.ValInteger 2) L.SRem
+
+sremNeg2Left :: L.Module
+sremNeg2Left = oneArithLeft "srem_neg2_left" i32 (L.ValInteger (-2)) L.SRem
+
+add1Right :: L.Module
+add1Right = oneArithRight "add1_right" i32 (L.ValInteger 1) (L.Add False False)
+
+add1NswRight :: L.Module
+add1NswRight = oneArithRight "add1_nsw_right" i32 (L.ValInteger 1) (L.Add False True)
+
+add1NuwRight :: L.Module
+add1NuwRight = oneArithRight "add1_nuw_right" i32 (L.ValInteger 1) (L.Add True False)
+
+addNeg1Right :: L.Module
+addNeg1Right = oneArithRight "add_neg1_right" i32 (L.ValInteger (-1)) (L.Add False False)
+
+addNeg1NswRight :: L.Module
+addNeg1NswRight = oneArithRight "add_neg1_nsw_right" i32 (L.ValInteger (-1)) (L.Add False True)
+
+addNeg1NuwRight :: L.Module
+addNeg1NuwRight = oneArithRight "add_neg1_nuw_right" i32 (L.ValInteger (-1)) (L.Add True False)
+
+add1FloatRight :: L.Module
+add1FloatRight = oneArithRight "add1_float_right" float (L.ValFloat 1.0) L.FAdd
+
+addNeg1FloatRight :: L.Module
+addNeg1FloatRight = oneArithRight "add_neg1_float_right" float (L.ValFloat (-1.0)) L.FAdd
+
+add1DoubleRight :: L.Module
+add1DoubleRight = oneArithRight "add1_double_right" double (L.ValDouble 1.0) L.FAdd
+
+addNeg1DoubleRight :: L.Module
+addNeg1DoubleRight = oneArithRight "add_neg1_double_right" double (L.ValDouble (-1.0)) L.FAdd
+
+sub1Right :: L.Module
+sub1Right = oneArithRight "sub1_right" i32 (L.ValInteger 1) (L.Sub False False)
+
+sub1NswRight :: L.Module
+sub1NswRight = oneArithRight "sub1_nsw_right" i32 (L.ValInteger 1) (L.Sub False True)
+
+sub1NuwRight :: L.Module
+sub1NuwRight = oneArithRight "sub1_nuw_right" i32 (L.ValInteger 1) (L.Sub True False)
+
+subNeg1Right :: L.Module
+subNeg1Right = oneArithRight "sub_neg1_right" i32 (L.ValInteger (-1)) (L.Sub False False)
+
+subNeg1NswRight :: L.Module
+subNeg1NswRight = oneArithRight "sub_neg1_nsw_right" i32 (L.ValInteger (-1)) (L.Sub False True)
+
+subNeg1NuwRight :: L.Module
+subNeg1NuwRight = oneArithRight "sub_neg1_nuw_right" i32 (L.ValInteger (-1)) (L.Sub True False)
+
+sub1FloatRight :: L.Module
+sub1FloatRight = oneArithRight "sub1_float_right" float (L.ValFloat 1.0) L.FSub
+
+subNeg1FloatRight :: L.Module
+subNeg1FloatRight = oneArithRight "sub_neg1_float_right" float (L.ValFloat (-1.0)) L.FSub
+
+sub1DoubleRight :: L.Module
+sub1DoubleRight = oneArithRight "sub1_double_right" double (L.ValDouble 1.0) L.FSub
+
+subNeg1DoubleRight :: L.Module
+subNeg1DoubleRight = oneArithRight "sub_neg1_double_right" double (L.ValDouble (-1.0)) L.FSub
+
+mul0Right :: L.Module
+mul0Right = oneArithRight "mul0_right" i32 (L.ValInteger 0) (L.Mul True True)
+
+mul1Right :: L.Module
+mul1Right = oneArithRight "mul1_right" i32 (L.ValInteger 1) (L.Mul False False)
+
+mul1NswRight :: L.Module
+mul1NswRight = oneArithRight "mul1_nsw_right" i32 (L.ValInteger 1) (L.Mul False True)
+
+mul1NuwRight :: L.Module
+mul1NuwRight = oneArithRight "mul1_nuw_right" i32 (L.ValInteger 1) (L.Mul True False)
+
+mulNeg1Right :: L.Module
+mulNeg1Right = oneArithRight "mul_neg1_right" i32 (L.ValInteger (-1)) (L.Mul False False)
+
+mulNeg1NswRight :: L.Module
+mulNeg1NswRight = oneArithRight "mul_neg1_nsw_right" i32 (L.ValInteger (-1)) (L.Mul False True)
+
+mulNeg1NuwRight :: L.Module
+mulNeg1NuwRight = oneArithRight "mul_neg1_nuw_right" i32 (L.ValInteger (-1)) (L.Mul True False)
+
+udiv0Right :: L.Module
+udiv0Right = oneArithRight "udiv0_right" i32 (L.ValInteger 0) (L.UDiv False)
+
+udiv1Right :: L.Module
+udiv1Right = oneArithRight "udiv1_right" i32 (L.ValInteger 1) (L.UDiv False)
+
+udiv1ExactRight :: L.Module
+udiv1ExactRight = oneArithRight "udiv1_exact_right" i32 (L.ValInteger 1) (L.UDiv True)
+
+udiv2Right :: L.Module
+udiv2Right = oneArithRight "udiv2_right" i32 (L.ValInteger 2) (L.UDiv False)
+
+udiv2ExactRight :: L.Module
+udiv2ExactRight = oneArithRight "udiv2_exact_right" i32 (L.ValInteger 2) (L.UDiv True)
+
+udivNeg1Right :: L.Module
+udivNeg1Right = oneArithRight "udiv_neg1_right" i32 (L.ValInteger (-1)) (L.UDiv False)
+
+udivNeg1ExactRight :: L.Module
+udivNeg1ExactRight = oneArithRight "udiv_neg1_exact_right" i32 (L.ValInteger (-1)) (L.UDiv True)
+
+sdiv0Right :: L.Module
+sdiv0Right = oneArithRight "sdiv0_right" i32 (L.ValInteger 0) (L.SDiv False)
+
+sdiv1Right :: L.Module
+sdiv1Right = oneArithRight "sdiv1_right" i32 (L.ValInteger 1) (L.SDiv False)
+
+sdiv1ExactRight :: L.Module
+sdiv1ExactRight = oneArithRight "sdiv1_exact_right" i32 (L.ValInteger 1) (L.SDiv True)
+
+sdivNeg1Right :: L.Module
+sdivNeg1Right = oneArithRight "sdiv_neg1_right" i32 (L.ValInteger (-1)) (L.SDiv False)
+
+sdivNeg1ExactRight :: L.Module
+sdivNeg1ExactRight = oneArithRight "sdiv_neg1_exact_right" i32 (L.ValInteger (-1)) (L.SDiv True)
+
+sdiv2Right :: L.Module
+sdiv2Right = oneArithRight "sdiv2_right" i32 (L.ValInteger 2) (L.SDiv False)
+
+sdiv2ExactRight :: L.Module
+sdiv2ExactRight = oneArithRight "sdiv2_exact_right" i32 (L.ValInteger 2) (L.SDiv True)
+
+sdivNeg2Right :: L.Module
+sdivNeg2Right = oneArithRight "sdiv_neg2_right" i32 (L.ValInteger (-2)) (L.SDiv False)
+
+sdivNeg2ExactRight :: L.Module
+sdivNeg2ExactRight = oneArithRight "sdiv_neg2_exact_right" i32 (L.ValInteger (-2)) (L.SDiv True)
+
+urem0Right :: L.Module
+urem0Right = oneArithRight "urem0_right" i32 (L.ValInteger 0) L.URem
+
+urem1Right :: L.Module
+urem1Right = oneArithRight "urem1_right" i32 (L.ValInteger 1) L.URem
+
+uremNeg1Right :: L.Module
+uremNeg1Right = oneArithRight "urem_neg1_right" i32 (L.ValInteger (-1)) L.URem
+
+urem2Right :: L.Module
+urem2Right = oneArithRight "urem2_right" i32 (L.ValInteger 2) L.URem
+
+srem0Right :: L.Module
+srem0Right = oneArithRight "srem0_right" i32 (L.ValInteger 0) L.SRem
+
+srem1Right :: L.Module
+srem1Right = oneArithRight "srem1_right" i32 (L.ValInteger 1) L.SRem
+
+sremNeg1Right :: L.Module
+sremNeg1Right = oneArithRight "srem_neg1_right" i32 (L.ValInteger (-1)) L.SRem
+
+srem2Right :: L.Module
+srem2Right = oneArithRight "srem2_right" i32 (L.ValInteger 2) L.SRem
+
+sremNeg2Right :: L.Module
+sremNeg2Right = oneArithRight "srem_neg2_right" i32 (L.ValInteger (-2)) L.SRem
+
+arithModules :: [L.Module]
+arithModules =
+  [ add1Left,
+    add1NswLeft,
+    add1NuwLeft,
+    addNeg1Left,
+    addNeg1NswLeft,
+    addNeg1NuwLeft,
+    add1FloatLeft,
+    addNeg1FloatLeft,
+    add1DoubleLeft,
+    addNeg1DoubleLeft,
+    sub1Left,
+    sub1NswLeft,
+    sub1NuwLeft,
+    subNeg1Left,
+    subNeg1NswLeft,
+    subNeg1NuwLeft,
+    sub1FloatLeft,
+    subNeg1FloatLeft,
+    sub1DoubleLeft,
+    subNeg1DoubleLeft,
+    mul0Left,
+    mul1Left,
+    mul1NswLeft,
+    mul1NuwLeft,
+    mulNeg1Left,
+    mulNeg1NswLeft,
+    mulNeg1NuwLeft,
+    udiv0Left,
+    udiv1Left,
+    udiv1ExactLeft,
+    udiv2Left,
+    udiv2ExactLeft,
+    udivNeg1Left,
+    udivNeg1ExactLeft,
+    sdiv0Left,
+    sdiv1Left,
+    sdiv1ExactLeft,
+    sdivNeg1Left,
+    sdivNeg1ExactLeft,
+    sdiv2Left,
+    sdiv2ExactLeft,
+    sdivNeg2Left,
+    sdivNeg2ExactLeft,
+    urem0Left,
+    urem1Left,
+    uremNeg1Left,
+    urem2Left,
+    srem0Left,
+    srem1Left,
+    sremNeg1Left,
+    srem2Left,
+    sremNeg2Left,
+    add1Right,
+    add1NswRight,
+    add1NuwRight,
+    addNeg1Right,
+    addNeg1NswRight,
+    addNeg1NuwRight,
+    add1FloatRight,
+    addNeg1FloatRight,
+    add1DoubleRight,
+    addNeg1DoubleRight,
+    sub1Right,
+    sub1NswRight,
+    sub1NuwRight,
+    subNeg1Right,
+    subNeg1NswRight,
+    subNeg1NuwRight,
+    sub1FloatRight,
+    subNeg1FloatRight,
+    sub1DoubleRight,
+    subNeg1DoubleRight,
+    mul0Right,
+    mul1Right,
+    mul1NswRight,
+    mul1NuwRight,
+    mulNeg1Right,
+    mulNeg1NswRight,
+    mulNeg1NuwRight,
+    udiv0Right,
+    udiv1Right,
+    udiv1ExactRight,
+    udiv2Right,
+    udiv2ExactRight,
+    udivNeg1Right,
+    udivNeg1ExactRight,
+    sdiv0Right,
+    sdiv1Right,
+    sdiv1ExactRight,
+    sdivNeg1Right,
+    sdivNeg1ExactRight,
+    sdiv2Right,
+    sdiv2ExactRight,
+    sdivNeg2Right,
+    sdivNeg2ExactRight,
+    urem0Right,
+    urem1Right,
+    uremNeg1Right,
+    urem2Right,
+    srem0Right,
+    srem1Right,
+    sremNeg1Right,
+    srem2Right,
+    sremNeg2Right
+  ]
+
+newtype ArithModule = ArithModule L.Module
+  deriving (Eq, Ord, Show)
+
+instance TQ.Arbitrary ArithModule where
+  arbitrary = TQ.oneof (map (pure . ArithModule) arithModules)
+
 moduleTests :: TT.TestTree
 moduleTests =
   TT.testGroup
@@ -681,431 +1187,461 @@ moduleTests =
     -- cases and missed a very real bug.
     [ inModule
         "add1_left.c"
-        (oneArithLeft "add1_left" i32 (L.ValInteger 1) (L.Add False False))
+        add1Left
         [("add1_left", isSafe mempty)],
       inModule
         "add1_nsw_left.c"
-        (oneArithLeft "add1_nsw_left" i32 (L.ValInteger 1) (L.Add False True))
+        add1NswLeft
         [("add1_nsw_left", isSafeWithPreconditions mempty DidntHitBounds)],
       inModule
         "add1_nuw_left.c"
-        (oneArithLeft "add1_nuw_left" i32 (L.ValInteger 1) (L.Add True False))
+        add1NuwLeft
         [("add1_nuw_left", isUnclassified)], -- TODO(lb) Goal: isSafeWithPreconditions
       inModule
         "add_neg1_left.c"
-        (oneArithLeft "add_neg1_left" i32 (L.ValInteger (-1)) (L.Add False False))
+        addNeg1Left
         [("add_neg1_left", isSafe mempty)],
       inModule
         "add_neg1_nsw_left.c"
-        (oneArithLeft "add_neg1_nsw_left" i32 (L.ValInteger (-1)) (L.Add False True))
+        addNeg1NswLeft
         [("add_neg1_nsw_left", isSafeWithPreconditions mempty DidntHitBounds)],
       inModule
         "add_neg1_nuw_left.c"
-        (oneArithLeft "add_neg1_nuw_left" i32 (L.ValInteger (-1)) (L.Add True False))
+        addNeg1NuwLeft
         [("add_neg1_nuw_left", isUnclassified)], -- TODO(lb) Goal: isSafeWithPreconditions
       inModule
         "add1_float_left.c"
-        (oneArithLeft "add1_float_left" float (L.ValFloat 1.0) L.FAdd)
+        add1FloatLeft
         [("add1_float_left", isSafe mempty)],
       inModule
         "add_neg1_float_left.c"
-        (oneArithLeft "add_neg1_float_left" float (L.ValFloat (-1.0)) L.FAdd)
+        addNeg1FloatLeft
         [("add_neg1_float_left", isSafe mempty)],
       inModule
         "add1_double_left.c"
-        (oneArithLeft "add1_double_left" double (L.ValDouble 1.0) L.FAdd)
+        add1DoubleLeft
         [("add1_double_left", isSafe mempty)],
       inModule
         "add_neg1_double_left.c"
-        (oneArithLeft "add_neg1_double_left" double (L.ValDouble (-1.0)) L.FAdd)
+        addNeg1DoubleLeft
         [("add_neg1_double_left", isSafe mempty)],
       inModule
         "sub1_left.c"
-        (oneArithLeft "sub1_left" i32 (L.ValInteger 1) (L.Sub False False))
+        sub1Left
         [("sub1_left", isSafe mempty)],
       -- TODO(lb) Goal: isSafeWithPreconditions, precondition is that the
       -- argument isn't near the min/max value.
       inModule
         "sub1_nsw_left.c"
-        (oneArithLeft "sub1_nsw_left" i32 (L.ValInteger 1) (L.Sub False True))
+        sub1NswLeft
         [("sub1_nsw_left", isUnclassified)],
       -- TODO(lb) Goal: isSafeWithPreconditions, precondition is that the
       -- argument isn't near the min/max value.
       inModule
         "sub1_nuw_left.c"
-        (oneArithLeft "sub1_nuw_left" i32 (L.ValInteger 1) (L.Sub True False))
+        sub1NuwLeft
         [("sub1_nuw_left", isUnclassified)],
       inModule
         "sub_neg1_left.c"
-        (oneArithLeft "sub_neg1_left" i32 (L.ValInteger (-1)) (L.Sub False False))
+        subNeg1Left
         [("sub_neg1_left", isSafe mempty)],
       -- TODO(lb) Goal: isSafeWithPreconditions, precondition is that the
       -- argument isn't near the min/max value.
       inModule
         "sub_neg1_nsw_left.c"
-        (oneArithLeft "sub_neg1_nsw_left" i32 (L.ValInteger (-1)) (L.Sub False True))
+        subNeg1NswLeft
         [("sub_neg1_nsw_left", isUnclassified)],
       -- TODO(lb) Goal: isSafeWithPreconditions, precondition is that the
       -- argument isn't near the min/max value.
       inModule
         "sub_neg1_nuw_left.c"
-        (oneArithLeft "sub_neg1_nuw_left" i32 (L.ValInteger (-1)) (L.Sub True False))
+        subNeg1NuwLeft
         [("sub_neg1_nuw_left", isUnclassified)],
       inModule
         "sub1_float_left.c"
-        (oneArithLeft "sub1_float_left" float (L.ValFloat 1.0) L.FSub)
+        sub1FloatLeft
         [("sub1_float_left", isSafe mempty)],
       inModule
         "sub_neg1_float_left.c"
-        (oneArithLeft "sub_neg1_float_left" float (L.ValFloat (-1.0)) L.FSub)
+        subNeg1FloatLeft
         [("sub_neg1_float_left", isSafe mempty)],
       inModule
         "sub1_double_left.c"
-        (oneArithLeft "sub1_double_left" double (L.ValDouble 1.0) L.FSub)
+        sub1DoubleLeft
         [("sub1_double_left", isSafe mempty)],
       inModule
         "sub_neg1_double_left.c"
-        (oneArithLeft "sub_neg1_double_left" double (L.ValDouble (-1.0)) L.FSub)
+        subNeg1DoubleLeft
         [("sub_neg1_double_left", isSafe mempty)],
       inModule
         "mul0_left.c"
-        (oneArithLeft "mul0_left" i32 (L.ValInteger 0) (L.Mul True True))
+        mul0Left
         [("mul0_left", isSafe mempty)],
       inModule
         "mul1_left.c"
-        (oneArithLeft "mul1_left" i32 (L.ValInteger 1) (L.Mul False False))
+        mul1Left
         [("mul1_left", isSafe mempty)],
       inModule
         "mul1_nsw_left.c"
-        (oneArithLeft "mul1_nsw_left" i32 (L.ValInteger 1) (L.Mul False True))
+        mul1NswLeft
         [("mul1_nsw_left", isSafe mempty)],
       inModule
         "mul1_nuw_left.c"
-        (oneArithLeft "mul1_nuw_left" i32 (L.ValInteger 1) (L.Mul True False))
+        mul1NuwLeft
         [("mul1_nuw_left", isSafe mempty)],
       inModule
         "mul_neg1_left.c"
-        (oneArithLeft "mul_neg1_left" i32 (L.ValInteger (-1)) (L.Mul False False))
+        mulNeg1Left
         [("mul_neg1_left", isSafe mempty)],
       inModule
         "mul_neg1_nsw_left.c"
-        (oneArithLeft "mul_neg1_nsw_left" i32 (L.ValInteger (-1)) (L.Mul False True))
+        mulNeg1NswLeft
         [("mul_neg1_nsw_left", isUnclassified)], -- TODO Goal: ???
       inModule
         "mul_neg1_nuw_left.c"
-        (oneArithLeft "mul_neg1_nuw_left" i32 (L.ValInteger (-1)) (L.Mul True False))
+        mulNeg1NuwLeft
         [("mul_neg1_nuw_left", isUnclassified)], -- TODO Goal: ???
       inModule
         "udiv0_left.c"
-        (oneArithLeft "udiv0_left" i32 (L.ValInteger 0) (L.UDiv False))
+        udiv0Left
         [("udiv0_left", hasBugs)],
       inModule
         "udiv1_left.c"
-        (oneArithLeft "udiv1_left" i32 (L.ValInteger 1) (L.UDiv False))
+        udiv1Left
         [("udiv1_left", isSafe mempty)],
       inModule
         "udiv1_exact_left.c"
-        (oneArithLeft "udiv1_exact_left" i32 (L.ValInteger 1) (L.UDiv True))
+        udiv1ExactLeft
         [("udiv1_exact_left", isSafe mempty)],
       inModule
         "udiv2_left.c"
-        (oneArithLeft "udiv2_left" i32 (L.ValInteger 2) (L.UDiv False))
+        udiv2Left
         [("udiv2_left", isSafe mempty)],
       inModule
         "udiv2_exact_left.c"
-        (oneArithLeft "udiv2_exact_left" i32 (L.ValInteger 2) (L.UDiv True))
+        udiv2ExactLeft
         [("udiv2_exact_left", isUnclassified)], -- TODO Goal: ???
       inModule
         "udiv_neg1_left.c"
-        (oneArithLeft "udiv_neg1_left" i32 (L.ValInteger (-1)) (L.UDiv False))
+        udivNeg1Left
         [("udiv_neg1_left", isSafe mempty)],
       inModule
         "udiv_neg1_exact_left.c"
-        (oneArithLeft "udiv_neg1_exact_left" i32 (L.ValInteger (-1)) (L.UDiv True))
+        udivNeg1ExactLeft
         [("udiv_neg1_exact_left", isUnclassified)], -- TODO Goal: ???
       inModule
         "sdiv0_left.c"
-        (oneArithLeft "sdiv0_left" i32 (L.ValInteger 0) (L.SDiv False))
+        sdiv0Left
         [("sdiv0_left", hasBugs)],
       inModule
         "sdiv1_left.c"
-        (oneArithLeft "sdiv1_left" i32 (L.ValInteger 1) (L.SDiv False))
+        sdiv1Left
         [("sdiv1_left", isSafe mempty)],
       inModule
         "sdiv1_exact_left.c"
-        (oneArithLeft "sdiv1_exact_left" i32 (L.ValInteger 1) (L.SDiv True))
+        sdiv1ExactLeft
         [("sdiv1_exact_left", isSafe mempty)],
       inModule
         "sdiv_neg1_left.c"
-        (oneArithLeft "sdiv_neg1_left" i32 (L.ValInteger (-1)) (L.SDiv False))
+        sdivNeg1Left
         [("sdiv_neg1_left", isUnclassified)], -- TODO Goal: ???
       inModule
         "sdiv_neg1_exact_left.c"
-        (oneArithLeft "sdiv_neg1_exact_left" i32 (L.ValInteger (-1)) (L.SDiv True))
+        sdivNeg1ExactLeft
         [("sdiv_neg1_exact_left", isUnclassified)], -- TODO Goal: ???
       inModule
         "sdiv2_left.c"
-        (oneArithLeft "sdiv2_left" i32 (L.ValInteger 2) (L.SDiv False))
+        sdiv2Left
         [("sdiv2_left", isSafe mempty)],
       inModule
         "sdiv2_exact_left.c"
-        (oneArithLeft "sdiv2_exact_left" i32 (L.ValInteger 2) (L.SDiv True))
+        sdiv2ExactLeft
         [("sdiv2_exact_left", isUnclassified)], -- TODO Goal: ???
       inModule
         "sdiv_neg2_left.c"
-        (oneArithLeft "sdiv_neg2_left" i32 (L.ValInteger (-2)) (L.SDiv False))
+        sdivNeg2Left
         [("sdiv_neg2_left", isSafe mempty)],
       inModule
         "sdiv_neg2_exact_left.c"
-        (oneArithLeft "sdiv_neg2_exact_left" i32 (L.ValInteger (-2)) (L.SDiv True))
+        sdivNeg2ExactLeft
         [("sdiv_neg2_exact_left", isUnclassified)], -- TODO Goal: ???
       inModule
         "urem0_left.c"
-        (oneArithLeft "urem0_left" i32 (L.ValInteger 0) L.URem)
+        urem0Left
         [("urem0_left", hasBugs)],
       inModule
         "urem1_left.c"
-        (oneArithLeft "urem1_left" i32 (L.ValInteger 1) L.URem)
+        urem1Left
         [("urem1_left", isSafe mempty)],
       inModule
         "urem_neg1_left.c"
-        (oneArithLeft "urem_neg1_left" i32 (L.ValInteger (-1)) L.URem)
+        uremNeg1Left
         [("urem_neg1_left", isSafe mempty)],
       inModule
         "urem2_left.c"
-        (oneArithLeft "urem2_left" i32 (L.ValInteger 2) L.URem)
+        urem2Left
         [("urem2_left", isSafe mempty)],
       inModule
         "srem0_left.c"
-        (oneArithLeft "srem0_left" i32 (L.ValInteger 0) L.SRem)
+        srem0Left
         [("srem0_left", hasBugs)],
       inModule
         "srem1_left.c"
-        (oneArithLeft "srem1_left" i32 (L.ValInteger 1) L.SRem)
+        srem1Left
         [("srem1_left", isSafe mempty)],
       inModule
         "srem_neg1_left.c"
-        (oneArithLeft "srem_neg1_left" i32 (L.ValInteger (-1)) L.SRem)
+        sremNeg1Left
         [("srem_neg1_left", isUnclassified)], -- TODO Goal: ???
       inModule
         "srem2_left.c"
-        (oneArithLeft "srem2_left" i32 (L.ValInteger 2) L.SRem)
+        srem2Left
         [("srem2_left", isSafe mempty)],
       inModule
         "srem_neg2_left.c"
-        (oneArithLeft "srem_neg2_left" i32 (L.ValInteger (-2)) L.SRem)
+        sremNeg2Left
         [("srem_neg2_left", isSafe mempty)],
       -- --------------------------------------------------- On the right
       inModule
         "add1_right.c"
-        (oneArithRight "add1_right" i32 (L.ValInteger 1) (L.Add False False))
+        add1Right
         [("add1_right", isSafe mempty)],
       inModule
         "add1_nsw_right.c"
-        (oneArithRight "add1_nsw_right" i32 (L.ValInteger 1) (L.Add False True))
+        add1NswRight
         [("add1_nsw_right", isSafeWithPreconditions mempty DidntHitBounds)],
       -- TODO(lb) Goal: isSafeWithPreconditions, precondition is that the
       -- argument isn't near the min/max value.
       inModule
         "add1_nuw_right.c"
-        (oneArithRight "add1_nuw_right" i32 (L.ValInteger 1) (L.Add True False))
+        add1NuwRight
         [("add1_nuw_right", isUnclassified)],
       inModule
         "add_neg1_right.c"
-        (oneArithRight "add_neg1_right" i32 (L.ValInteger (-1)) (L.Add False False))
+        addNeg1Right
         [("add_neg1_right", isSafe mempty)],
       inModule
         "add_neg1_nsw_right.c"
-        (oneArithRight "add_neg1_nsw_right" i32 (L.ValInteger (-1)) (L.Add False True))
+        addNeg1NswRight
         [("add_neg1_nsw_right", isSafeWithPreconditions mempty DidntHitBounds)],
       inModule
         "add_neg1_nuw_right.c"
-        (oneArithRight "add_neg1_nuw_right" i32 (L.ValInteger (-1)) (L.Add True False))
+        addNeg1NuwRight
         [("add_neg1_nuw_right", isUnclassified)], -- TODO(lb) Goal: isSafeWithPreconditions
       inModule
         "add1_float_right.c"
-        (oneArithRight "add1_float_right" float (L.ValFloat 1.0) L.FAdd)
+        add1FloatRight
         [("add1_float_right", isSafe mempty)],
       inModule
         "add_neg1_float_right.c"
-        (oneArithRight "add_neg1_float_right" float (L.ValFloat (-1.0)) L.FAdd)
+        addNeg1FloatRight
         [("add_neg1_float_right", isSafe mempty)],
       inModule
         "add1_double_right.c"
-        (oneArithRight "add1_double_right" double (L.ValDouble 1.0) L.FAdd)
+        add1DoubleRight
         [("add1_double_right", isSafe mempty)],
       inModule
         "add_neg1_double_right.c"
-        (oneArithRight "add_neg1_double_right" double (L.ValDouble (-1.0)) L.FAdd)
+        addNeg1DoubleRight
         [("add_neg1_double_right", isSafe mempty)],
       inModule
         "sub1_right.c"
-        (oneArithRight "sub1_right" i32 (L.ValInteger 1) (L.Sub False False))
+        sub1Right
         [("sub1_right", isSafe mempty)],
       inModule
         "sub1_nsw_right.c"
-        (oneArithRight "sub1_nsw_right" i32 (L.ValInteger 1) (L.Sub False True))
+        sub1NswRight
         [("sub1_nsw_right", isSafeWithPreconditions mempty DidntHitBounds)],
       inModule
         "sub1_nuw_right.c"
-        (oneArithRight "sub1_nuw_right" i32 (L.ValInteger 1) (L.Sub True False))
+        sub1NuwRight
         [("sub1_nuw_right", isUnclassified)], -- TODO(lb) Goal: isSafeWithPreconditions
       inModule
         "sub_neg1_right.c"
-        (oneArithRight "sub_neg1_right" i32 (L.ValInteger (-1)) (L.Sub False False))
+        subNeg1Right
         [("sub_neg1_right", isSafe mempty)],
       inModule
         "sub_neg1_nsw_right.c"
-        (oneArithRight "sub_neg1_nsw_right" i32 (L.ValInteger (-1)) (L.Sub False True))
+        subNeg1NswRight
         [("sub_neg1_nsw_right", isSafe mempty)], -- TODO Is this right?
       inModule
         "sub_neg1_nuw_right.c"
-        (oneArithRight "sub_neg1_nuw_right" i32 (L.ValInteger (-1)) (L.Sub True False))
+        subNeg1NuwRight
         [("sub_neg1_nuw_right", isSafe mempty)],
       inModule
         "sub1_float_right.c"
-        (oneArithRight "sub1_float_right" float (L.ValFloat 1.0) L.FSub)
+        sub1FloatRight
         [("sub1_float_right", isSafe mempty)],
       inModule
         "sub_neg1_float_right.c"
-        (oneArithRight "sub_neg1_float_right" float (L.ValFloat (-1.0)) L.FSub)
+        subNeg1FloatRight
         [("sub_neg1_float_right", isSafe mempty)],
       inModule
         "sub1_double_right.c"
-        (oneArithRight "sub1_double_right" double (L.ValDouble 1.0) L.FSub)
+        sub1DoubleRight
         [("sub1_double_right", isSafe mempty)],
       inModule
         "sub_neg1_double_right.c"
-        (oneArithRight "sub_neg1_double_right" double (L.ValDouble (-1.0)) L.FSub)
+        subNeg1DoubleRight
         [("sub_neg1_double_right", isSafe mempty)],
       inModule
         "mul0_right.c"
-        (oneArithRight "mul0_right" i32 (L.ValInteger 0) (L.Mul True True))
+        mul0Right
         [("mul0_right", isSafe mempty)],
       inModule
         "mul1_right.c"
-        (oneArithRight "mul1_right" i32 (L.ValInteger 1) (L.Mul False False))
+        mul1Right
         [("mul1_right", isSafe mempty)],
       inModule
         "mul1_nsw_right.c"
-        (oneArithRight "mul1_nsw_right" i32 (L.ValInteger 1) (L.Mul False True))
+        mul1NswRight
         [("mul1_nsw_right", isSafe mempty)],
       inModule
         "mul1_nuw_right.c"
-        (oneArithRight "mul1_nuw_right" i32 (L.ValInteger 1) (L.Mul True False))
+        mul1NuwRight
         [("mul1_nuw_right", isSafe mempty)],
       inModule
         "mul_neg1_right.c"
-        (oneArithRight "mul_neg1_right" i32 (L.ValInteger (-1)) (L.Mul False False))
+        mulNeg1Right
         [("mul_neg1_right", isSafe mempty)],
       inModule
         "mul_neg1_nsw_right.c"
-        (oneArithRight "mul_neg1_nsw_right" i32 (L.ValInteger (-1)) (L.Mul False True))
+        mulNeg1NswRight
         [("mul_neg1_nsw_right", isUnclassified)], -- TODO Goal: ???
       inModule
         "mul_neg1_nuw_right.c"
-        (oneArithRight "mul_neg1_nuw_right" i32 (L.ValInteger (-1)) (L.Mul True False))
+        mulNeg1NuwRight
         [("mul_neg1_nuw_right", isUnclassified)], -- TODO Goal: ???
       inModule
         "udiv0_right.c"
-        (oneArithRight "udiv0_right" i32 (L.ValInteger 0) (L.UDiv False))
+        udiv0Right
         [("udiv0_right", isSafeWithPreconditions mempty DidntHitBounds)],
       inModule
         "udiv1_right.c"
-        (oneArithRight "udiv1_right" i32 (L.ValInteger 1) (L.UDiv False))
+        udiv1Right
         [("udiv1_right", isSafeWithPreconditions mempty DidntHitBounds)],
       inModule
         "udiv1_exact_right.c"
-        (oneArithRight "udiv1_exact_right" i32 (L.ValInteger 1) (L.UDiv True))
+        udiv1ExactRight
         [("udiv1_exact_right", isUnclassified)], -- TODO Goal: ???
       inModule
         "udiv2_right.c"
-        (oneArithRight "udiv2_right" i32 (L.ValInteger 2) (L.UDiv False))
+        udiv2Right
         [("udiv2_right", isSafeWithPreconditions mempty DidntHitBounds)],
       inModule
         "udiv2_exact_right.c"
-        (oneArithRight "udiv2_exact_right" i32 (L.ValInteger 2) (L.UDiv True))
+        udiv2ExactRight
         [("udiv2_exact_right", isUnclassified)], -- TODO Goal: ???
       inModule
         "udiv_neg1_right.c"
-        (oneArithRight "udiv_neg1_right" i32 (L.ValInteger (-1)) (L.UDiv False))
+        udivNeg1Right
         [("udiv_neg1_right", isSafeWithPreconditions mempty DidntHitBounds)],
       inModule
         "udiv_neg1_exact_right.c"
-        (oneArithRight "udiv_neg1_exact_right" i32 (L.ValInteger (-1)) (L.UDiv True))
+        udivNeg1ExactRight
         [("udiv_neg1_exact_right", isUnclassified)], -- TODO Goal: ???
       inModule
         "sdiv0_right.c"
-        (oneArithRight "sdiv0_right" i32 (L.ValInteger 0) (L.SDiv False))
+        sdiv0Right
         [("sdiv0_right", isSafeWithPreconditions mempty DidntHitBounds)],
       inModule
         "sdiv1_right.c"
-        (oneArithRight "sdiv1_right" i32 (L.ValInteger 1) (L.SDiv False))
+        sdiv1Right
         [("sdiv1_right", isSafeWithPreconditions mempty DidntHitBounds)],
       inModule
         "sdiv1_exact_right.c"
-        (oneArithRight "sdiv1_exact_right" i32 (L.ValInteger 1) (L.SDiv True))
+        sdiv1ExactRight
         [("sdiv1_exact_right", isUnclassified)], -- TODO Goal: ???
       inModule
         "sdiv_neg1_right.c"
-        (oneArithRight "sdiv_neg1_right" i32 (L.ValInteger (-1)) (L.SDiv False))
+        sdivNeg1Right
         [("sdiv_neg1_right", isSafeWithPreconditions mempty DidntHitBounds)],
       inModule
         "sdiv_neg1_exact_right.c"
-        (oneArithRight "sdiv_neg1_exact_right" i32 (L.ValInteger (-1)) (L.SDiv True))
+        sdivNeg1ExactRight
         [("sdiv_neg1_exact_right", isUnclassified)], -- TODO Goal: ???
       inModule
         "sdiv2_right.c"
-        (oneArithRight "sdiv2_right" i32 (L.ValInteger 2) (L.SDiv False))
+        sdiv2Right
         [("sdiv2_right", isSafeWithPreconditions mempty DidntHitBounds)],
       inModule
         "sdiv2_exact_right.c"
-        (oneArithRight "sdiv2_exact_right" i32 (L.ValInteger 2) (L.SDiv True))
+        sdiv2ExactRight
         [("sdiv2_exact_right", isUnclassified)], -- TODO Goal: ???
       inModule
         "sdiv_neg2_right.c"
-        (oneArithRight "sdiv_neg2_right" i32 (L.ValInteger (-2)) (L.SDiv False))
+        sdivNeg2Right
         [("sdiv_neg2_right", isSafeWithPreconditions mempty DidntHitBounds)],
       inModule
         "sdiv_neg2_exact_right.c"
-        (oneArithRight "sdiv_neg2_exact_right" i32 (L.ValInteger (-2)) (L.SDiv True))
+        sdivNeg2ExactRight
         [("sdiv_neg2_exact_right", isUnclassified)], -- TODO Goal: ???
       inModule
         "urem0_right.c"
-        (oneArithRight "urem0_right" i32 (L.ValInteger 0) L.URem)
+        urem0Right
         [("urem0_right", isSafeWithPreconditions mempty DidntHitBounds)],
       inModule
         "urem1_right.c"
-        (oneArithRight "urem1_right" i32 (L.ValInteger 1) L.URem)
+        urem1Right
         [("urem1_right", isSafeWithPreconditions mempty DidntHitBounds)],
       inModule
         "urem_neg1_right.c"
-        (oneArithRight "urem_neg1_right" i32 (L.ValInteger (-1)) L.URem)
+        uremNeg1Right
         [("urem_neg1_right", isSafeWithPreconditions mempty DidntHitBounds)],
       inModule
         "urem2_right.c"
-        (oneArithRight "urem2_right" i32 (L.ValInteger 2) L.URem)
+        urem2Right
         [("urem2_right", isSafeWithPreconditions mempty DidntHitBounds)],
       inModule
         "srem0_right.c"
-        (oneArithRight "srem0_right" i32 (L.ValInteger 0) L.SRem)
+        srem0Right
         [("srem0_right", isSafeWithPreconditions mempty DidntHitBounds)],
       inModule
         "srem1_right.c"
-        (oneArithRight "srem1_right" i32 (L.ValInteger 1) L.SRem)
+        srem1Right
         [("srem1_right", isSafeWithPreconditions mempty DidntHitBounds)],
       inModule
         "srem_neg1_right.c"
-        (oneArithRight "srem_neg1_right" i32 (L.ValInteger (-1)) L.SRem)
+        sremNeg1Right
         [("srem_neg1_right", isSafeWithPreconditions mempty DidntHitBounds)],
       inModule
         "srem2_right.c"
-        (oneArithRight "srem2_right" i32 (L.ValInteger 2) L.SRem)
+        srem2Right
         [("srem2_right", isSafeWithPreconditions mempty DidntHitBounds)],
       inModule
         "srem_neg2_right.c"
-        (oneArithRight "srem_neg2_right" i32 (L.ValInteger (-2)) L.SRem)
-        [("srem_neg2_right", isSafeWithPreconditions mempty DidntHitBounds)]
+        sremNeg2Right
+        [("srem_neg2_right", isSafeWithPreconditions mempty DidntHitBounds)],
+      -- This one passes because they share no functions to be tested for
+      -- equivalence:
+      checkCrashDiff "add1_left.c" add1Left "udiv0_left.c" udiv0Left True False,
+      -- This one passes because add1_left.c doesn't crash, whereas udiv0_left.c
+      -- does, so the latter's crashes are a superset of the former's. We have to
+      -- rename the function in add1_left.c to match, though.
+      checkCrashDiff
+        "udiv0_left.c"
+        udiv0Left
+        "add1_left.c"
+        (oneArithLeft "udiv0_left" i32 (L.ValInteger 1) (L.Add False False))
+        False
+        False,
+      -- This is the inverse of the above: udiv0_left.c *isn't* crash-less-than
+      -- add1_left.c.
+      checkCrashDiff
+        "add1_left.c"
+        (oneArithLeft "udiv0_left" i32 (L.ValInteger 1) (L.Add False False))
+        "udiv0_left.c"
+        udiv0Left
+        True
+        True,
+      TQ.testProperty "Crash equivalence is reflexive" $
+        \(ArithModule llvmModule) ->
+          TQ.ioProperty $
+            do
+              (appCtx, (diffs12, diffs21)) <-
+                getCrashDiff "fake1" llvmModule "fake2" llvmModule
+              reportDiffs appCtx diffs12 diffs21
+              pure (null diffs12 && null diffs21)
     ]
 
 main :: IO ()

--- a/uc-crux-llvm/uc-crux-llvm.cabal
+++ b/uc-crux-llvm/uc-crux-llvm.cabal
@@ -40,6 +40,7 @@ library
     UCCrux.LLVM.Context.Function
     UCCrux.LLVM.Context.Module
     UCCrux.LLVM.Cursor
+    UCCrux.LLVM.Equivalence
     UCCrux.LLVM.Errors.Panic
     UCCrux.LLVM.Errors.Unimplemented
     UCCrux.LLVM.FullType
@@ -146,5 +147,6 @@ test-suite uc-crux-llvm-test
                 parameterized-utils,
                 tasty            >= 0.10,
                 tasty-hunit      >= 0.10,
+                tasty-quickcheck >= 0.10,
                 text,
                 uc-crux-llvm


### PR DESCRIPTION
This commit adds another feature from the original paper
"Under-Constrained Symbolic Execution: Correctness Checking for Real
Code" by Ramos and Engler, namely the ability to check two versions of
the same function for "crash equivalence" or "crash ordering", where one
version is "crash less than" the other just if the all the undefined
behaviors present in the former are also present in the latter.

The idea is that this can be used e.g. to test patches: patches should
generally only *remove* instances of undefined behavior, not add them.

This can also be used as a generic, automated "rough equivalence" check.

There's also some refactoring & plumbing through of source locations, it's probably easiest to review the three commits separately.