### PR TITLE
Use correct load address for floating-point values in valueLoad

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Common.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Common.hs
@@ -520,9 +520,9 @@ valueLoad lo ltp so v
   | otherwise =
     case storageTypeF ltp of
       Bitvector lw -> loadBitvector lo lw so v
-      Float  -> BVToFloat  $ valueLoad 0 (bitvectorType 4) so v
-      Double -> BVToDouble $ valueLoad 0 (bitvectorType 8) so v
-      X86_FP80 -> BVToX86_FP80 $ valueLoad 0 (bitvectorType 10) so v
+      Float  -> BVToFloat  $ valueLoad lo (bitvectorType 4) so v
+      Double -> BVToDouble $ valueLoad lo (bitvectorType 8) so v
+      X86_FP80 -> BVToX86_FP80 $ valueLoad lo (bitvectorType 10) so v
       Array ln tp ->
         let leSize = storageTypeSize tp
             val i = valueLoad (lo+leSize*fromIntegral i) tp so v

--- a/crux-llvm/test-data/golden/T828.c
+++ b/crux-llvm/test-data/golden/T828.c
@@ -1,0 +1,10 @@
+#include <stdlib.h>
+
+double const arr[2] = { -42, 42 };
+
+int main() {
+  if (arr[1] < 0) {
+    abort();
+  }
+  return 0;
+}

--- a/crux-llvm/test-data/golden/T828.config
+++ b/crux-llvm/test-data/golden/T828.config
@@ -1,0 +1,1 @@
+opt-level: 0

--- a/crux-llvm/test-data/golden/T828.good
+++ b/crux-llvm/test-data/golden/T828.good
@@ -1,0 +1,1 @@
+[Crux] Overall status: Valid.


### PR DESCRIPTION
This change is sufficient to allow the [`float-newlib/double_req_bl_0682a.c`](https://github.com/sosy-lab/sv-benchmarks/blob/99d37c5b4072891803b9e5c154127c912477f705/c/float-newlib/double_req_bl_0682a.c) SV-COMP benchmark program to be verified. I have checked in a significantly minimized version of this program as a regression test.

Fixes #828.