### PR TITLE
Minor SV-COMP tweaks

### DIFF
--- a/crux-llvm/svcomp/config-files/no-overflow.config
+++ b/crux-llvm/svcomp/config-files/no-overflow.config
@@ -1,5 +1,6 @@
 -- For no-overflow, check the following ub-sanitizers
 ub-sanitizers: [ "signed-integer-overflow", "shift",  "integer-divide-by-zero" ]
+supply-main-arguments: empty
 
 -- Don't produce counterexamples upon abnormal exits
 abnormal-exit-behavior: never-fail

--- a/crux-llvm/svcomp/def-files/crux.py
+++ b/crux-llvm/svcomp/def-files/crux.py
@@ -51,6 +51,13 @@ class Tool(benchexec.tools.template.BaseTool2):
             m = override_pat.search(line)
             if m:
                 return result.RESULT_UNKNOWN + "(no override: " + m.group(1) + ")"
+            # Crucible does not currently support inline assembly
+            elif "unsupported LLVM value: ValAsm" in line:
+                return result.RESULT_UNKNOWN + "(inline assembly)"
+            # Crucible does not currently support translating `long double`s
+            # (https://github.com/GaloisInc/crucible/issues/810)
+            elif "unsupported LLVM value: ValFP80" in line:
+                return result.RESULT_UNKNOWN + "(long double)"
             elif "Verification result: VERIFIED" in line:
                 return result.RESULT_TRUE_PROP
             elif "Verification result: FALSIFIED (valid-free)" in line:


### PR DESCRIPTION
* Use `supply-main-arguments: empty` in `no-overflow.config`
* Use `UNKNOWN` for programs with inline assembly or `long double`s. This should prevent us from getting a couple hundred `incorrect false` results in various SoftwareSystems categories.