### PR TITLE
Overhaul crux-llvm-svcomp to fit in with SV-COMP's benchmark harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,11 @@ In addition, there are the following library/executable packages:
  * **`crux-llvm`**, a standalone frontend for executing C and C++ programs
    in the crucible symbolic simulator.  The front-end invokes `clang`
    to produce LLVM bitcode, and runs the resulting programs using
-   the `crucible-llvm` language frontend.  Programs interact directly
-   with the symbolic simulator using the protocol established for
-   the [SV-COMP][sv-comp] competition. See [here](crux-llvm/README.md) for
-   more details.
+   the `crucible-llvm` language frontend.
+
+ * **`crux-llvm-svcomp`**, an alternative entrypoint to `crux-llvm`
+   that uses the protocol established for the [SV-COMP][sv-comp] competition.
+   See [here](crux-llvm/README.md) for more details.
 
 [sv-comp]: https://sv-comp.sosy-lab.org
 

--- a/crux-llvm/crux-llvm.cabal
+++ b/crux-llvm/crux-llvm.cabal
@@ -20,16 +20,16 @@ Description:
   .
   * a Haskell library with the core functionality,
   .
-  * a crux-llvm executable used to run the verification when given one
+  * a @crux-llvm@ executable used to run the verification when given one
     or more C or C++ source files
   .
   * a set of supplemental C source files, include files, and LLVM
     runtime library bitcode files to use for building the input C
     files into verifiable LLVM BC files.
   .
-  * a crux-llvm-svcomp that is designed to run verification on the set
-    of challenge inputs for the SV-COMP competition and generate
-    benchmark results.
+  * a @crux-llvm-svcomp@ executable that is designed to run verification
+    of challenge inputs for the SV-COMP competition, generating
+    results tailored to the format that SV-COMP expects.
 
 
 data-files:
@@ -151,18 +151,15 @@ executable crux-llvm-svcomp
   hs-source-dirs: svcomp
   main-is: Main.hs
 
-  if os(windows)
-    buildable: False
-
   build-depends:
-    aeson >= 1.4.7,
-    attoparsec >= 0.13,
-    async >= 2.2,
-    ansi-terminal,
+    aeson,
+    attoparsec,
+    base16-bytestring,
     crux-llvm,
-    lumberjack,
-    time,
-    unix
+    cryptohash-sha256,
+    extra,
+    indexed-traversable,
+    time
 
   other-modules:
     SVComp.Log

