### PR TITLE
Guard whether overrides fail on abnormalExitBehavior

### DIFF
--- a/crucible-llvm/crucible-llvm.cabal
+++ b/crucible-llvm/crucible-llvm.cabal
@@ -95,6 +95,7 @@ library
     Lang.Crucible.LLVM.Intrinsics.Libc
     Lang.Crucible.LLVM.Intrinsics.Libcxx
     Lang.Crucible.LLVM.Intrinsics.LLVM
+    Lang.Crucible.LLVM.Intrinsics.Options
     Lang.Crucible.LLVM.MemModel.Common
     Lang.Crucible.LLVM.MemModel.MemLog
     Lang.Crucible.LLVM.MemModel.Options

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics.hs
@@ -69,7 +69,7 @@ llvmIntrinsicTypes =
 -- | Register all declare and define overrides
 register_llvm_overrides ::
   ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch
-  , ?memOpts :: MemOptions ) =>
+  , ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions ) =>
   L.Module ->
   [OverrideTemplate p sym arch rtp l a] {- ^ Additional "define" overrides -} ->
   [OverrideTemplate p sym arch rtp l a] {- ^ Additional "declare" overrides -} ->
@@ -134,7 +134,7 @@ register_llvm_define_overrides llvmModule addlOvrs llvmctx =
 
 register_llvm_declare_overrides ::
   ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch
-  , ?memOpts :: MemOptions ) =>
+  , ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions ) =>
   L.Module ->
   [OverrideTemplate p sym arch rtp l a] ->
   LLVMContext arch ->
@@ -148,7 +148,7 @@ register_llvm_declare_overrides llvmModule addlOvrs llvmctx =
 -- | Register overrides for declared-but-not-defined functions
 declare_overrides ::
   ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch
-  , ?lc :: TypeContext, ?memOpts :: MemOptions ) =>
+  , ?lc :: TypeContext, ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions ) =>
   [OverrideTemplate p sym arch rtp l a]
 declare_overrides =
   [ basic_llvm_override LLVM.llvmLifetimeStartOverride

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics.hs
@@ -28,6 +28,7 @@ module Lang.Crucible.LLVM.Intrinsics
 , llvmDeclToFunHandleRepr
 
 , module Lang.Crucible.LLVM.Intrinsics.Common
+, module Lang.Crucible.LLVM.Intrinsics.Options
 ) where
 
 import           Control.Lens hiding (op, (:>), Empty)
@@ -57,6 +58,7 @@ import           Lang.Crucible.LLVM.Intrinsics.Common
 import qualified Lang.Crucible.LLVM.Intrinsics.LLVM as LLVM
 import qualified Lang.Crucible.LLVM.Intrinsics.Libc as Libc
 import qualified Lang.Crucible.LLVM.Intrinsics.Libcxx as Libcxx
+import           Lang.Crucible.LLVM.Intrinsics.Options
 
 llvmIntrinsicTypes :: IsSymInterface sym => IntrinsicTypes sym
 llvmIntrinsicTypes =

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libc.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libc.hs
@@ -60,6 +60,7 @@ import           Lang.Crucible.LLVM.QQ( llvmOvr )
 import           Lang.Crucible.LLVM.TypeContext
 
 import           Lang.Crucible.LLVM.Intrinsics.Common
+import           Lang.Crucible.LLVM.Intrinsics.Options
 
 ------------------------------------------------------------------------
 -- ** Declarations
@@ -480,7 +481,7 @@ callStrlen sym mvar (regValue -> strPtr) = do
 
 callAssert
   :: ( IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym
-     , ?memOpts :: MemOptions )
+     , ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions )
   => GlobalVar Mem
   -> sym
   -> Ctx.Assignment (RegEntry sym)
@@ -495,7 +496,8 @@ callAssert mvar sym (Empty :> _pfn :> _pfile :> _pline :> ptxt ) =
         let err = AssertFailureSimError "Call to assert()" (UTF8.toString txt)
         liftIO $ addFailedAssertion sym err
 
