### PR TITLE
crux: add command-line arguments for websockets communication

### DIFF
--- a/crux-llvm/crux-llvm.cabal
+++ b/crux-llvm/crux-llvm.cabal
@@ -86,6 +86,7 @@ library
     Paths_crux_llvm
 
   build-depends:
+    aeson,
     bv-sized,
     config-schema,
     data-binary-ieee754,
@@ -117,6 +118,31 @@ executable crux-llvm
     build-depends: unix
 
   other-modules: RealMain
+
+
+executable crux-llvm-for-ide
+  import: bldflags
+
+  hs-source-dirs: for-ide
+
+  build-depends:
+    aeson,
+    ansi-terminal,
+    crux-llvm,
+    lumberjack,
+    websockets >= 0.12
+
+  main-is: Main.hs
+
+  if os(windows)
+    hs-source-dirs: for-ide/windows
+  else
+    hs-source-dirs: for-ide/unix
+    build-depends: unix
+
+  other-modules:
+    Paths_crux_llvm
+    RealMain
 
 
 executable crux-llvm-svcomp

--- a/crux-llvm/for-ide/Main.hs
+++ b/crux-llvm/for-ide/Main.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Main (main) where
+
+import Control.Lens (makeLenses, set, view)
+import Crux (OutputConfig)
+import qualified Crux
+import Crux.Config.Common (CruxOptions)
+import Crux.LLVM.Config (LLVMOptions, llvmCruxConfig)
+import CruxLLVMMain
+  ( CruxLLVMLogging,
+    mainWithOptions,
+    withCruxLLVMLogging,
+  )
+import qualified Data.Aeson as JSON
+import Data.Text as Text (Text, unpack)
+import qualified Lumberjack as LJ
+import qualified Network.WebSockets as WS
+import Paths_crux_llvm (version)
+import RealMain (makeMain)
+import System.Exit (ExitCode)
+import Text.Read (readEither)
+
+data ForIDEOptions = ForIDEOptions
+  { _cruxLLVMOptions :: LLVMOptions,
+    _ideHost :: String,
+    _idePort :: Int
+  }
+
+makeLenses ''ForIDEOptions
+
+ideHostDoc :: Text
+ideHostDoc = "Host where the IDE is listening"
+
+idePortDoc :: Text
+idePortDoc = "Port at which the IDE is listening"
+
+forIDEConfig :: IO (Crux.Config ForIDEOptions)
+forIDEConfig = do
+  llvmOpts <- llvmCruxConfig
+  return
+    Crux.Config
+      { Crux.cfgFile =
+          ForIDEOptions
+            <$> Crux.cfgFile llvmOpts
+            <*> Crux.section
+              "ide-host"
+              Crux.stringSpec
+              "127.0.0.1"
+              ideHostDoc
+            <*> Crux.section
+              "ide-port"
+              Crux.numSpec
+              0
+              idePortDoc,
+        Crux.cfgEnv = Crux.liftEnvDescr cruxLLVMOptions <$> Crux.cfgEnv llvmOpts,
+        Crux.cfgCmdLineFlag =
+          (Crux.liftOptDescr cruxLLVMOptions <$> Crux.cfgCmdLineFlag llvmOpts)
+            ++ [ Crux.Option
+                   []
+                   ["ide-host"]
+                   (Text.unpack ideHostDoc)
+                   $ Crux.ReqArg "STR" $
+                     \v opts -> Right (set ideHost v opts),
+                 Crux.Option
+                   []
+                   ["ide-port"]
+                   (Text.unpack idePortDoc)
+                   $ Crux.ReqArg "INT" $
+                     \v opts -> set idePort <$> readEither v <*> pure opts
+               ]
+      }
+
+mainWithOutputConfig ::
+  (Maybe CruxOptions -> OutputConfig CruxLLVMLogging) -> IO ExitCode
+mainWithOutputConfig mkOutCfg =
+  CruxLLVMMain.withCruxLLVMLogging $
+    do
+      conf <- forIDEConfig
+      Crux.loadOptions mkOutCfg "crux-llvm-for-ide" version conf $ \(cruxOpts, forIDEOpts) ->
+        WS.runClient (view ideHost forIDEOpts) (view idePort forIDEOpts) "/" $ \conn ->
+          do
+            let ?outputConfig =
+                  ?outputConfig
+                    { Crux._logMsg =
+                        Crux._logMsg ?outputConfig
+                          <> LJ.LogAction (WS.sendTextData conn . JSON.encode)
+                    }
+            mainWithOptions (cruxOpts, view cruxLLVMOptions forIDEOpts)
+
+main :: IO ()
+main = makeMain mainWithOutputConfig

