### PR TITLE
crux: log prover milestones

### DIFF
--- a/crux/src/Crux.hs
+++ b/crux/src/Crux.hs
@@ -648,6 +648,10 @@ doSimWithResults cruxOpts simCallback sym execFeatures profInfo monline goalProv
       let ctx = execResultContext res
       inFrame profInfo "<Prove Goals>" $ do
         todo <- getProofObligations sym
+        let showGoal = \ g -> ( T.pack (show (view labeledPred g))
+                              , T.pack (show (view labeledPredMsg g))
+                              )
+        sayCrux $ Log.Goals (showGoal . proofGoal <$> maybe [] goalsToList todo)
         when (isJust todo) $ sayCrux Log.AttemptingProvingVCs
         (nms, proved) <- goalProver cruxOpts ctx explainFailure todo
         mgt <- provedGoalsTree sym proved

--- a/crux/src/Crux.hs
+++ b/crux/src/Crux.hs
@@ -648,10 +648,7 @@ doSimWithResults cruxOpts simCallback sym execFeatures profInfo monline goalProv
       let ctx = execResultContext res
       inFrame profInfo "<Prove Goals>" $ do
         todo <- getProofObligations sym
-        let showGoal = \ g -> ( T.pack (show (view labeledPred g))
-                              , T.pack (show (view labeledPredMsg g))
-                              )
-        sayCrux $ Log.Goals (showGoal . proofGoal <$> maybe [] goalsToList todo)
+        sayCrux $ Log.ProofObligations (LogProofObligation <$> maybe [] goalsToList todo)
         when (isJust todo) $ sayCrux Log.AttemptingProvingVCs
         (nms, proved) <- goalProver cruxOpts ctx explainFailure todo
         mgt <- provedGoalsTree sym proved

--- a/crux/src/Crux/Goal.hs
+++ b/crux/src/Crux/Goal.hs
@@ -184,7 +184,7 @@ proveGoalsOffline adapters opts ctx explainFailure (Just gs0) = do
     failfast = proofGoalsFailFast opts
 
     go :: SupportsCruxLogMessage msgs
-       => (Integer -> IO (), Integer -> IO ())
+       => (ProverMilestoneStartGoal, ProverMilestoneEndGoal)
        -> IORef ProcessedGoals
        -> Assumptions sym
        -> Goals (Assumptions sym) (Assertion sym)
@@ -318,11 +318,11 @@ dispatchSolversOnGoalAsync mtimeoutSeconds adapters withAdapter = do
 proverMilestoneCallbacks ::
   Log.Logs msgs =>
   Log.SupportsCruxLogMessage msgs =>
-  Goals asmp ast -> IO (Integer -> IO (), Integer -> IO (), IO ())
+  Goals asmp ast -> IO ProverMilestoneCallbacks
 proverMilestoneCallbacks goals = do
   (start, end, finish) <-
     if view quiet ?outputConfig then
-      return (\_ -> return (), \_ -> return (), return ())
+      return silentProverMilestoneCallbacks
     else
       prepStatus "Checking: " (countGoals goals)
   return

--- a/crux/src/Crux/Log.hs
+++ b/crux/src/Crux/Log.hs
@@ -98,7 +98,9 @@ data CruxLogMessage
   | Checking [FilePath]
   | DisablingBranchCoverageRequiresPathSatisfiability
   | DisablingProfilingIncompatibleWithPathSplitting
+  | EndedGoal Integer
   | FoundCounterExample
+  | Goals [(T.Text, T.Text)]
   | Help LogDoc
   | PathsUnexplored Int
   | SimulationComplete
@@ -153,8 +155,14 @@ cruxLogMessageToSayWhat DisablingProfilingIncompatibleWithPathSplitting =
   cruxWarn
     "Path splitting strategies are incompatible with Crucible profiling. Profiling is disabled!"
 
+-- for now, this message is only for IDE consumers
+cruxLogMessageToSayWhat (EndedGoal {}) = SayNothing
+
 cruxLogMessageToSayWhat FoundCounterExample =
   cruxOK "Counterexample found, skipping remaining goals"
+
+-- for now, this message is only for IDE consumers
+cruxLogMessageToSayWhat (Goals {}) = SayNothing
 
 cruxLogMessageToSayWhat (Help (LogDoc doc)) =
   cruxOK (renderStrict doc)
@@ -177,8 +185,8 @@ cruxLogMessageToSayWhat SimulationTimedOut =
 cruxLogMessageToSayWhat SkippingUnsatCoresBecauseMCSatEnabled =
   cruxWarn "Warning: skipping unsat cores because MC-SAT is enabled."
 
-cruxLogMessageToSayWhat (StartedGoal goalNumber) =
-  cruxOK (T.pack ("Started goal " ++ show goalNumber))
+-- for now, this message is only for IDE consumers
+cruxLogMessageToSayWhat (StartedGoal {}) = SayNothing
 
 cruxLogMessageToSayWhat (TotalPathsExplored i) =
   cruxSimply ("Total paths explored: " <> T.pack (show i))

--- a/crux/src/Crux/ProgressBar.hs
+++ b/crux/src/Crux/ProgressBar.hs
@@ -4,19 +4,19 @@ import System.IO
 import System.Console.ANSI
 import Control.Monad(zipWithM)
 
-prepStatus :: String -> Int -> IO (Integer -> IO (), IO (), IO ())
+prepStatus :: String -> Int -> IO (Integer -> IO (), Integer -> IO (), IO ())
 prepStatus pref tot =
    do ansi <- hSupportsANSI stdout
       if ansi then
         return (start,end,finish)
       else
-        return (const (return ()), return (), return ())
+        return (const (return ()), const (return ()), return ())
 
   where
   start n = do hSaveCursor stdout
                hPutStr stdout (msg n)
                hFlush stdout
-  end     = do hRestoreCursor stdout
+  end _n  = do hRestoreCursor stdout
                hFlush stdout
 
   finish = do hClearLine stdout
@@ -37,7 +37,7 @@ withProgressBar' pref xs f =
        let one n a =
             do start n
                b <- f a
-               end
+               end n
                return b
        zipWithM one [ 1 .. ] xs <* finish
 


### PR DESCRIPTION
(Not sure who the best reviewer is, so I'm pinging a few of you!)

For vscode-crux-llvm, we would like to have a notification when Crux knows what
goals it is about to start solving, and whenever each goal is started and
ended.

The goals are too verbose for displaying to the user, so they are not.  We
already have a progress bar system for the goals starting/ending, so these
messages are also not displayed to the user.

Because I did not want to build on the assumption that a goal ending was
necessarily the last started goal, I also made changes so that the ending of a
goal repeats the goal number.  This should be more future-proof in case we ever
process goals in parallel.  It can also help IDEs be a little more stateless.

Also, my apologies for inadvertently introducing 'StartedGoal' in a previous
commit where it was unused.