### PR TITLE
`crucible-llvm`: Add `readUnwrittenMemory` option, use it in `readMem'`

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/ArraySizeProfile.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/ArraySizeProfile.hs
@@ -112,7 +112,8 @@ ptrArraySize mem ptr
   | otherwise = Nothing
 
 ptrIsInitialized ::
-  (C.IsSymInterface sym, C.HasLLVMAnn sym, C.HasPtrWidth w) =>
+  ( C.IsSymInterface sym, C.HasLLVMAnn sym, C.HasPtrWidth w
+  , ?memOpts :: C.MemOptions ) =>
   sym ->
   G.Mem sym ->
   C.LLVMPtr sym w ->
@@ -123,7 +124,8 @@ ptrIsInitialized sym mem ptr =
   _ -> pure False
 
 intrinsicArgProfile ::
-  (C.IsSymInterface sym, C.HasLLVMAnn sym, C.HasPtrWidth w) =>
+  ( C.IsSymInterface sym, C.HasLLVMAnn sym, C.HasPtrWidth w
+  , ?memOpts :: C.MemOptions ) =>
   sym ->
   G.Mem sym ->
   SymbolRepr nm ->
@@ -137,7 +139,8 @@ intrinsicArgProfile sym mem
 intrinsicArgProfile _ _ _ _ _ = pure $ ArgProfile Nothing False
 
 regValueArgProfile ::
-  (C.IsSymInterface sym, C.HasLLVMAnn sym, C.HasPtrWidth w) =>
+  ( C.IsSymInterface sym, C.HasLLVMAnn sym, C.HasPtrWidth w
+  , ?memOpts :: C.MemOptions ) =>
   sym ->
   G.Mem sym ->
   C.TypeRepr tp ->
@@ -147,7 +150,8 @@ regValueArgProfile sym mem (C.IntrinsicRepr nm ctx) i = intrinsicArgProfile sym 
 regValueArgProfile _ _ _ _ = pure $ ArgProfile Nothing False
 
 regEntryArgProfile ::
-  (C.IsSymInterface sym, C.HasLLVMAnn sym, C.HasPtrWidth w) =>
+  ( C.IsSymInterface sym, C.HasLLVMAnn sym, C.HasPtrWidth w
+  , ?memOpts :: C.MemOptions ) =>
   sym ->
   G.Mem sym ->
   C.RegEntry sym tp ->
@@ -156,7 +160,8 @@ regEntryArgProfile sym mem (C.RegEntry t v) = regValueArgProfile sym mem t v
 
 newtype Wrap a (b :: C.CrucibleType) = Wrap { unwrap :: a }
 argProfiles ::
-  (C.IsSymInterface sym, C.HasLLVMAnn sym, C.HasPtrWidth w) =>
+  ( C.IsSymInterface sym, C.HasLLVMAnn sym, C.HasPtrWidth w
+  , ?memOpts :: C.MemOptions ) =>
   sym ->
   G.Mem sym ->
   Ctx.Assignment (C.RegEntry sym) ctx ->
@@ -168,7 +173,8 @@ argProfiles sym mem as =
 -- Execution feature for learning profiles
 
 updateProfiles ::
-  (C.IsSymInterface sym, C.HasLLVMAnn sym, C.HasPtrWidth (C.ArchWidth arch)) =>
+  ( C.IsSymInterface sym, C.HasLLVMAnn sym, C.HasPtrWidth (C.ArchWidth arch)
+  , ?memOpts :: C.MemOptions ) =>
   C.LLVMContext arch ->
   IORef (Map Text [FunctionProfile]) ->
   C.ExecState p sym ext rtp ->
@@ -191,7 +197,8 @@ updateProfiles llvm cell state
 
 arraySizeProfile ::
   forall sym ext arch p rtp.
