### PR TITLE
Float printf

### DIFF
--- a/crucible-llvm/doc/limitations.md
+++ b/crucible-llvm/doc/limitations.md
@@ -14,3 +14,19 @@ given program are the same size, so it is unlikely that `crucible-llvm` would
 work on code that uses differently sized address spaces. In practice,
 `crucible-llvm` will only look at the part of the data layout which specifies
 the default address space when determining what size pointers should be.
+
+
+Printf accuracy
+=====================
+
+The `printf` implementation provided with `crucible-llvm` makes a
+reasonable effort to implement the various conversion codes, but there
+are some places where the formatting does not strictly conform to
+the specification (most notably, regarding displayed precision for
+floating-point values). We also do not implement the "%a" conversion
+code for binary formatted floating-point values.
+We also will simply print a collection of '?' characters for symbolic
+values.
+
+Thus the exact printed output, number of characters printed, etc,
+may not exactly match that of a conforming implementation.

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libc.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libc.hs
@@ -39,6 +39,7 @@ import           Data.Parameterized.Context ( pattern (:>), pattern Empty )
 import qualified Data.Parameterized.Context as Ctx
 
 import           What4.Interface
+import           What4.InterpretedFloatingPoint (iFloatToReal)
 import           What4.ProgramLoc (plSourceLoc)
 
 import           Lang.Crucible.Backend
@@ -550,9 +551,9 @@ printfOps sym valist =
 
   , printfGetFloat = \i _len ->
      case valist V.!? (i-1) of
-       Just (AnyValue (FloatRepr _fi) _x) ->
-         -- TODO: handle interpreted floats
-         return Nothing
+       Just (AnyValue (FloatRepr (_fi :: FloatInfoRepr fi)) x) ->
+         do xr <- liftIO (iFloatToReal @_ @fi sym x)
+            return (asRational xr)
        Just (AnyValue tpr _) ->
          lift $ addFailedAssertion sym
               $ AssertFailureSimError

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Printf.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Printf.hs
@@ -158,6 +158,16 @@ insertThousands sep = reverse . go . reverse
   go (a:b:c:xs@(_:_)) = a:b:c:sep:go xs
   go xs = xs
 
+
+addLeadingZeros ::
+  Maybe Int -> -- precision
+  String ->
+  String
+addLeadingZeros Nothing digits = digits
+addLeadingZeros (Just p) digits =
+   let n = max 0 (p - length digits) in
+   replicate n '0' ++ digits
+
 formatSignedDec
   :: Integer -- value to format
   -> Int     -- minwidth
@@ -170,11 +180,7 @@ formatSignedDec i minwidth prec flags = do
                | Set.member PrintfPosSpace flags -> " "
                | otherwise -> ""
   let digits = N.showInt (abs i) []
-  let precdigits = case prec of
-                     Just p ->
-                       let n = max 0 (p - length digits) in
-                       replicate n '0' ++ digits
-                     Nothing -> digits
+  let precdigits = addLeadingZeros prec digits
   let sepdigits = if Set.member PrintfThousandsSep flags then
                       insertThousands ',' precdigits -- FIXME, get thousands separator from somewhere?
                   else
@@ -196,11 +202,7 @@ formatUnsignedDec
   -> String
 formatUnsignedDec i minwidth prec flags = do
   let digits = N.showInt (abs i) []
-  let precdigits = case prec of
-                     Just p ->
-                       let n = max 0 (p - length digits) in
-                       replicate n '0' ++ digits
-                     Nothing -> digits
+  let precdigits = addLeadingZeros prec digits
   let sepdigits = if Set.member PrintfThousandsSep flags then
                       insertThousands ',' precdigits -- FIXME, get thousands separator from somewhere?
                   else
@@ -222,11 +224,7 @@ formatOctal
   -> String
 formatOctal i minwidth prec flags = do
   let digits = N.showOct (abs i) []
-  let precdigits = case prec of
-                     Just p ->
-                       let n = max 0 (p - length digits) in
-                       replicate n '0' ++ digits
-                     Nothing -> digits
+  let precdigits = addLeadingZeros prec digits
   let altdigits = if Set.member PrintfAlternateForm flags && head precdigits /= '0' then
                      '0':precdigits
                   else
@@ -248,11 +246,7 @@ formatHex
   -> String
 formatHex i c minwidth prec flags = do
   let digits = N.showHex (abs i) []
-  let precdigits = case prec of
-                     Just p ->
-                        let n = max 0 (p - length digits) in
-                        replicate n '0' ++ digits
-                     Nothing -> digits
+  let precdigits = addLeadingZeros prec digits
   -- Why only add "0x" when i is non-zero?  I have no idea,
   -- that's just what the docs say...
   let altstring = if Set.member PrintfAlternateForm flags && i /= 0 then

--- a/crux-llvm/test-data/golden/golden/floatprint.c
+++ b/crux-llvm/test-data/golden/golden/floatprint.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+
+int main() {
+  float  x = 1.123;
+  double y = 100e5;
+
+  printf("%f %g %.10e\n", (double)x, y, x+y );
+}

--- a/crux-llvm/test-data/golden/golden/floatprint.good
+++ b/crux-llvm/test-data/golden/golden/floatprint.good
@@ -1,0 +1,2 @@
+1.123000 1.000000e7 1.0000001123e7
+[Crux] Overall status: Valid.


### PR DESCRIPTION
Add support for floating-point conversion codes to `crux-llvm`.

This basically just coerces the floating-point value to a real value, and prints it as a rational, if it is concrete.

We still do no have full support for the "%a" conversions (which print bit-exact representations of the float), and some of the formatting does not exactly match a proper printf implementation, but it isn't clear how much we care about those kinds of details.