-callExit :: (IsSymInterface sym)
+callExit :: ( IsSymInterface sym
+            , ?intrinsicsOpts :: IntrinsicsOptions )
          => sym
          -> RegEntry sym (BVType 32)
          -> OverrideSim p sym ext r args ret (RegValue sym UnitType)
@@ -658,7 +660,7 @@ printfOps sym valist =
 -- from OSX libc
 llvmAssertRtnOverride
   :: ( IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym
-     , ?memOpts :: MemOptions )
+     , ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions )
   => LLVMOverride p sym
         (EmptyCtx ::> LLVMPointerType wptr
                   ::> LLVMPointerType wptr
@@ -672,7 +674,7 @@ llvmAssertRtnOverride =
 -- From glibc
 llvmAssertFailOverride
   :: ( IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym
-     , ?memOpts :: MemOptions )
+     , ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions )
   => LLVMOverride p sym
         (EmptyCtx ::> LLVMPointerType wptr
                   ::> LLVMPointerType wptr
@@ -685,7 +687,8 @@ llvmAssertFailOverride =
 
 
 llvmAbortOverride
-  :: (IsSymInterface sym)
+  :: ( IsSymInterface sym
+     , ?intrinsicsOpts :: IntrinsicsOptions )
   => LLVMOverride p sym EmptyCtx UnitType
 llvmAbortOverride =
   [llvmOvr| void @abort() |]
@@ -698,7 +701,8 @@ llvmAbortOverride =
 
 llvmExitOverride
   :: forall sym p
-   . (IsSymInterface sym)
+   . ( IsSymInterface sym
+     , ?intrinsicsOpts :: IntrinsicsOptions )
   => LLVMOverride p sym
          (EmptyCtx ::> BVType 32)
          UnitType

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Options.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Options.hs
@@ -1,0 +1,48 @@
+------------------------------------------------------------------------
+-- |
+-- Module           : Lang.Crucible.LLVM.Intrinsics.Options
+-- Description      : Definition of options that affect LLVM overrides
+-- Copyright        : (c) Galois, Inc 2021
+-- License          : BSD3
+-- Maintainer       : Rob Dockins <rdockins@galois.com>
+-- Stability        : provisional
+------------------------------------------------------------------------
+module Lang.Crucible.LLVM.Intrinsics.Options
+  ( IntrinsicsOptions(..)
+  , AbnormalExitBehavior(..)
+  , defaultIntrinsicsOptions
+  ) where
+
+-- | Should Crucible fail when simulating a function which triggers an abnormal
+-- exit, such as @abort()@?
+data AbnormalExitBehavior
+  = AlwaysFail
+    -- ^ Functions which trigger an abnormal exit will always cause Crucible
+    --   to fail.
+  | OnlyAssertFail
+    -- ^ The @__assert_fail()@ function will cause Crucible to fail, while
+    --   other functions which triggern an abnormal exit will not cause
+    --   failures. This option is primarily useful for SV-COMP.
+  | NeverFail
+    -- ^ Functions which trigger an abnormal exit will never cause Crucible
+    --   to fail. This option is primarily useful for SV-COMP.
+  deriving Eq
+
+-- | This datatype encodes a variety of tweakable settings that to LLVM
+--   overrides.
+newtype IntrinsicsOptions
+  = IntrinsicsOptions
+    { abnormalExitBehavior :: AbnormalExitBehavior
+      -- ^ Should Crucible fail when simulating a function which triggers an
+      --   abnormal exit, such as @abort()@?
+    }
+
+-- | The default translation options:
+--
+-- * Functions which trigger an abnormal exit will always cause Crucible
+--   to fail.
+defaultIntrinsicsOptions :: IntrinsicsOptions
+defaultIntrinsicsOptions =
+  IntrinsicsOptions
+  { abnormalExitBehavior = AlwaysFail
+  }

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Options.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Options.hs
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------
 -- |
--- Module           : Lang.Crucible.LLVM.MemModel.Options
+-- Module           : Lang.Crucible.LLVM.Translation.Options
 -- Description      : Definition of options that can be tweaked during LLVM translation
 -- Copyright        : (c) Galois, Inc 2021
 -- License          : BSD3

--- a/crux-llvm/src/Crux/LLVM/Overrides.hs
+++ b/crux-llvm/src/Crux/LLVM/Overrides.hs
@@ -77,7 +77,7 @@ type TBits n        = BVType n
 
 cruxLLVMOverrides ::
   ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch
-  , ?lc :: TypeContext, ?memOpts :: MemOptions ) =>
+  , ?lc :: TypeContext, ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions ) =>
   Proxy# arch ->
   [OverrideTemplate (personality sym) sym arch rtp l a]
 cruxLLVMOverrides arch =
