### PR TITLE
`crux-llvm-svcomp`: Treat lack of overrides as `UNKNOWN`, not `FALSIFIED`

### DIFF
--- a/crux-llvm/svcomp/Main.hs
+++ b/crux-llvm/svcomp/Main.hs
@@ -145,7 +145,7 @@ processInputFiles cruxOpts llvmOpts svOpts =
              Log.logException (e :: SomeException)
              exitFailure
 
-        Right (CruxSimulationResult cmpl gls) ->
+        Right res@(CruxSimulationResult cmpl gls) ->
           do let numTotalGoals = sum (Crux.totalProcessedGoals . fst <$> gls)
              let numDisprovedGoals = sum (Crux.disprovedGoals . fst <$> gls)
              let numProvedGoals = sum (Crux.provedGoals . fst <$> gls)
@@ -165,9 +165,11 @@ processInputFiles cruxOpts llvmOpts svOpts =
                        Right p -> return p
 
              witType <- case verdict of
-                          Verified  -> do Log.saySVComp $ Log.Verdict Verified prop
+                          Verified  -> do Crux.logSimResult True res
+                                          Log.saySVComp $ Log.Verdict Verified prop
                                           pure CorrectnessWitness
-                          Falsified -> do Log.saySVComp $ Log.Verdict Falsified prop
+                          Falsified -> do Crux.logSimResult True res
+                                          Log.saySVComp $ Log.Verdict Falsified prop
                                           pure ViolationWitness
                           Unknown   -> do Log.saySVComp $ Log.Verdict Unknown prop
                                           exitSuccess

--- a/crux-llvm/svcomp/README.md
+++ b/crux-llvm/svcomp/README.md
@@ -72,11 +72,11 @@ will need to prepare three files:
    instructions on how to do this, refer to the "Create a bindist for SV-COMP"
    section.
 2. A `crux.xml` benchmark definition file containing the metadata for the
