### PR TITLE
Add debug-intrinsics option to control translating llvm.dbg statements

### DIFF
--- a/crucible-llvm/crucible-llvm.cabal
+++ b/crucible-llvm/crucible-llvm.cabal
@@ -102,6 +102,7 @@ library
     Lang.Crucible.LLVM.Translation.Expr
     Lang.Crucible.LLVM.Translation.Instruction
     Lang.Crucible.LLVM.Translation.Monad
+    Lang.Crucible.LLVM.Translation.Options
     Lang.Crucible.LLVM.Translation.Types
     Lang.Crucible.LLVM.Types
 

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation.hs
@@ -187,7 +187,7 @@ buildRegTypeMap m0 bb = foldM stmt m0 (L.bbStmts bb)
 
 
 -- | Generate crucible code for each LLVM statement in turn.
-generateStmts :: (?laxArith :: Bool)
+generateStmts :: (?laxArith :: Bool, ?debugIntrinsics :: Bool)
         => TypeRepr ret
         -> L.BlockLabel
         -> [L.Stmt]
@@ -308,7 +308,7 @@ findFile _ = Nothing
 -- | Lookup the block info for the given LLVM block and then define a new crucible block
 --   by translating the given LLVM statements.
 defineLLVMBlock
-        :: (?laxArith :: Bool)
+        :: (?laxArith :: Bool, ?debugIntrinsics :: Bool)
         => TypeRepr ret
         -> Map L.BlockLabel (LLVMBlockInfo s)
         -> L.BasicBlock
@@ -326,7 +326,7 @@ defineLLVMBlock _ _ _ = fail "LLVM basic block has no label!"
 --
 --   This step introduces a new dummy entry point that simply jumps to the LLVM entry
 --   point.  It is inconvenient to avoid doing this when using the Generator interface.
-genDefn :: (?laxArith :: Bool)
+genDefn :: (?laxArith :: Bool, ?debugIntrinsics :: Bool)
         => L.Define
         -> TypeRepr ret
         -> LLVMGenerator s arch ret (Expr ext s ret)
@@ -357,7 +357,8 @@ genDefn defn retType =
 --
 -- | Translate a single LLVM function definition into a crucible CFG.
 transDefine :: forall arch wptr.
-               (HasPtrWidth wptr, wptr ~ ArchWidth arch, ?laxArith :: Bool, ?optLoopMerge :: Bool)
+               ( HasPtrWidth wptr, wptr ~ ArchWidth arch
+               , ?laxArith :: Bool, ?optLoopMerge :: Bool, ?debugIntrinsics :: Bool )
             => HandleAllocator
             -> LLVMContext arch
             -> L.Define
@@ -386,7 +387,7 @@ transDefine halloc ctx d = do
 -- | Translate a module into Crucible control-flow graphs.
 -- Note: We may want to add a map from symbols to existing function handles
 -- if we want to support dynamic loading.
-translateModule :: (?laxArith :: Bool, ?optLoopMerge :: Bool)
+translateModule :: (?laxArith :: Bool, ?optLoopMerge :: Bool, ?debugIntrinsics :: Bool)
                 => HandleAllocator -- ^ Generator for nonces.
                 -> GlobalVar Mem   -- ^ Memory model to associate with this context
                 -> L.Module        -- ^ Module to translate

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Instruction.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Instruction.hs
@@ -78,6 +78,7 @@ import           Lang.Crucible.LLVM.MemType
 import           Lang.Crucible.LLVM.Translation.Constant
 import           Lang.Crucible.LLVM.Translation.Expr
 import           Lang.Crucible.LLVM.Translation.Monad
+import           Lang.Crucible.LLVM.Translation.Options
 import           Lang.Crucible.LLVM.Translation.Types
 import           Lang.Crucible.LLVM.TypeContext
 import           Lang.Crucible.Syntax hiding (IsExpr)
@@ -528,7 +529,7 @@ calcGEP_struct fi base =
      if ioff == 0 then return base else callPtrAddOffset base off
 
 
-translateConversion :: (?laxArith :: Bool) =>
+translateConversion :: (?transOpts :: TranslationOptions) =>
   L.Instr ->
   L.ConvOp ->
   MemType {- Input type -} ->