-  (C.IsSymInterface sym, C.HasLLVMAnn sym, C.HasPtrWidth (C.ArchWidth arch)) =>
+  ( C.IsSymInterface sym, C.HasLLVMAnn sym, C.HasPtrWidth (C.ArchWidth arch)
+  , ?memOpts :: C.MemOptions ) =>
   C.LLVMContext arch ->
   IORef (Map Text [FunctionProfile]) ->
   IO (C.ExecutionFeature p sym ext rtp)

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics.hs
@@ -66,7 +66,8 @@ llvmIntrinsicTypes =
 
 -- | Register all declare and define overrides
 register_llvm_overrides ::
-  (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch) =>
+  ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch
+  , ?memOpts :: MemOptions ) =>
   L.Module ->
   [OverrideTemplate p sym arch rtp l a] {- ^ Additional "define" overrides -} ->
   [OverrideTemplate p sym arch rtp l a] {- ^ Additional "declare" overrides -} ->
@@ -130,7 +131,8 @@ register_llvm_define_overrides llvmModule addlOvrs llvmctx =
      (allModuleDeclares llvmModule)
 
 register_llvm_declare_overrides ::
-  (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch) =>
+  ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch
+  , ?memOpts :: MemOptions ) =>
   L.Module ->
   [OverrideTemplate p sym arch rtp l a] ->
   LLVMContext arch ->
@@ -143,7 +145,8 @@ register_llvm_declare_overrides llvmModule addlOvrs llvmctx =
 
 -- | Register overrides for declared-but-not-defined functions
 declare_overrides ::
-  (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch, ?lc :: TypeContext) =>
+  ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch
+  , ?lc :: TypeContext, ?memOpts :: MemOptions ) =>
   [OverrideTemplate p sym arch rtp l a]
 declare_overrides =
   [ basic_llvm_override LLVM.llvmLifetimeStartOverride

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libc.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libc.hs
@@ -216,7 +216,8 @@ llvmFreeOverride =
 -- *** Strings and I/O
 
 llvmPrintfOverride
-  :: (IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym)
+  :: ( IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym
+     , ?memOpts :: MemOptions )
   => LLVMOverride p sym
          (EmptyCtx ::> LLVMPointerType wptr
                    ::> VectorType AnyType)
@@ -226,7 +227,8 @@ llvmPrintfOverride =
   (\memOps sym args -> Ctx.uncurryAssignment (callPrintf sym memOps) args)
 
 llvmPrintfChkOverride
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
+  :: ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
+     , ?memOpts :: MemOptions )
   => LLVMOverride p sym
          (EmptyCtx ::> BVType 32
                    ::> LLVMPointerType wptr
@@ -246,14 +248,16 @@ llvmPutCharOverride =
 
 
 llvmPutsOverride
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
+  :: ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
+     , ?memOpts :: MemOptions )
   => LLVMOverride p sym (EmptyCtx ::> LLVMPointerType wptr) (BVType 32)
 llvmPutsOverride =
   [llvmOvr| i32 @puts( i8* ) |]
   (\memOps sym args -> Ctx.uncurryAssignment (callPuts sym memOps) args)
 
 llvmStrlenOverride
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
+  :: ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
+     , ?memOpts :: MemOptions )
   => LLVMOverride p sym (EmptyCtx ::> LLVMPointerType wptr) (BVType wptr)
 llvmStrlenOverride =
   [llvmOvr| size_t @strlen( i8* ) |]
@@ -448,7 +452,8 @@ callPutChar _sym _mvar
     return ch
 
 callPuts
-  :: (IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym)
+  :: ( IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym
+     , ?memOpts :: MemOptions )
   => sym
   -> GlobalVar Mem
   -> RegEntry sym (LLVMPointerType wptr)
@@ -463,7 +468,8 @@ callPuts sym mvar
     liftIO $ bvLit sym knownNat (BV.one knownNat)
 
 callStrlen
-  :: (IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym)
+  :: ( IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym
+     , ?memOpts :: MemOptions )
   => sym
   -> GlobalVar Mem
   -> RegEntry sym (LLVMPointerType wptr)
@@ -473,7 +479,8 @@ callStrlen sym mvar (regValue -> strPtr) = do
   liftIO $ strLen sym mem strPtr
 
 callAssert
