### PR TITLE
`crux-llvm`: Add `supply-main-arguments` option

### DIFF
--- a/crux-llvm/README.md
+++ b/crux-llvm/README.md
@@ -131,6 +131,16 @@ that property `f(x) < 100` holds whenever the assumption on `x` is
 satisfied. The proof will fail in this case and `crux-llvm` will produce
 a counterexample describing the case where `x` is 99.
 
+## Counterexample limitations
+
+All counterexamples assume that the entrypoint function is `main`, even
+if `entry-point` option is used to specify a different entrypoint during
+simulation. Counterexamples also do not respect the `supply-main-arguments`
+option. That is, if you simulate a `main(int argc, char *argv[])` function
+and use `supply-main-arguments: empty` to pass `argc=0` and `argv={}` to
+`main`, these arguments will _not_ be passed automatically to the
+counterexample executables.
+
 # API
 
 The [`crucible.h` header file](c-src/includes/crucible.h) contains

--- a/crux-llvm/src/Crux/LLVM/Config.hs
+++ b/crux-llvm/src/Crux/LLVM/Config.hs
@@ -31,7 +31,7 @@ data CError =
     ClangError Int String String
   | LLVMParseError LLVM.Error
   | MissingFun String
-  | BadFun
+  | BadFun String
   | EnvError String
   | NoFiles
     deriving Show
@@ -43,7 +43,7 @@ ppCError :: CError -> String
 ppCError err = case err of
     NoFiles                -> "crux-llvm requires at least one input file."
     EnvError msg           -> msg
-    BadFun                 -> "Function should have no arguments"
+    BadFun fnName          -> "The '" ++ fnName ++ "' function should have no arguments"
     MissingFun x           -> "Cannot find code for " ++ show x
     LLVMParseError e       -> LLVM.formatError e
     ClangError n sout serr ->

--- a/crux-llvm/src/Crux/LLVM/Config.hs
+++ b/crux-llvm/src/Crux/LLVM/Config.hs
@@ -31,7 +31,10 @@ data CError =
     ClangError Int String String
   | LLVMParseError LLVM.Error
   | MissingFun String
-  | BadFun String
+  | BadFun String {- The function name -}
+           Bool   {- Is is the main() function?
+                     If so, we can recommend the use of the
+                     `supply-main-arguments` option. -}
   | EnvError String
   | NoFiles
     deriving Show
@@ -43,7 +46,11 @@ ppCError :: CError -> String
 ppCError err = case err of
     NoFiles                -> "crux-llvm requires at least one input file."
     EnvError msg           -> msg
-    BadFun fnName          -> "The '" ++ fnName ++ "' function should have no arguments"
+    BadFun fnName isMain   -> unlines $
+                                [ "The '" ++ fnName ++ "' function should have no arguments"] ++
+                                [ "Enable `supply-main-arguments` to relax this restriction"
+                                | isMain
+                                ]
     MissingFun x           -> "Cannot find code for " ++ show x
     LLVMParseError e       -> LLVM.formatError e
     ClangError n sout serr ->
@@ -66,6 +73,27 @@ abnormalExitBehaviorSpec =
   (OnlyAssertFail <$ atomSpec "only-assert-fail") <!>
   (NeverFail <$ atomSpec "never-fail")
 
+-- | What sort of @main@ functions should @crux-llvm@ support simulating?
+data SupplyMainArguments
+  = NoArguments
+    -- ^ Only support simulating @main@ functions with the signature
+    --   @int main()@. Attempting to simulate a @main@ function that
+    --   takes arguments will result in an error. This is @crux-llvm@'s default
+    --   behavior.
+
+  | EmptyArguments
+    -- ^ Support simulating both @int main()@ and
+    --   @int(main argc, char *argv[])@. If simulating the latter, supply the
+    --   arguments @argc=0@ and @argv={}@. This is a reasonable choice for
+    --   programs whose @main@ function is declared with the latter signature
+    --   but never make use of @argc@ or @argv@.
+  deriving Show
+
+supplyMainArgumentsSpec :: ValueSpec SupplyMainArguments
+supplyMainArgumentsSpec =
+  (NoArguments <$ atomSpec "none") <!>
+  (EmptyArguments <$ atomSpec "empty")
+
 data LLVMOptions = LLVMOptions
   { clangBin   :: FilePath
   , linkBin    :: FilePath
@@ -82,6 +110,7 @@ data LLVMOptions = LLVMOptions
   , noCompile :: Bool
   , optLevel :: Int
   , symFSRoot :: Maybe FilePath
+  , supplyMainArguments :: SupplyMainArguments
   }
 
 -- | The @c-src@ directory, which contains @crux-llvm@–specific files such as