@@ -797,7 +798,7 @@ vecSplit elLen expr =
   lay = llvmDataLayout ?lc
 
 
-bitop :: (?laxArith :: Bool) =>
+bitop :: (?transOpts :: TranslationOptions) =>
   L.BitOp ->
   MemType ->
   LLVMExpr s arch ->
@@ -819,7 +820,7 @@ bitop op _ x y =
 
     _ -> fail $ unwords ["bitwise operation on unsupported values", show x, show y]
 
-raw_bitop :: (?laxArith :: Bool, 1 <= w) =>
+raw_bitop :: (?transOpts :: TranslationOptions, 1 <= w) =>
   L.BitOp ->
   NatRepr w ->
   Expr LLVM s (BVType w) ->
@@ -827,6 +828,7 @@ raw_bitop :: (?laxArith :: Bool, 1 <= w) =>
   LLVMGenerator s arch ret (Expr LLVM s (BVType w))
 raw_bitop op w a b =
   let withSideConds val lst = sideConditionsA (BVRepr w) val lst
+      noLaxArith = not (laxArith ?transOpts)
   in
     case op of
       L.And -> return $ App (BVAnd w a b)
@@ -837,16 +839,16 @@ raw_bitop op w a b =
         let wlit = App (BVLit w (BV.width w))
         result <- AtomExpr <$> mkAtom (App (BVShl w a b))
         withSideConds result