-  :: (IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym)
+  :: ( IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym
+     , ?memOpts :: MemOptions )
   => GlobalVar Mem
   -> sym
   -> Ctx.Assignment (RegEntry sym)
@@ -501,7 +508,8 @@ callExit sym ec = liftIO $
      abortExecBecause $ EarlyExit loc
 
 callPrintf
-  :: (IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym)
+  :: ( IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym
+     , ?memOpts :: MemOptions )
   => sym
   -> GlobalVar Mem
   -> RegEntry sym (LLVMPointerType wptr)
@@ -521,7 +529,8 @@ callPrintf sym mvar
         liftIO $ hPutStr h str
         liftIO $ bvLit sym knownNat (BV.mkBV knownNat (toInteger n))
 
-printfOps :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
+printfOps :: ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
+             , ?memOpts :: MemOptions )
           => sym
           -> V.Vector (AnyValue sym)
           -> PrintfOperations (StateT (MemImpl sym) IO)
@@ -648,7 +657,8 @@ printfOps sym valist =
 
 -- from OSX libc
 llvmAssertRtnOverride
-  :: (IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym)
+  :: ( IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym
+     , ?memOpts :: MemOptions )
   => LLVMOverride p sym
         (EmptyCtx ::> LLVMPointerType wptr
                   ::> LLVMPointerType wptr
@@ -661,7 +671,8 @@ llvmAssertRtnOverride =
 
 -- From glibc
 llvmAssertFailOverride
-  :: (IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym)
+  :: ( IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym
+     , ?memOpts :: MemOptions )
   => LLVMOverride p sym
         (EmptyCtx ::> LLVMPointerType wptr
                   ::> LLVMPointerType wptr

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
@@ -518,7 +518,7 @@ evalStmt sym = eval
   eval (LLVM_PtrSubtract _w mvar (regValue -> x) (regValue -> y)) =
     do mem <- getMem mvar
        liftIO $ doPtrSubtract sym mem x y
-  
+
   eval LLVM_Debug{} = pure ()
 
 
@@ -549,7 +549,8 @@ ptrMessage msg ptr ty =
 --
 -- Precondition: the pointer is valid and aligned, and the loaded value is defined.
 doLoad ::
-  (IsSymInterface sym, HasPtrWidth wptr, Partial.HasLLVMAnn sym) =>
+  ( IsSymInterface sym, HasPtrWidth wptr, Partial.HasLLVMAnn sym
+  , ?memOpts :: MemOptions ) =>
   sym ->
   MemImpl sym ->
   LLVMPtr sym wptr {- ^ pointer to load from      -} ->
@@ -1025,7 +1026,8 @@ isAllocatedAlignedPointer sym w alignment mutability ptr size mem =
 --   of the string may be symbolic; HOWEVER, this function will not terminate
 --   until it eventually reaches a concete null-terminator or a load error.
 strLen :: forall sym wptr.
-  (IsSymInterface sym, HasPtrWidth wptr, Partial.HasLLVMAnn sym) =>
+  ( IsSymInterface sym, HasPtrWidth wptr, Partial.HasLLVMAnn sym
+  , ?memOpts :: MemOptions ) =>
   sym ->
   MemImpl sym      {- ^ memory to read from        -} ->
   LLVMPtr sym wptr {- ^ pointer to string value    -} ->
@@ -1063,7 +1065,8 @@ strLen sym mem = go (BV.zero PtrWidth) (truePred sym)
 -- `loadString` will stop reading if it encounters a null-terminator.
 loadString ::
   forall sym wptr.
-  (IsSymInterface sym, HasPtrWidth wptr, Partial.HasLLVMAnn sym) =>
+  ( IsSymInterface sym, HasPtrWidth wptr, Partial.HasLLVMAnn sym
+  , ?memOpts :: MemOptions ) =>
   sym ->
   MemImpl sym      {- ^ memory to read from        -} ->
   LLVMPtr sym wptr {- ^ pointer to string value    -} ->
@@ -1091,7 +1094,8 @@ loadString sym mem = go id
 --   the string as with 'loadString' and return it.
 loadMaybeString ::
   forall sym wptr.
-  (IsSymInterface sym, HasPtrWidth wptr, Partial.HasLLVMAnn sym) =>
+  ( IsSymInterface sym, HasPtrWidth wptr, Partial.HasLLVMAnn sym
+  , ?memOpts :: MemOptions ) =>
   sym ->
   MemImpl sym      {- ^ memory to read from        -} ->
   LLVMPtr sym wptr {- ^ pointer to string value    -} ->
@@ -1132,7 +1136,8 @@ toStorableType mt =
 
 -- | Load an LLVM value from memory. Asserts that the pointer is valid and the
 -- result value is not undefined.
-loadRaw :: (IsSymInterface sym, HasPtrWidth wptr, Partial.HasLLVMAnn sym)
+loadRaw :: ( IsSymInterface sym, HasPtrWidth wptr, Partial.HasLLVMAnn sym
+           , ?memOpts :: MemOptions )
         => sym
         -> MemImpl sym
         -> LLVMPtr sym wptr

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Generic.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Generic.hs
@@ -13,6 +13,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -103,6 +104,7 @@ import           Lang.Crucible.LLVM.DataLayout
 import           Lang.Crucible.LLVM.Errors.MemoryError (MemErrContext, MemoryErrorReason(..), MemoryOp(..))
 import qualified Lang.Crucible.LLVM.Errors.UndefinedBehavior as UB
 import           Lang.Crucible.LLVM.MemModel.Common
+import           Lang.Crucible.LLVM.MemModel.Options
 import           Lang.Crucible.LLVM.MemModel.MemLog
 import           Lang.Crucible.LLVM.MemModel.Pointer
 import           Lang.Crucible.LLVM.MemModel.Type
@@ -680,7 +682,9 @@ readMemInvalidate sym w end mop (LLVMPointer blk off) tp d msg sz readPrev =
 
 -- | Read a value from memory.
 readMem :: forall sym w.
-  (1 <= w, IsSymInterface sym, HasLLVMAnn sym) => sym ->
+  ( 1 <= w, IsSymInterface sym, HasLLVMAnn sym
+  , ?memOpts :: MemOptions ) =>
+  sym ->
   NatRepr w ->
   Maybe String ->
   LLVMPtr sym w ->
@@ -740,7 +744,9 @@ toCacheEntry tp (llvmPointerView -> (blk, bv)) = CacheEntry tp blk bv
 -- handled in 'readMem'.
 readMem' ::
   forall w sym.
-  (1 <= w, IsSymInterface sym, HasLLVMAnn sym) => sym ->
+  ( 1 <= w, IsSymInterface sym, HasLLVMAnn sym
+  , ?memOpts :: MemOptions ) =>
+  sym ->
   NatRepr w ->
   EndianForm ->
   Maybe String ->

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Options.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Options.hs
@@ -33,6 +33,10 @@ data MemOptions
       --   be consolidated, so pointer apparently-distinct pointers
       --   will sometimes compare equal if the compiler decides to
       --   consolidate their storage.
+
+    , readUnwrittenMemory :: !Bool
+      -- ^ Should we allow reading from previously unwritten memory? Such a
+      ---  read will return an arbitrary, fixed value of the appropriate type.
     }
 
 
@@ -43,6 +47,7 @@ defaultMemOptions =
   MemOptions
   { laxPointerOrdering = False
   , laxConstantEquality = False
+  , readUnwrittenMemory = False
   }
 
 
@@ -53,4 +58,5 @@ laxPointerMemOptions =
   MemOptions
   { laxPointerOrdering = True
   , laxConstantEquality = True
+  , readUnwrittenMemory = False
   }

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Partial.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Partial.hs
@@ -672,8 +672,8 @@ appendArray sym errCtx (NoErr _ v1) (NoErr _ v2) =
 
 -- | Make a partial LLVM array value.
 --
--- It returns 'Unassigned' if any of the elements of the vector are
--- 'Unassigned'. Otherwise, the 'AssertionTree' on the returned value
+-- It returns 'Err' if any of the elements of the vector are
+-- 'Err'. Otherwise, the 'Pred' on the returned 'NoErr' value
 -- is the 'And' of all the assertions on the values.
 mkArray :: forall sym. (IsExprBuilder sym, IsSymInterface sym) =>
   sym ->
@@ -695,8 +695,8 @@ mkArray sym tp vec =
 
 -- | Make a partial LLVM struct value.
 --
--- It returns 'Unassigned' if any of the struct fields are 'Unassigned'.
--- Otherwise, the 'AssertionTree' on the returned value is the 'And' of all the
+-- It returns 'Err' if any of the struct fields are 'Err'.
+-- Otherwise, the 'Pred' on the returned 'NoErr' value is the 'And' of all the
 -- assertions on the values.
 mkStruct :: forall sym. IsExprBuilder sym =>
   sym ->

--- a/crucible-llvm/test/TestMemory.hs
+++ b/crucible-llvm/test/TestMemory.hs
@@ -56,13 +56,15 @@ withMem ::
     , CB.IsSymInterface sym
     , LLVMMem.HasLLVMAnn sym
     , W4O.OnlineSolver solver
-    , LLVMMem.HasPtrWidth wptr ) =>
+    , LLVMMem.HasPtrWidth wptr
+    , ?memOpts :: LLVMMem.MemOptions ) =>
     sym -> LLVMMem.MemImpl sym -> IO a) ->
   IO a
 withMem endianess action = withIONonceGenerator $ \nonce_gen ->
   CBO.withZ3OnlineBackend W4B.FloatIEEERepr nonce_gen CBO.NoUnsatFeatures noFeatures $ \sym -> do
     let ?ptrWidth = knownNat @64
     let ?recordLLVMAnnotation = \_ _ -> pure ()