--- a/crux-llvm/svcomp/.gitignore
+++ b/crux-llvm/svcomp/.gitignore
@@ -1,0 +1,3 @@
+clang/*
+crux-llvm-svcomp-*-Linux-x86_64/*
+crux-llvm-svcomp-*-Linux-x86_64.zip

--- a/crux-llvm/svcomp/Main.hs
+++ b/crux-llvm/svcomp/Main.hs
@@ -1,57 +1,70 @@
 {- | This is the SVCOMP utility for crux-llvm.  It is designed to run
-   the inputs for the "Competition on Software Verification" (SV-COMP)
-   and produce benchmark data for that run.
+   the inputs for the "Competition on Software Verification" (SV-COMP).
+   Specifically, it takes as inputs:
+
+   * A file containing a specification to check, and
+
+   * An architecture (either @32bit@ or @64bit@) to assume, and
+
+   * A input C file.
+
+   It will then attempt to verify the file against that specification,
+   eventually printing @VERIFIED@, @FALSIFIED@, or @UNKNOWN@ depending on the
+   results. If the result is @VERIFIED@ or @FALSFIED@, it will also produce a
+   witness automaton which represents a proof that the program does or does not
+   meet the specification.
 -}
 
 {-# Language DeriveAnyClass #-}
 {-# Language DeriveGeneric #-}
 {-# Language ImplicitParams #-}
-{-# Language LambdaCase #-}
 {-# Language OverloadedStrings #-}
 {-# Language RankNTypes #-}
-{-# Language RecordWildCards #-}
-{-# Language ScopedTypeVariables #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Main (main) where
 
-import Control.Concurrent.Async( async, wait )
-import Control.Exception
-  (bracket, catch, throwIO, SomeException, fromException, AsyncException, displayException, try )
+import Control.Applicative ( Alternative(..) )
+import Control.Exception ( SomeException, try )
+import Control.Monad.Extra ( whenJust )
+import qualified Crypto.Hash.SHA256 as SHA256 ( hash )
+import Data.Aeson ( ToJSON )
+import qualified Data.Attoparsec.Text as Atto
+import qualified Data.ByteString.Base16 as B16 ( encode )
+import qualified Data.ByteString.Char8 as B ( readFile, unpack )
+import Data.Foldable ( traverse_, toList )
+import Data.Function ( on )
+import Data.Functor.Identity ( Identity(..) )
+import Data.Functor.WithIndex ( FunctorWithIndex(..) )
+import qualified Data.List.Extra as L
+import Data.Maybe ( mapMaybe )
+import Data.Sequence ( Seq )
 import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+import Data.Time.LocalTime ( getZonedTime )
+import Data.Version ( showVersion )
+import GHC.Generics ( Generic )
+import System.Exit ( exitFailure, exitSuccess )
+import System.FilePath ( (</>), takeBaseName )
 
-import Data.Aeson ( encode, ToJSON(..), FromJSON, ToJSONKey, eitherDecode', object )
-import Data.Bits( bit )
-import qualified Data.ByteString.Lazy as LBS
-import GHC.Generics (Generic)
-import Data.List
-  ( isSuffixOf )
-import qualified Data.Map as Map
-import Data.Time.Clock
-  ( getCurrentTime, diffUTCTime, NominalDiffTime )
-import System.Exit
-  ( ExitCode(..), exitSuccess, exitFailure )
-import System.FilePath ( takeFileName, takeDirectory, (</>), (-<.>) )
-import System.Directory ( copyFile, createDirectoryIfMissing, removeDirectoryRecursive )
-import System.IO
-  ( Handle, hGetContents, hClose, openFile, IOMode(..), hFlush )
-
--- unix
-import System.Posix.IO
-import System.Posix.Process
-import System.Posix.Resource
+-- crucible
+import Lang.Crucible.Backend ( CrucibleEvent(..) )
 
 -- crux
 import qualified Crux
-import Crux.Config.Common(CruxOptions(..))
+import Crux.Config.Common ( CruxOptions(..) )
 import qualified Crux.Log as Log
 import Crux.Report
-import Crux.SVCOMP
+import Crux.SVCOMP hiding (SVCompLanguage(..))
+import Crux.SVCOMP.Witness
 import Crux.Types as Crux
 
+-- what4
+import What4.Expr.GroundEval ( GroundValueWrapper )
+import What4.ProgramLoc ( Position(..), ProgramLoc, plFunction, plSourceLoc )
+
 -- local
-import Crux.LLVM.Config
 import Crux.LLVM.Compile
+import Crux.LLVM.Config
 import qualified Crux.LLVM.Log as Log
 import Crux.LLVM.Simulate
 import CruxLLVMMain ( processLLVMOptions )
@@ -88,301 +101,144 @@ main = withSVCompLogging $ do
   Crux.loadOptions (Crux.defaultOutputConfig svCompLoggingToSayWhat) "crux-llvm-svcomp" version opts
     $ \(co0,(lo0,svOpts)) ->
     do (cruxOpts, llvmOpts) <- processLLVMOptions (co0{ outDir = "results" </> "SVCOMP" },lo0)
-       bss <- loadSVCOMPBenchmarks cruxOpts
-       let taskMap = deduplicateTasks bss
-       ts <- genSVCOMPBitCode cruxOpts llvmOpts svOpts taskMap
-       evaluateBenchmarkLLVM cruxOpts llvmOpts svOpts ts
+       svOpts' <- processSVCOMPOptions svOpts
+       let tgt = case runIdentity $ svcompArch svOpts' of
+                   Arch32 -> "i386-unknown-linux-elf"
+                   Arch64 -> "x86_64-unknown-linux-elf"
+           llvmOpts' = llvmOpts { targetArch = Just tgt }
+       processInputFiles cruxOpts llvmOpts' svOpts'
 
+processInputFiles :: Log.Logs msgs
+                  => Log.SupportsCruxLLVMLogMessage msgs
+                  => Log.SupportsSVCompLogMessage msgs
+                  => CruxOptions -> LLVMOptions -> SVCOMPOptions Identity
+                  -> IO ()
+processInputFiles cruxOpts llvmOpts svOpts =
+  traverse_ process $ Crux.inputFiles cruxOpts
+  where
+    process :: FilePath -> IO ()
+    process inputFile = do
+      mbBcFile <- genBitCodeMaybe inputFile
+      whenJust mbBcFile $ \bcFile ->
+        evaluateBitCode inputFile bcFile
 
+    genBitCodeMaybe :: FilePath -> IO (Maybe FilePath)
+    genBitCodeMaybe inputFile
+      | or [ L.isSuffixOf bl inputFile | bl <- svcompBlacklist svOpts ]
+      = do Log.saySVComp (Log.Skipping Log.DueToBlacklist (T.pack inputFile))
+           return Nothing
+      | otherwise
+      = Just <$> genBitCode cruxOpts llvmOpts
 
-genSVCOMPBitCode :: forall msgs
-                  . Log.Logs msgs
-                 => Log.SupportsCruxLLVMLogMessage msgs
-                 => Log.SupportsSVCompLogMessage msgs
-                 => CruxOptions -> LLVMOptions -> SVCOMPOptions -> TaskMap
-                 -> IO [(Int, VerificationTask, Either SomeException FilePath)]
-genSVCOMPBitCode cruxOpts llvmOpts svOpts tm = concat <$> mapM goTask (zip [0::Int ..] (Map.toList tm))
- where
- goTask :: Log.SupportsSVCompLogMessage msgs
-        => (Int, (VerificationTask, [BenchmarkSet]))
-        -> IO [(Int, VerificationTask, Either SomeException FilePath)]
- goTask (n, (task, bss)) =
-   action `catch` handler
-   where
-   outputPath = svTaskDirectory (Crux.outDir cruxOpts) n task
-
-   action =
-     do tgt <- getTarget task bss
-        rslt <- processVerificationTask tgt n task
-        return $! maybe [] (\outFile -> [(n, task, Right outFile)]) rslt
-
-   handler e
-     | Just (_::AsyncException) <- fromException e = throwIO e
-     | otherwise =
-         do Log.saySVComp (Log.FailedToCompileTask (T.pack (verificationSourceFile task)))
-            Log.logException e
-            removeDirectoryRecursive outputPath `catch` \e' -> do
-               Log.saySVComp (Log.DoubleFaultWhileTryingToRemove (T.pack outputPath))
-               Log.logException (e'::SomeException)
-            return [(n, task, Left e)]
-
-
- getTarget task bss =
-   case verificationLanguage task of
-     C ILP32 -> return "i386-unknown-linux-elf"
-     C LP64  -> return "x86_64-unknown-linux-elf"
-     Java    -> fail $ "Cannot handle Java benchmark(s) " ++ show (map benchmarkName bss)
-
- processVerificationTask _tgt _num task
-   | or [ isSuffixOf bl (verificationSourceFile task) | bl <- svcompBlacklist svOpts ]
-   = do Log.saySVComp (Log.Skipping Log.DueToBlacklist (T.pack (verificationSourceFile task)))
-        return Nothing
-
- processVerificationTask tgt num task =
-   let files = verificationInputFiles task in
-     if null files
-     then do Log.saySVComp (Log.Skipping Log.NoInputFiles (T.pack (verificationSourceFile task)))
-             return Nothing
-     else
-       do let taskFile = verificationSourceFile task
-              inputBase = takeDirectory taskFile
-              outputPath  = svTaskDirectory (Crux.outDir cruxOpts) num task
-              llvmOpts' = llvmOpts { targetArch = Just tgt }
-              cruxOpts' = cruxOpts { bldDir = outputPath }
-              outName = "svcomp~" <> head files -<.> ".bc"
-          createDirectoryIfMissing True outputPath
-          copyFile taskFile (outputPath </> takeFileName taskFile)
-          Just <$> genBitCodeToFile outName ((inputBase </>) <$> files) cruxOpts' llvmOpts' True
-
-
-svTaskDirectory :: FilePath -> Int -> VerificationTask -> FilePath
-svTaskDirectory base num task = base </> path
- where
- files = verificationInputFiles task
- path  = padTaskNum ++ filebase files
-
- padWidth = 5
-
- filebase [] = ""
- filebase (f:_) = '_' : takeFileName f
-
- padTaskNum = padding ++ xs
-   where
-   padding = replicate (padWidth - length xs) '0'
-   xs = show num
-
-hGetContentsStrict :: Handle -> IO String
-hGetContentsStrict hdl =
-  do s <- hGetContents hdl
-     length s `seq` return s
-
-evaluateBenchmarkLLVM :: Crux.Logs SVCompLogging
-                      => CruxOptions -> LLVMOptions -> SVCOMPOptions
-                      -> [(Int, VerificationTask, Either SomeException FilePath)]
-                      -> IO ()
-evaluateBenchmarkLLVM cruxOpts llvmOpts svOpts ts =
-   bracket (openFile (svcompOutputFile svOpts) WriteMode)
-           (\jsonOutHdl -> LBS.hPutStr jsonOutHdl "]\n" >> hClose jsonOutHdl)
-           (\jsonOutHdl -> mapM_ (evaluateVerificationTask jsonOutHdl) ts)
-
- where
- megabyte = bit 20 :: Integer
-
- maybeSetLim _ Nothing = return ()
- maybeSetLim res (Just lim) =
-   setResourceLimit res (ResourceLimits (ResourceLimit lim) ResourceLimitUnknown)
-
- root = Crux.outDir cruxOpts
-
- evaluateVerificationTask jsonOutHdl (num, task, compileErrOrOutFile) =
-   withSVCompLogging $
-    do ed <- case compileErrOrOutFile of
-         Left ex ->
-           failTask num task "Failed to compile task" ex
-         Right inpBCFile ->
-           try (executeTask num task inpBCFile) >>= \case
-             Left ex
-               | Just (_::AsyncException) <- fromException ex -> throwIO ex
-               | otherwise -> failTask num task "Failed during process coordination" ex
-             Right ed -> return ed
-
-       let leadingString
-              | num == 0 = "[\n"
-              | otherwise= ",\n"
-
-       LBS.hPutStr jsonOutHdl leadingString
-       LBS.hPutStr jsonOutHdl (encode ed)
-       LBS.hPutStr jsonOutHdl "\n"
-       hFlush jsonOutHdl
-
- failTask num task msg ex =
-    do let taskRoot = svTaskDirectory root num task
-       let sourceFile = verificationSourceFile task
-       let err = unlines [msg, displayException ex]
-       return EvaluationData
-              { taskRoot = taskRoot
-              , sourceFile = sourceFile
-              , elapsedTime = 0
-              , exitCode = Nothing
-              , evaluationResult = Left err
-              , subprocessOutput = ""
-              }
-
- executeTask num task inpBCFile =
-    do let taskRoot = svTaskDirectory root num task
-       let sourceFile = verificationSourceFile task
-
-       (readFd, writeFd) <- createPipe
-       (jsonReadFd, jsonWriteFd) <- createPipe
-       readHdl <- fdToHandle readFd
-       jsonReadHdl <- fdToHandle jsonReadFd
-
-       Log.saySVComp (Log.Evaluating (T.pack taskRoot) (T.pack sourceFile))
-
-       startTime <- getCurrentTime
-
-       pid <- forkProcess $
-                do maybeSetLim ResourceCPUTime (svcompCPUlimit svOpts)
-                   maybeSetLim ResourceTotalMemory ((megabyte *) <$> svcompMemlimit svOpts)
-                   writeHdl <- fdToHandle writeFd
-                   jsonHdl <- fdToHandle jsonWriteFd
-                   evaluateSingleTask writeHdl jsonHdl cruxOpts llvmOpts root num task inpBCFile
-                   exitSuccess
-
-       ast  <- async (getProcessStatus True {- Block -} False {- stopped -} pid)
-       aout <- async (hGetContentsStrict readHdl)
-       ares <- async (eitherDecode' <$> LBS.hGetContents jsonReadHdl)
-
-       st <- wait ast
-       endTime <- getCurrentTime
-
-       closeFd writeFd
-       out <- wait aout
-       Log.output out
-
-       closeFd jsonWriteFd
-       res <- wait ares
-
-       let wallTime = diffUTCTime endTime startTime
-       Log.saySVComp (Log.ElapsedWallClockTime (T.pack (show wallTime)))
-
-       case st of
-         Just (Exited ExitSuccess) ->
-           return ()
-         Just (Exited (ExitFailure x)) ->
-           Log.saySVComp (Log.EvaluationProcessFailed (Log.ExitedWithFailureCode (T.pack (show x))))
-         Just (Terminated sig _) ->
-           Log.saySVComp (Log.EvaluationProcessFailed (Log.TerminatedBySignal (T.pack (show sig))))
-         Just (Stopped sig) ->
-           Log.saySVComp (Log.EvaluationProcessFailed (Log.StoppedBySignal (T.pack (show sig))))
-         Nothing ->
-           Log.saySVComp (Log.EvaluationProcessFailed Log.UnknownStatus)
-
-       return EvaluationData
-              { taskRoot = taskRoot
-              , sourceFile = sourceFile
-              , elapsedTime = wallTime
-              , exitCode = st
-              , evaluationResult = res
-              , subprocessOutput = out
-              }
-
-
-instance ToJSON ProcessStatus where
-  toJSON (Exited ec)        = object [("exited", toJSON x)]
-    where x = case ec of
-                ExitSuccess  -> 0
-                ExitFailure e -> e
-  toJSON (Terminated sig _) = object [("terminated",toJSON (fromEnum sig))]
-  toJSON (Stopped sig)      = object [("stopped", toJSON (fromEnum sig))]
-
-data EvaluationData =
-  EvaluationData
-  { taskRoot :: String
-  , sourceFile :: String
-  , evaluationResult :: Either String EvaluationResult
-  , elapsedTime :: NominalDiffTime
-  , exitCode :: Maybe ProcessStatus
-  , subprocessOutput :: String
-  }
- deriving (Eq,Ord,Show,Generic)
-
-
-instance ToJSON EvaluationData
-instance ToJSONKey EvaluationData
-
-data EvaluationResult =
-  EvaluationResult
-  { computedResult :: Maybe Bool
-  , expectedResult :: Maybe Bool
-  , totalGoals :: Integer
-  , disprovedGoals :: Integer
-  , unknownGoals :: Integer
-  , provedGoals :: Integer
-  , incompleteGoals :: Integer
-  , programComplete :: Bool
-  }
- deriving (Eq,Ord,Show,Generic)
-
-instance ToJSON EvaluationResult
-instance FromJSON EvaluationResult
-instance ToJSONKey EvaluationResult
-
-evaluateSingleTask :: Handle -> Handle -> CruxOptions -> LLVMOptions
-                   -> FilePath
-                   -> Int -> VerificationTask -> FilePath -> IO ()
-evaluateSingleTask writeHdl jsonHdl cruxOpts llvmOpts bsRoot num task inpBCFile =
-   withSVCompLogging $
-   do let taskRoot = svTaskDirectory bsRoot num task
-      let srcRoot  = takeDirectory (verificationSourceFile task)
-      let inputs   = map (srcRoot </>) (verificationInputFiles task)
-      let cruxOpts' = cruxOpts { outDir = taskRoot, inputFiles = inputs }
-
-      let ?outputConfig = Crux.mkOutputConfig True writeHdl writeHdl svCompLoggingToSayWhat $ Just cruxOpts
+    evaluateBitCode :: FilePath -> FilePath -> IO ()
+    evaluateBitCode inputFile bcFile = withSVCompLogging $ do
+      let ?outputConfig = Crux.defaultOutputConfig svCompLoggingToSayWhat $ Just cruxOpts
 
       mres <- try $
-               do res <- Crux.runSimulator cruxOpts' (simulateLLVMFile inpBCFile llvmOpts)
-                  generateReport cruxOpts' res
+               do res <- Crux.runSimulator cruxOpts (simulateLLVMFile bcFile llvmOpts)
+                  generateReport cruxOpts res
                   return res
 
       case mres of
         Left e ->
           do Log.saySVComp Log.SimulatorThrewException
              Log.logException (e :: SomeException)
-             hClose writeHdl
-             hClose jsonHdl
              exitFailure
 
         Right (CruxSimulationResult cmpl gls) ->
-          do let totalGoals = sum (Crux.totalProcessedGoals . fst <$> gls)
-             let disprovedGoals = sum (Crux.disprovedGoals . fst <$> gls)
-             let provedGoals = sum (Crux.provedGoals . fst <$> gls)
-             let incompleteGoals = sum (Crux.incompleteGoals . fst <$> gls)
-             let unknownGoals = totalGoals - (disprovedGoals + provedGoals + incompleteGoals)
-
-             let programComplete =
-                   case cmpl of
-                     ProgramComplete -> True
-                     ProgramIncomplete -> False
+          do let numTotalGoals = sum (Crux.totalProcessedGoals . fst <$> gls)
+             let numDisprovedGoals = sum (Crux.disprovedGoals . fst <$> gls)
+             let numProvedGoals = sum (Crux.provedGoals . fst <$> gls)
 
              let verdict
-                   | disprovedGoals > 0 = Falsified
+                   | numDisprovedGoals > 0 = Falsified
                    | ProgramComplete <- cmpl
-                   , provedGoals == totalGoals = Verified
+                   , numProvedGoals == numTotalGoals = Verified
                    | otherwise = Unknown
 
-             let expectedResult = propertyVerdict task
+             specFileContents <- B.readFile $ runIdentity $ svcompSpec svOpts
+             let specFileText = T.decodeUtf8 specFileContents
+             prop <- case Atto.parseOnly propParse specFileText of
+                       Left msg ->
+                         do Log.saySVComp $ Log.PropertyParseError specFileText (T.pack msg)
+                            exitFailure
+                       Right p -> return p
 
-             let computedResult = case verdict of
-                                    Verified -> Just True
-                                    Falsified -> Just False
-                                    Unknown -> Nothing
+             witType <- case verdict of
+                          Verified  -> do Log.saySVComp $ Log.Verdict Verified prop
+                                          pure CorrectnessWitness
+                          Falsified -> do Log.saySVComp $ Log.Verdict Falsified prop
+                                          pure ViolationWitness
+                          Unknown   -> do Log.saySVComp $ Log.Verdict Unknown prop
+                                          exitSuccess
 
-             case expectedResult of
-               Nothing -> Log.saySVComp (Log.NoVerdict (T.pack . show <$> verificationProperties task))
-               Just expected -> Log.saySVComp (Log.VerdictExpecting expected verdict)
+             inputFileContents <- B.readFile inputFile
+             creationTime <- getZonedTime
+             let mkWitness nodes edges = Witness
+                   { witnessType           = witType
+                   , witnessSourceCodeLang = C
+                   , witnessProducer       = "crux-llvm-" ++ showVersion version
+                   , witnessSpecification  = L.trim $ B.unpack specFileContents
+                   , witnessProgramFile    = inputFile
+                   , witnessProgramHash    = B16.encode $ SHA256.hash inputFileContents
+                   , witnessArchitecture   = runIdentity $ svcompArch svOpts
+                   , witnessCreationTime   = creationTime
+                   , witnessNodes          = nodes
+                   , witnessEdges          = edges
+                   }
+                 trivialCorrectnessWitness = mkWitness [(mkNode 0) { nodeEntry = Just True }] []
 
-             LBS.hPut jsonHdl (encode EvaluationResult{ .. })
+             let witnessFileName = takeBaseName inputFile ++ "-witness.graphml"
+             writeFile witnessFileName $ ppWitness $ case witType of
+               CorrectnessWitness -> trivialCorrectnessWitness
+               ViolationWitness   -> let (nodes, edges) = mkViolationWitness $ fmap snd gls
+                                     in mkWitness nodes edges
 
-             hClose writeHdl
-             hClose jsonHdl
+mkViolationWitness :: Seq ProvedGoals -> ([WitnessNode], [WitnessEdge])
+mkViolationWitness gs =
+  case L.firstJust findNotProvedGoal $ toList gs of
+    Nothing -> error "Could not find event log for counterexample"
+    Just (_mv, events) ->
+      let locs  = -- Witness validators aren't hugely fond of using the same
+                  -- line number multiple times successively, so remove
+                  -- consecutive duplicates.
+                  removeRepeatsBy ((==) `on` (fmap fst . programLocSourcePos)) $
+                  mapMaybe locationReachedEventLoc events
+          edges = imap violationEdge locs
+          nodes = violationNodes $ length edges
+      in (nodes, edges)
+  where
+    findNotProvedGoal :: ProvedGoals -> Maybe (ModelView, [CrucibleEvent GroundValueWrapper])
+    findNotProvedGoal (Branch pg1 pg2)          = findNotProvedGoal pg1 <|> findNotProvedGoal pg2
+    findNotProvedGoal (NotProvedGoal _ _ _ _ x) = x
+    findNotProvedGoal ProvedGoal{}              = Nothing
+
+    violationNodes :: Int -> [WitnessNode]
+    violationNodes numEdges =
+      map (\idx -> (mkNode idx)
+                     { nodeEntry     = if idx == 0        then Just True else Nothing
+                     , nodeViolation = if idx == numEdges then Just True else Nothing
+                     })
+          [0..numEdges]
+
+    locationReachedEventLoc :: CrucibleEvent GroundValueWrapper -> Maybe ProgramLoc
+    locationReachedEventLoc (LocationReachedEvent loc) = Just loc
+    locationReachedEventLoc CreateVariableEvent{}      = Nothing
+
+    violationEdge :: Int -> ProgramLoc -> WitnessEdge
+    violationEdge idx loc =
+      let mbSourcePos = programLocSourcePos loc in
+      (mkEdge idx (idx+1))
+        { edgeStartLine       = fst <$> mbSourcePos
+        , edgeAssumptionScope = Just $ show $ plFunction loc
+          -- crux-llvm–specific extensions
+        , edgeStartColumn     = snd <$> mbSourcePos
+        }
+
+    programLocSourcePos :: ProgramLoc -> Maybe (Int, Int)
+    programLocSourcePos pl =
+      case plSourceLoc pl of
+        SourcePos _ l c -> Just (l, c)
+        BinaryPos{}     -> Nothing
+        OtherPos{}      -> Nothing
+        InternalPos     -> Nothing

--- a/crux-llvm/svcomp/README.md
+++ b/crux-llvm/svcomp/README.md
@@ -1,0 +1,111 @@
+# `crux-llvm-svcomp`
+
+This is an alternative to `crux-llvm` that is specifically tailored to the
+needs of the
+[Competition on Software Verification (SV-COMP)](https://sv-comp.sosy-lab.org).
+This document describes various workflows that are useful in creating and using
+`crux-llvm-svcomp`.
+
+## Create a bindist for SV-COMP
+
+SV-COMP has very particular requirements for participant bindist, so for this
+reason, we have curated a separate script for producing a `crux-llvm-svcomp`
+bindist for SV-COMP purposes. To run the script, perform the following steps on
+a Linux machine:
+
+1. Download a Clang tarball from
+   [here](https://releases.llvm.org/download.html). This is done with the aim
+   of including certain LLVM binaries in the `crux-llvm-svcomp` bindist so that
+   we can be absolutely sure that we are using a specific LLVM version instead
+   of relying on the version of LLVM used on a competition machine.
+
+   We most recently tested this with Clang 10.0.0, so we recommend downloading
+   that version.
+2. Extract the downloaded Clang tarball to the following location:
+
+   ```
+   $ mkdir -p <path-to-crucible-repo>/crux-llvm/svcomp/clang
+   $ tar -xvf clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz -C <path-to-crucible-repo>/crux-llvm/svcomp/clang
+   ```
+3. Run the following script, which will build the necessary executables and
+   produce a bindist:
+
+   ```
+   $ ./mk-svcomp-bindist.sh
+   ```
+
+If everything goes as expected, you should now have a file named something like
+`crux-llvm-svcomp-2021-08-24-Linux-x86_64.zip`.
+
+## Recreating the SV-COMP competition environment
+
+We have had moderate success recreating the environment under which the SV-COMP
+benchmark harness should run by performing the following steps:
+
+1. [Install Docker](https://docs.docker.com/engine/install/).
+2. Clone the [`bench-defs`](https://gitlab.com/sosy-lab/sv-comp/bench-defs)
+   repo and initialize it with the following commands:
+
+   ```
+   $ git clone https://gitlab.com/sosy-lab/sv-comp/bench-defs && cd bench-defs/
+   $ git checkout svcomp21 # Or whichever year you want to target
+   $ make init
+   ```
+
+   Beware that the `sv-benchmarks` repo in particular is quite massive.
+   Moreover, many of the files in that repo are especially long (sometimes
+   over 150 characters in length), which may pose an issue if you are using an
+   encrypted file system that limits the length of file names.
+3. Make a note of where you cloned `bench-defs`. Navigate to the `docker`
+   subdirectory, open the `Makefile`, and replace the value of `BENCH_DEFS_DIR`
+   with the location of where you cloned `bench-defs`.
+4. From within the `docker` directory, run `make`. This will build a Docker
+   image suitable for running the SV-COMP benchmark harness and start a
+   container from within `bench-defs`.
+
+## Preparing the necessary files for SV-COMP benchmark runs
+
+Before you can actually run Crux in an SV-COMP competition environment, you
+will need to prepare three files:
+
+1. A `.zip` file containing the `crux-llvm-svcomp` bindist and friends. For
+   instructions on how to do this, refer to the "Create a bindist for SV-COMP"
+   section.
+2. A `crux.xml` benchmark definition file containing the metadata for the
+   `crux-llvm-svcomp` tool and which benchmarks programs it will run.
+   TODO: Add a link to `crux.xml` once it has been upstreamed.
+3. A `crux.py` tool module that informs `benchexec` (SV-COMP's benchmark
+   harness) how to invoke `crux-llvm-svcomp` and how to interpret its results.
+   TODO: Add a link to `crux.py` once it has been upstreamed.
+
+You will need to put each of these files in particular locations under your
+checkout of `bench-defs` (see the "Recreating the SV-COMP competition environment"
+section):
+
+1. Put the `.zip` file in `bench-defs/archives/2021/crux.zip`.
+2. Put the `crux.xml` file in `bench-defs/benchmark-defs/crux.xml`.
+3. Put the `crux.py` file in `bench-defs/benchexec/benchexec/tools/crux.py`.
+
+## Executing an SV-COMP benchmark run
+
+From within an SV-COMP competition Docker container (see the
+"Recreating the SV-COMP competition environment" section), run the following
+command:
+
+```
+$ ./scripts/execute-runs/mkInstall.sh crux crux-path
+```
+
+For whatever reason, the secon argument (ostensibly the path to extract to)
+doesn't seem to actually get used in practice, and the directory it will
+_actually_ be extracted to is the basename of the Crux `.zip` file itself.
+Navigate into this newly extracted directory and run the following:
+
+```
+$ PYTHONPATH=../benchexec python3 -m benchexec.benchexec -r SV-COMP21_unreach-call ../benchmark-defs/crux.xml
+```
+
+This will start a run of the `SV-COMP21_unreach-call` benchmark definition as
+defined in `../benchmark-defs/crux.xml`. (See the "Preparing the necessary
+files for SV-COMP benchmark runs" section.) To execute a different benchmark
+definition, change the argument to `-r`.

--- a/crux-llvm/svcomp/config-files/unreach-call.config
+++ b/crux-llvm/svcomp/config-files/unreach-call.config
@@ -1,0 +1,22 @@
+-- For unreach-call, make assert() a fatal error
+abnormal-exit-behavior: only-assert-fail
+
+-- Generic SV-COMP options
+clang-opts: "-fbracket-depth=1024"
+solver: "z3"
+timeout: 30
+floating-point: "ieee"
+goal-timeout: 30
+make-executables: no
+skip-report: yes
+iteration-bound: 50
+recursion-bound: 100
+lax-pointer-ordering: yes
+lax-constant-equality: yes
+lax-arithmetic: yes
+proof-goals-fail-fast: yes
+hash-consing: yes
+lazy-compile: no
+unsat-cores: no
+path-sat: yes
+lax-loads-and-stores: yes

--- a/crux-llvm/svcomp/crux-llvm-svcomp-driver.sh
+++ b/crux-llvm/svcomp/crux-llvm-svcomp-driver.sh
@@ -1,0 +1,6 @@
+#!/bin/env bash
+
+TOOL_NAME=crux-llvm-svcomp
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+PATH=${SCRIPT_DIR}/bin:$PATH ${TOOL_NAME} ${1+"$@"}

--- a/crux-llvm/svcomp/docker/Dockerfile
+++ b/crux-llvm/svcomp/docker/Dockerfile
@@ -1,0 +1,4 @@
+FROM registry.gitlab.com/sosy-lab/benchmarking/competition-scripts/user:2021
+
+RUN apt-get update && \
+    apt-get install -y git software-properties-common vim zip

--- a/crux-llvm/svcomp/docker/Makefile
+++ b/crux-llvm/svcomp/docker/Makefile
@@ -1,0 +1,12 @@
+all: do-it
+
+DOCKER_TAG=svcomp-runner:latest
+BENCH_DEFS_DIR=/home/rscott2/bench-defs
+
+do-it:
+	docker build . -t $(DOCKER_TAG)
+	docker run --rm -i -t --privileged \
+	           --volume=/sys/fs/cgroup:/sys/fs/cgroup:rw \
+			   --volume=$(BENCH_DEFS_DIR):/home/bench-defs \
+			   --workdir=/home/bench-defs \
+			   $(DOCKER_TAG) bash

--- a/crux-llvm/svcomp/mk-svcomp-bindist.sh
+++ b/crux-llvm/svcomp/mk-svcomp-bindist.sh
@@ -1,0 +1,73 @@
+#!/bin/env bash
+set -Eeuxo pipefail
+
+DATE=$(date "+%Y-%m-%d")
+EXT=""
+IS_WIN=false
+OS_TAG=Linux
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+extract_exe() {
+  exe="$(cabal v2-exec which "$1$EXT" | tail -1)"
+  name="$(basename "$exe")"
+  echo "Copying $name to $2"
+  mkdir -p "$2"
+  cp -f "$exe" "$2/$name"
+  $IS_WIN || chmod +x "$2/$name"
+}
+
+setup_dist() {
+  rm -rf dist
+  mkdir -p dist/bin dist/doc
+}
+
+zip_dist() {
+  : "${VERSION?VERSION is required as an environment variable}"
+  pkgname="${pkgname:-"$1-$VERSION-$OS_TAG-x86_64"}"
+  mv dist "$pkgname"
+  zip -r "$pkgname".zip "$pkgname"
+  rm -rf dist
+}
+
+bundle_crux_llvm_svcomp_files() {
+  setup_dist
+  extract_exe crux-llvm dist/bin
+  if ! $IS_WIN; then
+    extract_exe crux-llvm-svcomp dist/bin
+  fi
+  cp -r ../c-src dist
+
+  # SV-COMP–specific requirements begin
+  ## SMT solvers
+  cp "$(which cvc4)"       dist/bin/
+  cp "$(which yices)"      dist/bin/
+  cp "$(which yices-smt2)" dist/bin/
+  cp "$(which z3)"         dist/bin/
+  ## LLVM binaries
+  cp "$(which clang)"      dist/bin/
+  cp "$(which llvm-link)"  dist/bin/
+  ## A wrapper script for crux-llvm-svcomp that puts the aforementioned
+  ## binaries on the PATH before invocation
+  cp crux-llvm-svcomp-driver.sh dist/
+  ## Competition-specific configuration files
+  cp config-files/unreach-call.config dist/
+  ## The LICENSE and README (a particular SV-COMP requirement listed in
+  ## https://sv-comp.sosy-lab.org/2021/rules.php#verifier)
+  cp ../LICENSE dist/
+  cp ../README.md dist/README
+
+  VERSION=${VERSION:-$DATE}
+  zip_dist crux-llvm-svcomp
+}
+
+# Make sure executables are up to date
+cabal build exe:crux-llvm exe:crux-llvm-svcomp
+
+# Extend PATH to include LLVM binaries
+PATH=$SCRIPT_DIR/clang/bin:$PATH
+
+# Make sure we're in the right directory
+cd "$SCRIPT_DIR" || exit
+
+# Create the bindist
+bundle_crux_llvm_svcomp_files

--- a/crux/crux.cabal
+++ b/crux/crux.cabal
@@ -28,6 +28,7 @@ library
     async,
     attoparsec,
     bv-sized >= 1.0.0,
+    bytestring,
     containers,
     contravariant >= 1.5 && < 1.6,
     crucible,
@@ -56,6 +57,7 @@ library
     config-schema,
     semigroupoids,
     unordered-containers,
+    xml,
     yaml >= 0.11 && < 0.12
 
   hs-source-dirs: src
@@ -76,6 +78,7 @@ library
     Crux.Config.Common,
     Crux.Config.Solver,
     Crux.SVCOMP,
+    Crux.SVCOMP.Witness,
     Crux.UI.JS,
     Crux.Version
 

--- a/crux/src/Crux/Report.hs
+++ b/crux/src/Crux/Report.hs
@@ -130,11 +130,16 @@ renderSideConds opts = concatMapM go
 
 
 removeRepeats :: Eq a => [a] -> [a]
-removeRepeats [] = []
-removeRepeats [x] = [x]
-removeRepeats (x:y:zs)
-  | x == y = removeRepeats (y:zs)
-  | otherwise = x : removeRepeats (y:zs)
+removeRepeats = removeRepeatsBy (==)
+
+removeRepeatsBy :: (a -> a -> Bool) -> [a] -> [a]
+removeRepeatsBy f = go
+  where
+    go [] = []
+    go [x] = [x]
+    go (x:y:zs)
+      | f x y = go (y:zs)
+      | otherwise = x : go (y:zs)
 
 jsPath :: [ProgramLoc] -> IO [ JS ]
 jsPath locs = concat <$> mapM mkStep locs'

--- a/crux/src/Crux/SVCOMP/Witness.hs
+++ b/crux/src/Crux/SVCOMP/Witness.hs
@@ -1,0 +1,329 @@
+-- | This module defines a data type for SV-COMP witness automatons, as
+--   specified in https://github.com/sosy-lab/sv-witnesses.
+
+{-# Language NamedFieldPuns #-}
+module Crux.SVCOMP.Witness where
+
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString.Char8 as B (unpack)
+import qualified Data.List as L (intercalate)
+import           Data.Maybe (catMaybes)
+import           Data.Time.Format.ISO8601 (iso8601Show)
+import           Data.Time.LocalTime (ZonedTime)
+import           Text.XML.Light
+
+import Crux.SVCOMP (Arch(..))
+
+-- | A witness automaton. Adheres to the format specified in
+-- https://github.com/sosy-lab/sv-witnesses/tree/a592b52c4034423d42bed2059addbc6d8f1fa443#data-elements.
+data Witness = Witness
+  { witnessType           :: WitnessType
+  , witnessSourceCodeLang :: SourceCodeLang
+  , witnessProducer       :: String
+  , witnessSpecification  :: String
+  , witnessProgramFile    :: FilePath
+  , witnessProgramHash    :: ByteString
+  , witnessArchitecture   :: Arch
+  , witnessCreationTime   :: ZonedTime
+  , witnessNodes          :: [WitnessNode]
+  , witnessEdges          :: [WitnessEdge]
+  }
+  deriving Show
+
+data WitnessNode = WitnessNode
+  { nodeId             :: Id
+  , nodeEntry          :: Maybe Bool
+  , nodeSink           :: Maybe Bool
+  , nodeViolation      :: Maybe Bool
+  , nodeInvariant      :: Maybe String
+  , nodeInvariantScope :: Maybe String
+  }
+  deriving Show
+
+mkNode :: Int -> WitnessNode
+mkNode i = WitnessNode
+  { nodeId             = mkNodeId i
+  , nodeEntry          = Nothing
+  , nodeSink           = Nothing
+  , nodeViolation      = Nothing
+  , nodeInvariant      = Nothing
+  , nodeInvariantScope = Nothing
+  }
+
+mkNodeId :: Int -> Id
+mkNodeId i = "N" ++ show i
+
+data WitnessEdge = WitnessEdge
+  { edgeSource                   :: Id
+  , edgeTarget                   :: Id
+  , edgeAssumption               :: Maybe Assumption
+  , edgeAssumptionScope          :: Maybe String
+  , edgeAssumptionResultFunction :: Maybe String
+  , edgeControl                  :: Maybe Control
+  , edgeStartLine                :: Maybe Int
+  , edgeEndLine                  :: Maybe Int
+  , edgeStartOffset              :: Maybe Int
+  , edgeEndOffset                :: Maybe Int
+  , edgeEnterLoopHead            :: Maybe Bool
+  , edgeEnterFunction            :: Maybe String
+  , edgeReturnFromFunction       :: Maybe String
+  , edgeThreadId                 :: Maybe String
+  , edgeCreateThread             :: Maybe String
+
+    -- crux-llvm–specific extensions
+  , edgeStartColumn              :: Maybe Int
+      -- Not to be confused with startoffset, which records the total number
+      -- of characters from the very start of the program. This, on the other
+      -- hand, simply records the number of characters from the start of the
+      -- current line, which I find to be a nice debugging tool.
+  }
+  deriving Show
+
+mkEdge :: Int -> Int -> WitnessEdge
+mkEdge source target = WitnessEdge
+  { edgeSource                   = mkNodeId source
+  , edgeTarget                   = mkNodeId target
+  , edgeAssumption               = Nothing
+  , edgeAssumptionScope          = Nothing
+  , edgeAssumptionResultFunction = Nothing
+  , edgeControl                  = Nothing
+  , edgeStartLine                = Nothing
+  , edgeEndLine                  = Nothing
+  , edgeStartOffset              = Nothing
+  , edgeEndOffset                = Nothing
+  , edgeEnterLoopHead            = Nothing
+  , edgeEnterFunction            = Nothing
+  , edgeReturnFromFunction       = Nothing
+  , edgeThreadId                 = Nothing
+  , edgeCreateThread             = Nothing
+
+    -- crux-llvm–specific extensions
+  , edgeStartColumn              = Nothing
+  }
+
+data WitnessType
+  = CorrectnessWitness
+  | ViolationWitness
+  deriving Show
+
+ppWitnessType :: WitnessType -> String
+ppWitnessType witnessType =
+  case witnessType of
+    CorrectnessWitness -> "correctness_witness"
+    ViolationWitness   -> "violation_witness"
+
+data SourceCodeLang
+  = C
+  | Java
+  deriving Show
+
+ppSourceCodeLang :: SourceCodeLang -> String
+ppSourceCodeLang sourceCodeLang =
+  case sourceCodeLang of
+    C    -> "C"
+    Java -> "Java"
+
+ppArch :: Arch -> String
+ppArch arch =
+  case arch of
+    Arch32 -> "32bit"
+    Arch64 -> "64bit"
+
+newtype Assumption = Assumption [String]
+  deriving Show
+
+ppAssumption :: Assumption -> String
+ppAssumption (Assumption exprs) =
+  L.intercalate ";" exprs
+
+data Control
+  = ConditionTrue
+  | ConditionFalse
+  deriving Show
+
+ppControl :: Control -> String
+ppControl control =
+  case control of
+    ConditionTrue  -> "condition-true"
+    ConditionFalse -> "condition-false"
+
+data GraphMLAttrType
+  = Boolean
+  | Int
+  | Long
+  | Float
+  | Double
+  | String
+  deriving Show
+
+ppGraphMLAttrType :: GraphMLAttrType -> String
+ppGraphMLAttrType ty =
+  case ty of
+    Boolean -> "boolean"
+    Int     -> "int"
+    Long    -> "long"
+    Float   -> "float"
+    Double  -> "double"
+    String  -> "string"
+
+data GraphMLAttrDomain
+  = Graph
+  | Node
+  | Edge
+  | All
+  deriving Show
+
+ppGraphMLAttrDomain :: GraphMLAttrDomain -> String
+ppGraphMLAttrDomain domain =
+  case domain of
+    Graph -> "graph"
+    Node  -> "node"
+    Edge  -> "edge"
+    All   -> "all"
+
+ppBool :: Bool -> String
+ppBool b =
+  case b of
+    False -> "false"
+    True  -> "true"
+
+ppByteString :: ByteString -> String
+ppByteString = B.unpack
+
+ppInt :: Int -> String
+ppInt = show
+
+ppString :: String -> String
+ppString = id
+
+ppZonedTime :: ZonedTime -> String
+ppZonedTime = iso8601Show
+
+type Id = String
+
+dataNode :: String -> (a -> String) -> a -> Element
+dataNode keyVal ppThing thing =
+  add_attr (Attr{attrKey = unqual "key", attrVal = keyVal}) $
+  unode "data" $
+    ppThing thing
+
+ppWitness :: Witness -> String
+ppWitness witness =
+  unlines [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+          , ppElement $ unode "graph" witness
+          ]
+
+instance Node Witness where
+  node n Witness{ witnessType, witnessSourceCodeLang, witnessProducer
+                , witnessSpecification, witnessProgramFile, witnessProgramHash
+                , witnessArchitecture, witnessCreationTime
+                , witnessNodes, witnessEdges
+                } =
+    add_attrs [ Attr{ attrKey = unqual "xmlns"
+                    , attrVal = "http://graphml.graphdrawing.org/xmlns"
+                    }
+              , Attr{ attrKey = unqual "xmlns:xsi"
+                    , attrVal = "http://www.w3.org/2001/XMLSchema-instance"
+                    }
+              , Attr{ attrKey = unqual "xsi:schemaLocation"
+                    , attrVal = "http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd"
+                    }
+              ] $
+    unode "graphml" $
+      [ keyNode "witness-type"   String Graph
+      , keyNode "sourcecodelang" String Graph
+      , keyNode "producer"       String Graph
+      , keyNode "specification"  String Graph
+      , keyNode "programfile"    String Graph
+      , keyNode "programhash"    String Graph
+      , keyNode "architecture"   String Graph
+      , keyNode "creationtime"   String Graph
+
+      , keyNode "entry"           Boolean Node
+      , keyNode "sink"            Boolean Node
+      , keyNode "violation"       Boolean Node
+      , keyNode "invariant"       String  Node
+      , keyNode "invariant.scope" String  Node
+
+      , keyNode "assumption"                String  Edge
+      , keyNode "assumption.scope"          String  Edge
+      , keyNode "assumption.resultfunction" String  Edge
+      , keyNode "control"                   String  Edge
+      , keyNode "startline"                 Int     Edge
+      , keyNode "endline"                   Int     Edge
+      , keyNode "startoffset"               Int     Edge
+      , keyNode "endoffset"                 Int     Edge
+      , keyNode "enterLoopHead"             Boolean Edge
+      , keyNode "enterFunction"             String  Edge
+      , keyNode "returnFromFunction"        String  Edge
+      , keyNode "threadId"                  String  Edge
+      , keyNode "createThread"              String  Edge
+        -- crux-llvm–specific extensions
+      , keyNode "startcolumn"               Int     Edge
+
+      , add_attr (Attr{attrKey = unqual "edgedefault", attrVal = "directed"}) $
+        node n $
+          [ dataNode "witness-type"   ppWitnessType    witnessType
+          , dataNode "sourcecodelang" ppSourceCodeLang witnessSourceCodeLang
+          , dataNode "producer"       ppString         witnessProducer
+          , dataNode "specification"  ppString         witnessSpecification
+          , dataNode "programfile"    ppString         witnessProgramFile
+          , dataNode "programhash"    ppByteString     witnessProgramHash
+          , dataNode "architecture"   ppArch           witnessArchitecture
+          , dataNode "creationtime"   ppZonedTime      witnessCreationTime
+          ] ++ map (unode "node") witnessNodes
+            ++ map (unode "edge") witnessEdges
+      ]
+    where
+      keyNode :: Id -> GraphMLAttrType -> GraphMLAttrDomain -> Element
+      keyNode name ty domain =
+        add_attrs [ Attr{attrKey = unqual "id",        attrVal = name}
+                  , Attr{attrKey = unqual "attr.name", attrVal = name}
+                  , Attr{attrKey = unqual "attr.type", attrVal = ppGraphMLAttrType ty}
+                  , Attr{attrKey = unqual "for",       attrVal = ppGraphMLAttrDomain domain}
+                  ] $
+        case ty of
+          Boolean -> unode "key" [unode "default" (ppBool False)]
+          _       -> unode "key" ()
+
+instance Node WitnessNode where
+  node n WitnessNode{ nodeId, nodeEntry, nodeSink
+                    , nodeViolation, nodeInvariant, nodeInvariantScope
+                    } =
+    add_attr (Attr{attrKey = unqual "id", attrVal = nodeId}) $
+    node n $ catMaybes
+      [ dataNode "entry"           ppBool   <$> nodeEntry
+      , dataNode "sink"            ppBool   <$> nodeSink
+      , dataNode "violation"       ppBool   <$> nodeViolation
+      , dataNode "invariant"       ppString <$> nodeInvariant
+      , dataNode "invariant.scope" ppString <$> nodeInvariantScope
+      ]
+
+instance Node WitnessEdge where
+  node n WitnessEdge{ edgeSource, edgeTarget
+                    , edgeAssumption, edgeAssumptionScope, edgeAssumptionResultFunction
+                    , edgeControl, edgeStartLine, edgeEndLine, edgeStartOffset, edgeEndOffset
+                    , edgeEnterLoopHead, edgeEnterFunction, edgeReturnFromFunction
+                    , edgeThreadId, edgeCreateThread
+                      -- crux-llvm–specific extensions
+                    , edgeStartColumn
+                    } =
+    add_attrs [ Attr{attrKey = unqual "source", attrVal = edgeSource}
+              , Attr{attrKey = unqual "target", attrVal = edgeTarget}
+              ] $
+    node n $ catMaybes
+      [ dataNode "assumption"                ppAssumption <$> edgeAssumption
+      , dataNode "assumption.scope"          ppString     <$> edgeAssumptionScope
+      , dataNode "assumption.resultfunction" ppString     <$> edgeAssumptionResultFunction
+      , dataNode "control"                   ppControl    <$> edgeControl
+      , dataNode "startline"                 ppInt        <$> edgeStartLine
+      , dataNode "endline"                   ppInt        <$> edgeEndLine
+      , dataNode "startoffset"               ppInt        <$> edgeStartOffset
+      , dataNode "endoffset"                 ppInt        <$> edgeEndOffset
+      , dataNode "enterLoopHead"             ppBool       <$> edgeEnterLoopHead
+      , dataNode "enterFunction"             ppString     <$> edgeEnterFunction
+      , dataNode "returnFromFunction"        ppString     <$> edgeReturnFromFunction
+      , dataNode "threadId"                  ppString     <$> edgeThreadId
+      , dataNode "createThread"              ppString     <$> edgeCreateThread
+      , dataNode "startcolumn"               ppInt        <$> edgeStartColumn
+      ]


### PR DESCRIPTION
This is the current snapshot of my work to rewrite `crux-llvm-svcomp` to be capable of participating in SV-COMP (see #351). It is not complete yet, but there is enough scaffolding in place that I wanted to upstream it to avoid bitrot. This is split up into two commits, one of which is focused exclusively on the code in `crux-llvm-svcomp` itself, and the other of which focuses on auxiliary scripting used to produce `crux-llvm-svcomp` bindists.