-          [ ( not ?laxArith
+          [ ( noLaxArith
             , pure  $ App (BVUlt w b wlit) -- TODO: is this the right condition?
             , UB.PoisonValueCreated $ Poison.ShlOp2Big a b
             )
-          , ( nuw && not ?laxArith
+          , ( nuw && noLaxArith
             , fmap (App . BVEq w a . AtomExpr)
                    (mkAtom (App (BVLshr w result b)))
             , UB.PoisonValueCreated $ Poison.ShlNoUnsignedWrap a b
             )
-          , ( nsw && not ?laxArith
+          , ( nsw && noLaxArith
             , fmap (App . BVEq w a . AtomExpr)
                    (mkAtom (App (BVAshr w result b)))
             , UB.PoisonValueCreated $ Poison.ShlNoSignedWrap a b
@@ -857,11 +859,11 @@ raw_bitop op w a b =
         let wlit = App (BVLit w (BV.width w))
         result <- AtomExpr <$> mkAtom (App (BVLshr w a b))
         withSideConds result
-          [ ( not ?laxArith
+          [ ( noLaxArith
             , pure  $ App (BVUlt w b wlit)
             , UB.PoisonValueCreated $ Poison.LshrOp2Big a b
             )
-          , ( exact && not ?laxArith
+          , ( exact && noLaxArith
             , fmap (App . BVEq w a . AtomExpr)
                    (mkAtom (App (BVShl w result b)))
             , UB.PoisonValueCreated $ Poison.LshrExact a b
@@ -873,11 +875,11 @@ raw_bitop op w a b =
             let wlit = App (BVLit w (BV.width w))
             result <- AtomExpr <$> mkAtom (App (BVAshr w a b))
             withSideConds result
-              [ ( not ?laxArith
+              [ ( noLaxArith
                 , pure  $ App (BVUlt w b wlit)
                 , UB.PoisonValueCreated $ Poison.AshrOp2Big a b
                 )
-              , ( exact && not ?laxArith
+              , ( exact && noLaxArith
                 , fmap (App . BVEq w a)
                        (AtomExpr <$> mkAtom (App (BVShl w result b)))
                 , UB.PoisonValueCreated $ Poison.AshrExact a b
@@ -890,7 +892,7 @@ raw_bitop op w a b =
 -- | Translate an LLVM integer operation into a Crucible CFG expression.
 --
 -- Poison values can arise from such operations.
-intop :: forall w s arch ret. (?laxArith :: Bool, 1 <= w)
+intop :: forall w s arch ret. (?transOpts :: TranslationOptions, 1 <= w)
       => L.ArithOp
       -> NatRepr w
       -> Expr LLVM s (BVType w)
@@ -906,24 +908,25 @@ intop op w a b =
       bNeqZero = \ub -> (True, pure (notExpr (App (BVEq w z b))), ub)
       neg1     = App (BVLit w (BV.mkBV w (-1)))
       minInt   = App (BVLit w (BV.minSigned w))
+      noLaxArith = not (laxArith ?transOpts)
   in case op of
        L.Add nuw nsw -> withPoison (App (BVAdd w a b))
-         [ ( nuw && not ?laxArith
+         [ ( nuw && noLaxArith
            , notExpr (App (BVCarry w a b))
            , Poison.AddNoUnsignedWrap a b
            )
-         , ( nsw && not ?laxArith
+         , ( nsw && noLaxArith
            , notExpr (App (BVSCarry w a b))
            , Poison.AddNoSignedWrap a b
            )
          ]
 
        L.Sub nuw nsw -> withPoison (App (BVSub w a b))
-         [ ( nuw && not ?laxArith
+         [ ( nuw && noLaxArith
            , notExpr (App (BVUlt w a b))
            , Poison.SubNoUnsignedWrap a b
            )
-         , ( nsw && not ?laxArith
+         , ( nsw && noLaxArith
            , notExpr (App (BVSBorrow w a b))
            , Poison.SubNoSignedWrap a b
            )
@@ -936,7 +939,7 @@ intop op w a b =
 
          prod <- AtomExpr <$> mkAtom (App (BVMul w a b))
          withSideConds prod
-           [ ( nuw && not ?laxArith
+           [ ( nuw && noLaxArith
              , do
                  az       <- AtomExpr <$> mkAtom (App (BVZext w' w a))
                  bz       <- AtomExpr <$> mkAtom (App (BVZext w' w b))
@@ -945,7 +948,7 @@ intop op w a b =
                  return (App (BVEq w' wideprod prodz))
              , UB.PoisonValueCreated $ Poison.MulNoUnsignedWrap a b
              )
-           , ( nsw && not ?laxArith
+           , ( nsw && noLaxArith
              , do
                  as       <- AtomExpr <$> mkAtom (App (BVSext w' w a))
                  bs       <- AtomExpr <$> mkAtom (App (BVSext w' w b))
@@ -959,7 +962,7 @@ intop op w a b =
        L.UDiv exact -> do
          q <- AtomExpr <$> mkAtom (App (BVUdiv w a b))
          withSideConds q
-           [ ( exact && not ?laxArith
+           [ ( exact && noLaxArith
              , fmap (App . BVEq w a . AtomExpr)
                     (mkAtom (App (BVMul w q b)))
              , UB.PoisonValueCreated $ Poison.UDivExact a b
@@ -971,12 +974,12 @@ intop op w a b =
          | Just LeqProof <- isPosNat w -> do
            q <- AtomExpr <$> mkAtom (App (BVSdiv w a b))
            withSideConds q
-            [ ( exact && not ?laxArith
+            [ ( exact && noLaxArith
               , fmap (App . BVEq w a . AtomExpr)
                      (mkAtom (App (BVMul w q b)))
               , UB.PoisonValueCreated $ Poison.SDivExact a b
               )
-            , ( not ?laxArith
+            , ( noLaxArith
               , pure (notExpr (App (BVEq w neg1 b) .&& App (BVEq w minInt a)))
               , UB.SDivOverflow a b
               )
@@ -991,7 +994,7 @@ intop op w a b =
          | Just LeqProof <- isPosNat w ->
             do r <- AtomExpr <$> mkAtom (App (BVSrem w a b))
                withSideConds r
-                 [ ( not ?laxArith
+                 [ ( noLaxArith
                    , pure (notExpr (App (BVEq w neg1 b) .&& App (BVEq w minInt a)))
                    , UB.SRemOverflow a b
                    )
@@ -1243,7 +1246,7 @@ pointerCmp op x y =
                 ]
 
 pointerOp
-   :: (wptr ~ ArchWidth arch, ?laxArith :: Bool)
+   :: (wptr ~ ArchWidth arch, ?transOpts :: TranslationOptions)
    => L.ArithOp
    -> Expr LLVM s (LLVMPointerType wptr)
    -> Expr LLVM s (LLVMPointerType wptr)
@@ -1362,7 +1365,7 @@ translateSelect instr _ _ _ _ _ _ =
 
 -- | Do the heavy lifting of translating LLVM instructions to crucible code.
 generateInstr :: forall s arch ret a.
-   (?laxArith :: Bool, ?debugIntrinsics :: Bool) =>
+   (?transOpts :: TranslationOptions) =>
    TypeRepr ret   {- ^ Type of the function return value -} ->
    L.BlockLabel   {- ^ The label of the current LLVM basic block -} ->
    L.Instr        {- ^ The instruction to translate -} ->
@@ -1711,7 +1714,7 @@ generateInstr retType lab instr assign_f k =
  unsupported = reportError $ App $ StringLit $ UnicodeLiteral $ Text.pack $
                  unwords ["unsupported instruction", showInstr instr]
 
-arithOp :: (?laxArith :: Bool) =>
+arithOp :: (?transOpts :: TranslationOptions) =>
   L.ArithOp ->
   MemType ->
   LLVMExpr s arch ->
@@ -1811,7 +1814,7 @@ callFunction instr _tailCall fnTy _fn _args _assign_f =
 -- | Generate a call to an LLVM function, with a continuation to fetch more
 -- instructions.
 callFunctionWithCont :: forall s arch ret a.
-   (?debugIntrinsics :: Bool) =>
+   (?transOpts :: TranslationOptions) =>
    L.Instr {- ^ Source instruction o the call -} ->
    Bool    {- ^ Is the function a tail call? -} ->
    L.Type  {- ^ type of the function to call -} ->
@@ -1873,7 +1876,7 @@ callFunctionWithCont instr tailCall_ fnTy fn args assign_f k
 
 -- | Match the arguments used by @dbg.addr@, @dbg.declare@, and @dbg.value@.
 dbgArgs ::
-  (?debugIntrinsics :: Bool) =>
+  (?transOpts :: TranslationOptions) =>
   [L.Typed L.Value] {- ^ debug call arguments -} ->
   LLVMGenerator s arch ret (Either String (LLVMExpr s arch, L.DILocalVariable, L.DIExpression))
 dbgArgs args
@@ -1882,7 +1885,7 @@ dbgArgs args
     -- scoped arguments—see https://bugs.llvm.org/show_bug.cgi?id=51155. This
     -- wreaks all sorts of havoc on Crucible's later analyses, so one can work
     -- around the issue by not translating the llvm.dbg statements at all.
-    ?debugIntrinsics
+    debugIntrinsics ?transOpts
   = case args of
       [valArg, lvArg, diArg] ->
         case valArg of

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Options.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Options.hs
@@ -1,0 +1,55 @@
+------------------------------------------------------------------------
+-- |
+-- Module           : Lang.Crucible.LLVM.MemModel.Options
+-- Description      : Definition of options that can be tweaked during LLVM translation
+-- Copyright        : (c) Galois, Inc 2021
+-- License          : BSD3
+-- Maintainer       : Rob Dockins <rdockins@galois.com>
+-- Stability        : provisional
+------------------------------------------------------------------------
+module Lang.Crucible.LLVM.Translation.Options
+  ( TranslationOptions(..)
+  , defaultTranslationOptions
+  , debugIntrinsicsTranslationOptions
+  ) where
+
+-- | This datatype encodes a variety of tweakable settings that apply during
+--   LLVM translation.
+data TranslationOptions
+  = TranslationOptions
+    { debugIntrinsics :: !Bool
+      -- ^ Should we translate @llvm.dbg@ intrinsic statements? The upside to
+      --   translating them is that they encode debugging information about a
+      --   program that can be useful for external clients. The downside is
+      --   that they can bloat the size of translated programs, despite being
+      --   no-ops during simulation.
+    , laxArith :: !Bool
+      -- ^ Should we omit proof obligations related to arithmetic overflow
+      --   and similar assertions?
+    , optLoopMerge :: !Bool
+      -- ^ Should we insert merge blocks in loops with early exits (i.e. breaks
+      --   or returns)? This may improve simulation performance.
+    }
+
+-- | The default translation options:
+--
+-- * Do not translate @llvm.dbg@ intrinsic statements
+--
+-- * Do not produce proof obligations for arithmetic-related assertions.
+--
+-- * Do not insert merge blocks in loops with early exits.
+defaultTranslationOptions :: TranslationOptions
+defaultTranslationOptions =
+  TranslationOptions
+  { debugIntrinsics = False
+  , laxArith = False
+  , optLoopMerge = False
+  }
+
+-- | Like 'defaultTranslationOptions', but @llvm.dbg@ intrinsic statements are
+-- translated.
+debugIntrinsicsTranslationOptions :: TranslationOptions
+debugIntrinsicsTranslationOptions =
+  defaultTranslationOptions
+  { debugIntrinsics = True
+  }

--- a/crucible-llvm/test/MemSetup.hs
+++ b/crucible-llvm/test/MemSetup.hs
@@ -60,9 +60,7 @@ withLLVMCtx mod' action =
       with :: forall s. NonceGenerator IO s -> HandleAllocator -> IO a
       with nonceGen halloc = do
         sym <- CBS.newSimpleBackend CBS.FloatRealRepr nonceGen
-        let ?laxArith = False
-        let ?optLoopMerge = False
-        let ?debugIntrinsics = False
+        let ?transOpts = LLVMTr.defaultTranslationOptions
         memVar <- LLVMM.mkMemVar "test_llvm_memory" halloc
         Some (LLVMTr.ModuleTranslation _ ctx _ _) <- LLVMTr.translateModule halloc memVar mod'
         case LLVMTr.llvmArch ctx            of { LLVME.X86Repr width ->

--- a/crucible-llvm/test/MemSetup.hs
+++ b/crucible-llvm/test/MemSetup.hs
@@ -62,6 +62,7 @@ withLLVMCtx mod' action =
         sym <- CBS.newSimpleBackend CBS.FloatRealRepr nonceGen
         let ?laxArith = False
         let ?optLoopMerge = False
+        let ?debugIntrinsics = False
         memVar <- LLVMM.mkMemVar "test_llvm_memory" halloc
         Some (LLVMTr.ModuleTranslation _ ctx _ _) <- LLVMTr.translateModule halloc memVar mod'
         case LLVMTr.llvmArch ctx            of { LLVME.X86Repr width ->

--- a/crucible-llvm/test/Tests.hs
+++ b/crucible-llvm/test/Tests.hs
@@ -222,6 +222,7 @@ testBuildTranslation srcPath llvmTransTests =
       trans = do halloc <- newHandleAllocator
                  let ?laxArith = False
                  let ?optLoopMerge = False
+                 let ?debugIntrinsics = False
                  memVar <- mkMemVar "buildTranslation_test_llvm_memory" halloc
                  translateModule halloc memVar =<<
                    (fromRight (error "parsing was already verified") <$> parseLLVM bcPath)

--- a/crucible-llvm/test/Tests.hs
+++ b/crucible-llvm/test/Tests.hs
@@ -220,9 +220,7 @@ testBuildTranslation srcPath llvmTransTests =
           Right _ -> pure ()
 
       trans = do halloc <- newHandleAllocator
-                 let ?laxArith = False
-                 let ?optLoopMerge = False
-                 let ?debugIntrinsics = False
+                 let ?transOpts = defaultTranslationOptions
                  memVar <- mkMemVar "buildTranslation_test_llvm_memory" halloc
                  translateModule halloc memVar =<<
                    (fromRight (error "parsing was already verified") <$> parseLLVM bcPath)

--- a/crux-llvm/src/Crux/LLVM/Config.hs
+++ b/crux-llvm/src/Crux/LLVM/Config.hs
@@ -71,6 +71,7 @@ data LLVMOptions = LLVMOptions
   , noCompile :: Bool
   , optLevel :: Int
   , loopMerge :: Bool
+  , debugIntrinsics :: Bool
   }
 
 -- | The @c-src@ directory, which contains @crux-llvm@–specific files such as
@@ -160,6 +161,9 @@ llvmCruxConfig = do
 
          loopMerge <- Crux.section "opt-loop-merge" Crux.yesOrNoSpec False
                         "Insert merge blocks in loops with early exits (i.e. breaks or returns). This may improve simulation performance."
+
+         debugIntrinsics <- Crux.section "debug-intrinsics" Crux.yesOrNoSpec False
+                              "Translate statements using certain llvm.dbg intrinsic functions."
 
          return LLVMOptions { .. }
 

--- a/crux-llvm/src/Crux/LLVM/Config.hs
+++ b/crux-llvm/src/Crux/LLVM/Config.hs
@@ -15,6 +15,7 @@ import           System.FilePath ( (</>), joinPath, normalise, splitPath, takeDi
 import qualified Data.LLVM.BitCode as LLVM
 
 import           Lang.Crucible.LLVM.MemModel ( MemOptions(..), laxPointerMemOptions )
+import           Lang.Crucible.LLVM.Translation ( TranslationOptions(..) )
 
 import qualified Crux
 import           Paths_crux_llvm ( getDataDir )
@@ -65,13 +66,11 @@ data LLVMOptions = LLVMOptions
   , targetArch :: Maybe String
   , ubSanitizers :: [String]
   , memOpts    :: MemOptions
-  , laxArithmetic :: Bool
+  , transOpts  :: TranslationOptions
   , entryPoint :: String
   , lazyCompile :: Bool
   , noCompile :: Bool
   , optLevel :: Int
-  , loopMerge :: Bool
-  , debugIntrinsics :: Bool
   }
 
 -- | The @c-src@ directory, which contains @crux-llvm@–specific files such as
@@ -141,11 +140,18 @@ llvmCruxConfig = do
                            "Allow equality comparisons between pointers to constant data"
                        return MemOptions{..}
 
+         transOpts <- do laxArith <-
+                           Crux.section "lax-arithmetic" Crux.yesOrNoSpec False
+                             "Do not produce proof obligations related to arithmetic overflow, etc."
+                         optLoopMerge <-
+                           Crux.section "opt-loop-merge" Crux.yesOrNoSpec False
+                             "Insert merge blocks in loops with early exits (i.e. breaks or returns). This may improve simulation performance."
+                         debugIntrinsics <- Crux.section "debug-intrinsics" Crux.yesOrNoSpec False
+                              "Translate statements using certain llvm.dbg intrinsic functions."
+                         return TranslationOptions{..}
+
          entryPoint <- Crux.section "entry-point" Crux.stringSpec "main"
                            "Name of the entry point function to begin simulation."
-
-         laxArithmetic <- Crux.section "lax-arithmetic" Crux.yesOrNoSpec False
-                           "Do not produce proof obligations related to arithmetic overflow, etc."
 
          lazyCompile <- Crux.section "lazy-compile" Crux.yesOrNoSpec False
                            "Avoid compiling bitcode from source if intermediate files already exist"
@@ -158,12 +164,6 @@ llvmCruxConfig = do
 
          optLevel <- Crux.section "opt-level" Crux.numSpec 1
                            "Optimization level to request from `clang`"
-
-         loopMerge <- Crux.section "opt-loop-merge" Crux.yesOrNoSpec False
-                        "Insert merge blocks in loops with early exits (i.e. breaks or returns). This may improve simulation performance."
-
-         debugIntrinsics <- Crux.section "debug-intrinsics" Crux.yesOrNoSpec False
-                              "Translate statements using certain llvm.dbg intrinsic functions."
 
          return LLVMOptions { .. }
 
@@ -198,12 +198,12 @@ llvmCruxConfig = do
       , Crux.Option [] ["lax-arithmetic"]
         "Turn on lax rules for arithemetic overflow"
         $ Crux.NoArg
-        $ \opts -> Right opts { laxArithmetic = True }
+        $ \opts -> Right opts { transOpts = (transOpts opts) { laxArith = True } }
 
       , Crux.Option [] ["opt-loop-merge"]
         "Insert merge blocks in loops with early exits"
         $ Crux.NoArg
-        $ \opts -> Right opts { loopMerge = True }
+        $ \opts -> Right opts { transOpts = (transOpts opts) { optLoopMerge = True } }
 
       , Crux.Option [] ["lazy-compile"]
         "Avoid compiling bitcode from source if intermediate files already exist (default: off)"

--- a/crux-llvm/src/Crux/LLVM/Simulate.hs
+++ b/crux-llvm/src/Crux/LLVM/Simulate.hs
@@ -190,9 +190,7 @@ prepLLVMModule :: IsSymInterface sym
                -> IO (PreppedLLVM sym)
 prepLLVMModule llvmOpts halloc sym bcFile memVar = do
     llvmMod <- parseLLVM bcFile
-    Some trans <- let ?laxArith = laxArithmetic llvmOpts
-                      ?optLoopMerge = loopMerge llvmOpts
-                      ?debugIntrinsics = debugIntrinsics llvmOpts
+    Some trans <- let ?transOpts = transOpts llvmOpts
                   in translateModule halloc memVar llvmMod
     mem <- let llvmCtxt = trans ^. transContext in
              let ?lc = llvmCtxt ^. llvmTypeCtx

--- a/crux-llvm/src/Crux/LLVM/Simulate.hs
+++ b/crux-llvm/src/Crux/LLVM/Simulate.hs
@@ -192,6 +192,7 @@ prepLLVMModule llvmOpts halloc sym bcFile memVar = do
     llvmMod <- parseLLVM bcFile
     Some trans <- let ?laxArith = laxArithmetic llvmOpts
                       ?optLoopMerge = loopMerge llvmOpts
+                      ?debugIntrinsics = debugIntrinsics llvmOpts
                   in translateModule halloc memVar llvmMod
     mem <- let llvmCtxt = trans ^. transContext in
              let ?lc = llvmCtxt ^. llvmTypeCtx

--- a/crux-llvm/test-data/golden/T778.c
+++ b/crux-llvm/test-data/golden/T778.c
@@ -1,0 +1,22 @@
+unsigned int addflt(unsigned int a , unsigned int b )
+{
+  unsigned int ma = a;
+  unsigned int mb = b;
+  int ea = (int)(a >> 24U) - 128;
+  int eb = (int)(b >> 24U) - 128;
+  unsigned int delta = ea - eb;
+
+  mb = mb >> delta;
+  ma = ma + mb;
+
+  // This if statement seems critical
+  if (ma) {
+    ea = ea + 1;
+  }
+
+  return ((unsigned int) ea);
+}
+
+int main() {
+  return 0;
+}

--- a/crux-llvm/test-data/golden/T778.config
+++ b/crux-llvm/test-data/golden/T778.config
@@ -1,0 +1,3 @@
+-- We may wish to reconsider this choice if
+-- https://bugs.llvm.org/show_bug.cgi?id=51155 is fixed in the future.
+debug-intrinsics: no

--- a/crux-llvm/test-data/golden/T778.good
+++ b/crux-llvm/test-data/golden/T778.good
@@ -1,0 +1,1 @@
+[Crux] Overall status: Valid.

--- a/uc-crux-llvm/src/UCCrux/LLVM/Main.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Main.hs
@@ -175,9 +175,7 @@ translateLLVMModule ucOpts halloc memVar moduleFilePath llvmMod =
   do
     let llvmOpts = Config.ucLLVMOptions ucOpts
     Some trans <-
-      let ?laxArith = laxArithmetic llvmOpts
-          ?optLoopMerge = loopMerge llvmOpts
-          ?debugIntrinsics = debugIntrinsics llvmOpts
+      let ?transOpts = transOpts llvmOpts
        in translateModule halloc memVar llvmMod
     llvmPtrWidth
       (trans ^. transContext)

--- a/uc-crux-llvm/src/UCCrux/LLVM/Main.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Main.hs
@@ -177,6 +177,7 @@ translateLLVMModule ucOpts halloc memVar moduleFilePath llvmMod =
     Some trans <-
       let ?laxArith = laxArithmetic llvmOpts
           ?optLoopMerge = loopMerge llvmOpts
+          ?debugIntrinsics = debugIntrinsics llvmOpts
        in translateModule halloc memVar llvmMod
     llvmPtrWidth
       (trans ^. transContext)


### PR DESCRIPTION
Unfortunately, Clang can sometimes generate ill-scoped `llvm.dbg` statements (see #778), so this patch adds a `debug-intrinsics` option that controls whether `llvm.dbg` statements should be translated at all. The default value for `crux-llvm` is `no`, as `crux-llvm` does not yet make use of `llvm.dbg` information. We may wish to revisit this choice in the future should the upstream LLVM bug (https://bugs.llvm.org/show_bug.cgi?id=51155) be fixed.

Fixes #778.