@@ -152,7 +152,7 @@ cruxLLVMOverrides arch =
 
 cbmcOverrides ::
   ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch
-  , ?lc :: TypeContext, ?memOpts :: MemOptions ) =>
+  , ?lc :: TypeContext, ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions ) =>
   Proxy# arch ->
   [OverrideTemplate (personality sym) sym arch rtp l a]
 cbmcOverrides arch =
@@ -245,7 +245,8 @@ cbmcOverrides arch =
 
 
 svCompOverrides ::
-  (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr) =>
+  ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
+  , ?intrinsicsOpts :: IntrinsicsOptions ) =>
   [OverrideTemplate (personality sym) sym arch rtp l a]
 svCompOverrides =
   [ basic_llvm_override $
@@ -453,7 +454,7 @@ do_assume arch mvar sym (Empty :> p :> pFile :> line) =
 
 do_assert ::
   ( ArchOk arch, IsSymInterface sym, HasLLVMAnn sym
-  , ?memOpts :: MemOptions ) =>
+  , ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions ) =>
   Proxy# arch ->
   GlobalVar Mem ->
   sym ->
@@ -510,7 +511,7 @@ cprover_assume _mvar sym (Empty :> p) = liftIO $
 
 cprover_assert ::
   ( ArchOk arch, IsSymInterface sym, HasLLVMAnn sym
-  , ?memOpts :: MemOptions ) =>
+  , ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions ) =>
   Proxy# arch ->
   GlobalVar Mem ->
   sym ->
@@ -559,7 +560,8 @@ sv_comp_assume _mvar sym (Empty :> p) = liftIO $
      addAssumption sym (GenericAssumption loc "__VERIFIER_assume" cond)
 
 sv_comp_assert ::
-  (IsSymInterface sym) =>
+  ( IsSymInterface sym
+  , ?intrinsicsOpts :: IntrinsicsOptions ) =>
   GlobalVar Mem ->
   sym ->
   Assignment (RegEntry sym) (EmptyCtx ::> TBits 32) ->
@@ -571,7 +573,8 @@ sv_comp_assert _mvar sym (Empty :> p) = liftIO $
      addDurableAssertion sym (LabeledPred cond (SimError loc msg))
 
 sv_comp_error ::
-  (IsSymInterface sym) =>
+  ( IsSymInterface sym
+  , ?intrinsicsOpts :: IntrinsicsOptions ) =>
   GlobalVar Mem ->
   sym ->
   Assignment (RegEntry sym) EmptyCtx ->

--- a/crux-llvm/src/Crux/LLVM/Simulate.hs
+++ b/crux-llvm/src/Crux/LLVM/Simulate.hs
@@ -113,15 +113,16 @@ parseLLVM file =
 
 registerFunctions ::
   (ArchOk arch, IsSymInterface sym, HasLLVMAnn sym, ptrW ~ ArchWidth arch) =>
-  MemOptions ->
+  LLVMOptions ->
   LLVM.Module ->
   ModuleTranslation arch ->
   Maybe (LLVMFileSystem ptrW) ->
   OverM Crux sym LLVM ()