-   `crux-llvm-svcomp` tool and which benchmarks programs it will run.
-   TODO: Add a link to `crux.xml` once it has been upstreamed.
+   `crux-llvm-svcomp` tool and which benchmarks programs it will run. This is
+   located under `<path-to-crucible-repo>/crux-llvm/svcomp/def-files`.
 3. A `crux.py` tool module that informs `benchexec` (SV-COMP's benchmark
-   harness) how to invoke `crux-llvm-svcomp` and how to interpret its results.
-   TODO: Add a link to `crux.py` once it has been upstreamed.
+   executor) how to invoke `crux-llvm-svcomp` and how to interpret its results.
+   This is located under `<path-to-crucible-repo>/crux-llvm/svcomp/def-files`.
 
 You will need to put each of these files in particular locations under your
 checkout of `bench-defs` (see the "Recreating the SV-COMP competition environment"

--- a/crux-llvm/svcomp/config-files/README.md
+++ b/crux-llvm/svcomp/config-files/README.md
@@ -1,0 +1,3 @@
+This directory contains configuration files that are tailored to specific
+SV-COMP benchmark tasks. For instance, `unreach-call.config` is tailored to
+tasks that check the `unreach-call.prp` property.

--- a/crux-llvm/svcomp/config-files/no-overflow.config
+++ b/crux-llvm/svcomp/config-files/no-overflow.config
@@ -1,0 +1,25 @@
+-- For no-overflow, check the following ub-sanitizers
+ub-sanitizers: [ "signed-integer-overflow", "shift",  "integer-divide-by-zero" ]
+
+-- Don't produce counterexamples upon abnormal exits
+abnormal-exit-behavior: never-fail
+
+-- Generic SV-COMP options
+clang-opts: "-fbracket-depth=1024"
+solver: "z3"
+timeout: 30
+floating-point: "ieee"
+goal-timeout: 30
+make-executables: no
+skip-report: yes
+iteration-bound: 50
+recursion-bound: 100
+lax-pointer-ordering: yes
+lax-constant-equality: yes
+lax-arithmetic: yes
+proof-goals-fail-fast: yes
+hash-consing: yes
+lazy-compile: no
+unsat-cores: no
+path-sat: yes
+lax-loads-and-stores: yes

--- a/crux-llvm/svcomp/def-files/README.md
+++ b/crux-llvm/svcomp/def-files/README.md
@@ -1,0 +1,22 @@
+This directory contains two files which define Crux as used in SV-COMP's
+benchmark harness:
+
+* `crux.xml`: This is the benchmark definition that states which run
+  definitions and tasks Crux should participate in. The benchmark definition is
+  also a convenient place to configure `crux-llvm-svcomp` options that should
+  only be used for specific run definitions or tasks (e.g., Crux configuration
+  files).
+
+  This is ultimately destined to be placed in the
+  https://gitlab.com/sosy-lab/sv-comp/bench-defs repo under the
+  `benchmark-defs` directory.
+* `crux.py`: This is a Python module that informs `benchexec` (SV-COMP's benchmark
+  executor) how to invoke `crux-llvm-svcomp` and how to interpret its results.
+  This is responsible for converting the information in a benchmark program's
+  `.yml` file to Crux-appropriate command-line arguments
+  (e.g., `--svcomp-arch`). It is also responsible for parsing the output of
+  `crux-llvm-svcomp` to determine which `RESULT_*` string to return.
+
+  This is ultimately destined to be placed in the
+  https://github.com/sosy-lab/benchexec repo under the `benchexec/tools`
+  directory.

--- a/crux-llvm/svcomp/def-files/crux.py
+++ b/crux-llvm/svcomp/def-files/crux.py
@@ -1,0 +1,67 @@
+# This file is part of BenchExec, a framework for reliable benchmarking:
+# https://github.com/sosy-lab/benchexec
+#
+# SPDX-FileCopyrightText: 2007-2020 Dirk Beyer <https://www.sosy-lab.org>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import benchexec.tools.template
+import benchexec.result as result
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task, ILP32, LP64
+
+
+class Tool(benchexec.tools.template.BaseTool2):
+    """
+    Tool info for Crux (https://crux.galois.com/).
+    """
+
+    def executable(self, tool_locator):
+        return tool_locator.find_executable("crux-llvm-svcomp-driver.sh")
+
+    def name(self):
+        return "Crux"
+
+    def cmdline(self, executable, options, task, rlimits):
+        if task.property_file:
+            options += ["--svcomp-spec", task.property_file]
+        data_model_param = get_data_model_from_task(
+            task, {ILP32: "32bit", LP64: "64bit"}
+        )
+        if data_model_param:
+            options += ["--svcomp-arch", data_model_param]
+        # TODO: Move this to crux.xml
+        options += ["--config", "unreach-call.config"]
+        return [executable] + options + list(task.input_files_or_identifier)
+
+    def version(self, executable):
+        s = self._version_from_tool(executable)
+        return s[s.find("version:"):]
+
+    def determine_result(self, run):
+        for line in run.output:
+            if "Verification result: VERIFIED" in line:
+                return result.RESULT_TRUE_PROP
+            elif "Verification result: FALSIFIED (valid-free)" in line:
+                return result.RESULT_FALSE_FREE
+            elif "Verification result: FALSIFIED (valid-deref)" in line:
+                return result.RESULT_FALSE_DEREF
+            elif "Verification result: FALSIFIED (valid-memtrack)" in line:
+                return result.RESULT_FALSE_MEMTRACK
+            elif "Verification result: FALSIFIED (valid-memcleanup)" in line:
+                return result.RESULT_FALSE_MEMCLEANUP
+            elif "Verification result: FALSIFIED (no-overflow)" in line:
+                return result.RESULT_FALSE_OVERFLOW
+            elif "Verification result: FALSIFIED (termination)" in line:
+                return result.RESULT_FALSE_TERMINATION
+            elif "Verification result: FALSIFIED (unreach-call)" in line:
+                return result.RESULT_FALSE_REACH
+            elif "Verification result: FALSIFIED" in line:
+                return result.RESULT_FALSE_PROP
+            elif "Verification result: UNKNOWN" in line:
+                return result.RESULT_UNKNOWN + "(incomplete)"
+            elif "Verification result: ERROR" in line:
+                return result.RESULT_ERROR
+        return result.RESULT_UNKNOWN
+
+    def program_files(self, executable):
+        return [executable] + self.REQUIRED_PATHS

--- a/crux-llvm/svcomp/def-files/crux.py
+++ b/crux-llvm/svcomp/def-files/crux.py
@@ -7,6 +7,7 @@
 
 import benchexec.tools.template
 import benchexec.result as result
+import re
 from benchexec.tools.sv_benchmarks_util import get_data_model_from_task, ILP32, LP64
 
 
@@ -36,8 +37,21 @@ class Tool(benchexec.tools.template.BaseTool2):
         return s[s.find("version:"):]
 
     def determine_result(self, run):
+        override_pat = re.compile("No implementation or override found for pointer: \"(.+?)\"")
+
         for line in run.output:
-            if "Verification result: VERIFIED" in line:
+            # There are still a good number of functions for which Crux lacks
+            # overrides (see, for example, issue #187). Rather than reporting
+            # FALSIFIED for such programs (which will dock us points), we will
+            # instead conservatively return UNKNOWN, which doesn't lose (or
+            # gain) points. To make it more obvious which programs are UNKNOWN
+            # due to failing overrides versus incomplete goals, we include the
+            # name of the failing override in parentheses after UNKNOWN, which
+            # will show up in benchexec's reports.
+            m = override_pat.search(line)
+            if m:
+                return result.RESULT_UNKNOWN + "(no override: " + m.group(1) + ")"
+            elif "Verification result: VERIFIED" in line:
                 return result.RESULT_TRUE_PROP
             elif "Verification result: FALSIFIED (valid-free)" in line:
                 return result.RESULT_FALSE_FREE

--- a/crux-llvm/svcomp/def-files/crux.py
+++ b/crux-llvm/svcomp/def-files/crux.py
@@ -29,8 +29,6 @@ class Tool(benchexec.tools.template.BaseTool2):
         )
         if data_model_param:
             options += ["--svcomp-arch", data_model_param]
