### PR TITLE
crux-llvm: Remove overrides for `__VERIFIER_{assert,assume,error}`

### DIFF
--- a/crux-llvm/README.md
+++ b/crux-llvm/README.md
@@ -146,19 +146,10 @@ properties of a program that you would like to prove.
   succeed.
 
 For programs that have been written for the [SV-COMP
-competition](https://sv-comp.sosy-lab.org/), the following alternative
-API is available.
-
-* The `__VERIFIER_assume` function is equivalent to `crucible_assume`,
-  but does not take location information as an argument.
-
-* The `__VERIFIER_error` function indicates that correct control flow
-  should never reach the point of the call. It is equivalent to
-  `check(0)`.
-
-* The `__VERIFIER_nondet_*` functions create non-deterministic values of
-  the corresponding type. These symbolic values all have the name `x`.
-  To supply distinct names, use the `crucible_*_t` functions, instead.
+competition](https://sv-comp.sosy-lab.org/), the `__VERIFIER_nondet_*`
+functions create non-deterministic values of the corresponding type.
+These symbolic values all have the name `x`. To supply distinct names,
+use the `crucible_*_t` functions, instead.
 
 Note that support for the SV-COMP API exists primarily for backward
 compatibility, since a large number of benchmarks already exist in that
@@ -249,7 +240,7 @@ In addition, the following flags can optionally be provided:
 
 * `--sim-verbose=NUM`, `-d NUM`: Set the verbosity level of the symbolic
   simulator to `N`.
-  
+
 * `--floating-point=FPREP`, `-f FPREP`: Select the floating point
   representation to use. The value of `FPREP` can be one of `real`,
   `ieee`, `uninterpreted`, or `default`. Default representation is
@@ -303,7 +294,7 @@ In addition, the following flags can optionally be provided:
 
 * `--goal-timeout=N`: Set the timeout for each call to the SMT solver to
   `N` seconds.
-  
+
 * `--hash-consing`: Enable hash-consing in the symbolic expression
   backend.
 

--- a/crux-llvm/c-src/concrete-backend.c
+++ b/crux-llvm/c-src/concrete-backend.c
@@ -41,7 +41,5 @@ char           __VERIFIER_nondet_char (void)   { return crucible_int8_t("x");  }
 int            __VERIFIER_nondet_bool (void)   { return crucible_int32_t("x"); }
 float          __VERIFIER_nondet_float (void)  { return crucible_float("x");   }
 double         __VERIFIER_nondet_double (void) { return crucible_double("x");  }
-void           __VERIFIER_assume(int x)        { crucible_assume(x, "??", 0);  }
-void           __VERIFIER_error(void)          { crucible_assert(0, "??", 0);  }
 
 

--- a/crux-llvm/test-data/golden/T785a.c
+++ b/crux-llvm/test-data/golden/T785a.c
@@ -4,8 +4,6 @@
 #include <stdlib.h>
 
 extern void __CPROVER_assert(int32_t, const char *);
-extern void __VERIFIER_assert(int32_t);
-extern void __VERIFIER_error();
 
 int main() {
   if (crucible_int8_t("test_abort")) {
@@ -18,10 +16,6 @@ int main() {
     crucible_assert(0, "T785a.c", 18);
   } else if (crucible_int8_t("test_CPROVER_assert")) {
     __CPROVER_assert(0, "__CPROVER_assert");
-  } else if (crucible_int8_t("test_VERIFIER_assert")) {
-    __VERIFIER_assert(0);
-  } else if (crucible_int8_t("test_VERIFIER_error")) {
-    __VERIFIER_error();
   }
 
   return 0;

--- a/crux-llvm/test-data/golden/T785b.c
+++ b/crux-llvm/test-data/golden/T785b.c
@@ -4,8 +4,6 @@
 #include <stdlib.h>
 
 extern void __CPROVER_assert(int32_t, const char *);
-extern void __VERIFIER_assert(int32_t);
-extern void __VERIFIER_error();
 
 int main() {
   if (crucible_int8_t("test_abort")) {
@@ -18,10 +16,6 @@ int main() {
     crucible_assert(0, "T785b.c", 18);
   } else if (crucible_int8_t("test_CPROVER_assert")) {
     __CPROVER_assert(0, "__CPROVER_assert");
-  } else if (crucible_int8_t("test_VERIFIER_assert")) {
-    __VERIFIER_assert(0);
-  } else if (crucible_int8_t("test_VERIFIER_error")) {
-    __VERIFIER_error();
   }
 
   return 0;

--- a/crux-llvm/test-data/golden/T785b.good
+++ b/crux-llvm/test-data/golden/T785b.good
@@ -1,5 +1,5 @@
 [Crux] Found counterexample for verification goal
-[Crux]   test-data/golden/T785b.c:16:5: error: in main
+[Crux]   test-data/golden/T785b.c:14:5: error: in main
 [Crux]   Call to assert()
 [Crux]   Details:
 [Crux]     __assert_fail

--- a/crux-llvm/tests/sv-comp/byte_add.c
+++ b/crux-llvm/tests/sv-comp/byte_add.c
@@ -1,15 +1,13 @@
-
-extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+/* emulates multi-precision addition */
+#include <assert.h>
 
 extern unsigned int __VERIFIER_nondet_uint(void);
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
-    ERROR: __VERIFIER_error();
+    ERROR: assert(0);
   }
   return;
 }
-/* emulates multi-precision addition */
-#include <assert.h>
 
 unsigned int mp_add(unsigned int a, unsigned int b)
 {
@@ -54,7 +52,7 @@ unsigned int mp_add(unsigned int a, unsigned int b)
             }
         }
     }
-    
+
     carry = (unsigned short)0;
     i = (unsigned char)0;
     while ((i < na) || (i < nb) || (carry != (unsigned short)0)) {
@@ -81,7 +79,7 @@ unsigned int mp_add(unsigned int a, unsigned int b)
         if (i == (unsigned char)0) { r0 = (unsigned char)partial_sum; }
         if (i == (unsigned char)1) { r1 = (unsigned char)partial_sum; }
         if (i == (unsigned char)2) { r2 = (unsigned char)partial_sum; }
-        if (i == (unsigned char)3) { r3 = (unsigned char)partial_sum; }        
+        if (i == (unsigned char)3) { r3 = (unsigned char)partial_sum; }
 
         i = i + (unsigned char)1;
     }
@@ -114,6 +112,6 @@ int main()
     r = mp_add(a, b);
 
     __VERIFIER_assert(r == a + b);
-    
+
     return 0;
 }

