### PR TITLE
Add overrides for `llvm.copysign.{f32,f64}`

### DIFF
--- a/.github/workflows/crucible-wasm-build.yml
+++ b/.github/workflows/crucible-wasm-build.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: actions/setup-haskell@v1
+      - uses: haskell/actions/setup@v1
         id: setup-haskell
         with:
           ghc-version: ${{ matrix.ghc }}

--- a/.github/workflows/crux-llvm-build.yml
+++ b/.github/workflows/crux-llvm-build.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: actions/setup-haskell@v1
+      - uses: haskell/actions/setup@v1
         id: setup-haskell
         with:
           ghc-version: ${{ matrix.ghc }}

--- a/.github/workflows/crux-mir-build.yml
+++ b/.github/workflows/crux-mir-build.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: actions/setup-haskell@v1
+      - uses: haskell/actions/setup@v1
         id: setup-haskell
         with:
           ghc-version: ${{ matrix.ghc }}

--- a/crucible-llvm/doc/limitations.md
+++ b/crucible-llvm/doc/limitations.md
@@ -30,3 +30,12 @@ values.
 
 Thus the exact printed output, number of characters printed, etc,
 may not exactly match that of a conforming implementation.
+
+
+Floating-point accuracy
+=======================
+
+The implementations of some floating-point operations are imprecise with
+respect to NaN values. For example, `crucible-llvm`'s implementation of the
+`copysign` function will always return a positive, "quiet" NaN value if its
+first argument is a NaN, regardless of the sign of the second argument.

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics.hs
@@ -229,6 +229,8 @@ declare_overrides =
   , polymorphic1_llvm_override "llvm.umul.with.overflow"
       (\w -> SomeLLVMOverride (LLVM.llvmUmulWithOverflow w))
 
+  , basic_llvm_override LLVM.llvmCopysignOverride_F32
+  , basic_llvm_override LLVM.llvmCopysignOverride_F64
   , basic_llvm_override LLVM.llvmFabsF32
   , basic_llvm_override LLVM.llvmFabsF64
 

--- a/crux-llvm/test-data/golden/copysign.c
+++ b/crux-llvm/test-data/golden/copysign.c
@@ -1,0 +1,33 @@
+#include <crucible.h>
+#include <float.h>
+#include <math.h>
+#include <stdbool.h>
+
+// A reasonable specification for copysign, assuming that x isn't NAN or
+// INFINITY.
+float copysign_spec(float x, float y) {
+  float magnitude = fabs(x);
+  if (signbit(y)) {
+    return -magnitude;
+  } else {
+    return magnitude;
+  }
+}
+
+int main() {
+  // The general cases
+  float x = crucible_float("x");
+  float y = crucible_float("y");
+  assuming(!isnan(x));
+  check(copysign(x, y) == copysign_spec(x, y));
+
+  // NAN edge cases
+  //
+  // We don't have a way to distinguish the sign bits of NAN values in
+  // Crucible, so the best we can do is check using isnan().
+  float z = crucible_float("z");
+  assuming(isnan(z));
+  check(isnan(copysign(z, y)));
+
+  return 0;
+}

--- a/crux-llvm/test-data/golden/copysign.config
+++ b/crux-llvm/test-data/golden/copysign.config
@@ -1,0 +1,2 @@
+floating-point: "ieee"
+solver: "z3"

--- a/crux-llvm/test-data/golden/copysign.good
+++ b/crux-llvm/test-data/golden/copysign.good
@@ -1,0 +1,1 @@
+[Crux] Overall status: Valid.


### PR DESCRIPTION
LLVM 12 is much more eager to simplify certain expressions to calls to `llvm.copysign.f*`, as illustrated in https://github.com/GaloisInc/crucible/issues/187#issuecomment-917047901. It proves relatively straightforward to just add overrides for the `llvm.copysign.f{32,64}` instrinsics, so this patch accomplishes just that. The one caveat is that we cannot accurately represent the semantics of `llvm.copysign.f*` with respect to NaN arguments, since What4 does not possess a way to distinguish the sign bits of NaN values. I decided not to let perfect be the enemy of good, however, so I simply made a note of this limitation in the `crucible-llvm/doc/limitations.md` file.

Addresses one bullet point in #187.