-registerFunctions memOptions llvm_module mtrans fs0 =
+registerFunctions llvmOpts llvm_module mtrans fs0 =
   do let llvm_ctx = mtrans ^. transContext
      let ?lc = llvm_ctx ^. llvmTypeCtx
-         ?memOpts = memOptions
+         ?intrinsicsOpts = intrinsicsOpts llvmOpts
+         ?memOpts = memOpts llvmOpts
 
      -- register the callable override functions
      register_llvm_overrides llvm_module []
@@ -186,7 +187,7 @@ setupFileSim halloc llvm_file llvmOpts sym _maybeOnline =
          InitialState simctx globSt' defaultAbortHandler UnitRepr $
            runOverrideSim UnitRepr $
              withPtrWidth ptrW $
-                do registerFunctions (memOpts llvmOpts) (prepLLVMMod prepped) trans (Just fs0)
+                do registerFunctions llvmOpts (prepLLVMMod prepped) trans (Just fs0)
                    initFSOverride
                    checkFun (entryPoint llvmOpts) (cfgMap trans)
 

--- a/crux-llvm/test-data/golden/T785a.c
+++ b/crux-llvm/test-data/golden/T785a.c
@@ -1,0 +1,28 @@
+#include <assert.h>
+#include <crucible.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+extern void __CPROVER_assert(int32_t, const char *);
+extern void __VERIFIER_assert(int32_t);
+extern void __VERIFIER_error();
+
+int main() {
+  if (crucible_int8_t("test_abort")) {
+    abort();
+  } else if (crucible_int8_t("test_exit")) {
+    exit(1);
+  } else if (crucible_int8_t("test_assert_fail")) {
+    __assert_fail("0", "T785a.c", 16, "__assert_fail");
+  } else if (crucible_int8_t("test_crucible_assert")) {
+    crucible_assert(0, "T785a.c", 18);
+  } else if (crucible_int8_t("test_CPROVER_assert")) {
+    __CPROVER_assert(0, "__CPROVER_assert");
+  } else if (crucible_int8_t("test_VERIFIER_assert")) {
+    __VERIFIER_assert(0);
+  } else if (crucible_int8_t("test_VERIFIER_error")) {
+    __VERIFIER_error();
+  }
+
+  return 0;
+}

--- a/crux-llvm/test-data/golden/T785a.config
+++ b/crux-llvm/test-data/golden/T785a.config
@@ -1,0 +1,1 @@
+abnormal-exit-behavior: never-fail

--- a/crux-llvm/test-data/golden/T785a.good
+++ b/crux-llvm/test-data/golden/T785a.good
@@ -1,0 +1,1 @@
+[Crux] Overall status: Valid.

--- a/crux-llvm/test-data/golden/T785b.c
+++ b/crux-llvm/test-data/golden/T785b.c
@@ -1,0 +1,28 @@
+#include <assert.h>
+#include <crucible.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+extern void __CPROVER_assert(int32_t, const char *);
+extern void __VERIFIER_assert(int32_t);
+extern void __VERIFIER_error();
+
+int main() {
+  if (crucible_int8_t("test_abort")) {
+    abort();
+  } else if (crucible_int8_t("test_exit")) {
+    exit(1);
+  } else if (crucible_int8_t("test_assert_fail")) {
+    __assert_fail("0", "T785b.c", 16, "__assert_fail");
+  } else if (crucible_int8_t("test_crucible_assert")) {
+    crucible_assert(0, "T785b.c", 18);
+  } else if (crucible_int8_t("test_CPROVER_assert")) {
+    __CPROVER_assert(0, "__CPROVER_assert");
+  } else if (crucible_int8_t("test_VERIFIER_assert")) {
+    __VERIFIER_assert(0);
+  } else if (crucible_int8_t("test_VERIFIER_error")) {
+    __VERIFIER_error();
+  }
+
+  return 0;
+}

