### PR TITLE
Update correct MemImpl when supply-main-arguments is enabled

### DIFF
--- a/crux-llvm/test-data/golden/T816.c
+++ b/crux-llvm/test-data/golden/T816.c
@@ -1,3 +1,16 @@
+#include <stdlib.h>
+
+int a = 42;
+
+void f(int b) {
+  a = b;
+}
+
 int main(int argc, char *argv[]) {
-  return 0;
+  f(argc);
+  if (!a) {
+    return 0;
+  } else {
+    abort();
+  }
 }


### PR DESCRIPTION
Previously, `checkMainWithArguments` was incorrectly using a `MemImpl` from a `PreppedLLVM` rather than looking up the `MemImpl` in the `GlobalVar Mem`. Doing so led to #833. Luckily, this is easily fixed.

Fixes #833.