### PR TITLE
`crucible-llvm`: Add override for `exit`

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics.hs
@@ -242,6 +242,7 @@ declare_overrides =
   , basic_llvm_override Libc.llvmPrintfChkOverride
   , basic_llvm_override Libc.llvmPutsOverride
   , basic_llvm_override Libc.llvmPutCharOverride
+  , basic_llvm_override Libc.llvmExitOverride
   , basic_llvm_override Libc.llvmGetenvOverride
 
   , basic_llvm_override Libc.cxa_atexitOverride

--- a/crucible/src/Lang/Crucible/Backend.hs
+++ b/crucible/src/Lang/Crucible/Backend.hs
@@ -322,6 +322,9 @@ data AbortExecReason =
     -- ^ We tried all possible cases for a variant, and now we should
     -- do something else.
 
+  | EarlyExit ProgramLoc
+    -- ^ TODO RGS
+
     deriving Show
 
 instance Exception AbortExecReason
@@ -337,6 +340,7 @@ ppAbortExecReason e =
       , PP.indent 2 (ppSimError err)
       ]
     VariantOptionsExhausted l -> ppLocated l "Variant options exhausted."
+    EarlyExit l -> ppLocated l "Program exited early."
 
 ppAssumption :: (forall tp. e tp -> PP.Doc ann) -> CrucibleAssumption e -> PP.Doc ann
 ppAssumption ppDoc e =

--- a/crux-llvm/test-data/golden/T784-fail.c
+++ b/crux-llvm/test-data/golden/T784-fail.c
@@ -1,0 +1,6 @@
+#include <stdlib.h>
+
+int main() {
+  exit(1);
+  exit(0);
+}

--- a/crux-llvm/test-data/golden/T784-fail.good
+++ b/crux-llvm/test-data/golden/T784-fail.good
@@ -1,0 +1,4 @@
+[Crux] Found counterexample for verification goal
+[Crux]   test-data/golden/T784-fail.c:4:3: error: in main
+[Crux]   Call to exit() with non-zero argument
+[Crux] Overall status: Invalid.

--- a/crux-llvm/test-data/golden/T784-pass.c
+++ b/crux-llvm/test-data/golden/T784-pass.c
@@ -1,0 +1,6 @@
+#include <stdlib.h>
+
+int main() {
+  exit(0);
+  exit(1);
+}

--- a/crux-llvm/test-data/golden/T784-pass.good
+++ b/crux-llvm/test-data/golden/T784-pass.good
@@ -1,0 +1,1 @@
+[Crux] Overall status: Valid.


### PR DESCRIPTION
Fixes #784.