### PR TITLE
crucible-wasm: Only define ?recordLLVMAnnotation once

### DIFF
--- a/crucible-wasm/src/Lang/Crucible/Wasm.hs
+++ b/crucible-wasm/src/Lang/Crucible/Wasm.hs
@@ -49,6 +49,7 @@ import Lang.Crucible.FunctionHandle
 import Lang.Crucible.Simulator
 import Lang.Crucible.Types
 
+import           Lang.Crucible.LLVM.MemModel (HasLLVMAnn)
 import qualified Lang.Crucible.LLVM.MemModel.Generic as G
 
 import Lang.Crucible.Wasm.Extension
@@ -84,10 +85,12 @@ emptyScriptState =
 
 type WasmOverride p sym = OverrideSim p sym WasmExt (RegEntry sym UnitType)
 
-execScript :: [Wasm.Command] -> ScriptState -> WasmOverride p sym EmptyCtx UnitType ScriptState
+execScript :: HasLLVMAnn sym =>
+              [Wasm.Command] -> ScriptState -> WasmOverride p sym EmptyCtx UnitType ScriptState
 execScript script ss = foldM (flip execCommand) ss script
 
-execCommand :: Wasm.Command -> ScriptState -> WasmOverride p sym EmptyCtx UnitType ScriptState
+execCommand :: HasLLVMAnn sym =>
+               Wasm.Command -> ScriptState -> WasmOverride p sym EmptyCtx UnitType ScriptState
 execCommand (Wasm.ModuleDef mdef) ss =
   do halloc <- use (stateContext . to simHandleAllocator)
      let st = scriptStore ss
@@ -137,6 +140,7 @@ executeStart im =
            callFnVal' (HandleFnVal startFn) Empty
 
 writeDataSegment ::
+  HasLLVMAnn sym =>
   (GlobalVar WasmMem, Word32, LBS.ByteString) ->
   WasmOverride p sym EmptyCtx UnitType ()
 writeDataSegment (mvar, offset, chunk) =

--- a/crucible-wasm/src/Lang/Crucible/Wasm/Extension.hs
+++ b/crucible-wasm/src/Lang/Crucible/Wasm/Extension.hs
@@ -30,7 +30,7 @@ import Lang.Crucible.Simulator.GlobalState
 import Lang.Crucible.Simulator.ExecutionTree
 import Lang.Crucible.Types
 
-import Lang.Crucible.LLVM.MemModel (MemOptions)
+import Lang.Crucible.LLVM.MemModel (HasLLVMAnn, MemOptions)
 
 import Lang.Crucible.Wasm.Instantiate
 import Lang.Crucible.Wasm.Memory
@@ -132,7 +132,8 @@ data WasmStmt (f :: CrucibleType -> Type) :: CrucibleType -> Type where
     !(f (FloatType DoubleFloat)) ->
     WasmStmt f UnitType
 
-extImpl :: MemOptions ->
+extImpl :: HasLLVMAnn sym =>
+           MemOptions ->
            ExtensionImpl p sym WasmExt
 extImpl mo =
   let ?memOpts = mo in
@@ -142,7 +143,7 @@ extImpl mo =
   , extensionExec = evalWasmExt
   }
 
-evalWasmExt :: (?memOpts :: MemOptions) =>
+evalWasmExt :: (HasLLVMAnn sym, ?memOpts :: MemOptions) =>
                EvalStmtFunc p sym WasmExt
 evalWasmExt stmt cst =
   let sym = cst^.stateSymInterface
@@ -152,7 +153,7 @@ type EvalM p sym ext rtp blocks ret args a =
   StateT (CrucibleState p sym ext rtp blocks ret args) IO a
 
 evalStmt :: forall p sym ext rtp blocks ret args tp.
-  (IsSymInterface sym, ?memOpts :: MemOptions) =>
+  (IsSymInterface sym, HasLLVMAnn sym, ?memOpts :: MemOptions) =>
   sym ->
   WasmStmt (RegEntry sym) tp ->
   EvalM p sym ext rtp blocks ret args (RegValue sym tp)

--- a/crucible-wasm/tool/Main.hs
+++ b/crucible-wasm/tool/Main.hs
@@ -40,10 +40,11 @@ setupWasmState :: IsSymInterface sym =>
 setupWasmState sym memOptions s =
   do halloc <- newHandleAllocator
 
+     let ?recordLLVMAnnotation = \_ _ -> pure ()
+     let ?memOpts = memOptions
      let globals = emptyGlobals
      let bindings = emptyHandleMap
      let simctx = initSimContext sym wasmIntrinsicTypes halloc stdout (FnBindings bindings) (extImpl memOptions) Crux.CruxPersonality
-     let ?memOpts = memOptions
      let m = execScript s emptyScriptState >> pure ()
 
      pure (InitialState simctx globals defaultAbortHandler knownRepr (runOverrideSim knownRepr m))


### PR DESCRIPTION
Fixes #791.