--- a/crux-llvm/test-data/golden/T785b.config
+++ b/crux-llvm/test-data/golden/T785b.config
@@ -1,0 +1,2 @@
+abnormal-exit-behavior: only-assert-fail
+make-executables: no

--- a/crux-llvm/test-data/golden/T785b.good
+++ b/crux-llvm/test-data/golden/T785b.good
@@ -1,0 +1,6 @@
+[Crux] Found counterexample for verification goal
+[Crux]   test-data/golden/T785b.c:16:5: error: in main
+[Crux]   Call to assert()
+[Crux]   Details:
+[Crux]     __assert_fail
+[Crux] Overall status: Invalid.

--- a/uc-crux-llvm/src/UCCrux/LLVM/Run/Loop.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Run/Loop.hs
@@ -29,7 +29,7 @@ import qualified Lang.Crucible.CFG.Core as Crucible
 import qualified Lang.Crucible.FunctionHandle as Crucible
 
 -- crucible-llvm
-import Lang.Crucible.LLVM.MemModel (MemOptions, withPtrWidth)
+import Lang.Crucible.LLVM.MemModel (withPtrWidth)
 import Lang.Crucible.LLVM.Extension( LLVM )
 import Lang.Crucible.LLVM.Translation (llvmPtrWidth, transContext)
 
@@ -38,7 +38,7 @@ import Crux.Config.Common
 import Crux.Log as Crux
 
  -- local
-import Crux.LLVM.Config (throwCError, CError(MissingFun), memOpts)
+import Crux.LLVM.Config (LLVMOptions, throwCError, CError(MissingFun))
 import Crux.LLVM.Overrides
 
 import           UCCrux.LLVM.Classify.Types (partitionExplanations)
@@ -67,13 +67,13 @@ bugfindingLoop ::
   FunctionContext m arch argTypes ->
   Crucible.CFG LLVM blocks (MapToCrucibleType arch argTypes) ret ->
   CruxOptions ->
-  MemOptions ->
+  LLVMOptions ->
   Crucible.HandleAllocator ->
   IO (BugfindingResult m arch argTypes)
-bugfindingLoop appCtx modCtx funCtx cfg cruxOpts memOptions halloc =
+bugfindingLoop appCtx modCtx funCtx cfg cruxOpts llvmOpts halloc =
   do
     let runSim preconds =
-          Sim.runSimulator appCtx modCtx funCtx halloc preconds cfg cruxOpts memOptions
+          Sim.runSimulator appCtx modCtx funCtx halloc preconds cfg cruxOpts llvmOpts
 
     -- Loop, learning preconditions and reporting errors
     let loop truePositives constraints precondTags unsoundness =
@@ -166,7 +166,7 @@ loopOnFunction appCtx modCtx halloc cruxOpts ucOpts fn =
                           funCtx
                           cfg
                           cruxOpts
-                          (memOpts (Config.ucLLVMOptions ucOpts))
+                          (Config.ucLLVMOptions ucOpts)
                           halloc
             )
       )


### PR DESCRIPTION
This commit adds a new `IntrinsicsOptions` data type which allows fine tuning the behavior of LLVM overrides. Currently, there is only one option, `abnormalExitBehavior`, which controls the behavior of functions which abnormally end execution (e.g., `abort()`). There are currently three options: `AlwaysFail` (the default), `OnlyAssertFail` (which fails if the function in question is `__assert_fail()`, and does not fail otherwise), and `NeverFail` (which is like `OnlyAssertFail` without the special case for `__assert_fail()`). The special case for `__assert_fail()` is motivated by SV-COMP's `unreach-call` category, where the `reach_error` function (implemented in terms of `__assert_fail()`) indicates failure, a status no other function (not even `abort()` etc.) enjoy.

The last commit, with the same title as this PR, contains the interesting part of the pull request. The remaining commits are mostly plumbing.

Fixes #785.