### PR TITLE
Fancy assumptions

### DIFF
--- a/crucible-concurrency/crucibles/Main.hs
+++ b/crucible-concurrency/crucibles/Main.hs
@@ -9,9 +9,9 @@
 {-# LANGUAGE ImplicitParams #-}
 module Main where
 
-import qualified Data.Text.IO as T
-import qualified Options.Applicative.Simple as Opts
-import           System.IO
+--import qualified Data.Text.IO as T
+--import qualified Options.Applicative.Simple as Opts
+--import           System.IO
 
 import qualified Crux
 import Cruces.CrucesMain

--- a/crucible-concurrency/crucibles/Main.hs
+++ b/crucible-concurrency/crucibles/Main.hs
@@ -9,10 +9,6 @@
 {-# LANGUAGE ImplicitParams #-}
 module Main where
 
---import qualified Data.Text.IO as T
---import qualified Options.Applicative.Simple as Opts
---import           System.IO
-
 import qualified Crux
 import Cruces.CrucesMain
 import Paths_crucible_concurrency (version)

--- a/crucible-concurrency/src/Cruces/CrucesMain.hs
+++ b/crucible-concurrency/src/Cruces/CrucesMain.hs
@@ -153,7 +153,5 @@ run (cruxOpts, opts) =
 
             return ()
 
-printCounterexamples :: Crux.Logs
-                     => ProvedGoals (Either (CrucibleAssumption ()) SimError)
-                     -> IO ()
+printCounterexamples :: Crux.Logs => ProvedGoals -> IO ()
 printCounterexamples = Crux.logGoal

--- a/crucible-concurrency/src/Cruces/CrucesMain.hs
+++ b/crucible-concurrency/src/Cruces/CrucesMain.hs
@@ -154,6 +154,6 @@ run (cruxOpts, opts) =
             return ()
 
 printCounterexamples :: Crux.Logs
-                     => ProvedGoals (Either AssumptionReason SimError)
+                     => ProvedGoals (Either (CrucibleAssumption ()) SimError)
                      -> IO ()
 printCounterexamples = Crux.logGoal

--- a/crucible-concurrency/src/Cruces/ExploreCrux.hs
+++ b/crucible-concurrency/src/Cruces/ExploreCrux.hs
@@ -29,7 +29,6 @@ import           Lang.Crucible.CFG.Extension (IsSyntaxExtension)
 import           Lang.Crucible.Backend
 
 import qualified Crux
-import           Crux.Model
 
 import           Crucibles.SchedulingAlgorithm hiding (_exec, exec)
 import           Crucibles.Execution
@@ -73,7 +72,6 @@ emptyExploration :: SchedulingAlgorithm alg => Exploration alg ext C.UnitType sy
 emptyExploration = Exploration { _exec      = initialExecutions
                                , _scheduler = s0
                                , _schedAlg  = initialAlgState
-                               , _model     = emptyModel
                                , _num       = 0
                                , _gVars     = mempty
                                }

--- a/crucible-concurrency/src/Crucibles/Explore.hs
+++ b/crucible-concurrency/src/Crucibles/Explore.hs
@@ -129,19 +129,10 @@ schedule prims globs = \case
   -- we might have conservatively added this thread to a backtracking list even
   -- though it wasn't actually runnable. In any case, restart the computation
   -- using the mainCont continuation.
-  ResultState (AbortedResult ctx (AbortedExec rsn gps))
-    | InfeasibleBranch _ <- rsn ->
-      return $ ExecutionFeatureNewState s0
-    | AssertionFailure _ <- rsn ->
-      return $ ExecutionFeatureNewState s0
-
-      -- TODO? This only covers the `VariantOptionExhausted` constructor.  Why is it different?
-    | otherwise               -> return ExecutionFeatureNoChange
-
+  ResultState (AbortedResult ctx (AbortedExec _rsn _gps)) -> return (ExecutionFeatureNewState s0)
     where
       k  = ctx ^. cruciblePersonality.scheduler.to mainCont
       t  = ctx ^. cruciblePersonality.scheduler.retRepr
-      globVars = gps ^. gpGlobals
       s0 = InitialState ctx emptyGlobals defaultAbortHandler t $ runOverrideSim t k
 
   -- TODO: I don't think this is reachable anymore, but this needs to be

--- a/crucible-concurrency/src/Crucibles/ExploreTypes.hs
+++ b/crucible-concurrency/src/Crucibles/ExploreTypes.hs
@@ -15,7 +15,6 @@ import Data.Map.Strict
 import Data.Parameterized (Some(..))
 
 import Lang.Crucible.Simulator
-import Crux.Types (Model, HasModel(..))
 
 import Crucibles.Scheduler
 import Crucibles.Execution
@@ -45,17 +44,12 @@ data Exploration alg ext ret sym = Exploration
     -- ^ State of each thread
   , _schedAlg  :: !alg
     -- ^ State required by the scheduling algorithm
-  , _model     :: !(Model sym)
-    -- ^ For use by Crux
   , _num       :: !Int
     -- ^ Number of executions explored
   , _gVars     :: !(Map Text (Some GlobalVar))
     -- ^ Map from name to GlobalVars that the exploration has invented. Typically these are locks.
   }
 makeLenses ''Exploration
-
-instance HasModel (Exploration alg ext ret) where
-  personalityModel = model
 
 stateExpl :: Simple Lens (SimState (ThreadExec alg sym ext ret) sym ext r f a) (ThreadExec alg sym ext ret)
 stateExpl = stateContext.cruciblePersonality

--- a/crucible-go/src/Lang/Crucible/Go/Overrides.hs
+++ b/crucible-go/src/Lang/Crucible/Go/Overrides.hs
@@ -99,8 +99,7 @@ do_assume = do
   sym <- C.getSymInterface
   RegMap (Empty :> mgs :> file :> b) <- C.getOverrideArgs
   loc <- liftIO $ W4.getCurrentProgramLoc sym
-  liftIO $ addAssumption sym (LabeledPred (regValue b) $
-                              AssumptionReason loc "assume")
+  liftIO $ addAssumption sym (GenericAssumption loc "assume" (regValue b))
   return Ctx.empty
 
 do_assert :: IsSymInterface sym

--- a/crucible-jvm/tool/Main.hs
+++ b/crucible-jvm/tool/Main.hs
@@ -92,7 +92,7 @@ import           Paths_crucible_jvm (version)
 import System.Console.GetOpt
 
 -- | A simulator context
-type SimCtxt sym = SimContext (Crux.Model sym) sym JVM
+type SimCtxt sym = SimContext (Crux.Crux sym) sym JVM
 
 data JVMOptions = JVMOptions
   { classPath        :: [FilePath]
@@ -193,7 +193,7 @@ simulateJVM copts opts = Crux.SimulatorCallback $ \sym _maybeOnline -> do
    let nullstr = RegEntry refRepr W4.Unassigned
    let regmap = RegMap (Ctx.Empty `Ctx.extend` nullstr)
 
-   initSt <- setupCrucibleJVMCrux @UnitType cb verbosity sym Crux.emptyModel
+   initSt <- setupCrucibleJVMCrux @UnitType cb verbosity sym Crux.CruxPersonality
      cname mname regmap
 
    return (Crux.RunnableState initSt, \_ _ -> return mempty) -- TODO add failure explanations

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Partial.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Partial.hs
@@ -332,7 +332,7 @@ assertSafe sym (Err p) = do
      loc <- getCurrentProgramLoc sym
      let err = SimError loc rsn
      addProofObligation sym (LabeledPred p err)
-     abortExecBecause $ AssumedFalse $ AssumingNoError err
+     abortExecBecause (AssertionFailure err)
 
 
 ------------------------------------------------------------------------

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Monad.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Monad.hs
@@ -68,7 +68,6 @@ import           Lang.Crucible.LLVM.MemType
 import           Lang.Crucible.LLVM.Translation.Types
 import           Lang.Crucible.LLVM.TypeContext
 
---import           Lang.Crucible.FunctionHandle
 import           Lang.Crucible.Types
 
 ------------------------------------------------------------------------

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Monad.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Monad.hs
@@ -68,7 +68,7 @@ import           Lang.Crucible.LLVM.MemType
 import           Lang.Crucible.LLVM.Translation.Types
 import           Lang.Crucible.LLVM.TypeContext
 
-import           Lang.Crucible.FunctionHandle
+--import           Lang.Crucible.FunctionHandle
 import           Lang.Crucible.Types
 
 ------------------------------------------------------------------------

--- a/crucible-llvm/test/TestMemory.hs
+++ b/crucible-llvm/test/TestMemory.hs
@@ -73,8 +73,7 @@ userSymbol' s = case What4.userSymbol s of
 assume :: CB.IsSymInterface sym => sym -> What4.Pred sym -> IO ()
 assume sym p = do
   loc <- What4.getCurrentProgramLoc sym
-  CB.addAssumption sym $
-    CB.LabeledPred p $ CB.AssumptionReason loc ""
+  CB.addAssumption sym (CB.GenericAssumption loc "assume" p)
 
 checkSat ::
   W4O.OnlineSolver solver =>

--- a/crucible-syntax/src/Lang/Crucible/Syntax/Overrides.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Overrides.hs
@@ -48,11 +48,11 @@ proveObligations =
      liftIO $ do
        hPutStrLn h "Attempting to prove all outstanding obligations!\n"
 
-       obls <- proofGoalsToList <$> getProofObligations sym
+       obls <- maybe [] goalsToList <$> getProofObligations sym
        clearProofObligations sym
 
        forM_ obls $ \o ->
-         do let asms = map (view labeledPred) $ toList $ proofAssumptions o
+         do let asms = map (assumptionPred sym) $ toList $ proofAssumptions o
             gl <- notPred sym ((proofGoal o)^.labeledPred)
             let logData = defaultLogData { logCallbackVerbose = \_ -> hPutStrLn h
                                          , logReason = "assertion proof" }

--- a/crucible-syntax/src/Lang/Crucible/Syntax/Overrides.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Overrides.hs
@@ -51,11 +51,11 @@ proveObligations =
        clearProofObligations sym
 
        forM_ obls $ \o ->
-         do let asms = o ^.. to proofAssumptions.foldAssumptions
+         do asms <- assumptionsPred sym (proofAssumptions o)
             gl <- notPred sym (o ^. to proofGoal.labeledPred)
             let logData = defaultLogData { logCallbackVerbose = \_ -> hPutStrLn h
                                          , logReason = "assertion proof" }
-            runZ3InOverride sym logData (asms ++ [gl]) $ \case
+            runZ3InOverride sym logData [asms,gl] $ \case
               Unsat{}  -> hPutStrLn h $ unlines ["Proof Succeeded!", show $ ppSimError $ (proofGoal o)^.labeledPredMsg]
               Sat _mdl -> hPutStrLn h $ unlines ["Proof failed!", show $ ppSimError $ (proofGoal o)^.labeledPredMsg]
               Unknown  -> hPutStrLn h $ unlines ["Proof inconclusive!", show $ ppSimError $ (proofGoal o)^.labeledPredMsg]

--- a/crucible-syntax/src/Lang/Crucible/Syntax/Overrides.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Overrides.hs
@@ -51,7 +51,7 @@ proveObligations =
        clearProofObligations sym
 
        forM_ obls $ \o ->
-         do let asms = o ^.. to proofAssumptions.folded.foldAssumption
+         do let asms = o ^.. to proofAssumptions.foldAssumptions
             gl <- notPred sym (o ^. to proofGoal.labeledPred)
             let logData = defaultLogData { logCallbackVerbose = \_ -> hPutStrLn h
                                          , logReason = "assertion proof" }

--- a/crucible-syntax/src/Lang/Crucible/Syntax/Overrides.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Overrides.hs
@@ -12,7 +12,6 @@ module Lang.Crucible.Syntax.Overrides
 import Control.Lens hiding ((:>), Empty)
 import Control.Monad (forM_)
 import Control.Monad.IO.Class
-import Data.Foldable(toList)
 import System.IO
 
 import Data.Parameterized.Context hiding (view)
@@ -52,8 +51,8 @@ proveObligations =
        clearProofObligations sym
 
        forM_ obls $ \o ->
-         do let asms = map (assumptionPred sym) $ toList $ proofAssumptions o
-            gl <- notPred sym ((proofGoal o)^.labeledPred)
+         do let asms = o ^.. to proofAssumptions.folded.foldAssumption
+            gl <- notPred sym (o ^. to proofGoal.labeledPred)
             let logData = defaultLogData { logCallbackVerbose = \_ -> hPutStrLn h
                                          , logReason = "assertion proof" }
             runZ3InOverride sym logData (asms ++ [gl]) $ \case

--- a/crucible-syntax/src/Lang/Crucible/Syntax/Prog.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Prog.hs
@@ -33,7 +33,6 @@ import Lang.Crucible.Syntax.Atoms
 
 import Lang.Crucible.Analysis.Postdom
 import Lang.Crucible.Backend
-import Lang.Crucible.Backend.ProofGoals
 import Lang.Crucible.Backend.Simple
 import Lang.Crucible.FunctionHandle
 import Lang.Crucible.Simulator
@@ -138,7 +137,7 @@ simulateProgram fn theInput outh profh opts setup =
                               forM_ (goalsToList gs) (\g ->
                                 do hPrint outh (ppProofObligation sym g)
                                    neggoal <- notPred sym (view labeledPred (proofGoal g))
-                                   let bs = neggoal : map (view labeledPred) (toList (proofAssumptions g))
+                                   let bs = neggoal : map (assumptionPred sym) (toList (proofAssumptions g))
                                    runZ3InOverride sym defaultLogData bs (\case
                                      Sat _   -> hPutStrLn outh "COUNTEREXAMPLE"
                                      Unsat _ -> hPutStrLn outh "PROVED"

--- a/crucible-syntax/src/Lang/Crucible/Syntax/Prog.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Prog.hs
@@ -5,7 +5,7 @@
 
 module Lang.Crucible.Syntax.Prog where
 
-import Control.Lens (view, (^..), to)
+import Control.Lens (view)
 import Control.Monad
 
 import Data.List (find)
@@ -133,9 +133,10 @@ simulateProgram fn theInput outh profh opts setup =
                          Just gs ->
                            do hPutStrLn outh "==== Proof obligations ===="
                               forM_ (goalsToList gs) (\g ->
-                                do hPrint outh (ppProofObligation sym g)
+                                do hPrint outh =<< ppProofObligation sym g
                                    neggoal <- notPred sym (view labeledPred (proofGoal g))
-                                   let bs = neggoal : (g ^.. to proofAssumptions.foldAssumptions)
+                                   asms <- assumptionsPred sym (proofAssumptions g)
+                                   let bs = [neggoal, asms]
                                    runZ3InOverride sym defaultLogData bs (\case
                                      Sat _   -> hPutStrLn outh "COUNTEREXAMPLE"
                                      Unsat _ -> hPutStrLn outh "PROVED"

--- a/crucible-syntax/src/Lang/Crucible/Syntax/Prog.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Prog.hs
@@ -5,14 +5,12 @@
 
 module Lang.Crucible.Syntax.Prog where
 
-import Control.Lens (view)
+import Control.Lens (view, (^..), folded, to)
 import Control.Monad
 
-import Data.Foldable (toList)
 import Data.List (find)
 import Data.Text (Text)
 import Data.String (IsString(..))
---import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import System.IO
 import System.Exit
@@ -137,7 +135,7 @@ simulateProgram fn theInput outh profh opts setup =
                               forM_ (goalsToList gs) (\g ->
                                 do hPrint outh (ppProofObligation sym g)
                                    neggoal <- notPred sym (view labeledPred (proofGoal g))
-                                   let bs = neggoal : map (assumptionPred sym) (toList (proofAssumptions g))
+                                   let bs = neggoal : (g ^.. to proofAssumptions.folded.foldAssumption)
                                    runZ3InOverride sym defaultLogData bs (\case
                                      Sat _   -> hPutStrLn outh "COUNTEREXAMPLE"
                                      Unsat _ -> hPutStrLn outh "PROVED"

--- a/crucible-syntax/src/Lang/Crucible/Syntax/Prog.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Prog.hs
@@ -5,7 +5,7 @@
 
 module Lang.Crucible.Syntax.Prog where
 
-import Control.Lens (view, (^..), folded, to)
+import Control.Lens (view, (^..), to)
 import Control.Monad
 
 import Data.List (find)
@@ -135,7 +135,7 @@ simulateProgram fn theInput outh profh opts setup =
                               forM_ (goalsToList gs) (\g ->
                                 do hPrint outh (ppProofObligation sym g)
                                    neggoal <- notPred sym (view labeledPred (proofGoal g))
-                                   let bs = neggoal : (g ^.. to proofAssumptions.folded.foldAssumption)
+                                   let bs = neggoal : (g ^.. to proofAssumptions.foldAssumptions)
                                    runZ3InOverride sym defaultLogData bs (\case
                                      Sat _   -> hPutStrLn outh "COUNTEREXAMPLE"
                                      Unsat _ -> hPutStrLn outh "PROVED"

--- a/crucible-syntax/test-data/simulator-tests/override-test2.out.good
+++ b/crucible-syntax/test-data/simulator-tests/override-test2.out.good
@@ -16,9 +16,9 @@ Prove:
 COUNTEREXAMPLE
 Assuming:
 * The branch in symbolicBranchesTest from after branch 1 to third branch
-    let -- default branch
-        v26 = and (not (eq 1 cx@0:i)) (not (eq 2 cx@0:i)) (not (eq 3 cx@0:i))
-     in not v26
+    let -- test-data/simulator-tests/override-test2.cbl:7:5
+        v30 = and (not (eq 1 cx@0:i)) (not (eq 2 cx@0:i)) (not (eq 3 cx@0:i))
+     in not v30
 Prove:
   test-data/simulator-tests/override-test2.cbl:6:5: error: in main
   bogus!

--- a/crucible-syntax/test-data/simulator-tests/seq-test3.out.good
+++ b/crucible-syntax/test-data/simulator-tests/seq-test3.out.good
@@ -2,49 +2,49 @@
 
 ==== Finish Simulation ====
 ==== Proof obligations ====
-Assuming:
+
 Prove:
   test-data/simulator-tests/seq-test3.cbl:95:5: error: in eqseq
   value mismatch!
   eq (ite cb1@0:b cx@2:i cy@3:i) (ite cb1@0:b cx@2:i cy@3:i)
 PROVED
-Assuming:
+
 Prove:
   test-data/simulator-tests/seq-test3.cbl:95:5: error: in eqseq
   value mismatch!
   eq (ite cb2@1:b cz@4:i cw@5:i) (ite cb2@1:b cz@4:i cw@5:i)
 PROVED
-Assuming:
+
 Prove:
   test-data/simulator-tests/seq-test3.cbl:56:5: error: in main
   head 1 eq check
   eq (ite cb1@0:b cx@2:i cy@3:i) (ite cb1@0:b cx@2:i cy@3:i)
 PROVED
-Assuming:
+
 Prove:
   test-data/simulator-tests/seq-test3.cbl:57:5: error: in main
   head 1 check
   eq (ite cb1@0:b cx@2:i cy@3:i) (ite cb1@0:b cx@2:i cy@3:i)
 PROVED
-Assuming:
+
 Prove:
   test-data/simulator-tests/seq-test3.cbl:95:5: error: in eqseq
   value mismatch!
   eq (ite cb2@1:b cz@4:i cw@5:i) (ite cb2@1:b cz@4:i cw@5:i)
 PROVED
-Assuming:
+
 Prove:
   test-data/simulator-tests/seq-test3.cbl:95:5: error: in eqseq
   value mismatch!
   eq (ite cb2@1:b cz@4:i cw@5:i) (ite cb2@1:b cz@4:i cw@5:i)
 PROVED
-Assuming:
+
 Prove:
   test-data/simulator-tests/seq-test3.cbl:95:5: error: in eqseq
   value mismatch!
   eq (ite cb2@1:b cz@4:i cw@5:i) (ite cb2@1:b cz@4:i cw@5:i)
 PROVED
-Assuming:
+
 Prove:
   test-data/simulator-tests/seq-test3.cbl:95:5: error: in eqseq
   value mismatch!

--- a/crucible-wasm/tool/Main.hs
+++ b/crucible-wasm/tool/Main.hs
@@ -14,8 +14,6 @@ import Lang.Crucible.Simulator
 import Lang.Crucible.FunctionHandle
 
 import qualified Crux
-import qualified Crux.Model as Crux
-import qualified Crux.Types as Crux
 
 import qualified Language.Wasm as Wasm
 
@@ -35,13 +33,13 @@ cruxWasmConfig = Crux.Config
   }
 
 setupWasmState :: IsSymInterface sym =>
-  sym -> Wasm.Script -> IO (ExecState (Crux.Model sym) sym WasmExt (RegEntry sym UnitType))
+  sym -> Wasm.Script -> IO (ExecState (Crux.Crux sym) sym WasmExt (RegEntry sym UnitType))
 setupWasmState sym s =
   do halloc <- newHandleAllocator
 
      let globals = emptyGlobals
      let bindings = emptyHandleMap
-     let simctx = initSimContext sym wasmIntrinsicTypes halloc stdout (FnBindings bindings) extImpl Crux.emptyModel
+     let simctx = initSimContext sym wasmIntrinsicTypes halloc stdout (FnBindings bindings) extImpl Crux.CruxPersonality
      let m = execScript s emptyScriptState >> pure ()
 
      pure (InitialState simctx globals defaultAbortHandler knownRepr (runOverrideSim knownRepr m))

--- a/crucible/crucible.cabal
+++ b/crucible/crucible.cabal
@@ -106,6 +106,7 @@ library
     Lang.Crucible.Simulator.OverrideSim
     Lang.Crucible.Simulator.PathSatisfiability
     Lang.Crucible.Simulator.PathSplitting
+    Lang.Crucible.Simulator.PositionTracking
     Lang.Crucible.Simulator.Profiling
     Lang.Crucible.Simulator.RegMap
     Lang.Crucible.Simulator.RegValue

--- a/crucible/src/Lang/Crucible/Backend.hs
+++ b/crucible/src/Lang/Crucible/Backend.hs
@@ -225,7 +225,7 @@ singleEvent x = SingleEvent x
 -- | Collect the program locations of all assumptions and
 --   events that did not occur in the context of a symbolic branch.
 --   These are locations that every program path represented by
---   this assumptions structure must have passed through.
+--   this @CrucibleAssumptions@ structure must have passed through.
 assumptionsTopLevelLocs :: CrucibleAssumptions e -> [ProgramLoc]
 assumptionsTopLevelLocs (SingleEvent e)      = [eventLoc e]
 assumptionsTopLevelLocs (SingleAssumption a) = [assumptionLoc a]
@@ -236,7 +236,7 @@ assumptionsTopLevelLocs MergeAssumptions{}   = []
 assumptionsPred :: IsExprBuilder sym => sym -> Assumptions sym -> IO (Pred sym)
 assumptionsPred sym (SingleEvent _) =
   return (truePred sym)
-assumptionsPred sym (SingleAssumption a) =
+assumptionsPred _sym (SingleAssumption a) =
   return (assumptionPred a)
 assumptionsPred sym (ManyAssumptions xs) =
   andAllOf sym folded =<< traverse (assumptionsPred sym) xs
@@ -269,7 +269,7 @@ concretizeEvents f = loop
       do b <- f p
          if b then loop xs else loop ys
 
--- | Given an assumptions structure, flatten all the muxed assumptions into
+-- | Given a @CrucibleAssumptions@ structure, flatten all the muxed assumptions into
 --   a flat sequence of assumptions that have been appropriately weakened.
 --   Note, once these assumptions have been flattened, their order might no longer
 --   strictly correspond to any concrete program run.

--- a/crucible/src/Lang/Crucible/Backend.hs
+++ b/crucible/src/Lang/Crucible/Backend.hs
@@ -142,7 +142,7 @@ traverseAssumption f = \case
   AssumingNoError err p -> AssumingNoError err <$> f p
 
 
-type Assumptions sym = Seq (Assumption sym)
+
 
 
 {- | Merge the assumptions collected from the branches of a conditional.
@@ -168,9 +168,10 @@ mergeAssumptions sym p thens elses =
 
 type Assertion sym  = LabeledPred (Pred sym) SimError
 type Assumption sym = CrucibleAssumption (Pred sym)
-type ProofObligation sym = AS.ProofGoal (Assumption sym) (Assertion sym)
-type ProofObligations sym = Maybe (AS.Goals (Assumption sym) (Assertion sym))
-type AssumptionState sym = PG.GoalCollector (Assumption sym) (Assertion sym)
+type Assumptions sym = Seq (Assumption sym)
+type ProofObligation sym = AS.ProofGoal (Assumptions sym) (Assertion sym)
+type ProofObligations sym = Maybe (AS.Goals (Assumptions sym) (Assertion sym))
+type AssumptionState sym = PG.GoalCollector (Assumptions sym) (Assertion sym)
 
 -- | This is used to signal that current execution path is infeasible.
 data AbortExecReason =

--- a/crucible/src/Lang/Crucible/Backend/AssumptionStack.hs
+++ b/crucible/src/Lang/Crucible/Backend/AssumptionStack.hs
@@ -59,6 +59,7 @@ import qualified Data.Foldable as F
 import           Data.IORef
 import           Data.Parameterized.Nonce
 import           Data.Sequence (Seq)
+import qualified Data.Sequence as Seq
 
 import           Lang.Crucible.Backend.ProofGoals
 import           Lang.Crucible.Panic (panic)
@@ -126,7 +127,7 @@ restoreAssumptionStack gc stk =
 addAssumption ::
   asm -> AssumptionStack asm ast -> IO ()
 addAssumption p stk =
-  modifyIORef' (proofObligations stk) (gcAssume p)
+  modifyIORef' (proofObligations stk) (gcAddAssumes (Seq.singleton p))
 
 -- | Add the given collection logical assumptions to the current stack frame.
 appendAssumptions ::

--- a/crucible/src/Lang/Crucible/Backend/AssumptionStack.hs
+++ b/crucible/src/Lang/Crucible/Backend/AssumptionStack.hs
@@ -1,10 +1,10 @@
 {-|
-Module      : Lang.Crucible.Backend.AssumptionStakck
+Module      : Lang.Crucible.Backend.AssumptionStack
 Copyright   : (c) Galois, Inc 2018
 License     : BSD3
 Maintainer  : Rob Dockins <rdockins@galois.com>
 
-This module provides managament support for keeping track
+This module provides management support for keeping track
 of a context of logical assumptions.  The API provided here
 is similar to the interactive mode of an SMT solver.  Logical
 conditions can be assumed into the current context, and bundles
@@ -62,7 +62,7 @@ import           Lang.Crucible.Backend.ProofGoals
 import           Lang.Crucible.Panic (panic)
 
 -- | A single @AssumptionFrame@ represents a collection
---   of assumtptions.  They will later be recinded when
+--   of assumptions.  They will later be rescinded when
 --   the associated frame is popped from the stack.
 data AssumptionFrame asmp =
   AssumptionFrame
@@ -107,7 +107,7 @@ saveAssumptionStack :: Monoid asmp => AssumptionStack asmp ast -> IO (GoalCollec
 saveAssumptionStack stk =
   gcRemoveObligations <$> readIORef (proofObligations stk)
 
--- | Restore a prevsiously saved assumption stack.  Any proof
+-- | Restore a previously saved assumption stack.  Any proof
 --   obligations in the saved stack will be copied into the
 --   assumption stack, which will also retain any proof obligations
 --   it had previously.  A saved stack created with `saveAssumptionStack`
@@ -166,7 +166,7 @@ pushFrame stk =
      return ident
 
 -- | Pop all frames up to and including the frame with the
---   given identifier.  The return value indiciates how
+--   given identifier.  The return value indicates how
 --   many stack frames were popped.
 popFramesUntil :: Monoid asmp => FrameIdentifier -> AssumptionStack asmp ast -> IO Int
 popFramesUntil ident stk = atomicModifyIORef' (proofObligations stk) (go 1)

--- a/crucible/src/Lang/Crucible/Backend/Online.hs
+++ b/crucible/src/Lang/Crucible/Backend/Online.hs
@@ -86,6 +86,7 @@ import           Data.Foldable
 import           Data.IORef
 import           Data.Parameterized.Nonce
 import           Data.Sequence (Seq)
+import qualified Data.Sequence as Seq
 import           Data.Typeable (Typeable)
 import           GHC.Generics (Generic)
 import           System.IO
@@ -307,7 +308,7 @@ data SolverState scope solver =
 data OnlineBackendState solver userState scope = OnlineBackendState
   { assumptionStack ::
       !(AssumptionStack
-          (CrucibleAssumption (B.BoolExpr scope))
+          (Seq (CrucibleAssumption (B.BoolExpr scope)))
           (LabeledPred (B.BoolExpr scope) SimError))
 
   , solverProc :: !(IORef (SolverState scope solver))
@@ -340,7 +341,7 @@ initialOnlineBackendState gen feats ust =
 
 getAssumptionStack ::
   OnlineBackendUserSt scope solver userSt fs ->
-  IO (AssumptionStack (CrucibleAssumption (B.BoolExpr scope))
+  IO (AssumptionStack (Seq (CrucibleAssumption (B.BoolExpr scope)))
                       (LabeledPred (B.BoolExpr scope) SimError))
 getAssumptionStack sym = pure (assumptionStack (B.sbUserState sym))
 
@@ -564,7 +565,7 @@ instance OnlineSolver solver => IsBoolSolver (OnlineBackendUserSt scope solver u
 
              -- Record assumption, even if trivial.
              -- This allows us to keep track of the full path we are on.
-             AS.addAssumption a =<< getAssumptionStack sym
+             AS.appendAssumptions (Seq.singleton a) =<< getAssumptionStack sym
 
   addAssumptions sym as =
     -- NB, don't add the assumption to the assumption stack unless

--- a/crucible/src/Lang/Crucible/Backend/Online.hs
+++ b/crucible/src/Lang/Crucible/Backend/Online.hs
@@ -85,6 +85,7 @@ import           Data.Data (Data)
 import           Data.Foldable
 import           Data.IORef
 import           Data.Parameterized.Nonce
+import           Data.Sequence (Seq)
 import           Data.Typeable (Typeable)
 import           GHC.Generics (Generic)
 import           System.IO
@@ -374,7 +375,7 @@ resetSolverProcess' st = do
 
 restoreSolverState ::
   OnlineSolver solver =>
-  PG.GoalCollector (CrucibleAssumption (B.BoolExpr scope))
+  PG.GoalCollector (Seq (CrucibleAssumption (B.BoolExpr scope)))
                    (LabeledPred (B.BoolExpr scope) SimError) ->
   OnlineBackendState solver userSt scope ->
   IO ()
@@ -468,7 +469,7 @@ data BranchResult
 restoreAssumptionFrames ::
   OnlineSolver solver =>
   SolverProcess scope solver ->
-  AssumptionFrames (CrucibleAssumption (B.BoolExpr scope)) ->
+  AssumptionFrames (Seq (CrucibleAssumption (B.BoolExpr scope))) ->
   IO ()
 restoreAssumptionFrames proc (AssumptionFrames base frms) =
   do -- assume the base-level assumptions

--- a/crucible/src/Lang/Crucible/Backend/ProofGoals.hs
+++ b/crucible/src/Lang/Crucible/Backend/ProofGoals.hs
@@ -13,7 +13,7 @@ proof obligations, and the current state of assumptions.
 
 module Lang.Crucible.Backend.ProofGoals
   ( -- * Goals
-    ProofGoal(..), Goals(..), goalsToList, proveAll, goalsConj -- , assuming
+    ProofGoal(..), Goals(..), goalsToList, proveAll, goalsConj
     -- ** traversals
   , traverseGoals, traverseOnlyGoals
   , traverseGoalsWithAssumptions

--- a/crucible/src/Lang/Crucible/Backend/ProofGoals.hs
+++ b/crucible/src/Lang/Crucible/Backend/ProofGoals.hs
@@ -12,7 +12,7 @@ proof obligations, and the current state of assumptions.
 
 module Lang.Crucible.Backend.ProofGoals
   ( -- * Goals
-    ProofGoal(..), Goals(..), goalsToList, proveAll, goalsConj, assuming
+    ProofGoal(..), Goals(..), goalsToList, proveAll, goalsConj -- , assuming
     -- ** traversals
   , traverseGoals, traverseOnlyGoals
   , traverseGoalsWithAssumptions
@@ -27,7 +27,7 @@ module Lang.Crucible.Backend.ProofGoals
   , traverseGoalCollectorWithAssumptions
 
     -- ** Context management
-  , gcAssume, gcAddAssumes, gcProve
+  , gcAddAssumes, gcProve
   , gcPush, gcPop, gcAddGoals,
 
     -- ** Global operations on context
@@ -259,10 +259,6 @@ gcAddGoals g gc = CollectingGoals (Seq.singleton g) gc
 -- | Add a new proof obligation to the current context.
 gcProve :: goal -> GoalCollector asmp goal -> GoalCollector asmp goal
 gcProve g = gcAddGoals (Prove g)
-
--- | Add an extra assumption to the current context.
-gcAssume :: asmp -> GoalCollector asmp goal -> GoalCollector asmp goal
-gcAssume a = gcAddAssumes (Seq.singleton a)
 
 -- | Add a sequence of extra assumptions to the current context.
 gcAddAssumes :: Seq asmp -> GoalCollector asmp goal -> GoalCollector asmp goal

--- a/crucible/src/Lang/Crucible/Backend/Simple.hs
+++ b/crucible/src/Lang/Crucible/Backend/Simple.hs
@@ -33,6 +33,7 @@ module Lang.Crucible.Backend.Simple
 import           Control.Lens
 import           Control.Monad (void)
 import           Data.Parameterized.Nonce
+import qualified Data.Sequence as Seq
 
 import           What4.Config
 import           What4.Interface
@@ -51,7 +52,7 @@ type SimpleBackend t fs = B.ExprBuilder t SimpleBackendState fs
 -- It contains the current assertion stack.
 
 type AS t =
-     AssumptionStack (CrucibleAssumption (B.BoolExpr t))
+     AssumptionStack (Seq.Seq (CrucibleAssumption (B.BoolExpr t)))
                      (LabeledPred (B.BoolExpr t) SimError)
 
 newtype SimpleBackendState t = SimpleBackendState { sbAssumptionStack :: AS t }
@@ -83,7 +84,7 @@ instance IsBoolSolver (SimpleBackend t fs) where
   addAssumption sym a =
     case impossibleAssumption a of
       Just rsn -> abortExecBecause rsn
-      Nothing  -> AS.addAssumption a =<< getAssumptionStack sym
+      Nothing  -> AS.appendAssumptions (Seq.singleton a) =<< getAssumptionStack sym
 
   addAssumptions sym ps = do
     stk <- getAssumptionStack sym

--- a/crucible/src/Lang/Crucible/Backend/Simple.hs
+++ b/crucible/src/Lang/Crucible/Backend/Simple.hs
@@ -95,7 +95,7 @@ instance IsBoolSolver (SimpleBackend t fs) where
   getPathCondition sym = do
     stk <- getAssumptionStack sym
     ps <- AS.collectAssumptions stk
-    andAllOf sym (folded.traverseAssumption) ps
+    andAllOf sym (folded.foldAssumption) ps
 
   getProofObligations sym = do
     stk <- getAssumptionStack sym

--- a/crucible/src/Lang/Crucible/Simulator/BoundedExec.hs
+++ b/crucible/src/Lang/Crucible/Simulator/BoundedExec.hs
@@ -258,7 +258,7 @@ boundedExecFeature getLoopBounds generateSideConditions =
             let loc = st^.stateCrucibleFrame.to frameProgramLoc
             let err = SimError loc (ResourceExhausted msg)
             when generateSideConditions (addProofObligation sym (LabeledPred (falsePred sym) err))
-            return (ExecutionFeatureNewState (AbortState (AssumedFalse (AssumingNoError err)) st'))
+            return (ExecutionFeatureNewState (AbortState (AssertionFailure err) st'))
        Nothing -> return (ExecutionFeatureModifiedState (ControlTransferState res st'))
 
  onStep ::

--- a/crucible/src/Lang/Crucible/Simulator/BoundedRecursion.hs
+++ b/crucible/src/Lang/Crucible/Simulator/BoundedRecursion.hs
@@ -121,7 +121,7 @@ boundedRecursionFeature getRecursionBound generateSideConditions =
                       let msg = ("reached maximum number of recursive calls to function " ++ show h ++ " (" ++ show b ++ ")")
                       let err = SimError loc (ResourceExhausted msg)
                       when generateSideConditions (addProofObligation sym (LabeledPred (falsePred sym) err))
-                      return (ExecutionFeatureNewState (AbortState (AssumedFalse (AssumingNoError err)) st))
+                      return (ExecutionFeatureNewState (AbortState (AssertionFailure err) st))
                  _ ->
                    do let x'  = Map.insert h v x
                       let st' = st & stateGlobals %~ insertGlobal gv (rebuildStack x' x xs)

--- a/crucible/src/Lang/Crucible/Simulator/EvalStmt.hs
+++ b/crucible/src/Lang/Crucible/Simulator/EvalStmt.hs
@@ -327,7 +327,8 @@ stepStmt verb stmt rest =
                          _ -> show (printSymExpr msg)
             liftIO $
               do loc <- getCurrentProgramLoc sym
-                 addAssumption sym (LabeledPred c (AssumptionReason loc msg'))
+                 addAssumption sym (GenericAssumption loc msg' c)
+
             continueWith (stateCrucibleFrame  . frameStmts .~ rest)
 
 

--- a/crucible/src/Lang/Crucible/Simulator/ExecutionTree.hs
+++ b/crucible/src/Lang/Crucible/Simulator/ExecutionTree.hs
@@ -146,7 +146,6 @@ import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Parameterized.Ctx
 import qualified Data.Parameterized.Context as Ctx
-import           Data.Sequence (Seq)
 import           Data.Text (Text)
 import           System.Exit (ExitCode)
 import           System.IO
@@ -157,7 +156,7 @@ import           What4.Interface (Pred, getConfiguration)
 import           What4.FunctionName (FunctionName, startFunctionName)
 import           What4.ProgramLoc (ProgramLoc, plSourceLoc)
 
-import           Lang.Crucible.Backend (IsSymInterface, AbortExecReason, FrameIdentifier, Assumption)
+import           Lang.Crucible.Backend (IsSymInterface, AbortExecReason, FrameIdentifier, Assumptions)
 import           Lang.Crucible.CFG.Core (BlockID, CFG, CFGPostdom, StmtSeq)
 import           Lang.Crucible.CFG.Extension (StmtExtension, ExprExtension)
 import           Lang.Crucible.FunctionHandle (FnHandleMap, HandleAllocator, mkHandle')
@@ -625,7 +624,7 @@ data VFFOtherPath p sym ext ret f args
 
      {- | This is a completed execution path. -}
    | VFFCompletePath
-        !(Seq (Assumption sym))
+        !(Assumptions sym)
           {- Assumptions that we collected while analyzing the branch -}
         !(PartialResultFrame sym ext f args)
           {- Result of running the other branch -}

--- a/crucible/src/Lang/Crucible/Simulator/Operations.hs
+++ b/crucible/src/Lang/Crucible/Simulator/Operations.hs
@@ -82,8 +82,6 @@ import           Data.Maybe (fromMaybe)
 import           Data.List (isPrefixOf)
 import qualified Data.Parameterized.Context as Ctx
 import           Data.Parameterized.Some
-import           Data.Sequence (Seq)
-import qualified Data.Sequence as Seq
 import qualified Data.Vector as V
 import           Data.Type.Equality hiding (sym)
 import           System.IO
@@ -197,26 +195,6 @@ mergePartialResult s tgt pred x y =
           PartialRes loc' <$> itePred sym pred px py
                           <*> merge_fn pred cx cy
                           <*> pure (AbortedBranch loc' pred fx fy)
-
-{- | Merge the assumptions collected from the branches of a conditional.
-The result is a bunch of qualified assumptions: if the branch condition
-is @p@, then the true assumptions become @p => a@, while the false ones
-beome @not p => a@.
--}
-mergeAssumptions ::
-  IsExprBuilder sym =>
-  sym ->
-  Pred sym ->
-  Seq (Assumption sym) ->
-  Seq (Assumption sym) ->
-  IO (Seq (Assumption sym))
-mergeAssumptions sym p thens elses =
-  do pnot <- notPred sym p
-     th' <- (traverse.traverseAssumption) (impliesPred sym p) thens
-     el' <- (traverse.traverseAssumption) (impliesPred sym pnot) elses
-     let xs = th' <> el'
-     -- Filter out all the trivally true assumptions
-     return (Seq.filter (not . trivialAssumption) xs)
 
 forgetPostdomFrame ::
   PausedFrame p sym ext rtp g ->

--- a/crucible/src/Lang/Crucible/Simulator/Operations.hs
+++ b/crucible/src/Lang/Crucible/Simulator/Operations.hs
@@ -212,11 +212,11 @@ mergeAssumptions ::
   IO (Seq (Assumption sym))
 mergeAssumptions sym p thens elses =
   do pnot <- notPred sym p
-     th' <- (traverse.labeledPred) (impliesPred sym p) thens
-     el' <- (traverse.labeledPred) (impliesPred sym pnot) elses
+     th' <- (traverse.traverseAssumption) (impliesPred sym p) thens
+     el' <- (traverse.traverseAssumption) (impliesPred sym pnot) elses
      let xs = th' <> el'
      -- Filter out all the trivally true assumptions
-     return (Seq.filter ((/= Just True) . asConstantPred . view labeledPred) xs)
+     return (Seq.filter (not . trivialAssumption) xs)
 
 forgetPostdomFrame ::
   PausedFrame p sym ext rtp g ->
@@ -428,10 +428,8 @@ runErrorHandler msg st =
    in ctxSolverProof ctx $
       do loc <- getCurrentProgramLoc sym
          let err = SimError loc msg
-         let obl = LabeledPred (falsePred sym) err
-         let rsn = AssumedFalse (AssumingNoError err)
-         addProofObligation sym obl
-         return (AbortState rsn st)
+         addProofObligation sym (LabeledPred (falsePred sym) err)
+         return (AbortState (AssertionFailure err) st)
 
 -- | Abort the current thread of execution with an error.
 --   This adds a proof obligation that requires the current
@@ -615,7 +613,7 @@ performIntraFrameMerge tgt = do
             do pathAssumes      <- liftIO $ popAssumptionFrame sym assume_frame
                pnot             <- liftIO $ notPred sym pred
                new_assume_frame <-
-                  liftIO $ assumeInNewFrame sym (LabeledPred pnot (ExploringAPath loc (pausedLoc next)))
+                  liftIO $ assumeInNewFrame sym (BranchCondition loc (pausedLoc next) pnot)
 
                -- The current branch is done
                let new_other = VFFCompletePath pathAssumes er
@@ -735,7 +733,7 @@ resumeValueFromFrameAbort ctx0 ar0 = do
 
            -- We have some more work to do.
            VFFActivePath n ->
-             do liftIO $ addAssumption sym (LabeledPred pnot (ExploringAPath loc (pausedLoc n)))
+             do liftIO $ addAssumption sym (BranchCondition loc (pausedLoc n) pnot)
                 resumeFrame n nextCtx
 
            -- The other branch had finished successfully;
@@ -937,7 +935,7 @@ intra_branch p t_label f_label tgt = do
       do p' <- liftIO $ predEqConst sym p chosen_branch
          let a_frame = if chosen_branch then t_label else f_label
          loc <- liftIO $ getCurrentProgramLoc sym
-         liftIO $ addAssumption sym (LabeledPred p' (ExploringAPath loc (pausedLoc a_frame)))
+         liftIO $ addAssumption sym (BranchCondition loc (pausedLoc a_frame) p')
          resumeFrame a_frame ctx
 {-# INLINABLE intra_branch #-}
 
@@ -966,7 +964,7 @@ performIntraFrameSplit p a_frame o_frame tgt =
      o_frame' <- pushPausedFrame o_frame
 
      assume_frame <-
-       liftIO $ assumeInNewFrame sym (LabeledPred p (ExploringAPath loc (pausedLoc a_frame')))
+       liftIO $ assumeInNewFrame sym (BranchCondition loc (pausedLoc a_frame') p)
 
      -- Create context for paused frame.
      let todo = VFFActivePath o_frame'

--- a/crucible/src/Lang/Crucible/Simulator/PathSatisfiability.hs
+++ b/crucible/src/Lang/Crucible/Simulator/PathSatisfiability.hs
@@ -77,17 +77,18 @@ pathSatisfiabilityFeature sym considerSatisfiability =
  onStep pathSatOpt (SymbolicBranchState p tp fp _tgt st) =
    getOpt pathSatOpt >>= \case
      False -> return ExecutionFeatureNoChange
-     True -> considerSatisfiability ploc p >>= \case
+     True ->
+       do loc <- getCurrentProgramLoc sym
+          considerSatisfiability ploc p >>= \case
                IndeterminateBranchResult ->
                  return ExecutionFeatureNoChange
                NoBranch chosen_branch ->
                  do p' <- if chosen_branch then return p else notPred sym p
                     let frm = if chosen_branch then tp else fp
-                    loc <- getCurrentProgramLoc sym
-                    addAssumption sym (LabeledPred p' (ExploringAPath loc (pausedLoc frm)))
+                    addAssumption sym (BranchCondition loc (pausedLoc frm) p')
                     ExecutionFeatureNewState <$> runReaderT (resumeFrame frm (asContFrame (st^.stateTree))) st
                UnsatisfiableContext ->
-                 return (ExecutionFeatureNewState (AbortState InfeasibleBranch st))
+                 return (ExecutionFeatureNewState (AbortState (InfeasibleBranch loc) st))
    where
      ploc = st ^. stateLocation
 

--- a/crucible/src/Lang/Crucible/Simulator/PathSplitting.hs
+++ b/crucible/src/Lang/Crucible/Simulator/PathSplitting.hs
@@ -99,7 +99,7 @@ restoreWorkItem (WorkItem branchPred loc frm st assumes) =
   do let sym = st ^. stateSymInterface
      setCurrentProgramLoc sym loc
      restoreAssumptionState sym assumes
-     addAssumption sym (LabeledPred branchPred (ExploringAPath loc (pausedLoc frm)))
+     addAssumption sym (BranchCondition loc (pausedLoc frm) branchPred)
      let ctx = st ^. stateTree . actContext
      runReaderT (resumeFrame frm ctx) st
 
@@ -130,7 +130,7 @@ pathSplittingFeature wl = ExecutionFeature $ \case
                 }
        queueWorkItem wi wl
 
-       addAssumption sym (LabeledPred p (ExploringAPath loc (pausedLoc trueFrame)))
+       addAssumption sym (BranchCondition loc (pausedLoc trueFrame) p)
 
        let ctx = st ^. stateTree . actContext
        ExecutionFeatureNewState <$> runReaderT (resumeFrame (forgetPostdomFrame trueFrame) ctx) st

--- a/crucible/src/Lang/Crucible/Simulator/PositionTracking.hs
+++ b/crucible/src/Lang/Crucible/Simulator/PositionTracking.hs
@@ -1,0 +1,50 @@
+-----------------------------------------------------------------------
+-- |
+-- Module           : Lang.Crucible.Simulator.PositionTracking
+-- Description      : Execution feature for tracking program positions
+-- Copyright        : (c) Galois, Inc 2021
+-- License          : BSD3
+-- Maintainer       : Rob Dockins <rdockins@galois.com>
+-- Stability        : provisional
+------------------------------------------------------------------------
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
+module Lang.Crucible.Simulator.PositionTracking
+  ( positionTrackingFeature
+  ) where
+
+import Control.Lens ((^.), to)
+import Control.Monad.IO.Class
+
+import Lang.Crucible.Backend
+import Lang.Crucible.Simulator.CallFrame
+import Lang.Crucible.Simulator.EvalStmt
+import Lang.Crucible.Simulator.ExecutionTree
+
+
+-- | This execution feature adds a @LocationReachedEvent@ to
+--   the backend assumption tracking whenever execution reaches the
+--   head of a basic block.
+positionTrackingFeature ::
+  IsSymInterface sym =>
+  sym ->
+  IO (GenericExecutionFeature sym)
+positionTrackingFeature sym = return $ GenericExecutionFeature onStep
+ where
+   onStep ::
+     ExecState p sym ext rtp ->
+     IO (ExecutionFeatureResult p sym ext rtp)
+   onStep exst@(RunningState (RunBlockStart _bid) st) =
+     do let loc = st ^. (stateCrucibleFrame.to frameProgramLoc)
+        liftIO $ addAssumptions sym (singleEvent (LocationReachedEvent loc))
+        return (ExecutionFeatureModifiedState exst)
+
+   onStep _ = return ExecutionFeatureNoChange

--- a/crux-llvm/src/Crux/LLVM/Compile.hs
+++ b/crux-llvm/src/Crux/LLVM/Compile.hs
@@ -234,11 +234,11 @@ makeCounterExamplesLLVM cruxOpts llvmOpts res
     -- skip proved goals
     ProvedGoal{} -> return ()
     -- skip unknown goals
-    NotProvedGoal _ _ _ Nothing -> return ()
+    NotProvedGoal _ _ _ _ Nothing -> return ()
     -- skip resource exhausted goals
-    NotProvedGoal _ (simErrorReason -> ResourceExhausted{}) _ _ -> return ()
+    NotProvedGoal _ (simErrorReason -> ResourceExhausted{}) _ _ _ -> return ()
     -- counterexample to non-resource-exhaustion goal
-    NotProvedGoal _ c _ (Just (m,_evs)) ->
+    NotProvedGoal _ c _ _ (Just (m,_evs)) ->
       do let suff = case plSourceLoc (simErrorLoc c) of
                       SourcePos _ l _ -> show l
                       _               -> "unknown"

--- a/crux-llvm/src/Crux/LLVM/Compile.hs
+++ b/crux-llvm/src/Crux/LLVM/Compile.hs
@@ -236,9 +236,9 @@ makeCounterExamplesLLVM cruxOpts llvmOpts res
     -- skip unknown goals
     NotProvedGoal _ _ _ Nothing -> return ()
     -- skip resource exhausted goals
-    NotProvedGoal _ (simErrorReason -> ResourceExhausted{},_) _ _ -> return ()
+    NotProvedGoal _ (simErrorReason -> ResourceExhausted{}) _ _ -> return ()
     -- counterexample to non-resource-exhaustion goal
-    NotProvedGoal _ (c,_) _ (Just m) ->
+    NotProvedGoal _ c _ (Just m) ->
       do let suff = case plSourceLoc (simErrorLoc c) of
                       SourcePos _ l _ -> show l
                       _               -> "unknown"

--- a/crux-llvm/src/Crux/LLVM/Compile.hs
+++ b/crux-llvm/src/Crux/LLVM/Compile.hs
@@ -238,7 +238,7 @@ makeCounterExamplesLLVM cruxOpts llvmOpts res
     -- skip resource exhausted goals
     NotProvedGoal _ (simErrorReason -> ResourceExhausted{}) _ _ -> return ()
     -- counterexample to non-resource-exhaustion goal
-    NotProvedGoal _ c _ (Just m) ->
+    NotProvedGoal _ c _ (Just (m,_evs)) ->
       do let suff = case plSourceLoc (simErrorLoc c) of
                       SourcePos _ l _ -> show l
                       _               -> "unknown"

--- a/crux-llvm/src/Crux/LLVM/Compile.hs
+++ b/crux-llvm/src/Crux/LLVM/Compile.hs
@@ -73,7 +73,7 @@ getClang = attempt (map inPath clangs)
                        Right a -> return a
 
 runClang :: Logs => CruxOptions -> LLVMOptions -> [String] -> IO ()
-runClang cruxOpts llvmOpts params =
+runClang _cruxOpts llvmOpts params =
   do let clang = clangBin llvmOpts
          allParams = clangOpts llvmOpts ++ params
      say Noisily "CLANG" $ T.unwords (T.pack <$> (clang : map show allParams))

--- a/crux-llvm/src/Crux/LLVM/Compile.hs
+++ b/crux-llvm/src/Crux/LLVM/Compile.hs
@@ -230,7 +230,6 @@ makeCounterExamplesLLVM cruxOpts llvmOpts res
  where
  go gs =
   case gs of
-    AtLoc _ _ gs1 -> go gs1
     Branch g1 g2  -> go g1 >> go g2
     -- skip proved goals
     ProvedGoal{} -> return ()

--- a/crux-llvm/src/Crux/LLVM/Compile.hs
+++ b/crux-llvm/src/Crux/LLVM/Compile.hs
@@ -74,8 +74,8 @@ getClang = attempt (map inPath clangs)
                        Left (SomeException {}) -> attempt more
                        Right a -> return a
 
-runClang :: Logs => CruxOptions -> LLVMOptions -> [String] -> IO ()
-runClang _cruxOpts llvmOpts params =
+runClang :: Logs => LLVMOptions -> [String] -> IO ()
+runClang llvmOpts params =
   do let clang = clangBin llvmOpts
          allParams = clangOpts llvmOpts ++ params
      say Noisily "CLANG" $ T.unwords (T.pack <$> (clang : map show allParams))
@@ -163,7 +163,7 @@ genBitCodeToFile finalBCFileName files cruxOpts llvmOpts copySrc = do
            unless (or [ ".bc" `isSuffixOf` src
                       , bcExists && lazyCompile llvmOpts
                       ]) $
-             runClang cruxOpts llvmOpts =<< params f
+             runClang llvmOpts =<< params f
          ver <- llvmLinkVersion llvmOpts
          let libcxxBitcode | anyCPPFiles files = [libDir llvmOpts </> "libcxx-" ++ ver ++ ".bc"]
                            | otherwise = []
@@ -268,14 +268,14 @@ buildModelExes cruxOpts llvmOpts suff counter_src =
          libcxx | anyCPPFiles files = ["-lstdc++"]
                 | otherwise = []
 
-     runClang cruxOpts llvmOpts
+     runClang llvmOpts
                    [ "-I", libs </> "includes"
                    , counterFile
                    , libs </> "print-model.c"
                    , "-o", printExe
                    ]
 
-     runClang cruxOpts llvmOpts $
+     runClang llvmOpts $
               concat [ [ "-I", idir ] | idir <- incs ] ++
                      [ counterFile
                      , libs </> "concrete-backend.c"

--- a/crux-llvm/src/Crux/LLVM/Overrides.hs
+++ b/crux-llvm/src/Crux/LLVM/Overrides.hs
@@ -51,7 +51,8 @@ import Lang.Crucible.Simulator.OverrideSim
 import Lang.Crucible.Simulator.SimError (SimErrorReason(..),SimError(..))
 import Lang.Crucible.Backend
           ( IsSymInterface, addDurableAssertion, addFailedAssertion
-          , addAssumption, LabeledPred(..), CrucibleAssumption(..))
+          , addAssumption, LabeledPred(..), CrucibleAssumption(..)
+          , addAssumptions, singleEvent, CrucibleEvent(..), ppEvent )
 import Lang.Crucible.LLVM.QQ( llvmOvr )
 import Lang.Crucible.LLVM.DataLayout
   (noAlignment)
@@ -320,6 +321,8 @@ mkFresh nm ty =
      elt <- liftIO (freshConstant sym name ty)
      loc   <- liftIO $ getCurrentProgramLoc sym
      stateContext.cruciblePersonality.personalityModel %= addVar loc nm ty elt
+     let ev = CreateVariableEvent loc nm ty elt
+     liftIO $ addAssumptions sym (singleEvent ev)
      return elt
 
 mkFreshFloat

--- a/crux-llvm/src/Crux/LLVM/Overrides.hs
+++ b/crux-llvm/src/Crux/LLVM/Overrides.hs
@@ -51,7 +51,7 @@ import Lang.Crucible.Simulator.OverrideSim
 import Lang.Crucible.Simulator.SimError (SimErrorReason(..),SimError(..))
 import Lang.Crucible.Backend
           ( IsSymInterface, addDurableAssertion, addFailedAssertion
-          , addAssumption, LabeledPred(..), AssumptionReason(..))
+          , addAssumption, LabeledPred(..), CrucibleAssumption(..))
 import Lang.Crucible.LLVM.QQ( llvmOvr )
 import Lang.Crucible.LLVM.DataLayout
   (noAlignment)
@@ -443,8 +443,7 @@ do_assume arch mvar sym (Empty :> p :> pFile :> line) =
      let pos = SourcePos (T.pack file) l 0
      loc <- liftIO $ getCurrentProgramLoc sym
      let loc' = loc{ plSourceLoc = pos }
-     let msg = AssumptionReason loc' "crucible_assume"
-     liftIO $ addAssumption sym (LabeledPred cond msg)
+     liftIO $ addAssumption sym (GenericAssumption loc' "crucible_assume" cond)
 
 do_assert ::
   (ArchOk arch, IsSymInterface sym, HasLLVMAnn sym) =>
@@ -499,8 +498,8 @@ cprover_assume ::
 cprover_assume _mvar sym (Empty :> p) = liftIO $
   do cond <- bvIsNonzero sym (regValue p)
      loc  <- getCurrentProgramLoc sym
-     let msg = AssumptionReason loc "__CPROVER_assume"
-     addAssumption sym (LabeledPred cond msg)
+     addAssumption sym (GenericAssumption loc "__CPROVER_assume" cond)
+
 
 cprover_assert ::
   (ArchOk arch, IsSymInterface sym, HasLLVMAnn sym) =>
@@ -549,8 +548,7 @@ sv_comp_assume ::
 sv_comp_assume _mvar sym (Empty :> p) = liftIO $
   do cond <- bvIsNonzero sym (regValue p)
      loc  <- getCurrentProgramLoc sym
-     let msg = AssumptionReason loc "__VERIFIER_assume"
-     addAssumption sym (LabeledPred cond msg)
+     addAssumption sym (GenericAssumption loc "__VERIFIER_assume" cond)
 
 sv_comp_assert ::
   (IsSymInterface sym) =>

--- a/crux-llvm/src/Crux/LLVM/Simulate.hs
+++ b/crux-llvm/src/Crux/LLVM/Simulate.hs
@@ -73,7 +73,6 @@ import Lang.Crucible.LLVM.Extension( LLVM )
 import qualified Crux
 
 import Crux.Types
-import Crux.Model
 import Crux.Log
 
 import Crux.LLVM.Config
@@ -86,7 +85,7 @@ setupSimCtxt ::
   sym ->
   MemOptions ->
   GlobalVar Mem ->
-  SimCtxt Model sym LLVM
+  SimCtxt Crux sym LLVM
 setupSimCtxt halloc sym mo memVar =
   initSimContext sym
                  llvmIntrinsicTypes
@@ -94,7 +93,7 @@ setupSimCtxt halloc sym mo memVar =
                  stdout
                  (fnBindingsFromList [])
                  (llvmExtensionImpl mo)
-                 emptyModel
+                 CruxPersonality
     & profilingMetrics %~ Map.union (memMetrics memVar)
 
 -- | Parse an LLVM bit-code file.
@@ -109,7 +108,7 @@ registerFunctions ::
   (ArchOk arch, IsSymInterface sym, HasLLVMAnn sym) =>
   LLVM.Module ->
   ModuleTranslation arch ->
-  OverM Model sym LLVM ()
+  OverM Crux sym LLVM ()
 registerFunctions llvm_module mtrans =
   do let llvm_ctx = mtrans ^. transContext
      let ?lc = llvm_ctx ^. llvmTypeCtx

--- a/crux-llvm/test-data/golden/cex-test.c
+++ b/crux-llvm/test-data/golden/cex-test.c
@@ -1,0 +1,22 @@
+#include <crucible.h>
+#define N 2
+
+int main()
+{
+    int i;
+    for (i = 1; i <= N; i++) {
+      int i0 = i;
+      for (int j = 1; j <= i0; j++) {
+        int b = crucible_int32_t("b");
+        switch (b) {
+	  case 1: break;
+	  case 2: i++; break;
+	  default:
+	    return i;
+	}
+      }
+    }
+    crucible_assert(i <= 4, __FILE__, __LINE__);
+
+    return 0;
+}

--- a/crux-llvm/test-data/golden/cex-test.config
+++ b/crux-llvm/test-data/golden/cex-test.config
@@ -1,0 +1,3 @@
+print-symbolic-vars: yes
+print-failures: yes
+opt-level: 0

--- a/crux-llvm/test-data/golden/cex-test.good
+++ b/crux-llvm/test-data/golden/cex-test.good
@@ -1,0 +1,9 @@
+[Crux] Found counterexample for verification goal
+[Crux]   test-data/golden/cex-test.c:19:0: error: in main
+[Crux]   crucible_assert
+[Crux] 
+[Crux]   Symbolic variables:
+[Crux]     b = 1 at test-data/golden/cex-test.c:10:17
+[Crux]     b = 2 at test-data/golden/cex-test.c:10:17
+[Crux]     b = 2 at test-data/golden/cex-test.c:10:17
+[Crux] Overall status: Invalid.

--- a/crux-mir/src/Mir/Intrinsics.hs
+++ b/crux-mir/src/Mir/Intrinsics.hs
@@ -98,8 +98,6 @@ import           Lang.Crucible.Simulator.RegValue
 import           Lang.Crucible.Simulator.RegMap
 import           Lang.Crucible.Simulator.SimError
 
-import           Crux.Types (HasModel)
-
 import           What4.Concrete (ConcreteVal(..), concreteType)
 import           What4.Interface
 import           What4.Partial
@@ -1948,7 +1946,6 @@ class MethodSpecImpl sym ms where
     -- (`&str`).
     msPrettyPrint ::
         forall p rtp args ret.
-        (HasModel p) =>
         ms ->
         OverrideSim (p sym) sym MIR rtp args ret (RegValue sym (MirSlice (BVType 8)))
 
@@ -1956,7 +1953,6 @@ class MethodSpecImpl sym ms where
     -- current test.
     msEnable ::
         forall p rtp args ret.
-        (HasModel p) =>
         ms ->
         OverrideSim (p sym) sym MIR rtp args ret ()
 
@@ -1988,23 +1984,18 @@ instance IsSymInterface sym => IntrinsicClass sym MethodSpecSymbol where
 
 class MethodSpecBuilderImpl sym msb where
     msbAddArg :: forall p rtp args ret tp.
-        (HasModel p) =>
         TypeRepr tp -> MirReferenceMux sym tp -> msb ->
         OverrideSim (p sym) sym MIR rtp args ret msb
     msbSetReturn :: forall p rtp args ret tp.
-        (HasModel p) =>
         TypeRepr tp -> MirReferenceMux sym tp -> msb ->
         OverrideSim (p sym) sym MIR rtp args ret msb
     msbGatherAssumes :: forall p rtp args ret.
-        (HasModel p) =>
         msb ->
         OverrideSim (p sym) sym MIR rtp args ret msb
     msbGatherAsserts :: forall p rtp args ret.
-        (HasModel p) =>
         msb ->
         OverrideSim (p sym) sym MIR rtp args ret msb
     msbFinish :: forall p rtp args ret.
-        (HasModel p) =>
         msb ->
         OverrideSim (p sym) sym MIR rtp args ret (MethodSpec sym)
 

--- a/crux-mir/src/Mir/Language.hs
+++ b/crux-mir/src/Mir/Language.hs
@@ -257,8 +257,8 @@ runTestsWithExtraOverrides bindExtra (cruxOpts, mirOpts) = do
 
              -- Label the current path for later use
              sym <- C.getSymInterface
-             liftIO $ C.addAssumption sym $ C.LabeledPred (W4.truePred sym) $
-                 C.ExploringAPath entry (Just $ testStartLoc fnName)
+             liftIO $ C.addAssumption sym $
+                 C.BranchCondition entry (Just $ testStartLoc fnName) (W4.truePred sym)
 
              -- Find and run the target function
              C.AnyCFG cfg <- case Map.lookup (idText fnName) cfgMap of

--- a/crux-mir/src/Mir/Language.hs
+++ b/crux-mir/src/Mir/Language.hs
@@ -363,8 +363,8 @@ runTestsWithExtraOverrides bindExtra (cruxOpts, mirOpts) = do
     let printCounterexamples gs = case gs of
             Branch g1 g2 -> printCounterexamples g1 >> printCounterexamples g2
             ProvedGoal{} -> return ()
-            NotProvedGoal _ _ _ Nothing -> return ()
-            NotProvedGoal _ _ _ (Just (m,_evs)) -> do
+            NotProvedGoal _ _ _ _ Nothing -> return ()
+            NotProvedGoal _ _ _ _ (Just (m,_evs)) -> do
                logGoal gs
                when (showModel mirOpts) $ do
                   outputLn "Model:"

--- a/crux-mir/src/Mir/Language.hs
+++ b/crux-mir/src/Mir/Language.hs
@@ -366,15 +366,15 @@ runTestsWithExtraOverrides bindExtra (cruxOpts, mirOpts) = do
     let printCounterexamples gs = case gs of
             AtLoc _ _ gs1 -> printCounterexamples gs1
             Branch g1 g2 -> printCounterexamples g1 >> printCounterexamples g2
-            Goal _ (_, _) _ res ->
-                case res of
-                    NotProved _ (Just m) -> do
-                        logGoal gs
-                        when (showModel mirOpts) $ do
-                           outputLn "Model:"
-                           mjs <- Crux.modelJS m
-                           outputLn (Crux.renderJS mjs)
-                    _ -> return ()
+            ProvedGoal{} -> return ()
+            NotProvedGoal _ _ _ Nothing -> return ()
+            NotProvedGoal _ _ _ (Just m) -> do
+               logGoal gs
+               when (showModel mirOpts) $ do
+                  outputLn "Model:"
+                  mjs <- Crux.modelJS m
+                  outputLn (Crux.renderJS mjs)
+
     when anyFailed $ do
         outputLn ""
         outputLn "failures:"

--- a/crux-mir/src/Mir/Language.hs
+++ b/crux-mir/src/Mir/Language.hs
@@ -122,7 +122,7 @@ mainWithOutputConfig mkOutCfg bindExtra =
     $ runTestsWithExtraOverrides bindExtra
 
 type BindExtraOverridesFn = forall sym p t st fs args ret blocks rtp a r.
-    (C.IsSymInterface sym, sym ~ W4.ExprBuilder t st fs, HasModel p) =>
+    (C.IsSymInterface sym, sym ~ W4.ExprBuilder t st fs) =>
     Maybe (Crux.SomeOnlineSolver sym) ->
     CollectionState ->
     Text ->
@@ -145,7 +145,6 @@ orOverride f g symOnline cs name cfg =
 -- personality.
 data SomeTestOvr sym ctx (ty :: C.CrucibleType) =
   forall personality.
-  HasModel personality =>
     SomeTestOvr { testOvr      :: Fun personality sym MIR ctx ty
                 , testFeatures :: [C.ExecutionFeature (personality sym) sym MIR (C.RegEntry sym ty)]
                 , testPersonality :: personality sym
@@ -216,7 +215,7 @@ runTestsWithExtraOverrides bindExtra (cruxOpts, mirOpts) = do
     let cfgMap = mir^.rmCFGs
 
     -- Simulate each test case
-    let linkOverrides :: (C.IsSymInterface sym, sym ~ W4.ExprBuilder t st fs, HasModel p) =>
+    let linkOverrides :: (C.IsSymInterface sym, sym ~ W4.ExprBuilder t st fs) =>
             Maybe (Crux.SomeOnlineSolver sym) -> C.OverrideSim (p sym) sym MIR rtp a r ()
         linkOverrides symOnline =
             forM_ (Map.toList cfgMap) $ \(fn, C.AnyCFG cfg) -> do
@@ -246,7 +245,6 @@ runTestsWithExtraOverrides bindExtra (cruxOpts, mirOpts) = do
             ( C.IsSymInterface sym
             , sym ~ W4.ExprBuilder t st fs
             , Crux.Logs
-            , HasModel p
             ) =>
             Maybe (Crux.SomeOnlineSolver sym) ->
             DefId ->
@@ -307,7 +305,7 @@ runTestsWithExtraOverrides bindExtra (cruxOpts, mirOpts) = do
             { testOvr = do printTest fnName
                            simTestBody symOnline fnName
             , testFeatures = []
-            , testPersonality = Crux.emptyModel
+            , testPersonality = Crux.CruxPersonality
             }
 
     let simCallback fnName = Crux.SimulatorCallback $ \sym symOnline ->

--- a/crux-mir/src/Mir/Language.hs
+++ b/crux-mir/src/Mir/Language.hs
@@ -361,7 +361,6 @@ runTestsWithExtraOverrides bindExtra (cruxOpts, mirOpts) = do
     let anyFailed = any (not . isResultOK) results
 
     let printCounterexamples gs = case gs of
-            AtLoc _ _ gs1 -> printCounterexamples gs1
             Branch g1 g2 -> printCounterexamples g1 >> printCounterexamples g2
             ProvedGoal{} -> return ()
             NotProvedGoal _ _ _ Nothing -> return ()

--- a/crux-mir/src/Mir/Language.hs
+++ b/crux-mir/src/Mir/Language.hs
@@ -364,7 +364,7 @@ runTestsWithExtraOverrides bindExtra (cruxOpts, mirOpts) = do
             Branch g1 g2 -> printCounterexamples g1 >> printCounterexamples g2
             ProvedGoal{} -> return ()
             NotProvedGoal _ _ _ Nothing -> return ()
-            NotProvedGoal _ _ _ (Just m) -> do
+            NotProvedGoal _ _ _ (Just (m,_evs)) -> do
                logGoal gs
                when (showModel mirOpts) $ do
                   outputLn "Model:"

--- a/crux-mir/src/Mir/Overrides.hs
+++ b/crux-mir/src/Mir/Overrides.hs
@@ -63,7 +63,8 @@ import What4.SatResult (SatResult(..))
 import Lang.Crucible.Analysis.Postdom (postdomInfo)
 import Lang.Crucible.Backend
     ( CrucibleAssumption(..), IsBoolSolver, LabeledPred(..), addAssumption
-    , assert, getPathCondition, Assumption(..), addFailedAssertion, IsSymInterface )
+    , assert, getPathCondition, Assumption(..), addFailedAssertion, IsSymInterface
+    , singleEvent, addAssumptions, CrucibleEvent(..) )
 import Lang.Crucible.Backend.Online
 import Lang.Crucible.CFG.Core (CFG, cfgArgTypes, cfgHandle, cfgReturnType, lastReg)
 import Lang.Crucible.FunctionHandle
@@ -128,6 +129,8 @@ makeSymbolicVar nameReg btpr = do
     v <- liftIO $ freshConstant sym nameSymbol btpr
     loc <- liftIO $ getCurrentProgramLoc sym
     stateContext.cruciblePersonality.personalityModel %= addVar loc name btpr v
+    let ev = CreateVariableEvent loc name btpr v
+    liftIO $ addAssumptions sym (singleEvent ev)
     return v
 
 array_symbolic ::

--- a/crux-mir/src/Mir/Overrides.hs
+++ b/crux-mir/src/Mir/Overrides.hs
@@ -62,7 +62,7 @@ import What4.SatResult (SatResult(..))
 
 import Lang.Crucible.Analysis.Postdom (postdomInfo)
 import Lang.Crucible.Backend
-    ( AssumptionReason(..), IsBoolSolver, LabeledPred(..), addAssumption
+    ( CrucibleAssumption(..), IsBoolSolver, LabeledPred(..), addAssumption
     , assert, getPathCondition, Assumption(..), addFailedAssertion, IsSymInterface )
 import Lang.Crucible.Backend.Online
 import Lang.Crucible.CFG.Core (CFG, cfgArgTypes, cfgHandle, cfgReturnType, lastReg)
@@ -529,7 +529,7 @@ bindFn _symOnline _cs fn cfg =
                        col <- maybe (fail "not a constant column number") pure
                               (BV.asUnsigned <$> asBV (regValue colArg))
                        let locStr = Text.unpack file <> ":" <> show line <> ":" <> show col
-                       let reason = AssumptionReason loc $ "Assumption \n\t" <> src <> "\nfrom " <> locStr
-                       liftIO $ addAssumption s (LabeledPred (regValue c) reason)
+                       let reason = GenericAssumption loc ("Assumption \n\t" <> src <> "\nfrom " <> locStr) (regValue c)
+                       liftIO $ addAssumption s reason
                        return ()
                ]

--- a/crux-mir/src/Mir/Overrides.hs
+++ b/crux-mir/src/Mir/Overrides.hs
@@ -80,9 +80,8 @@ import Lang.Crucible.Types
 import Lang.Crucible.Utils.MuxTree
 
 
-import Crux (SomeOnlineSolver(..), HasModel(..))
-import Crux.Model (addVar, evalModel)
-import Crux.Types (Model(..), Vars(..), Vals(..), Entry(..))
+import Crux (SomeOnlineSolver(..))
+import Crux.Types (Vals(..), Entry(..))
 
 import Mir.DefId
 import Mir.FancyMuxTree
@@ -113,7 +112,7 @@ data SomeOverride p sym where
   SomeOverride :: CtxRepr args -> TypeRepr ret -> Override p sym MIR args ret -> SomeOverride p sym
 
 makeSymbolicVar ::
-    (IsSymInterface sym, HasModel p) =>
+    (IsSymInterface sym) =>
     RegEntry sym (MirSlice (BVType 8)) ->
     BaseTypeRepr btp ->
     OverrideSim (p sym) sym MIR rtp args ret (RegValue sym (BaseToType btp))
@@ -128,14 +127,13 @@ makeSymbolicVar nameReg btpr = do
         Right x -> return x
     v <- liftIO $ freshConstant sym nameSymbol btpr
     loc <- liftIO $ getCurrentProgramLoc sym
-    stateContext.cruciblePersonality.personalityModel %= addVar loc name btpr v
     let ev = CreateVariableEvent loc name btpr v
     liftIO $ addAssumptions sym (singleEvent ev)
     return v
 
 array_symbolic ::
   forall sym rtp btp p .
-  (IsSymInterface sym, HasModel p) =>
+  (IsSymInterface sym) =>
   BaseTypeRepr btp ->
   OverrideSim (p sym) sym MIR rtp
     (EmptyCtx ::> MirSlice (BVType 8)) (UsizeArrayType btp)
@@ -374,7 +372,7 @@ regEval sym baseEval tpr v = go tpr v
 
 -- | Override one Rust function with another.
 overrideRust ::
-  (IsSymInterface sym, HasModel p) =>
+  (IsSymInterface sym) =>
   CollectionState ->
   Text ->
   OverrideSim (p sym) sym MIR rtp args ret ()
@@ -406,7 +404,7 @@ overrideRust cs name = do
 
 bindFn ::
   forall p ng args ret blocks sym rtp a r.
-  (IsSymInterface sym, HasModel p) =>
+  (IsSymInterface sym) =>
   Maybe (SomeOnlineSolver sym) ->
   CollectionState ->
   Text ->

--- a/crux/src/Crux.hs
+++ b/crux/src/Crux.hs
@@ -576,8 +576,8 @@ type ProverCallback sym =
     CruxOptions ->
     SimCtxt personality sym ext ->
     Explainer sym t Void ->
-    Maybe (Goals (Assumption sym) (Assertion sym)) ->
-    IO (ProcessedGoals, Maybe (Goals (Assumption sym) (Assertion sym, ProofResult sym)))
+    Maybe (Goals (Assumptions sym) (Assertion sym)) ->
+    IO (ProcessedGoals, Maybe (Goals (Assumptions sym) (Assertion sym, ProofResult sym)))
 
 -- | Core invocation of the symbolic execution engine
 --

--- a/crux/src/Crux.hs
+++ b/crux/src/Crux.hs
@@ -21,7 +21,7 @@ module Crux
   , Explainer
   , CruxOptions(..)
   , SomeOnlineSolver(..)
-  , HasModel(..)
+  , Crux(..)
   , module Crux.Config
   , module Crux.Log
   ) where
@@ -92,13 +92,13 @@ import           Crux.Report
 import           Crux.Types
 import qualified Crux.Version as Crux
 
-pattern RunnableState :: forall sym . () => forall ext personality . (IsSyntaxExtension ext, HasModel personality) => ExecState (personality sym) sym ext (RegEntry sym UnitType) -> RunnableState sym
+pattern RunnableState :: forall sym . () => forall ext personality . (IsSyntaxExtension ext) => ExecState (personality sym) sym ext (RegEntry sym UnitType) -> RunnableState sym
 pattern RunnableState es = RunnableStateWithExtensions es []
 
 -- | A crucible @ExecState@ that is ready to be passed into the simulator.
 --   This will usually, but not necessarily, be an @InitialState@.
 data RunnableState sym where
-  RunnableStateWithExtensions :: (IsSyntaxExtension ext, HasModel personality)
+  RunnableStateWithExtensions :: (IsSyntaxExtension ext)
                               => ExecState (personality sym) sym ext (RegEntry sym UnitType)
                               -> [ExecutionFeature (personality sym) sym ext (RegEntry sym UnitType)]
                               -> RunnableState sym
@@ -572,7 +572,7 @@ runSimulator cruxOpts simCallback = do
 
 type ProverCallback sym =
   forall ext personality t st fs.
-    (HasModel personality, sym ~ WEB.ExprBuilder t st fs) =>
+    (sym ~ WEB.ExprBuilder t st fs) =>
     CruxOptions ->
     SimCtxt personality sym ext ->
     Explainer sym t Void ->

--- a/crux/src/Crux.hs
+++ b/crux/src/Crux.hs
@@ -578,9 +578,8 @@ type ProverCallback sym =
     CruxOptions ->
     SimCtxt personality sym ext ->
     Explainer sym t Void ->
-    Maybe (Goals (LPred sym AssumptionReason) (LPred sym SimError)) ->
-    IO (ProcessedGoals, Maybe (Goals (LPred sym AssumptionReason) (LPred sym SimError, ProofResult (Either (LPred sym AssumptionReason) (LPred sym SimError)))))
-
+    Maybe (Goals (Assumption sym) (Assertion sym)) ->
+    IO (ProcessedGoals, Maybe (Goals (Assumption sym) (Assertion sym, ProofResult (Either (Assumption sym) (Assertion sym)))))
 
 -- | Core invocation of the symbolic execution engine
 --
@@ -596,7 +595,7 @@ doSimWithResults ::
   CruxOptions ->
   SimulatorCallback ->
   IORef ProgramCompleteness ->
-  IORef (Seq.Seq (ProcessedGoals, ProvedGoals (Either AssumptionReason SimError))) ->
+  IORef (Seq.Seq (ProcessedGoals, ProvedGoals (Either (CrucibleAssumption ()) SimError))) ->
   sym ->
   [GenericExecutionFeature sym] ->
   ProfData sym ->

--- a/crux/src/Crux.hs
+++ b/crux/src/Crux.hs
@@ -647,7 +647,7 @@ doSimWithResults cruxOpts simCallback sym execFeatures profInfo monline goalProv
         when (isJust todo) $
           say Simply "Crux" "Attempting to prove verification conditions."
         (nms, proved) <- goalProver cruxOpts ctx explainFailure todo
-        mgt <- provedGoalsTree ctx proved
+        mgt <- provedGoalsTree sym proved
         case mgt of
           Nothing -> return (not timedOut)
           Just gt ->

--- a/crux/src/Crux.hs
+++ b/crux/src/Crux.hs
@@ -218,7 +218,9 @@ mkOutputConfig withColors outHandle errHandle opts =
           (m, SayNothing) -> m
           (m1', m2') -> SayMore m1' m2'
 
-      lgGoal = sayWhatFailedGoals (maybe True printFailures opts) >$< lgWhat
+      printFails = maybe True printFailures opts
+      printVars = maybe False printSymbolicVars opts
+      lgGoal = sayWhatFailedGoals printFails printVars >$< lgWhat
       splitResults r@(CruxSimulationResult _cmpl gls) = (snd <$> gls, r)
   in OutputConfig
      {

--- a/crux/src/Crux.hs
+++ b/crux/src/Crux.hs
@@ -64,6 +64,7 @@ import           Lang.Crucible.Simulator.BoundedExec
 import           Lang.Crucible.Simulator.BoundedRecursion
 import           Lang.Crucible.Simulator.PathSatisfiability
 import           Lang.Crucible.Simulator.PathSplitting
+import           Lang.Crucible.Simulator.PositionTracking
 import           Lang.Crucible.Simulator.Profiling
 import           Lang.Crucible.Types
 
@@ -476,7 +477,10 @@ setupExecutionFeatures cruxOpts sym maybeOnline = do
            $ pathSatisfiabilityFeature sym (considerSatisfiability sym)
     Nothing -> return []
 
-  return (concat [tfs, profExecFeatures profInfo, bfs, rfs, psat_fs], profInfo)
+  -- Position tracking
+  trackfs <- positionTrackingFeature sym
+
+  return (concat [tfs, profExecFeatures profInfo, bfs, rfs, psat_fs, [trackfs]], profInfo)
 
 -- | Select the What4 solver adapter for the user's solver choice (used for
 -- offline solvers)

--- a/crux/src/Crux.hs
+++ b/crux/src/Crux.hs
@@ -69,7 +69,6 @@ import           Lang.Crucible.Types
 
 
 import           What4.Config (Opt, ConfigOption, setOpt, getOptionSetting, verbosity, extendConfig)
-import           What4.Expr (GroundEvalFn)
 import qualified What4.Expr.Builder as WEB
 import           What4.FunctionName (FunctionName)
 import           What4.Interface (IsExprBuilder, getConfiguration)
@@ -102,13 +101,6 @@ data RunnableState sym where
                               => ExecState (personality sym) sym ext (RegEntry sym UnitType)
                               -> [ExecutionFeature (personality sym) sym ext (RegEntry sym UnitType)]
                               -> RunnableState sym
-
--- | A function that can be used to generate a pretty explanation of a
--- simulation error.
-
-type Explainer sym t ann = Maybe (GroundEvalFn t)
-                           -> LPred sym SimError
-                           -> IO (Doc ann)
 
 -- | Individual crux tools will generally call the @runSimulator@ combinator
 --   to handle the nitty-gritty of setting up and running the simulator.
@@ -569,15 +561,6 @@ runSimulator cruxOpts simCallback = do
 
     Left rsns -> fail ("Invalid solver configuration:\n" ++ unlines rsns)
 
-
-type ProverCallback sym =
-  forall ext personality t st fs.
-    (sym ~ WEB.ExprBuilder t st fs) =>
-    CruxOptions ->
-    SimCtxt personality sym ext ->
-    Explainer sym t Void ->
-    Maybe (Goals (Assumptions sym) (Assertion sym)) ->
-    IO (ProcessedGoals, Maybe (Goals (Assumptions sym) (Assertion sym, ProofResult sym)))
 
 -- | Core invocation of the symbolic execution engine
 --

--- a/crux/src/Crux/Config/Common.hs
+++ b/crux/src/Crux/Config/Common.hs
@@ -147,6 +147,10 @@ data CruxOptions = CruxOptions
 
   , printFailures            :: Bool
     -- ^ Print errors regarding failed verification goals
+
+  , printSymbolicVars        :: Bool
+    -- ^ Print values assigned to symbolic variables
+    --   when printing failed verification goals
   }
 
 
@@ -257,6 +261,11 @@ cruxOptions = Config
           printFailures <-
             section "print-failures" yesOrNoSpec True
             "Print error messages regarding failed verification goals"
+
+          printSymbolicVars <-
+            section "print-symbolic-vars" yesOrNoSpec False
+            ("Print values assigned to symbolic variables " <>
+             "when printing failed verification goals")
 
           skipReport <-
             section "skip-report" yesOrNoSpec False

--- a/crux/src/Crux/FormatOut.hs
+++ b/crux/src/Crux/FormatOut.hs
@@ -19,7 +19,7 @@ import           Prettyprinter ( (<+>) )
 import qualified Prettyprinter as PP
 import qualified Prettyprinter.Render.Text as PPR
 
-import           Lang.Crucible.Backend ( AssumptionReason )
+import           Lang.Crucible.Backend ( CrucibleAssumption () )
 import qualified Lang.Crucible.Simulator.SimError as CSE
 
 import           Crux.Types
@@ -55,7 +55,7 @@ sayWhatResultStatus (CruxSimulationResult cmpl gls) =
               SayWhat Fail "Crux" "Internal error computing overall status."
 
 sayWhatFailedGoals :: Bool
-                   -> Seq (ProvedGoals (Either AssumptionReason CSE.SimError))
+                   -> Seq (ProvedGoals (Either (CrucibleAssumption ()) CSE.SimError))
                    -> SayWhat
 sayWhatFailedGoals skipIncompl allGls =
   let failedDoc = \case

--- a/crux/src/Crux/FormatOut.hs
+++ b/crux/src/Crux/FormatOut.hs
@@ -19,7 +19,6 @@ import           Prettyprinter ( (<+>) )
 import qualified Prettyprinter as PP
 import qualified Prettyprinter.Render.Text as PPR
 
-import           Lang.Crucible.Backend ( CrucibleAssumption () )
 import qualified Lang.Crucible.Simulator.SimError as CSE
 
 import           Crux.Types
@@ -54,15 +53,13 @@ sayWhatResultStatus (CruxSimulationResult cmpl gls) =
           | otherwise ->
               SayWhat Fail "Crux" "Internal error computing overall status."
 
-sayWhatFailedGoals :: Bool
-                   -> Seq (ProvedGoals (Either (CrucibleAssumption ()) CSE.SimError))
-                   -> SayWhat
+sayWhatFailedGoals :: Bool -> Seq ProvedGoals -> SayWhat
 sayWhatFailedGoals skipIncompl allGls =
   let failedDoc = \case
         AtLoc _ _ gls -> failedDoc gls
         Branch gls1 gls2 -> failedDoc gls1 <> failedDoc gls2
-        Goal _asmps _goal _trivial (Proved _) -> []
-        Goal _asmps (err, _msg) _trivial (NotProved ex mdl) ->
+        ProvedGoal _asmps _goal _trivial -> []
+        NotProvedGoal _asmps (err, _msg) ex mdl ->
           if | skipIncompl, CSE.SimError _ (CSE.ResourceExhausted _) <- err -> []
              | Just _ <- mdl ->
                  [ PP.nest 2 $ PP.vcat

--- a/crux/src/Crux/FormatOut.hs
+++ b/crux/src/Crux/FormatOut.hs
@@ -58,7 +58,7 @@ sayWhatFailedGoals skipIncompl allGls =
   let failedDoc = \case
         Branch gls1 gls2 -> failedDoc gls1 <> failedDoc gls2
         ProvedGoal _asmps _goal _trivial -> []
-        NotProvedGoal _asmps (err, _msg) ex mdl ->
+        NotProvedGoal _asmps err ex mdl ->
           if | skipIncompl, CSE.SimError _ (CSE.ResourceExhausted _) <- err -> []
              | Just _ <- mdl ->
                  [ PP.nest 2 $ PP.vcat

--- a/crux/src/Crux/FormatOut.hs
+++ b/crux/src/Crux/FormatOut.hs
@@ -56,7 +56,6 @@ sayWhatResultStatus (CruxSimulationResult cmpl gls) =
 sayWhatFailedGoals :: Bool -> Seq ProvedGoals -> SayWhat
 sayWhatFailedGoals skipIncompl allGls =
   let failedDoc = \case
-        AtLoc _ _ gls -> failedDoc gls
         Branch gls1 gls2 -> failedDoc gls1 <> failedDoc gls2
         ProvedGoal _asmps _goal _trivial -> []
         NotProvedGoal _asmps (err, _msg) ex mdl ->

--- a/crux/src/Crux/FormatOut.hs
+++ b/crux/src/Crux/FormatOut.hs
@@ -57,8 +57,8 @@ sayWhatFailedGoals :: Bool -> Seq ProvedGoals -> SayWhat
 sayWhatFailedGoals skipIncompl allGls =
   let failedDoc = \case
         Branch gls1 gls2 -> failedDoc gls1 <> failedDoc gls2
-        ProvedGoal _asmps _goal _trivial -> []
-        NotProvedGoal _asmps err ex mdl ->
+        ProvedGoal{} -> []
+        NotProvedGoal _asmps err ex _locs mdl ->
           if | skipIncompl, CSE.SimError _ (CSE.ResourceExhausted _) <- err -> []
              | Just _ <- mdl ->
                  [ PP.nest 2 $ PP.vcat

--- a/crux/src/Crux/Goal.hs
+++ b/crux/src/Crux/Goal.hs
@@ -201,7 +201,7 @@ updateProcessedGoals _ (NotProved _ Nothing) pgs =
 -- Note that this function uses the same symbolic backend ('ExprBuilder') as the
 -- symbolic execution phase, which should not be a problem.
 proveGoalsOffline :: forall st sym p t fs personality.
-  (?outputConfig :: OutputConfig, sym ~ ExprBuilder t st fs, HasModel personality) =>
+  (?outputConfig :: OutputConfig, sym ~ ExprBuilder t st fs) =>
   [WS.SolverAdapter st] ->
   CruxOptions ->
   SimCtxt personality sym p ->
@@ -356,7 +356,6 @@ proveGoalsOnline ::
   , OnlineSolver solver
   , goalSym ~ OnlineBackend s goalSolver fs
   , OnlineSolver goalSolver
-  , HasModel personality
   , ?outputConfig :: OutputConfig
   ) =>
   goalSym ->

--- a/crux/src/Crux/Goal.hs
+++ b/crux/src/Crux/Goal.hs
@@ -12,7 +12,7 @@ module Crux.Goal where
 
 import Control.Concurrent.Async (async, asyncThreadId, waitAnyCatch)
 import Control.Exception (throwTo, SomeException, displayException)
-import Control.Lens ((^.), (^..), view)
+import Control.Lens ((^.), view)
 import qualified Control.Lens as L
 import Control.Monad (forM, forM_, unless, when)
 import Data.Either (partitionEithers)
@@ -26,7 +26,7 @@ import           Prettyprinter
 import           System.Exit (ExitCode(ExitSuccess))
 import qualified System.Timeout as ST
 
-import What4.Interface (notPred, printSymExpr,getConfiguration)
+import What4.Interface (notPred, getConfiguration)
 import What4.Config (setOpt, getOptionSetting)
 import What4.SatResult(SatResult(..))
 import What4.Expr (ExprBuilder, GroundEvalFn(..), BoolExpr, Expr, GroundValueWrapper(..))
@@ -87,8 +87,8 @@ proveToGoal sym allAsmps p pr =
         (asmps, _:_) -> return (ProvedGoal (map showAsmp asmps) (showGoal p) False)
 
  where
- showAsmp x = (forgetAssumption x, vcat (x ^.. foldAssumption. L.to printSymExpr))
- showGoal x = (x^.labeledPredMsg, printSymExpr (x^.labeledPred))
+ showAsmp x = forgetAssumption x
+ showGoal x = x^.labeledPredMsg
 
 
 countGoals :: Goals a b -> Int

--- a/crux/src/Crux/Goal.hs
+++ b/crux/src/Crux/Goal.hs
@@ -113,51 +113,6 @@ countGoals gs =
     Prove _         -> 1
     ProveConj g1 g2 -> countGoals g1 + countGoals g2
 
-countTotalGoals :: ProvedGoals -> Int
-countTotalGoals gs =
-  case gs of
-    AtLoc _ _ gs1 -> countTotalGoals gs1
-    Branch gs1 gs2 -> countTotalGoals gs1 + countTotalGoals gs2
-    ProvedGoal{} -> 1
-    NotProvedGoal{} -> 1
-
-countDisprovedGoals :: ProvedGoals -> Int
-countDisprovedGoals gs =
-  case gs of
-    AtLoc _ _ gs1 -> countDisprovedGoals gs1
-    Branch gs1 gs2 -> countDisprovedGoals gs1 + countDisprovedGoals gs2
-    NotProvedGoal _ _ _ (Just _) -> 1
-    NotProvedGoal _ _ _ Nothing -> 0
-    ProvedGoal{} -> 0
-
-countUnknownGoals :: ProvedGoals -> Int
-countUnknownGoals gs =
-  case gs of
-    AtLoc _ _ gs1 -> countUnknownGoals gs1
-    Branch gs1 gs2 -> countUnknownGoals gs1 + countUnknownGoals gs2
-    NotProvedGoal _ _ _ (Just _) -> 0
-    NotProvedGoal _ _ _ Nothing -> 1
-    ProvedGoal{} -> 0
-
-countProvedGoals :: ProvedGoals -> Int
-countProvedGoals gs =
-  case gs of
-    AtLoc _ _ gs1 -> countProvedGoals gs1
-    Branch gs1 gs2 -> countProvedGoals gs1 + countProvedGoals gs2
-    NotProvedGoal{} -> 0
-    ProvedGoal{} -> 1
-
-countIncompleteGoals :: ProvedGoals -> Int
-countIncompleteGoals gs =
-  case gs of
-    AtLoc _ _ gs1 -> countIncompleteGoals gs1
-    Branch gs1 gs2 -> countIncompleteGoals gs1 + countIncompleteGoals gs2
-    NotProvedGoal _ (SimError _ (ResourceExhausted _), _) _ Nothing -> 1
-    NotProvedGoal{} -> 0
-    ProvedGoal{} -> 0
-
-
-
 isResourceExhausted :: LabeledPred p SimError -> Bool
 isResourceExhausted (view labeledPredMsg -> SimError _ (ResourceExhausted _)) = True
 isResourceExhausted _ = False

--- a/crux/src/Crux/Goal.hs
+++ b/crux/src/Crux/Goal.hs
@@ -13,7 +13,7 @@ module Crux.Goal where
 import Control.Concurrent.Async (async, asyncThreadId, waitAnyCatch)
 import Control.Exception (throwTo, SomeException, displayException)
 import Control.Lens ((^.), view)
-import qualified Control.Lens as L
+
 import Control.Monad (forM, forM_, unless, when)
 import Data.Either (partitionEithers)
 import Data.IORef
@@ -372,10 +372,9 @@ proveGoalsOnline sym opts _ctxt explainFailure (Just gs0) =
         do ps <- flattenAssumptions sym asms
            forM_ ps $ \asm ->
              unless (trivialAssumption asm) $
-               L.traverseOf_ foldAssumption
-                 (\p -> do nm <- doAssume =<< mkFormula conn p
-                           bindName nm (Left asm) nameMap)
-                 asm
+               do let p = assumptionPred asm
+                  nm <- doAssume =<< mkFormula conn p
+                  bindName nm (Left asm) nameMap
            res <- go (start,end) sp (assumptionsInScope <> asms) gn gs1 nameMap
            return (Assuming (mconcat (map singleAssumption ps)) res)
 

--- a/crux/src/Crux/Goal.hs
+++ b/crux/src/Crux/Goal.hs
@@ -58,12 +58,12 @@ provedGoalsTree :: forall personality sym p.
   ( IsSymInterface sym
   ) =>
   SimCtxt personality sym p ->
-  Maybe (Goals (Assumption sym) (Assertion sym, ProofResult sym)) ->
+  Maybe (Goals (Assumptions sym) (Assertion sym, ProofResult sym)) ->
   IO (Maybe ProvedGoals)
 provedGoalsTree ctxt = traverse (go [])
   where
   go :: [Assumption sym] ->
-        Goals (Assumption sym) (Assertion sym, ProofResult sym) ->
+        Goals (Assumptions sym) (Assertion sym, ProofResult sym) ->
         IO ProvedGoals
   go asmps gs =
     case gs of
@@ -75,8 +75,8 @@ provedGoalsTree ctxt = traverse (go [])
 
   goAsmp ::
         [Assumption sym] ->
-        Seq.Seq (Assumption sym) ->
-        Goals (Assumption sym) (Assertion sym, ProofResult sym) ->
+        Assumptions sym ->
+        Goals (Assumptions sym) (Assertion sym, ProofResult sym) ->
         IO ProvedGoals
 
   goAsmp asmps Seq.Empty gs = go asmps gs
@@ -205,8 +205,8 @@ proveGoalsOffline :: forall st sym p t fs personality.
   CruxOptions ->
   SimCtxt personality sym p ->
   (Maybe (GroundEvalFn t) -> Assertion sym -> IO (Doc Void)) ->
-  Maybe (Goals (Assumption sym) (Assertion sym)) ->
-  IO (ProcessedGoals, Maybe (Goals (Assumption sym) (Assertion sym, ProofResult sym)))
+  Maybe (Goals (Assumptions sym) (Assertion sym)) ->
+  IO (ProcessedGoals, Maybe (Goals (Assumptions sym) (Assertion sym, ProofResult sym)))
 proveGoalsOffline _adapter _opts _ctx _explainFailure Nothing = return (ProcessedGoals 0 0 0 0, Nothing)
 proveGoalsOffline adapters opts ctx explainFailure (Just gs0) = do
   goalNum <- newIORef (ProcessedGoals 0 0 0 0)
@@ -225,9 +225,9 @@ proveGoalsOffline adapters opts ctx explainFailure (Just gs0) = do
 
     go :: (Integer -> IO (), IO ())
        -> IORef ProcessedGoals
-       -> [Seq.Seq (Assumption sym)]
-       -> Goals (Assumption sym) (Assertion sym)
-       -> IO (Goals (Assumption sym) (Assertion sym, ProofResult sym))
+       -> [Assumptions sym]
+       -> Goals (Assumptions sym) (Assertion sym)
+       -> IO (Goals (Assumptions sym) (Assertion sym, ProofResult sym))
     go (start,end) goalNum assumptionsInScope gs =
       case gs of
         Assuming ps gs1 -> do
@@ -267,7 +267,7 @@ proveGoalsOffline adapters opts ctx explainFailure (Just gs0) = do
               fail allExceptions
 
     runOneSolver :: Assertion sym
-                 -> [Seq.Seq (Assumption sym)]
+                 -> [Assumptions sym]
                  -> BoolExpr t
                  -> BoolExpr t
                  -> WS.SolverAdapter st
@@ -350,8 +350,8 @@ proveGoalsOnline ::
   CruxOptions ->
   SimCtxt personality sym p ->
   (Maybe (GroundEvalFn s) -> Assertion sym -> IO (Doc Void)) ->
-  Maybe (Goals (Assumption sym) (Assertion sym)) ->
-  IO (ProcessedGoals, Maybe (Goals (Assumption sym) (Assertion sym, ProofResult sym)))
+  Maybe (Goals (Assumptions sym) (Assertion sym)) ->
+  IO (ProcessedGoals, Maybe (Goals (Assumptions sym) (Assertion sym, ProofResult sym)))
 
 proveGoalsOnline _ _opts _ctxt _explainFailure Nothing =
      return (ProcessedGoals 0 0 0 0, Nothing)

--- a/crux/src/Crux/Goal.hs
+++ b/crux/src/Crux/Goal.hs
@@ -243,6 +243,8 @@ evalModelFromAssumptions gfn asms =
      return (ModelView (foldl f (modelVals emptyModelView) evs))
  where
    f m (CreateVariableEvent loc nm tpr (GVW v)) = MapF.insertWith jn tpr (Vals [Entry nm loc v]) m
+   f m _ = m
+
    jn (Vals new) (Vals old) = Vals (old++new)
 
 dispatchSolversOnGoalAsync :: forall a s time.

--- a/crux/src/Crux/Goal.hs
+++ b/crux/src/Crux/Goal.hs
@@ -254,7 +254,7 @@ proveGoalsOffline adapters opts ctx explainFailure (Just gs0) = do
             return (locs, Proved core)
           Sat (evalFn, _) -> do
             evs  <- concretizeEvents (groundEval evalFn) assumptionsInScope
-            vals <- evalModelFromEvents evs
+            let vals = evalModelFromEvents evs
             explain <- explainFailure (Just evalFn) p
             let locs = map eventLoc evs
             return (locs, NotProved explain (Just (vals,evs)))
@@ -263,11 +263,8 @@ proveGoalsOffline adapters opts ctx explainFailure (Just gs0) = do
             let locs = assumptionsTopLevelLocs assumptionsInScope
             return (locs, NotProved explain Nothing)
 
-evalModelFromEvents ::
-  [CrucibleEvent GroundValueWrapper] ->
-  IO ModelView
-evalModelFromEvents evs =
-   return (ModelView (foldl f (modelVals emptyModelView) evs))
+evalModelFromEvents :: [CrucibleEvent GroundValueWrapper] -> ModelView
+evalModelFromEvents evs = ModelView (foldl f (modelVals emptyModelView) evs)
  where
    f m (CreateVariableEvent loc nm tpr (GVW v)) = MapF.insertWith jn tpr (Vals [Entry nm loc v]) m
    f m _ = m
@@ -398,8 +395,8 @@ proveGoalsOnline sym opts _ctxt explainFailure (Just gs0) =
 
                       Sat ()  ->
                         do f <- smtExprGroundEvalFn conn (solverEvalFuns sp)
-                           evs  <- concretizeEvents (groundEval f) assumptionsInScope
-                           vals <- evalModelFromEvents evs
+                           evs <- concretizeEvents (groundEval f) assumptionsInScope
+                           let vals = evalModelFromEvents evs
 
                            explain <- explainFailure (Just f) p
                            end

--- a/crux/src/Crux/Log.hs
+++ b/crux/src/Crux/Log.hs
@@ -31,7 +31,7 @@ import qualified Lumberjack as LJ
 import           System.Console.ANSI
 import           System.IO
 
-import           Lang.Crucible.Backend ( AssumptionReason )
+import           Lang.Crucible.Backend ( CrucibleAssumption () )
 import qualified Lang.Crucible.Simulator.SimError as CSE
 
 import           Crux.Types
@@ -54,7 +54,7 @@ logSimResult :: Logs => Bool -> CruxSimulationResult -> IO ()
 logSimResult showFailedGoals = LJ.writeLog (_logSimResult ?outputConfig showFailedGoals)
 
 -- | Function used to output any individual goal proof failures from a simulation
-logGoal :: Logs => ProvedGoals (Either AssumptionReason CSE.SimError) -> IO ()
+logGoal :: Logs => ProvedGoals (Either (CrucibleAssumption ()) CSE.SimError) -> IO ()
 logGoal = LJ.writeLog (_logGoal ?outputConfig)
 
 
@@ -82,7 +82,7 @@ data OutputConfig =
                , _logSimResult :: Bool -> LJ.LogAction IO CruxSimulationResult
                  -- ^ True to show individual goals, false for summary only
                , _logGoal :: LJ.LogAction IO (ProvedGoals
-                                              (Either AssumptionReason
+                                              (Either (CrucibleAssumption ())
                                                CSE.SimError))
                }
 

--- a/crux/src/Crux/Log.hs
+++ b/crux/src/Crux/Log.hs
@@ -31,9 +31,6 @@ import qualified Lumberjack as LJ
 import           System.Console.ANSI
 import           System.IO
 
-import           Lang.Crucible.Backend ( CrucibleAssumption () )
-import qualified Lang.Crucible.Simulator.SimError as CSE
-
 import           Crux.Types
 
 ----------------------------------------------------------------------
@@ -54,7 +51,7 @@ logSimResult :: Logs => Bool -> CruxSimulationResult -> IO ()
 logSimResult showFailedGoals = LJ.writeLog (_logSimResult ?outputConfig showFailedGoals)
 
 -- | Function used to output any individual goal proof failures from a simulation
-logGoal :: Logs => ProvedGoals (Either (CrucibleAssumption ()) CSE.SimError) -> IO ()
+logGoal :: Logs => ProvedGoals -> IO ()
 logGoal = LJ.writeLog (_logGoal ?outputConfig)
 
 
@@ -81,9 +78,7 @@ data OutputConfig =
                , _logExc :: LJ.LogAction IO SomeException
                , _logSimResult :: Bool -> LJ.LogAction IO CruxSimulationResult
                  -- ^ True to show individual goals, false for summary only
-               , _logGoal :: LJ.LogAction IO (ProvedGoals
-                                              (Either (CrucibleAssumption ())
-                                               CSE.SimError))
+               , _logGoal :: LJ.LogAction IO ProvedGoals
                }
 
 -- | Some client code will want to output to the main output stream

--- a/crux/src/Crux/Model.hs
+++ b/crux/src/Crux/Model.hs
@@ -41,8 +41,21 @@ emptyModel = Model $ MapF.fromList
   , noVars (BaseFloatRepr (FloatingPointPrecisionRepr (knownNat @11) (knownNat @53)))
   ]
 
+emptyModelView :: ModelView
+emptyModelView = ModelView $ MapF.fromList
+  [ noVals (BaseBVRepr (knownNat @8))
+  , noVals (BaseBVRepr (knownNat @16))
+  , noVals (BaseBVRepr (knownNat @32))
+  , noVals (BaseBVRepr (knownNat @64))
+  , noVals (BaseFloatRepr (FloatingPointPrecisionRepr (knownNat @8) (knownNat @24)))
+  , noVals (BaseFloatRepr (FloatingPointPrecisionRepr (knownNat @11) (knownNat @53)))
+  ]
+
 noVars :: BaseTypeRepr ty -> Pair BaseTypeRepr (Vars sym)
 noVars ty = Pair ty (Vars [])
+
+noVals :: BaseTypeRepr ty -> Pair BaseTypeRepr Vals
+noVals ty = Pair ty (Vals [])
 
 addVar ::
   ProgramLoc ->

--- a/crux/src/Crux/Model.hs
+++ b/crux/src/Crux/Model.hs
@@ -15,7 +15,6 @@ module Crux.Model where
 import           Data.BitVector.Sized (BV)
 import qualified Data.BitVector.Sized as BV
 import qualified Data.Parameterized.Map as MapF
-import           Data.Parameterized.Pair (Pair(..))
 import qualified Numeric as N
 import           LibBF (BigFloat)
 import qualified LibBF as BF
@@ -27,17 +26,7 @@ import           Crux.Types
 
 
 emptyModelView :: ModelView
-emptyModelView = ModelView $ MapF.fromList
-  [ noVals (BaseBVRepr (knownNat @8))
-  , noVals (BaseBVRepr (knownNat @16))
-  , noVals (BaseBVRepr (knownNat @32))
-  , noVals (BaseBVRepr (knownNat @64))
-  , noVals (BaseFloatRepr (FloatingPointPrecisionRepr (knownNat @8) (knownNat @24)))
-  , noVals (BaseFloatRepr (FloatingPointPrecisionRepr (knownNat @11) (knownNat @53)))
-  ]
-
-noVals :: BaseTypeRepr ty -> Pair BaseTypeRepr Vals
-noVals ty = Pair ty (Vals [])
+emptyModelView = ModelView $ MapF.empty
 
 --------------------------------------------------------------------------------
 

--- a/crux/src/Crux/Model.hs
+++ b/crux/src/Crux/Model.hs
@@ -14,6 +14,7 @@ module Crux.Model where
 
 import           Data.BitVector.Sized (BV)
 import qualified Data.BitVector.Sized as BV
+import           Data.Maybe (fromMaybe)
 import qualified Data.Parameterized.Map as MapF
 import qualified Numeric as N
 import           LibBF (BigFloat)
@@ -77,7 +78,7 @@ valsJS ty (Vals xs) =
   where
   showEnt' :: Show b => (a -> String) -> b -> Entry a -> IO JS
   showEnt' repr n e =
-    do l <- jsLoc (entryLoc e)
+    do l <- fromMaybe jsNull <$> jsLoc (entryLoc e)
        pure $ jsObj
          [ "name" ~> jsStr (entryName e)
          , "loc"  ~> l

--- a/crux/src/Crux/Report.hs
+++ b/crux/src/Crux/Report.hs
@@ -88,8 +88,8 @@ provedGoalLocs :: ProvedGoals -> [ProgramLoc]
 --provedGoalLocs (AtLoc loc _ goals) = loc : provedGoalLocs goals
 provedGoalLocs (Branch goals1 goals2) = provedGoalLocs goals1 ++
                                         provedGoalLocs goals2
-provedGoalLocs (ProvedGoal _ (err, _) _) = [simErrorLoc err]
-provedGoalLocs (NotProvedGoal _ (err, _) _ _) = [simErrorLoc err]
+provedGoalLocs (ProvedGoal _ err _) = [simErrorLoc err]
+provedGoalLocs (NotProvedGoal _ err _ _) = [simErrorLoc err]
 
 -- | Return a list of all files referenced in a set of proved goals.
 provedGoalFiles :: ProvedGoals -> [FilePath]
@@ -121,14 +121,14 @@ renderSideConds opts = concatMapM (go ( [] :: [(JS,ProgramLoc)] ))
 
       ProvedGoal asmps conc triv
         | skipSuccessReports opts -> pure []
-        | otherwise -> jsProvedGoal apath (map fst asmps) (fst conc) triv
+        | otherwise -> jsProvedGoal apath asmps conc triv
 
       NotProvedGoal asmps conc explain cex
         | skipIncompleteReports opts
-        , (SimError _ (ResourceExhausted _), _) <- conc
+        , SimError _ (ResourceExhausted _) <- conc
         -> pure []
 
-        | otherwise -> jsNotProvedGoal apath (map fst asmps) (fst conc) explain cex
+        | otherwise -> jsNotProvedGoal apath asmps conc explain cex
 
     where
       (ls,ps) = unzip (reverse path)

--- a/crux/src/Crux/Report.hs
+++ b/crux/src/Crux/Report.hs
@@ -140,8 +140,8 @@ renderSideConds opts = concatMapM (go [])
 
 jsSideCond ::
   [ JS ] ->
-  [(AssumptionReason,String)] ->
-  (SimError,String) ->
+  [(CrucibleAssumption (), asdf)] ->
+  (SimError, asdf) ->
   Bool ->
   ProofResult b ->
   IO JS
@@ -180,7 +180,7 @@ jsSideCond path asmps (conc,_) triv status =
     do l <- jsLoc (assumptionLoc asmp)
        pure $ jsObj
          [ "loc" ~> l
-         , "text" ~> jsStr (show (ppAssumptionReason asmp))
+         , "text" ~> jsStr (show (ppAssumption (\_ -> mempty) asmp))
          ]
 
   goalReason  = jsStr (simErrorReasonMsg (simErrorReason conc))

--- a/crux/src/Crux/Report.hs
+++ b/crux/src/Crux/Report.hs
@@ -8,6 +8,7 @@ import System.FilePath
 import System.Directory (createDirectoryIfMissing, canonicalizePath)
 import System.IO
 import qualified Data.Foldable as Fold
+import Data.Functor.Const
 import Data.List (partition)
 import Data.Maybe (mapMaybe)
 import qualified Data.Set as Set
@@ -142,7 +143,7 @@ renderSideConds opts = concatMapM (go [])
 
 jsProvedGoal ::
   [ JS ] ->
-  [ CrucibleAssumption () ] ->
+  [ CrucibleAssumption (Const ()) ] ->
   SimError ->
   Bool ->
   IO [JS]
@@ -175,7 +176,7 @@ jsProvedGoal apath asmps conc triv =
 
 jsNotProvedGoal ::
   [ JS ] ->
-  [ CrucibleAssumption () ] ->
+  [ CrucibleAssumption (Const ()) ] ->
   SimError ->
   Doc Void ->
   Maybe ModelView ->

--- a/crux/src/Crux/Report.hs
+++ b/crux/src/Crux/Report.hs
@@ -44,7 +44,7 @@ generateReport opts res
   | otherwise =
     do let xs = cruxSimResultGoals res
            goals = map snd $ Fold.toList xs
-           referencedFiles = Set.toList (Set.fromList (inputFiles opts) <> mconcat (map provedGoalFiles goals))
+           referencedFiles = Set.toList (Set.fromList (inputFiles opts) <> foldMap provedGoalFiles goals)
        createDirectoryIfMissing True (outDir opts)
        maybeGenerateSource opts referencedFiles
        scs <- renderSideConds opts goals
@@ -109,7 +109,7 @@ renderSideConds opts = concatMapM go
   isGoal x = case x of
                ProvedGoal {} -> True
                NotProvedGoal {} -> True
-               _       -> False
+               Branch{} -> False
 
   go gs =
     case gs of

--- a/crux/src/Crux/Report.hs
+++ b/crux/src/Crux/Report.hs
@@ -22,6 +22,7 @@ import qualified Data.Text.IO as T
 import Lang.Crucible.Simulator.SimError
 import Lang.Crucible.Backend
 import What4.ProgramLoc
+import What4.Expr (GroundValueWrapper)
 
 import Crux.Types
 import Crux.Config.Common
@@ -176,14 +177,14 @@ jsNotProvedGoal ::
   [ CrucibleAssumption (Const ()) ] ->
   SimError ->
   Doc Void ->
-  Maybe ModelView ->
+  Maybe (ModelView, [CrucibleEvent GroundValueWrapper]) ->
   IO [JS]
 jsNotProvedGoal apath asmps conc explain cex =
   do loc <- jsLoc (simErrorLoc conc)
      asmps' <- mapM mkAsmp asmps
      ex <- case cex of
-             Just m -> modelJS m
-             _      -> pure jsNull
+             Just (m,_) -> modelJS m
+             _          -> pure jsNull
      pure [jsObj
        [ "status"          ~> status
        , "counter-example" ~> ex

--- a/crux/src/Crux/Report.hs
+++ b/crux/src/Crux/Report.hs
@@ -84,7 +84,8 @@ maybeGenerateSource opts files =
 -- | Return a list of all program locations referenced in a set of
 -- proved goals.
 provedGoalLocs :: ProvedGoals -> [ProgramLoc]
-provedGoalLocs (AtLoc loc _ goals) = loc : provedGoalLocs goals
+-- TODO?
+--provedGoalLocs (AtLoc loc _ goals) = loc : provedGoalLocs goals
 provedGoalLocs (Branch goals1 goals2) = provedGoalLocs goals1 ++
                                         provedGoalLocs goals2
 provedGoalLocs (ProvedGoal _ (err, _) _) = [simErrorLoc err]
@@ -99,7 +100,7 @@ provedGoalFiles = mapMaybe posFile . map plSourceLoc . provedGoalLocs
     posFile _ = Nothing
 
 renderSideConds :: CruxOptions -> [ProvedGoals] -> IO [ JS ]
-renderSideConds opts = concatMapM (go [])
+renderSideConds opts = concatMapM (go ( [] :: [(JS,ProgramLoc)] ))
   where
   concatMapM f xs = concat <$> mapM f xs
 
@@ -114,10 +115,6 @@ renderSideConds opts = concatMapM (go [])
 
   go path gs =
     case gs of
-      AtLoc pl _ gs1  ->
-        do pl' <- jsLoc pl
-           go ((pl', pl) : path) gs1
-
       Branch g1 g2 ->
         let (now,rest) = partition isGoal (flatBranch [g1,g2]) in
           (++) <$> concatMapM (go path) now <*> concatMapM (go path) rest

--- a/crux/src/Crux/Types.hs
+++ b/crux/src/Crux/Types.hs
@@ -67,13 +67,13 @@ type LPred sym   = LabeledPred (Pred sym)
 data ProvedGoals
   = Branch ProvedGoals ProvedGoals
   | NotProvedGoal
-         [(CrucibleAssumption (Const ()), Doc Void)]
-         (SimError, Doc Void)
+         [CrucibleAssumption (Const ())]
+         SimError
          (Doc Void)
          (Maybe ModelView)
   | ProvedGoal
-         [(CrucibleAssumption (Const ()), Doc Void)]
-         (SimError, Doc Void)
+         [CrucibleAssumption (Const ())]
+         SimError
          Bool
     -- ^ Keeps only the explanations for the relevant assumptions.
     --

--- a/crux/src/Crux/Types.hs
+++ b/crux/src/Crux/Types.hs
@@ -70,10 +70,12 @@ data ProvedGoals
          [CrucibleAssumption (Const ())]
          SimError
          (Doc Void)
+         [ProgramLoc]
          (Maybe (ModelView, [CrucibleEvent GroundValueWrapper]))
   | ProvedGoal
          [CrucibleAssumption (Const ())]
          SimError
+         [ProgramLoc]
          Bool
     -- ^ Keeps only the explanations for the relevant assumptions.
     --

--- a/crux/src/Crux/Types.hs
+++ b/crux/src/Crux/Types.hs
@@ -87,8 +87,8 @@ type LPred sym   = LabeledPred (Pred sym)
 data ProvedGoals a =
     AtLoc ProgramLoc (Maybe ProgramLoc) (ProvedGoals a)
   | Branch (ProvedGoals a) (ProvedGoals a)
-  | Goal [(AssumptionReason,String)]
-         (SimError,String) Bool (ProofResult a)
+  | Goal [(CrucibleAssumption (), Doc Void )]
+         (SimError, Doc Void) Bool (ProofResult a)
     -- ^ Keeps only the explanations for the relevant assumptions.
     --
     --   * The array of (AssumptionReason,String) is the set of
@@ -113,7 +113,7 @@ data ProgramCompleteness
 data CruxSimulationResult =
   CruxSimulationResult
   { cruxSimResultCompleteness :: ProgramCompleteness
-  , cruxSimResultGoals        :: Seq (ProcessedGoals, ProvedGoals (Either AssumptionReason SimError))
+  , cruxSimResultGoals        :: Seq (ProcessedGoals, ProvedGoals (Either (CrucibleAssumption ()) SimError))
   }
 
 

--- a/crux/src/Crux/Types.hs
+++ b/crux/src/Crux/Types.hs
@@ -8,7 +8,7 @@ import           Data.Text ( Text )
 import           Data.Void
 import           Prettyprinter
 
-import           What4.Expr (GroundValue)
+import           What4.Expr (GroundValue,GroundValueWrapper)
 import           What4.Interface (Pred)
 import           What4.ProgramLoc
 
@@ -57,7 +57,7 @@ data ProcessedGoals =
 
 data ProofResult sym
    = Proved [Either (Assumption sym) (Assertion sym)]
-   | NotProved (Doc Void) (Maybe ModelView)
+   | NotProved (Doc Void) (Maybe (ModelView, [CrucibleEvent GroundValueWrapper]))
      -- ^ The first argument is an explanation of the failure and
      -- counter example as provided by the Explainer (if any) and the
      -- second maybe a model for the counter-example.
@@ -70,7 +70,7 @@ data ProvedGoals
          [CrucibleAssumption (Const ())]
          SimError
          (Doc Void)
-         (Maybe ModelView)
+         (Maybe (ModelView, [CrucibleEvent GroundValueWrapper]))
   | ProvedGoal
          [CrucibleAssumption (Const ())]
          SimError

--- a/crux/src/Crux/Types.hs
+++ b/crux/src/Crux/Types.hs
@@ -115,7 +115,7 @@ data Crux sym = CruxPersonality
 -- datatype).
 newtype Vals ty     = Vals [ Entry (GroundValue ty) ]
 
--- | A named value of type `ty` with a program
+-- | A named value of type @a@ with a program
 -- location. Used to describe and report models from SMT
 -- queries (see Model and ModelView datatypes).
 data Entry a        = Entry { entryName :: String

--- a/crux/src/Crux/Types.hs
+++ b/crux/src/Crux/Types.hs
@@ -64,9 +64,8 @@ data ProofResult sym
 
 type LPred sym   = LabeledPred (Pred sym)
 
-data ProvedGoals =
-    AtLoc ProgramLoc (Maybe ProgramLoc) ProvedGoals
-  | Branch ProvedGoals ProvedGoals
+data ProvedGoals
+  = Branch ProvedGoals ProvedGoals
   | NotProvedGoal
          [(CrucibleAssumption (Const ()), Doc Void)]
          (SimError, Doc Void)

--- a/crux/src/Crux/Types.hs
+++ b/crux/src/Crux/Types.hs
@@ -2,6 +2,7 @@
 module Crux.Types where
 
 import qualified Control.Lens as L
+import           Data.Functor.Const
 import           Data.Parameterized.Map (MapF)
 import           Data.Sequence (Seq)
 import           Data.Text ( Text )
@@ -87,12 +88,12 @@ data ProvedGoals =
     AtLoc ProgramLoc (Maybe ProgramLoc) ProvedGoals
   | Branch ProvedGoals ProvedGoals
   | NotProvedGoal
-         [(CrucibleAssumption (), Doc Void)]
+         [(CrucibleAssumption (Const ()), Doc Void)]
          (SimError, Doc Void)
          (Doc Void)
          (Maybe ModelView)
   | ProvedGoal
-         [(CrucibleAssumption (), Doc Void)]
+         [(CrucibleAssumption (Const ()), Doc Void)]
          (SimError, Doc Void)
          Bool
     -- ^ Keeps only the explanations for the relevant assumptions.

--- a/crux/src/Crux/Types.hs
+++ b/crux/src/Crux/Types.hs
@@ -1,7 +1,6 @@
 {-# Language DeriveFunctor, RankNTypes, ConstraintKinds, TypeFamilies, ScopedTypeVariables, GADTs #-}
 module Crux.Types where
 
-import qualified Control.Lens as L
 import           Data.Functor.Const
 import           Data.Parameterized.Map (MapF)
 import           Data.Sequence (Seq)
@@ -16,22 +15,6 @@ import           What4.ProgramLoc
 import           Lang.Crucible.Backend
 import           Lang.Crucible.Simulator
 import           Lang.Crucible.Types
-
--- | A constraint on crucible personality types that requires them to contain a 'Model'
---
--- The personality is extra data carried around by the symbolic execution engine
--- for frontend-specific purposes.  Typically, the personality is consulted from
--- overrides and can allow extensible data sharing between overrides.  Crux
--- requires that the personality include at least a 'Model', which it will
--- populate based on SMT solver results.
-class HasModel personality where
-  personalityModel :: L.Lens' (personality sym) (Model sym)
-
--- | This instance handles the common case where a crux frontend does not need
--- any special instantiation of the personality parameter, and so can just use a
--- 'Model' directly.
-instance HasModel Model where
-  personalityModel = \f a -> fmap id (f a)
 
 -- | A simulator context
 type SimCtxt personality sym p = SimContext (personality sym) sym p
@@ -61,11 +44,8 @@ type Fun personality sym ext args ret =
     ret
     (RegValue sym ret)
 
--- NEW: the result of the simulation function, which hides the 'ext'
 data Result personality sym where
   Result :: (ExecResult (personality sym) sym ext (RegEntry sym UnitType)) -> Result personality sym
-
---- From Goal
 
 
 data ProcessedGoals =
@@ -124,24 +104,10 @@ data CruxSimulationResult =
   }
 
 
--- From Model
+-- | A dummy datatype that can be used for the "personality"
+--   type parameter.
+data Crux sym = CruxPersonality
 
--- | SMT model organized by crucible type. I.e., each
--- crucible type is associated with the list of entries
--- (i.e. named, possibly still symbolic, RegValues) at that
--- type for the given model, used to describe the conditions
--- under which an SMT query is satisfiable. N.B., because
--- the values may still be symbolic, they must be evaluated
--- before they are grounded (e.g., see the `evalModel` and
--- `groundEval` functions from Crux.Model and
--- What4.Expr.GroundEval, which are used to construct the
--- ModelView datatype described below).
-newtype Model sym   = Model (MapF BaseTypeRepr (Vars sym))
-
--- | A list of named (possibly still symbolic) RegValues of
--- the same type (used to describe SMT models -- see the
--- Model datatype).
-newtype Vars sym ty = Vars [ Entry (RegValue sym (BaseToType ty)) ]
 
 -- | A list of named GroundValues of the same type (used to
 -- report SMT models in a portable way -- see the ModelView
@@ -151,9 +117,9 @@ newtype Vals ty     = Vals [ Entry (GroundValue ty) ]
 -- | A named value of type `ty` with a program
 -- location. Used to describe and report models from SMT
 -- queries (see Model and ModelView datatypes).
-data Entry ty       = Entry { entryName :: String
+data Entry a        = Entry { entryName :: String
                             , entryLoc :: ProgramLoc
-                            , entryValue :: ty
+                            , entryValue :: a
                             }
 
 -- | A portable/concrete view of a model's contents, organized by

--- a/crux/src/Crux/Types.hs
+++ b/crux/src/Crux/Types.hs
@@ -74,21 +74,27 @@ data ProcessedGoals =
                  , incompleteGoals :: !Integer
                  }
 
-data ProofResult a
-   = Proved [a]
+data ProofResult sym
+   = Proved [Either (Assumption sym) (Assertion sym)]
    | NotProved (Doc Void) (Maybe ModelView)
      -- ^ The first argument is an explanation of the failure and
      -- counter example as provided by the Explainer (if any) and the
      -- second maybe a model for the counter-example.
- deriving (Functor)
 
 type LPred sym   = LabeledPred (Pred sym)
 
-data ProvedGoals a =
-    AtLoc ProgramLoc (Maybe ProgramLoc) (ProvedGoals a)
-  | Branch (ProvedGoals a) (ProvedGoals a)
-  | Goal [(CrucibleAssumption (), Doc Void )]
-         (SimError, Doc Void) Bool (ProofResult a)
+data ProvedGoals =
+    AtLoc ProgramLoc (Maybe ProgramLoc) ProvedGoals
+  | Branch ProvedGoals ProvedGoals
+  | NotProvedGoal
+         [(CrucibleAssumption (), Doc Void)]
+         (SimError, Doc Void)
+         (Doc Void)
+         (Maybe ModelView)
+  | ProvedGoal
+         [(CrucibleAssumption (), Doc Void)]
+         (SimError, Doc Void)
+         Bool
     -- ^ Keeps only the explanations for the relevant assumptions.
     --
     --   * The array of (AssumptionReason,String) is the set of
@@ -113,7 +119,7 @@ data ProgramCompleteness
 data CruxSimulationResult =
   CruxSimulationResult
   { cruxSimResultCompleteness :: ProgramCompleteness
-  , cruxSimResultGoals        :: Seq (ProcessedGoals, ProvedGoals (Either (CrucibleAssumption ()) SimError))
+  , cruxSimResultGoals        :: Seq (ProcessedGoals, ProvedGoals)
   }
 
 

--- a/crux/src/Crux/UI/JS.hs
+++ b/crux/src/Crux/UI/JS.hs
@@ -10,7 +10,7 @@ import System.Directory( canonicalizePath )
 
 import What4.ProgramLoc
 
-jsLoc :: ProgramLoc -> IO JS
+jsLoc :: ProgramLoc -> IO (Maybe JS)
 jsLoc x =
   case plSourceLoc x of
     SourcePos f l c ->
@@ -18,12 +18,12 @@ jsLoc x =
          fabsolute <-
             if | null fstr -> pure ""
                | otherwise -> canonicalizePath fstr
-         pure $ jsObj
+         pure $ Just $ jsObj
            [ "file" ~> jsStr fabsolute
            , "line" ~> jsStr (show l)
            , "col"  ~> jsStr (show c)
            ]
-    _ -> pure jsNull
+    _ -> pure Nothing
 
 --------------------------------------------------------------------------------
 newtype JS = JS { renderJS :: String }

--- a/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Skip.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Skip.hs
@@ -58,7 +58,7 @@ import           Lang.Crucible.LLVM.Translation (ModuleTranslation, transContext
 import           Lang.Crucible.LLVM.TypeContext (TypeContext)
 import           Lang.Crucible.LLVM.Intrinsics (OverrideTemplate(..), LLVMOverride(..), basic_llvm_override)
 
-import           Crux.Types (OverM, Model, HasModel)
+import           Crux.Types (OverM)
 
 -- crux-llvm
 import           Crux.LLVM.Overrides (ArchOk)
@@ -95,8 +95,7 @@ unsoundSkipOverrides ::
   ( IsSymInterface sym,
     HasLLVMAnn sym,
     ArchOk arch,
-    ?lc :: TypeContext,
-    HasModel personality
+    ?lc :: TypeContext
   ) =>
   ModuleContext m arch ->
   sym ->
@@ -108,7 +107,7 @@ unsoundSkipOverrides ::
   -- | Postconditions of each override (constraints on return values)
   Map (DeclSymbol m) (ConstrainedTypedValue m) ->
   [L.Declare] ->
-  OverM Model sym LLVM [OverrideTemplate (personality sym) sym arch rtp l a]
+  OverM personality sym LLVM [OverrideTemplate (personality sym) sym arch rtp l a]
 unsoundSkipOverrides modCtx sym mtrans usedRef annotationRef postconditions decls =
   do
     let llvmCtx = mtrans ^. transContext
@@ -151,8 +150,7 @@ createSkipOverride ::
   ( IsSymInterface sym,
     HasLLVMAnn sym,
     ArchOk arch,
-    ?lc :: TypeContext,
-    HasModel personality
+    ?lc :: TypeContext
   ) =>
   ModuleContext m arch ->
   sym ->

--- a/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Unsound.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Unsound.hs
@@ -54,8 +54,6 @@ import qualified Lang.Crucible.LLVM.MemModel.Generic as G
 import           Lang.Crucible.LLVM.TypeContext (TypeContext)
 import           Lang.Crucible.LLVM.Intrinsics (OverrideTemplate(..), basic_llvm_override)
 
-import           Crux.Types (HasModel)
-
 -- crux-llvm
 import           Crux.LLVM.Overrides (ArchOk)
 
@@ -78,8 +76,7 @@ unsoundOverrides ::
   ( IsSymInterface sym,
     HasLLVMAnn sym,
     ArchOk arch,
-    ?lc :: TypeContext,
-    HasModel personality
+    ?lc :: TypeContext
   ) =>
   proxy arch ->
   IORef (Set UnsoundOverrideName) ->

--- a/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
@@ -143,18 +143,16 @@ simulateLLVM appCtx modCtx funCtx halloc explRef skipOverrideRef unsoundOverride
                   try $
                     Crucible.addAssumption
                       sym
-                      ( Crucible.LabeledPred
-                          predicate
-                          ( Crucible.AssumptionReason
-                              ( What4.mkProgramLoc
-                                  (What4.functionNameFromText (funCtx ^. functionName))
-                                  What4.InternalPos
-                              )
-                              "constraint"
+                      ( Crucible.GenericAssumption
+                          ( What4.mkProgramLoc
+                              (What4.functionNameFromText (funCtx ^. functionName))
+                              What4.InternalPos
                           )
+                          "constraint"
+                          predicate
                       )
               case maybeException of
-                Left e@(Crucible.AssumedFalse _) ->
+                Left e@(Crucible.AssertionFailure _) ->
                   panic
                     "classify"
                     [ "Concretely false assumption",


### PR DESCRIPTION
Refactor various aspects of assumption handling.  The main aim here is to allow "events" to be tracked alongside the logical assumptions that are already tracked.  This will allow us to concretely reconstruct a linear sequence of events when counterexamples to proof goals are found so that we can replay the creation of symbolic variables and identify sequences of program points the run passed through.