--- a/crux-llvm/tests/sv-comp/modulus.c
+++ b/crux-llvm/tests/sv-comp/modulus.c
@@ -1,15 +1,19 @@
-extern void __VERIFIER_assume(int);
-extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+/* https://graphics.stanford.edu/~seander/bithacks.html#ModulusDivisionEasy */
+#include <assert.h>
+
+void __VERIFIER_assume(int cond) {
+  if (!cond) {
+    abort();
+  }
+}
 
 extern unsigned int __VERIFIER_nondet_uint(void);
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
-    ERROR: __VERIFIER_error();
+    ERROR: assert(0);
   }
   return;
 }
-/* https://graphics.stanford.edu/~seander/bithacks.html#ModulusDivisionEasy */
-#include <assert.h>
 
 int main()
 {

--- a/crux-llvm/tests/sv-comp/modulus.config
+++ b/crux-llvm/tests/sv-comp/modulus.config
@@ -1,0 +1,1 @@
+abnormal-exit-behavior: only-assert-fail

--- a/crux-llvm/tests/sv-comp/parity.c
+++ b/crux-llvm/tests/sv-comp/parity.c
@@ -1,14 +1,13 @@
-extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+/* see https://graphics.stanford.edu/~seander/bithacks.html#ParityNaive */
+#include <assert.h>
 
 extern unsigned int __VERIFIER_nondet_uint(void);
 void __VERIFIER_assert(int cond) {
   if (!(cond)) {
-    ERROR: __VERIFIER_error();
+    ERROR: assert(0);
   }
   return;
 }
-/* see https://graphics.stanford.edu/~seander/bithacks.html#ParityNaive */
-#include <assert.h>
 
 int main()
 {

--- a/crux-llvm/tests/sv-comp/simple_float.c
+++ b/crux-llvm/tests/sv-comp/simple_float.c
@@ -1,8 +1,14 @@
-extern float __VERIFIER_nondet_float(void);
-extern void __VERIFIER_assume(int cond);
-extern void __VERIFIER_assert(int cond);
-
 #include <assert.h>
+
+extern float __VERIFIER_nondet_float(void);
+void __VERIFIER_assume(int cond) {
+  if (!cond) {
+    abort();
+  }
+}
+void __VERIFIER_assert(int cond) {
+  assert(cond);
+}
 
 int main()
 {

--- a/crux-llvm/tests/sv-comp/simple_float.config
+++ b/crux-llvm/tests/sv-comp/simple_float.config
@@ -1,0 +1,1 @@
+abnormal-exit-behavior: only-assert-fail


### PR DESCRIPTION
This affects a couple of test cases in `test-data`, as well as some tests under `tests` (for which I made a best-effort attempt to repair them).

Fixes #804.