+    let ?memOpts = LLVMMem.defaultMemOptions
     mem <- LLVMMem.emptyMem endianess
     action sym mem
 

--- a/crucible-wasm/src/Lang/Crucible/Wasm/Memory.hs
+++ b/crucible-wasm/src/Lang/Crucible/Wasm/Memory.hs
@@ -198,7 +198,8 @@ wasmStoreDouble sym off v mem =
      (heap',_,_) <- G.writeMem sym knownNat Nothing p doubleType noAlignment val (wasmMemHeap mem)
      return mem{ wasmMemHeap = heap' }
 
-wasmLoadInt :: (1 <= w, IsSymInterface sym) => sym -> SymBV sym 32 -> NatRepr w -> WasmMemImpl sym -> IO (SymBV sym w)
+wasmLoadInt :: (1 <= w, IsSymInterface sym, ?memOpts :: MemOptions) =>
+               sym -> SymBV sym 32 -> NatRepr w -> WasmMemImpl sym -> IO (SymBV sym w)
 wasmLoadInt sym off w mem =
   do let bs = Bytes (intValue w `div` 8)
      assertInBounds sym off bs mem
@@ -211,7 +212,7 @@ wasmLoadInt sym off w mem =
        _ -> panic "wasmLoadInt" ["type mismatch"]
 
 wasmLoadFloat ::
-  IsSymInterface sym =>
+  (IsSymInterface sym, ?memOpts :: MemOptions) =>
   sym ->
   SymBV sym 32 ->
   WasmMemImpl sym ->
@@ -228,7 +229,7 @@ wasmLoadFloat sym off mem =
        _ -> panic "wasmLoadFloat" ["type mismatch"]
 
 wasmLoadDouble ::
-  IsSymInterface sym =>
+  (IsSymInterface sym, ?memOpts :: MemOptions) =>
   sym ->
   SymBV sym 32 ->
   WasmMemImpl sym ->

--- a/crucible/src/Lang/Crucible/Backend.hs
+++ b/crucible/src/Lang/Crucible/Backend.hs
@@ -323,7 +323,8 @@ data AbortExecReason =
     -- do something else.
 
   | EarlyExit ProgramLoc
-    -- ^ TODO RGS
+    -- ^ We invoked a function which ends the current thread of execution
+    --   (e.g., @abort()@ or @exit(1)@).
 
     deriving Show
 

--- a/crux-llvm/src/Crux/LLVM/Config.hs
+++ b/crux-llvm/src/Crux/LLVM/Config.hs
@@ -138,6 +138,9 @@ llvmCruxConfig = do
                        laxConstantEquality <-
                          Crux.section "lax-constant-equality" Crux.yesOrNoSpec False
                            "Allow equality comparisons between pointers to constant data"
+                       readUnwrittenMemory <-
+                         Crux.section "read-unwritten-memory" Crux.yesOrNoSpec False
+                           "Allow reading from previously unwritten memory"
                        return MemOptions{..}
 
          transOpts <- do laxArith <-

--- a/crux-llvm/src/Crux/LLVM/Overrides.hs
+++ b/crux-llvm/src/Crux/LLVM/Overrides.hs
@@ -59,7 +59,7 @@ import Lang.Crucible.LLVM.MemModel
    doMalloc, AllocType(HeapAlloc), Mutability(Mutable),
    doArrayStore, doArrayConstStore, HasLLVMAnn,
    isAllocatedAlignedPointer, Mutability(..),
-   pattern PtrWidth, doDumpMem
+   pattern PtrWidth, doDumpMem, MemOptions
    )
 
 import           Lang.Crucible.LLVM.TypeContext( TypeContext )
@@ -76,7 +76,8 @@ type TBits n        = BVType n
 
 
 cruxLLVMOverrides ::
-  (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch, ?lc :: TypeContext) =>
+  ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch
+  , ?lc :: TypeContext, ?memOpts :: MemOptions ) =>
   Proxy# arch ->
   [OverrideTemplate (personality sym) sym arch rtp l a]
 cruxLLVMOverrides arch =