--- a/crux-llvm/for-ide/unix/RealMain.hs
+++ b/crux-llvm/for-ide/unix/RealMain.hs
@@ -1,0 +1,34 @@
+module RealMain (makeMain) where
+
+import Control.Monad (void)
+import Crux.Log ( OutputConfig )
+import Crux.Config.Common (CruxOptions)
+import CruxLLVMMain ( CruxLLVMLogging, defaultOutputConfig )
+import System.Exit (ExitCode, exitWith)
+import System.Posix.Process (getProcessGroupID)
+import System.Posix.Signals
+  ( Handler (CatchOnce),
+    installHandler,
+    sigTERM,
+    signalProcessGroup,
+  )
+
+-- Rebroadcast SIGTERM to the entire process group.  The CatchOnce
+-- handler keeps this from handling and retransmitting SIGTERM to
+-- itself over and over.
+installSIGTERMHandler :: IO ()
+installSIGTERMHandler =
+  do
+    gid <- getProcessGroupID
+    void $ installHandler sigTERM (CatchOnce (handler gid)) Nothing
+  where
+    handler gid = signalProcessGroup sigTERM gid
+
+makeMain ::
+  ((Maybe CruxOptions -> OutputConfig CruxLLVMLogging) -> IO ExitCode) ->
+  IO ()
+makeMain mainWithOutputConfig =
+  do
+    installSIGTERMHandler
+    ec <- mainWithOutputConfig defaultOutputConfig
+    exitWith ec

--- a/crux-llvm/for-ide/windows/RealMain.hs
+++ b/crux-llvm/for-ide/windows/RealMain.hs
@@ -1,0 +1,10 @@
+module RealMain (makeMain) where
+
+import CruxLLVMMain (defaultOutputConfig, mainWithOutputConfig)
+import System.Exit
+
+makeMain ::
+  ((Maybe CruxOptions -> OutputConfig CruxLLVMLogging) -> IO ExitCode) ->
+  IO ()
+makeMain mainWithOutputConfig =
+  mainWithOutputConfig defaultOutputConfig >>= exitWith

--- a/crux-llvm/src/Crux/LLVM/Log.hs
+++ b/crux-llvm/src/Crux/LLVM/Log.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -12,7 +14,9 @@ where
 
 import Crux.Log (SayLevel (..), SayWhat (..), cruxLogTag)
 import qualified Crux.Log as Log
+import Data.Aeson (ToJSON)
 import Data.Text as Text (Text, pack, unwords)
+import GHC.Generics (Generic)
 
 data CruxLLVMLogMessage
   = Breakpoint Text
@@ -21,6 +25,7 @@ data CruxLLVMLogMessage
   | FailedToBuildCounterexampleExecutable
   | SimulatingFunction Text
   | UsingPointerWidthForFile Integer Text
+  deriving ( Generic, ToJSON )
 
 type SupportsCruxLLVMLogMessage msgs =
   (?injectCruxLLVMLogMessage :: CruxLLVMLogMessage -> msgs)

--- a/crux-llvm/svcomp/Main.hs
+++ b/crux-llvm/svcomp/Main.hs
@@ -3,6 +3,7 @@
    and produce benchmark data for that run.
 -}
 