@@ -193,6 +222,16 @@ llvmCruxConfig = do
          symFSRoot <- Crux.sectionMaybe "symbolic-fs-root" Crux.stringSpec
                       "The root of a symbolic filesystem to make available to\
                       \ the program during symbolic execution"
+
+         supplyMainArguments <-
+           Crux.section "supply-main-arguments" supplyMainArgumentsSpec NoArguments
+             (Text.unwords
+               [ "One of `none` or `empty` (default: none). If `none`, only"
+               , "support simulating `main` entrypoint functions with the"
+               , "signature `int main()`. If `empty`, also support simulating"
+               , "`int main(int argc, char *argv[])` such that argc=0 and"
+               , "argv={} are chosen as the arguments."
+               ])
 
          return LLVMOptions { .. }
 

--- a/crux-llvm/src/Crux/LLVM/Overrides.hs
+++ b/crux-llvm/src/Crux/LLVM/Overrides.hs
@@ -16,6 +16,7 @@ module Crux.LLVM.Overrides
   , svCompOverrides
   , cbmcOverrides
   , ArchOk
+  , TPtr
   ) where
 
 import qualified Data.ByteString as BS

--- a/crux-llvm/src/Crux/LLVM/Simulate.hs
+++ b/crux-llvm/src/Crux/LLVM/Simulate.hs
@@ -238,7 +238,7 @@ checkFun nm mp =
         Empty ->
           do liftIO $ Log.sayCruxLLVM (Log.SimulatingFunction (Text.pack nm))
              (callCFG anyCfg emptyRegMap) >> return ()
-        _     -> throwCError BadFun  -- TODO(lb): Suggest uc-crux-llvm?
+        _     -> throwCError (BadFun nm)  -- TODO(lb): Suggest uc-crux-llvm?
     Nothing -> throwCError (MissingFun nm)
 
 ---------------------------------------------------------------------

--- a/crux-llvm/svcomp/config-files/unreach-call.config
+++ b/crux-llvm/svcomp/config-files/unreach-call.config
@@ -1,5 +1,6 @@
 -- For unreach-call, make assert() a fatal error
 abnormal-exit-behavior: only-assert-fail
+supply-main-arguments: empty
 
 -- Generic SV-COMP options
 clang-opts: "-fbracket-depth=1024"

--- a/crux-llvm/test-data/golden/T812.c
+++ b/crux-llvm/test-data/golden/T812.c
@@ -1,0 +1,7 @@
+int main(int argc, char **argv) {
+  if (argc == 0) {
+    return 0;
+  } else {
+    abort();
+  }
+}

--- a/crux-llvm/test-data/golden/T812.config
+++ b/crux-llvm/test-data/golden/T812.config
@@ -1,0 +1,1 @@
+supply-main-arguments: empty

--- a/crux-llvm/test-data/golden/T812.good
+++ b/crux-llvm/test-data/golden/T812.good
@@ -1,0 +1,1 @@
+[Crux] Overall status: Valid.

--- a/crux-llvm/test-data/golden/T816.c
+++ b/crux-llvm/test-data/golden/T816.c
@@ -1,0 +1,3 @@
+int main(int argc, char *argv[]) {
+  return 0;
+}

--- a/crux-llvm/test-data/golden/T816.good
+++ b/crux-llvm/test-data/golden/T816.good
@@ -1,0 +1,1 @@
+The 'main' function should have no arguments

--- a/crux-llvm/test-data/golden/T816.good
+++ b/crux-llvm/test-data/golden/T816.good
@@ -1,1 +1,2 @@
 The 'main' function should have no arguments
+Enable `supply-main-arguments` to relax this restriction


### PR DESCRIPTION
When enabled, `supply-main-arguments` will allow simulating `int main(int argc, char *argv[])` functions by supplying `argc=0` and `argv={}` arguments. This is a very specialized option, but one that ends up being very useful for SV-COMP's purposes, as there are many SV-COMP benchmark programs that define `main` in this way.

Fixes #812.

While I was in town, I spruced up the error message that is given when an entrypoint function has arguments, thereby fixing #816.