@@ -150,7 +151,8 @@ cruxLLVMOverrides arch =
 
 
 cbmcOverrides ::
-  (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch, ?lc :: TypeContext) =>
+  ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch
+  , ?lc :: TypeContext, ?memOpts :: MemOptions ) =>
   Proxy# arch ->
   [OverrideTemplate (personality sym) sym arch rtp l a]
 cbmcOverrides arch =
@@ -338,7 +340,8 @@ mkFreshFloat nm fi = do
   return elt
 
 lookupString ::
-  (IsSymInterface sym, HasLLVMAnn sym, ArchOk arch) =>
+  ( IsSymInterface sym, HasLLVMAnn sym, ArchOk arch
+  , ?memOpts :: MemOptions ) =>
   Proxy# arch ->
   GlobalVar Mem -> RegEntry sym (TPtr arch) -> OverM personality sym ext String
 lookupString _ mvar ptr =
@@ -366,7 +369,8 @@ sv_comp_fresh_float ::
 sv_comp_fresh_float fi _mvar _sym Empty = mkFreshFloat "X" fi
 
 fresh_bits ::
-  (ArchOk arch, HasLLVMAnn sym, IsSymInterface sym, 1 <= w) =>
+  ( ArchOk arch, HasLLVMAnn sym, IsSymInterface sym, 1 <= w
+  , ?memOpts :: MemOptions ) =>
   Proxy# arch ->
   NatRepr w ->
   GlobalVar Mem ->