+{-# Language DeriveAnyClass #-}
 {-# Language DeriveGeneric #-}
 {-# Language ImplicitParams #-}
 {-# Language LambdaCase #-}
@@ -61,6 +62,7 @@ data SVCompLogging
   = LoggingCrux Log.CruxLogMessage
   | LoggingCruxLLVM Log.CruxLLVMLogMessage
   | LoggingSVComp Log.SVCompLogMessage
+  deriving (Generic, ToJSON)
 
 svCompLoggingToSayWhat :: SVCompLogging -> SayWhat
 svCompLoggingToSayWhat (LoggingCrux msg) = Log.cruxLogMessageToSayWhat msg

--- a/crux-llvm/svcomp/SVComp/Log.hs
+++ b/crux-llvm/svcomp/SVComp/Log.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -15,17 +17,21 @@ where
 import Crux (SayLevel (..), SayWhat (..))
 import qualified Crux.Log as Log
 import Crux.SVCOMP (ComputedVerdict (..))
+import Data.Aeson (ToJSON)
 import qualified Data.Text as T
+import GHC.Generics (Generic)
 
 data EvaluationProcessFailureReason
   = ExitedWithFailureCode T.Text
   | StoppedBySignal T.Text
   | TerminatedBySignal T.Text
   | UnknownStatus
+  deriving (Generic, ToJSON)
 
 data SVCompSkipReason
   = DueToBlacklist
   | NoInputFiles
+  deriving (Generic, ToJSON)
 
 svCompSkipReasonSuffix :: SVCompSkipReason -> T.Text
 svCompSkipReasonSuffix DueToBlacklist = " due to blacklist"
@@ -49,6 +55,7 @@ data SVCompLogMessage
       -- ^ the actual verdict
   | NoVerdict [T.Text]
   | Skipping SVCompSkipReason T.Text
+  deriving (Generic, ToJSON)
 
 type SupportsSVCompLogMessage msgs =
   (?injectSVCompLogMessage :: SVCompLogMessage -> msgs)

--- a/crux-mir/src/Mir/Language.hs
+++ b/crux-mir/src/Mir/Language.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ImplicitParams #-}
@@ -47,6 +49,7 @@ import           Data.Maybe (fromMaybe)
 import qualified Data.Sequence   as Seq
 import qualified Data.Vector     as Vector
 import           Control.Lens ((^.), (^?), (^..), ix, each)
+import           GHC.Generics (Generic)
 
 import System.Console.ANSI
 import           System.IO (Handle)
@@ -120,11 +123,13 @@ mainWithExtraOverrides bindExtra =
     mainWithOutputConfig defaultOutputConfig bindExtra >>= exitWith
 
 mainWithOutputTo :: Handle -> BindExtraOverridesFn -> IO ExitCode
-mainWithOutputTo h = mainWithOutputConfig $ Crux.mkOutputConfig False h h mirLoggingToSayWhat
+mainWithOutputTo h = mainWithOutputConfig $
+    Crux.mkOutputConfig False h h mirLoggingToSayWhat
 
 data MirLogging
     = LoggingCrux Crux.CruxLogMessage
     | LoggingMir Log.MirLogMessage
+    deriving (Generic, Aeson.ToJSON)
 
 mirLoggingToSayWhat :: MirLogging -> SayWhat
 mirLoggingToSayWhat (LoggingCrux msg) = Log.cruxLogMessageToSayWhat msg

--- a/crux-mir/src/Mir/Log.hs
+++ b/crux-mir/src/Mir/Log.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -10,12 +12,16 @@ module Mir.Log
   )
 where
 
+import Data.Aeson (ToJSON)
+import qualified Data.Text as T
+import GHC.Generics (Generic)
+
 import Crux.Log (SayLevel (..), SayWhat (..))
 import qualified Crux.Log as Log
-import qualified Data.Text as T
 
 data MirLogMessage
   = FinalResults
+  deriving (Generic, ToJSON)
 
 type SupportsMirLogMessage msgs =
   (?injectMirLogMessage :: MirLogMessage -> msgs)

--- a/crux/src/Crux.hs
+++ b/crux/src/Crux.hs
@@ -29,6 +29,7 @@ module Crux
 import qualified Control.Exception as Ex
 import           Control.Lens
 import           Control.Monad ( unless, void, when )
+import qualified Data.Aeson as JSON
 import           Data.Foldable
 import           Data.Functor.Contravariant ( (>$<) )
 import           Data.Functor.Contravariant.Divisible ( divide )
@@ -209,6 +210,7 @@ showVersion nm ver = sayCrux (Log.Version nm ver)
 --  * quietMode      (default stance: False)
 --  * simVerbose     (default stance: False)
 mkOutputConfig ::
+  JSON.ToJSON msgs =>
   Bool -> Handle -> Handle ->
   (msgs -> SayWhat) -> Maybe CruxOptions ->
   OutputConfig msgs
@@ -257,6 +259,7 @@ mkOutputConfig withColors outHandle errHandle logMessageToSayWhat opts =
      }
 
 defaultOutputConfig ::
+  JSON.ToJSON msgs =>
   (msgs -> SayWhat) -> Maybe CruxOptions -> OutputConfig msgs
 defaultOutputConfig = Crux.mkOutputConfig True stdout stderr
 

--- a/crux/src/Crux/SVCOMP.hs
+++ b/crux/src/Crux/SVCOMP.hs
@@ -4,6 +4,8 @@
 --   reporting results, etc.
 
 {-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -11,6 +13,7 @@ module Crux.SVCOMP where
 
 import           Config.Schema
 import           Control.Applicative
+import           Data.Aeson (ToJSON)
 import qualified Data.Attoparsec.Text as Atto
 import           Data.Map (Map)
 import qualified Data.Map as Map
@@ -18,6 +21,7 @@ import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import qualified Data.Yaml as Yaml
+import           GHC.Generics (Generic)
 import           System.FilePath
 import qualified System.FilePath.Glob as Glob
 import qualified Data.HashMap.Strict as HM
@@ -84,7 +88,7 @@ data ComputedVerdict
   = Verified
   | Falsified
   | Unknown
- deriving (Show,Eq,Ord)
+ deriving (Eq, Generic, Ord, Show, ToJSON)
 
 data BenchmarkSet =
   BenchmarkSet

--- a/uc-crux-llvm/src/UCCrux/LLVM/Logging.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Logging.hs
@@ -11,6 +11,8 @@ NOTE! This module contains an orphan instance of a 'LJ.HasLog' instance for
 work...
 -}
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE LambdaCase #-}
@@ -34,8 +36,10 @@ where
 {- ORMOLU_DISABLE -}
 import           Prelude hiding (log)
 
+import           Data.Aeson (ToJSON)
 import           Data.Text as Text
 import qualified Data.Text.IO as TextIO
+import           GHC.Generics (Generic)
 
 import qualified Lumberjack as LJ
 import           Lumberjack (writeLogM)
@@ -75,6 +79,7 @@ data UCCruxLLVMLogMessage
       -- ^ Function name
       Text
       -- ^ Summary
+  deriving (Generic, ToJSON)
 
 type SupportsUCCruxLLVMLogMessage msgs =
   (?injectUCCruxLLVMLogMessage :: UCCruxLLVMLogMessage -> msgs)

--- a/uc-crux-llvm/src/UCCrux/LLVM/Main.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Main.hs
@@ -7,6 +7,8 @@ Maintainer   : Langston Barrett <langston@galois.com>
 Stability    : provisional
 -}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
@@ -41,7 +43,9 @@ import           Prelude hiding (log)
 import           Control.Exception (throw)
 import           Control.Lens ((^.))
 import           Control.Monad (void)
+import           Data.Aeson (ToJSON)
 import           Data.Traversable (for)
+import           GHC.Generics (Generic)
 import           System.Exit (ExitCode(..))
 import           System.IO (Handle)
 import qualified Data.Map.Strict as Map
@@ -93,12 +97,13 @@ mainWithOutputTo h =
     Crux.mkOutputConfig False h h ucCruxLLVMLoggingToSayWhat
 
 defaultOutputConfig :: Maybe CruxOptions -> Log.OutputConfig UCCruxLLVMLogging
-defaultOutputConfig = Crux.defaultOutputConfig ucCruxLLVMLoggingToSayWhat
+defaultOutputConfig opts = Crux.defaultOutputConfig ucCruxLLVMLoggingToSayWhat opts
 
 data UCCruxLLVMLogging
   = LoggingCrux Log.CruxLogMessage
   | LoggingCruxLLVM Log.CruxLLVMLogMessage
   | LoggingUCCruxLLVM Log.UCCruxLLVMLogMessage
+  deriving (Generic, ToJSON)
 
 ucCruxLLVMLoggingToSayWhat :: UCCruxLLVMLogging -> Log.SayWhat
 ucCruxLLVMLoggingToSayWhat (LoggingCrux msg) = Log.cruxLogMessageToSayWhat msg

--- a/uc-crux-llvm/test/Test.hs
+++ b/uc-crux-llvm/test/Test.hs
@@ -41,6 +41,8 @@ a very real bug.
 -}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -52,11 +54,13 @@ module Main (main) where
 
 {- ORMOLU_DISABLE -}
 import           Control.Exception ( try )