-        # TODO: Move this to crux.xml
-        options += ["--config", "unreach-call.config"]
         return [executable] + options + list(task.input_files_or_identifier)
 
     def version(self, executable):

--- a/crux-llvm/svcomp/def-files/crux.xml
+++ b/crux-llvm/svcomp/def-files/crux.xml
@@ -7,6 +7,8 @@
   <resultfiles>**.graphml</resultfiles>
 
 <rundefinition name="SV-COMP21_unreach-call">
+  <option name="--config">unreach-call.config</option>
+
   <tasks name="ReachSafety-Arrays">
     <includesfile>../sv-benchmarks/c/ReachSafety-Arrays.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
@@ -128,6 +130,8 @@
 -->
 
 <rundefinition name="SV-COMP21_no-overflow">
+  <option name="--config">no-overflow.config</option>
+
   <tasks name="NoOverflows-BitVectors">
     <includesfile>../sv-benchmarks/c/NoOverflows-BitVectors.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/no-overflow.prp</propertyfile>

--- a/crux-llvm/svcomp/def-files/crux.xml
+++ b/crux-llvm/svcomp/def-files/crux.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0"?>
+<!DOCTYPE benchmark PUBLIC "+//IDN sosy-lab.org//DTD BenchExec benchmark 1.9//EN" "https://www.sosy-lab.org/benchexec/benchmark-2.3.dtd">
+<benchmark tool="crux" timelimit="15 min" hardtimelimit="16 min" memlimit="15 GB" cpuCores="8">
+
+<require cpuModel="Intel Xeon E3-1230 v5 @ 3.40 GHz" cpuCores="8"/>
+
+  <resultfiles>**.graphml</resultfiles>
+
+<rundefinition name="SV-COMP21_unreach-call">
+  <tasks name="ReachSafety-Arrays">
+    <includesfile>../sv-benchmarks/c/ReachSafety-Arrays.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-BitVectors">
+    <includesfile>../sv-benchmarks/c/ReachSafety-BitVectors.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-ControlFlow">
+    <includesfile>../sv-benchmarks/c/ReachSafety-ControlFlow.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-ECA">
+    <includesfile>../sv-benchmarks/c/ReachSafety-ECA.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-Floats">
+    <includesfile>../sv-benchmarks/c/ReachSafety-Floats.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-Heap">
+    <includesfile>../sv-benchmarks/c/ReachSafety-Heap.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-Loops">
+    <includesfile>../sv-benchmarks/c/ReachSafety-Loops.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-ProductLines">
+    <includesfile>../sv-benchmarks/c/ReachSafety-ProductLines.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-Recursive">
+    <includesfile>../sv-benchmarks/c/ReachSafety-Recursive.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-Sequentialized">
+    <includesfile>../sv-benchmarks/c/ReachSafety-Sequentialized.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-XCSP">
+    <includesfile>../sv-benchmarks/c/ReachSafety-XCSP.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-Combinations">
+    <includesfile>../sv-benchmarks/c/ReachSafety-Combinations.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+
+  <!--
+  <tasks name="ConcurrencySafety-Main">
+    <includesfile>../sv-benchmarks/c/ConcurrencySafety-Main.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  -->
+
+  <tasks name="SoftwareSystems-AWS-C-Common-ReachSafety">
+    <includesfile>../sv-benchmarks/c/SoftwareSystems-AWS-C-Common-ReachSafety.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="SoftwareSystems-DeviceDriversLinux64-ReachSafety">
+    <includesfile>../sv-benchmarks/c/SoftwareSystems-DeviceDriversLinux64-ReachSafety.set</includesfile>
+    <excludesfile>../sv-benchmarks/c/SoftwareSystems-DeviceDriversLinux64Large-ReachSafety.set</excludesfile>
+    <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="SoftwareSystems-DeviceDriversLinux64Large-ReachSafety">
+    <includesfile>../sv-benchmarks/c/SoftwareSystems-DeviceDriversLinux64Large-ReachSafety.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="SoftwareSystems-uthash-ReachSafety">
+    <includesfile>../sv-benchmarks/c/SoftwareSystems-uthash-ReachSafety.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+</rundefinition>
+
+<!--
+<rundefinition name="SV-COMP21_valid-memcleanup">
+  <tasks name="MemSafety-MemCleanup">
+    <includesfile>../sv-benchmarks/c/MemSafety-MemCleanup.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/valid-memcleanup.prp</propertyfile>
+  </tasks>
+</rundefinition>
+
+<rundefinition name="SV-COMP21_valid-memsafety">
+  <tasks name="MemSafety-Arrays">
+    <includesfile>../sv-benchmarks/c/MemSafety-Arrays.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+  </tasks>
+  <tasks name="MemSafety-Heap">
+    <includesfile>../sv-benchmarks/c/MemSafety-Heap.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+  </tasks>
+  <tasks name="MemSafety-LinkedLists">
+    <includesfile>../sv-benchmarks/c/MemSafety-LinkedLists.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+  </tasks>
+  <tasks name="MemSafety-Other">
+    <includesfile>../sv-benchmarks/c/MemSafety-Other.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+  </tasks>
+  <tasks name="MemSafety-Juliet">
+    <includesfile>../sv-benchmarks/c/MemSafety-Juliet.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+  </tasks>
+
+  <tasks name="SoftwareSystems-BusyBox-MemSafety">
+    <includesfile>../sv-benchmarks/c/SoftwareSystems-BusyBox-MemSafety.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+  </tasks>
+  <tasks name="SoftwareSystems-OpenBSD-MemSafety">
+    <includesfile>../sv-benchmarks/c/SoftwareSystems-OpenBSD-MemSafety.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+  </tasks>
+  <tasks name="SoftwareSystems-uthash-MemSafety">
+    <includesfile>../sv-benchmarks/c/SoftwareSystems-uthash-MemSafety.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+  </tasks>
+</rundefinition>
+-->
+
+<rundefinition name="SV-COMP21_no-overflow">
+  <tasks name="NoOverflows-BitVectors">
+    <includesfile>../sv-benchmarks/c/NoOverflows-BitVectors.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
+  </tasks>
+  <tasks name="NoOverflows-Other">
+    <includesfile>../sv-benchmarks/c/NoOverflows-Other.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
+  </tasks>
+
+  <tasks name="SoftwareSystems-BusyBox-NoOverflows">
+    <includesfile>../sv-benchmarks/c/SoftwareSystems-BusyBox-NoOverflows.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
+  </tasks>
+  <tasks name="SoftwareSystems-uthash-NoOverflows">
+    <includesfile>../sv-benchmarks/c/SoftwareSystems-uthash-NoOverflows.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
+  </tasks>
+</rundefinition>
+
+<!--
+<rundefinition name="SV-COMP21_termination">
+  <tasks name="Termination-MainControlFlow">
+    <includesfile>../sv-benchmarks/c/Termination-MainControlFlow.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/termination.prp</propertyfile>
+  </tasks>
+  <tasks name="Termination-MainHeap">
+    <includesfile>../sv-benchmarks/c/Termination-MainHeap.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/termination.prp</propertyfile>
+  </tasks>
+  <tasks name="Termination-Other">
+    <includesfile>../sv-benchmarks/c/Termination-Other.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/termination.prp</propertyfile>
+  </tasks>
+</rundefinition>
+-->
+
+</benchmark>

--- a/crux-llvm/svcomp/mk-svcomp-bindist.sh
+++ b/crux-llvm/svcomp/mk-svcomp-bindist.sh
@@ -50,7 +50,7 @@ bundle_crux_llvm_svcomp_files() {
   ## binaries on the PATH before invocation
   cp crux-llvm-svcomp-driver.sh dist/
   ## Competition-specific configuration files
-  cp config-files/unreach-call.config dist/
+  cp config-files/*.config dist/
   ## The LICENSE and README (a particular SV-COMP requirement listed in
   ## https://sv-comp.sosy-lab.org/2021/rules.php#verifier)
   cp ../LICENSE dist/


### PR DESCRIPTION
This avoids us getting docked points in this very common scenario.

Fixes #822.