@@ -378,7 +382,8 @@ fresh_bits arch w mvar _ (Empty :> pName) =
      mkFresh name (BaseBVRepr w)
 
 fresh_float ::
-  (ArchOk arch, IsSymInterface sym, HasLLVMAnn sym) =>
+  ( ArchOk arch, IsSymInterface sym, HasLLVMAnn sym
+  , ?memOpts :: MemOptions ) =>
   Proxy# arch ->
   FloatInfoRepr fi ->
   GlobalVar Mem ->
@@ -390,7 +395,8 @@ fresh_float arch fi mvar _ (Empty :> pName) =
      mkFreshFloat name fi
 
 fresh_str ::
-  (ArchOk arch, IsSymInterface sym, HasLLVMAnn sym) =>
+  ( ArchOk arch, IsSymInterface sym, HasLLVMAnn sym
+  , ?memOpts :: MemOptions ) =>
   Proxy# arch ->
   GlobalVar Mem ->
   sym ->
@@ -427,7 +433,8 @@ fresh_str arch mvar sym (Empty :> pName :> maxLen) =
      return ptr
 
 do_assume ::
-  (ArchOk arch, IsSymInterface sym, HasLLVMAnn sym) =>
+  ( ArchOk arch, IsSymInterface sym, HasLLVMAnn sym
+  , ?memOpts :: MemOptions ) =>
   Proxy# arch ->
   GlobalVar Mem ->
   sym ->