+import           Data.Aeson (ToJSON)
 import           Data.Foldable (for_)
 import qualified Data.Text as Text
 import qualified Data.Map as Map
 import           Data.Maybe (fromMaybe, isNothing)
 import qualified Data.Set as Set
+import           GHC.Generics (Generic)
 import           System.FilePath ((</>))
 import           System.IO (IOMode(WriteMode), withFile)
 
@@ -120,6 +124,7 @@ testDir = "test/programs"
 
 data UCCruxLLVMTestLogMessage
   = ClangTrouble
+  deriving (Generic, ToJSON)
 
 type SupportsUCCruxLLVMTestLogMessage msgs =
   (?injectUCCruxLLVMTestLogMessage :: UCCruxLLVMTestLogMessage -> msgs)
@@ -144,6 +149,7 @@ ucCruxLLVMTestLogMessageToSayWhat ClangTrouble =
 data UCCruxLLVMTestLogging
   = LoggingViaUCCruxLLVM Main.UCCruxLLVMLogging
   | LoggingUCCruxLLVMTest UCCruxLLVMTestLogMessage
+  deriving (Generic, ToJSON)
 
 ucCruxLLVMTestLoggingToSayWhat :: UCCruxLLVMTestLogging -> Log.SayWhat
 ucCruxLLVMTestLoggingToSayWhat (LoggingViaUCCruxLLVM msg) =