@@ -445,7 +452,8 @@ do_assume arch mvar sym (Empty :> p :> pFile :> line) =
      liftIO $ addAssumption sym (GenericAssumption loc' "crucible_assume" cond)
 
 do_assert ::
-  (ArchOk arch, IsSymInterface sym, HasLLVMAnn sym) =>
+  ( ArchOk arch, IsSymInterface sym, HasLLVMAnn sym
+  , ?memOpts :: MemOptions ) =>
   Proxy# arch ->
   GlobalVar Mem ->
   sym ->
@@ -501,7 +509,8 @@ cprover_assume _mvar sym (Empty :> p) = liftIO $
 
 
 cprover_assert ::
-  (ArchOk arch, IsSymInterface sym, HasLLVMAnn sym) =>
+  ( ArchOk arch, IsSymInterface sym, HasLLVMAnn sym
+  , ?memOpts :: MemOptions ) =>
   Proxy# arch ->
   GlobalVar Mem ->
   sym ->

--- a/crux-llvm/test-data/golden/T783.c
+++ b/crux-llvm/test-data/golden/T783.c
@@ -1,0 +1,14 @@
+struct s {
+  unsigned int a;
+  unsigned int b;
+};
+
+int f() {
+  struct s *ss = malloc(sizeof(struct s));
+  ss->b += 1;
+  return ss->b;
+}
+
+int main() {
+  return f();
+}

--- a/crux-llvm/test-data/golden/T783.config
+++ b/crux-llvm/test-data/golden/T783.config
@@ -1,0 +1,1 @@
+read-unwritten-memory: yes

--- a/crux-llvm/test-data/golden/T783.good
+++ b/crux-llvm/test-data/golden/T783.good
@@ -1,0 +1,1 @@
+[Crux] Overall status: Valid.

--- a/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
@@ -117,6 +117,7 @@ simulateLLVM appCtx modCtx funCtx halloc explRef skipOverrideRef unsoundOverride
       bbMapRef <- newIORef (Map.empty :: LLVMAnnMap sym)
       let ?lc = llvmCtxt ^. llvmTypeCtx
       let ?recordLLVMAnnotation = \an bb -> modifyIORef bbMapRef (Map.insert an bb)
+      let ?memOpts = memOptions
       let simctx =
             (setupSimCtxt halloc sym memOptions (llvmMemVar llvmCtxt))
               { Crucible.printHandle = view outputHandle ?outputConfig
@@ -195,7 +196,7 @@ simulateLLVM appCtx modCtx funCtx halloc explRef skipOverrideRef unsoundOverride
                   -- programs where the vast majority of functions wouldn't be
                   -- called from any particular function. Needs some
                   -- benchmarking.
-                  registerFunctions (modCtx ^. llvmModule) trans
+                  registerFunctions memOptions (modCtx ^. llvmModule) trans
                   let uOverrides = unsoundOverrides trans unsoundOverrideRef
                   sOverrides <-
                     unsoundSkipOverrides


### PR DESCRIPTION
This is an attempt at relaxing Crucible's requirement that all reads must come from previously written memory, as described in #783. The main changes are:

* A new `freshLLVMVal` function, which generates a fresh `LLVMVal` constant based on the `StorageType` supplied as an argument.
* A new `readUnwrittenMemory` option in `MemOptions`, which relaxes the aforementioned requirement.
* The `readMem'` function, which is responsible for throwing the `No previous write to this location was found` error, now takes a `MemOptions` as an implicit argument (which requires quite a bit of plumbing to accomplish). When `readUnwrittenMemory` is set to `True`, instead of failing, `readMem'` will return a value computed by `freshLLVMVal`.