--- a/uc-crux-llvm/uc-crux-llvm.cabal
+++ b/uc-crux-llvm/uc-crux-llvm.cabal
@@ -71,6 +71,7 @@ library
     Paths_uc_crux_llvm
 
   build-depends:
+    aeson,
     async,
     base >= 4.8 && < 4.15,
     bv-sized,
@@ -131,6 +132,7 @@ test-suite uc-crux-llvm-test
   autogen-modules: Paths_uc_crux_llvm
 
   build-depends:
+                aeson,
                 base             >= 4.7,
                 containers,
                 crucible,


### PR DESCRIPTION
Opening this draft pull request to discuss the design of such changes.
I'm not super happy with the current design, and would like to discuss some alternatives.

The current constraints are:
- `mkOutputConfig` is responsible for generating the `LogAction`s,
- `mkOutputConfig` is a pure function,
- `mkOutputConfig` returns the `OutputConfig`,
- `WebSockets.runClient` effective type is `(Connection -> IO a) -> IO a`, and is "bracketed", in the sense that the connection is only kept open while the callback `IO` action is executing.

These constraints make it quite awkward to set up logging to output to websockets: I must already have a handle to the `Connection` by the time I call `mkOutCfg`, so that it can use said connection when setting up the `LogAction`s, but the entire program continuation must be passed to `WebSockets.runClient` for that connection to stay alive for the duration of execution, resulting in the following:

https://github.com/GaloisInc/crucible/blob/e4d33e93d92bd8dc242faa694b503b6f737ab0a7/crux/src/Crux.hs#L185-L188

This is serviceable, but I'm considering whether we would benefit from an inversion of control in `mkOutCfg`: if instead of being `mkOutCfg :: ... -> OutputConfig` function, it was `withOutCfg :: ... -> (Logs msgs => IO a) -> IO a`, I think we would be able to call `WebSockets.runClient` from within it rather than prior to it, and guarantee that the continuation executes while the connection remains open.

I think the best people to ponder this are likely @kquick and @robdockins , so let me know what you think if/when you have some time to consider it.

Not particularly urgent, it will look about the same from the outside regardless of this internal design decision, so I can keep working without knowing what solution we end up choosing.