### PR TITLE
SV-COMP: various witness-related tweaks

### DIFF
--- a/crux-llvm/svcomp/Main.hs
+++ b/crux-llvm/svcomp/Main.hs
@@ -44,7 +44,7 @@ import Data.Time.LocalTime ( getZonedTime )
 import Data.Version ( showVersion )
 import GHC.Generics ( Generic )
 import System.Exit ( exitFailure, exitSuccess )
-import System.FilePath ( (</>), takeBaseName )
+import System.FilePath ( (</>) )
 
 -- crucible
 import Lang.Crucible.Backend ( CrucibleEvent(..) )
@@ -191,8 +191,7 @@ processInputFiles cruxOpts llvmOpts svOpts =
                    }
                  trivialCorrectnessWitness = mkWitness [(mkNode 0) { nodeEntry = Just True }] []
 
-             let witnessFileName = takeBaseName inputFile ++ "-witness.graphml"
-             writeFile witnessFileName $ ppWitness $ case witType of
+             writeFile (svcompWitnessOutput svOpts) $ ppWitness $ case witType of
                CorrectnessWitness -> trivialCorrectnessWitness
                ViolationWitness   -> let (nodes, edges) = mkViolationWitness $ fmap snd gls
                                      in mkWitness nodes edges

--- a/crux-llvm/svcomp/README.md
+++ b/crux-llvm/svcomp/README.md
@@ -108,4 +108,153 @@ $ PYTHONPATH=../benchexec python3 -m benchexec.benchexec -r SV-COMP21_unreach-ca
 This will start a run of the `SV-COMP21_unreach-call` benchmark definition as
 defined in `../benchmark-defs/crux.xml`. (See the "Preparing the necessary
 files for SV-COMP benchmark runs" section.) To execute a different benchmark
-definition, change the argument to `-r`.
+definition, change the argument to `-r`. When the run is complete, it will
+place various files under the `results/` directory, including:
+
+* `crux.<date>.results.<benchmark-definition>.txt`, a human-readable summary
+  of the run which contains the status of each individual benchmark and a
+  total score at the bottom.
+* `crux.<date>.results.<benchmark-definition>.xml.bz2`, an archive file
+  containing an XML file which much more information about the run. If you
+  want to perform analysis over the run results, this is the file you want.
+* `crux.<date>.files/`, a directory containing the witness automaton files that
+  `crux-llvm-svcomp` produced for each individual benchmark.
+* `crux.<date>.logfiles.zip`, an archive file containing the logs that were
+  recorded for each individual benchmark. This information can be useful after
+  the run to figure out why certain benchmark programs produce unexpected
+  results.
+
+## Scoring an SV-COMP benchmark run
+
+`benchexec` will compute a total score for each run that awards points for
+correct verdicts and deducts points for incorrect verdicts. The most convenient
+place to find this score is at the bottom of the
+`results/crux.<date>.results.<benchmark-definition>.txt` file, which will look
+something like this:
+
+```
+Statistics:            631 Files
+  correct:             277
+    correct true:       67
+    correct false:     210
+  incorrect:             2
+    incorrect true:      0
+    incorrect false:     2
+  unknown:             352
+  Score:               312 (max: 998)
+```
+
+There is one major caveat here: these scores do _not_ take witness automaton
+files into account. As a result, the score reported in this file is more like
+an upper bound on what the total score will be. In order to compute the score
+after taking witnesses into account, you will need to do the following:
+
+1. Use the `./scripts/execute-runs/mkInstall.sh` script to check out the
+   witness validator programs. They are:
+
+   * `val_cpa-seq`
+   * `val_cpa-witness2test`
+   * `val_fshell-witness2test`
+   * `val_metaval`
+   * `val_nitwit`
+   * `val_uautomizer`
+   * `val_witnesslint`
+
+   `val_witnesslint` is a bit special in that it only checks to see if a
+   witness automaton is syntactically well formed and adheres to the
+   requirements listed [here](https://github.com/sosy-lab/sv-witnesses/blob/20414d976d9e46da6a93be38c34237f71a01033f/README.md#data-elements).
+   It's a good idea to make sure that `val_witnesslint` accepts a witness
+   automaton that Crux produces, but if it accepts one, it will almost
+   assuredly accept them all.
+2. Witness validators are invoked by way of `benchexec` much like verifiers
+   are. To that end, each validator has its own `.xml` definition file inside
+   `bench-defs/benchmark-defs/`. These `.xml` files specify where a validator
+   should look for witness automaton files.
+
+   In order to point the validators at the right locations to find these files,
+   you will need to go into each `.xml` files and edit them accordingly. (Yes,
+   this is an extremely tedious process. It would be nice if we could find a
+   way to automate this.) For example, inside of
+   `cpa-seq-validate-correctness-witnesses.xml` you will find
+   [these lines](https://gitlab.com/sosy-lab/sv-comp/bench-defs/-/blob/a9bfd363f1c222165e09708585c5fdcfa1d47495/benchmark-defs/cpa-seq-validate-correctness-witnesses.xml#L87-89):
+
+   ```xml
+   <rundefinition name="SV-COMP21_no-overflow">
+     <requiredfiles>../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</requiredfiles>
+     <option name="-witness">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
+     ...
+   </rundefinition>
+   ```
+
+   You will need to change the `<requiredfiles>` and `<option name="-witness">`
+   bits to point to where your witness automaton files live. In my case, I was
+   used something like:
+
+   ```xml
+   <rundefinition name="SV-COMP21_no-overflow">
+     <requiredfiles>../crux-llvm-svcomp-2021-09-15-Linux-x86_64/results/crux.2021-09-16_02-25-33.files/${rundefinition_name}/${taskdef_name}/witness.graphml</requiredfiles>
+     <option name="-witness">../crux-llvm-svcomp-2021-09-15-Linux-x86_64/results/crux.2021-09-16_02-25-33.files/${rundefinition_name}/${taskdef_name}/witness.graphml</option>
+     ...
+   </rundefinition>
+   ```
+
+   You will need to repeat this process for each `<rundefinition>` for which
+   you have results for in each of these files:
+
+   * `cpa-seq-validate-correctness-witnesses.xml`
+   * `cpa-seq-validate-violation-witnesses.xml`
+   * `cpa-witness2test-validate-violation-witnesses.xml`
+   * `fshell-witness2test-validate-violation-witnesses.xml`
+   * `metaval-validate-correctness-witnesses.xml`
+   * `metaval-validate-violation-witnesses.xml`
+   * `nitwit-validate-violation-witnesses.xml`
+   * `uautomizer-validate-correctness-witnesses.xml`
+   * `uautomizer-validate-violation-witnesses.xml`
+3. Use `benchexec` to run each of the witness validators. I have checked in a
+   `benchexec-util-scripts/validate-witnesses.sh` script that I use to automate
+   this process.
+4. Each validators' `results/` directories will now have information about
+   witness validity that needs to be pieced together. The `benchexec` repo has
+   a [`mergeBenchmarkSets.py`](https://github.com/sosy-lab/benchexec/blob/344eb314bad07142a8ff0cebc2eae9502470ef60/contrib/mergeBenchmarkSets.py)
+   script that does this for you. This script takes the original run's
+   `.xml.bz2` file (containing the results of the run) as its first argument,
+   and each subsequent argument is an `.xml.bz2` file containing results from
+   a witness validator. Here is one example of how to invoke it:
+
+   ```bash
+   PYTHONPATH=benchexec-master python3 -m contrib.mergeBenchmarkSets /home/bench-defs/crux-llvm-svcomp-2021-09-15-Linux-x86_64/results/crux.2021-09-16_02-25-33.results.SV-COMP21_no-overflow.xml.bz2 /home/bench-defs/val_cpa-seq/results/cpa-seq-validate-correctness-witnesses.2021-09-21_19-28-15.results.SV-COMP21_no-overflow.xml.bz2 /home/bench-defs/val_cpa-seq/results/cpa-seq-validate-violation-witnesses.2021-09-21_20-48-27.results.SV-COMP21_no-overflow.xml.bz2 /home/bench-defs/val_cpa-witness2test/results/cpa-witness2test-validate-violation-witnesses.2021-09-21_21-36-02.results.SV-COMP21_no-overflow.xml.bz2 /home/bench-defs/val_fshell-witness2test/results/fshell-witness2test-validate-violation-witnesses.2021-09-21_21-50-30.results.SV-COMP21_no-overflow.xml.bz2 /home/bench-defs/val_metaval/results/metaval-validate-correctness-witnesses.2021-09-21_21-59-19.results.SV-COMP21_no-overflow.xml.bz2 /home/bench-defs/val_metaval/results/metaval-validate-violation-witnesses.2021-09-22_01-25-21.results.SV-COMP21_no-overflow.xml.bz2 /home/bench-defs/val_uautomizer/results/uautomizer-validate-correctness-witnesses.2021-09-22_02-20-16.results.SV-COMP21_no-overflow.xml.bz2 /home/bench-defs/val_uautomizer/results/uautomizer-validate-violation-witnesses.2021-09-22_09-45-00.results.SV-COMP21_no-overflow.xml.bz2
+   ```
+
+   This produce a `crux.<date>.results.<benchmark-definition>.xml.bz2.merged.xml.bz2`
+   file in the same `results/` directory as the original
+   `crux.<date>.results.<benchmark-definition>.xml.bz2`. This can be used to
+   compute a revised total score in one of two ways. The first way is to use
+   the `benchexec-util-scripts/CountScore.hs` script, which will output the
+   total score in a textual format:
+
+   ```bash
+   $ ./CountScore.hs /home/rscott/bench-defs/crux-llvm-svcomp-2021-09-15-Linux-x86_64/results/crux.2021-09-16_02-25-33.results.SV-COMP21_no-overflow.xml.bz2.merged.xml.bz2
+   Statistics:                     631 Files
+     correct:                      249
+       correct true:               61
+       correct false:              188
+     correct-unconfirmed:          28
+       correct-unconfirmed true:   6
+       correct-unconfirmed false:  22
+     incorrect:                    2
+       incorrect true:             0
+       incorrect false:            2
+     unknown:                      352
+   Score:                          278 (max: 998)
+   ```
+
+   Note the new `correct-unconfirmed` category, which corresponds to benchmark
+   programs where Crux was able to compute an answer, but no witness validator
+   was able to validate the corresponding witness automaton. Each
+   `correct-unconfirmed` result is worth zero points, so the total score is
+   slightly lower here.
+
+   The second way is to use the `benchexec/bin/table-generator` script. If you
+   invoke this script with the `.merged.xml.bz2` file as the argument, it will
+   produce an `.html` file that will contain the information above when opened
+   in a web browser, among other statistics.

--- a/crux-llvm/svcomp/benchexec-util-scripts/CountScore.hs
+++ b/crux-llvm/svcomp/benchexec-util-scripts/CountScore.hs
@@ -1,0 +1,303 @@
+#!/usr/bin/env cabal
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{- cabal:
+build-depends: base
+             , bytestring
+             , bzlib
+             , extra
+             , filepath
+             , Glob
+             , optparse-applicative
+             , parsec
+             , text
+             , xml
+-}
+{-# OPTIONS_GHC -Wall #-}
+module Main (main) where
+
+import Codec.Compression.BZip (decompress)
+import qualified Data.ByteString.Lazy as BL
+import Data.Foldable
+import qualified Data.List.Extra as L
+import Data.Maybe
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import qualified Options.Applicative as Options (Parser)
+import Options.Applicative hiding (Parser)
+import System.Exit (ExitCode(..))
+import System.FilePath ((</>))
+import System.FilePath.Glob
+import Text.Parsec
+import Text.XML.Light
+import Text.XML.Light.Cursor
+
+data Options = Options
+  { bz2File :: FilePath
+  , setBlacklist :: [FilePath]
+  } deriving stock Show
+
+optionsParser :: Options.Parser Options
+optionsParser = Options
+  <$> strArgument
+      (  metavar "FILE"
+      <> help "The .bz2 file with the results of a benchexec run" )
+  <*> csListOption
+      (  long "set-blacklist"
+      <> value []
+      <> help "Do not include results from these .set files" )
+
+-- | Comma-separated lists of arguments.
+csListOption :: Mod OptionFields String -> Options.Parser [String]
+csListOption flags = splitAtElement ',' <$> strOption flags
+
+splitAtElement :: Eq a => a -> [a] -> [[a]]
+splitAtElement x l =
+  case l of
+    []          -> []
+    e:es | e==x -> split' es
+    es          -> split' es
+  where
+    split' es = let (esx,esxs) = break (x==) es
+                in esx : splitAtElement x esxs
+
+main :: IO ()
+main = execParser opts >>= countScoreBZ2
+  where
+    opts = info (optionsParser <**> helper)
+      ( fullDesc
+     <> progDesc spiel
+     <> header spiel )
+
+    spiel = "Compute the scores in a benchexec run"
+
+countScoreBZ2 :: Options -> IO ()
+countScoreBZ2 opts@Options{bz2File} = do
+  bz2BS <- BL.readFile bz2File
+  countScoreXML opts $ parseXML $ decompress bz2BS
+
+data Verdict
+  = VerdictTrue
+  | VerdictFalse
+  | VerdictUnknown
+  deriving stock (Eq, Show)
+
+data Result
+  = ResultCorrect Bool
+  | ResultCorrectUnconfirmed Bool
+  | ResultIncorrect Bool
+  | ResultUnknown
+  deriving stock (Eq, Show)
+
+resultCorrectMaybe :: Result -> Maybe Bool
+resultCorrectMaybe (ResultCorrect b)          = Just b
+resultCorrectMaybe ResultCorrectUnconfirmed{} = Nothing
+resultCorrectMaybe ResultIncorrect{}          = Nothing
+resultCorrectMaybe ResultUnknown              = Nothing
+
+resultCorrectUnconfirmedMaybe :: Result -> Maybe Bool
+resultCorrectUnconfirmedMaybe (ResultCorrectUnconfirmed b) = Just b
+resultCorrectUnconfirmedMaybe ResultCorrect{}              = Nothing
+resultCorrectUnconfirmedMaybe ResultIncorrect{}            = Nothing
+resultCorrectUnconfirmedMaybe ResultUnknown                = Nothing
+
+resultIncorrectMaybe :: Result -> Maybe Bool
+resultIncorrectMaybe (ResultIncorrect b)        = Just b
+resultIncorrectMaybe ResultCorrect{}            = Nothing
+resultIncorrectMaybe ResultCorrectUnconfirmed{} = Nothing
+resultIncorrectMaybe ResultUnknown              = Nothing
+
+isResultUnknown :: Result -> Bool
+isResultUnknown ResultUnknown              = True
+isResultUnknown ResultCorrect{}            = False
+isResultUnknown ResultCorrectUnconfirmed{} = False
+isResultUnknown ResultIncorrect{}          = False
+
+data Category
+  = CategoryCorrect
+  | CategoryCorrectUnconfirmed
+  | CategoryWrong
+  | CategoryUnknown
+  | CategoryError
+  -- | CategoryMissing
+  deriving stock (Eq, Show)
+
+data Run = Run
+  { runName            :: FilePath
+  , runFile            :: FilePath
+  , runPropertyFile    :: FilePath
+  , runExpectedVerdict :: Verdict
+  , runStatus          :: Verdict
+  , runCategory        :: Category
+  } deriving stock Show
+
+data ValidationResult = ValidationResult
+  { vrRun      :: Run
+  , vrExitCode :: ExitCode
+  } deriving stock Show
+
+data CDataModel = ILP32 | LP64
+ deriving stock (Eq, Show)
+
+runFromElement_maybe :: Element -> Maybe Run
+runFromElement_maybe e =
+  let mbName            = firstAttrNamed "name" e
+      mbFiles           = firstAttrNamed "files" e
+      mbPropertyFile    = firstAttrNamed "propertyFile" e
+      mbExpectedVerdict = firstAttrNamed "expectedVerdict" e
+      mbStatus          = L.firstJust (firstColumnTitled "status") (elContent e)
+      mbCategory        = L.firstJust (firstColumnTitled "category") (elContent e) in
+  fmap (\(name, files, propertyFile, expectedVerdict, status, category) ->
+          Run{ runName            = name
+             , runFile            = parseSingleFile files
+             , runPropertyFile    = propertyFile
+             , runExpectedVerdict = parseVerdict expectedVerdict
+             , runStatus          = parseVerdict status
+             , runCategory        = parseCategory category
+             })
+       ((,,,,,) <$> mbName <*> mbFiles <*> mbPropertyFile <*> mbExpectedVerdict <*> mbStatus <*> mbCategory)
+  where
+    firstAttrNamed :: String -> Element -> Maybe String
+    firstAttrNamed n el = L.firstJust (attrWithKey n) (elAttribs el)
+
+    firstColumnTitled :: String -> Content -> Maybe String
+    firstColumnTitled n c =
+      case contentWithElName "column" c of
+        Nothing  -> Nothing
+        Just col -> L.firstJust (\a -> case liftA2 (,) (attrWithKey "title" a)
+                                                       (L.firstJust (attrWithKey "value") (elAttribs col)) of
+                                  Just (title, val) |  title == n
+                                                    -> Just val
+                                  _                 -> Nothing)
+                                  (elAttribs col)
+
+parseSingleFile :: String -> FilePath
+parseSingleFile s =
+  case parse parser "" s of
+    Left err -> error $ show err
+    Right fp -> fp
+  where
+    parser = char '[' *> manyTill anyChar (char ']')
+
+parseVerdict :: String -> Verdict
+parseVerdict "true"                         = VerdictTrue
+parseVerdict "TIMEOUT"                      = VerdictUnknown
+parseVerdict "OUT OF MEMORY"                = VerdictUnknown
+parseVerdict s | "false"   `L.isPrefixOf` s = VerdictFalse
+               | "unknown" `L.isPrefixOf` s = VerdictUnknown
+               | "ERROR"   `L.isPrefixOf` s = VerdictUnknown
+               | otherwise                  = error $ "Unrecognized verdict: " ++ s
+
+parseCategory :: String -> Category
+parseCategory "correct"             = CategoryCorrect
+parseCategory "correct-unconfirmed" = CategoryCorrectUnconfirmed
+parseCategory "wrong"               = CategoryWrong
+parseCategory "unknown"             = CategoryUnknown
+parseCategory "error"               = CategoryError
+parseCategory s                     = error $ "Unrecognized category: " ++ s
+
+countScoreXML :: Options -> [Content] -> IO ()
+countScoreXML Options{setBlacklist} xml = do
+  blacklistPatterns <- concat <$> traverse readBlacklistPatterns setBlacklist
+  case fromForest xml >>= findRec (contentHasElName "systeminfo" . current) of
+    Nothing -> fail "Unexpected XML"
+    Just c  -> do
+      let runs = filter (runNotInPatterns blacklistPatterns)
+               $ mapMaybe runFromElement_maybe
+               $ mapMaybe (contentWithElName "run")
+               $ rights c
+          results                   = map runResult runs
+          correctResults            = mapMaybe resultCorrectMaybe results
+          correctUnconfirmedResults = mapMaybe resultCorrectUnconfirmedMaybe results
+          incorrectResults          = mapMaybe resultIncorrectMaybe results
+          unknownResults            = filter isResultUnknown results
+          totalScore                = foldl' (\s r -> s + resultScore r) 0 results
+          maxScore                  = foldl' (\s r -> s + runMaxScore r) 0 runs
+
+      putStrLn $ "Statistics:\t\t\t"                ++ show (length runs) ++ " Files"
+      putStrLn $ "  correct:\t\t\t"                 ++ show (length correctResults)
+      putStrLn $ "    correct true:\t\t"            ++ show (length $ filter id correctResults)
+      putStrLn $ "    correct false:\t\t"           ++ show (length $ filter not correctResults)
+      putStrLn $ "  correct-unconfirmed:\t\t"       ++ show (length correctUnconfirmedResults)
+      putStrLn $ "    correct-unconfirmed true:\t"  ++ show (length $ filter id correctUnconfirmedResults)
+      putStrLn $ "    correct-unconfirmed false:\t" ++ show (length $ filter not correctUnconfirmedResults)
+      putStrLn $ "  incorrect:\t\t\t"               ++ show (length incorrectResults)
+      putStrLn $ "    incorrect true:\t\t"          ++ show (length $ filter id incorrectResults)
+      putStrLn $ "    incorrect false:\t\t"         ++ show (length $ filter not incorrectResults)
+      putStrLn $ "  unknown:\t\t\t"                 ++ show (length unknownResults)
+      putStrLn $ "Score:\t\t\t\t"                   ++ show totalScore ++ " (max: " ++ show maxScore ++ ")"
+  where
+    runNotInPatterns :: [Pattern] -> Run -> Bool
+    runNotInPatterns ps Run{runName} = not $ any (`match` runName') ps
+      where
+        -- Unbelievably hacky
+        runName' = L.dropPrefix "../../sv-benchmarks/c/" runName
+
+    readBlacklistPatterns :: FilePath -> IO [Pattern]
+    readBlacklistPatterns setFile = do
+      setFileContents <- T.readFile $ ".." </> ".." </> "sv-benchmarks" </> "c" </> setFile
+      pure $ map compile $ lines $ T.unpack setFileContents
+
+    resultScore :: Result -> Int
+    resultScore (ResultCorrect   True)       = 2
+    resultScore (ResultCorrect   False)      = 1
+    resultScore (ResultCorrectUnconfirmed _) = 0
+    resultScore (ResultIncorrect True)       = -32
+    resultScore (ResultIncorrect False)      = -16
+    resultScore ResultUnknown                = 0
+
+    runMaxScore :: Run -> Int
+    runMaxScore Run{runExpectedVerdict} =
+      case runExpectedVerdict of
+        VerdictTrue    -> 2
+        VerdictFalse   -> 1
+        VerdictUnknown -> 0
+
+    runResult :: Run -> Result
+    runResult Run{runExpectedVerdict, runStatus, runCategory}
+      | runStatus == VerdictUnknown
+      = ResultUnknown
+      | runCategory == CategoryCorrect
+      , runExpectedVerdict == VerdictTrue
+      , runStatus == VerdictTrue
+      = ResultCorrect True
+      | runCategory == CategoryCorrectUnconfirmed
+      , runExpectedVerdict == VerdictTrue
+      , runStatus == VerdictTrue
+      = ResultCorrectUnconfirmed True
+      | runCategory == CategoryWrong
+      , runExpectedVerdict == VerdictTrue
+      , runStatus == VerdictFalse
+      = ResultIncorrect False
+      | runCategory == CategoryCorrect
+      , runExpectedVerdict == VerdictFalse
+      , runStatus == VerdictFalse
+      = ResultCorrect False
+      | runCategory == CategoryCorrectUnconfirmed
+      , runExpectedVerdict == VerdictFalse
+      , runStatus == VerdictFalse
+      = ResultCorrectUnconfirmed False
+      | runCategory == CategoryWrong
+      , runExpectedVerdict == VerdictFalse
+      , runStatus == VerdictTrue
+      = ResultIncorrect True
+      | otherwise
+      = error $ "Invalid combination: "
+            ++ unwords [show runExpectedVerdict, show runStatus, show runCategory]
+
+contentHasElName :: String -> Content -> Bool
+contentHasElName n = isJust . contentWithElName n
+
+contentWithElName :: String -> Content -> Maybe Element
+contentWithElName n c = case c of
+  Elem e |  qName (elName e) == n
+         -> Just e
+  _      -> Nothing
+
+attrWithKey :: String -> Attr -> Maybe String
+attrWithKey n a | qName (attrKey a) == n
+                = Just (attrVal a)
+                | otherwise
+                = Nothing

--- a/crux-llvm/svcomp/benchexec-util-scripts/validate-witnesses.sh
+++ b/crux-llvm/svcomp/benchexec-util-scripts/validate-witnesses.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -xe
+
+RUNDEFINITION=unreach-call
+
+cd val_cpa-seq
+PYTHONPATH=../benchexec python3 -m benchexec.benchexec -r SV-COMP21_${RUNDEFINITION} ../benchmark-defs/cpa-seq-validate-correctness-witnesses.xml
+PYTHONPATH=../benchexec python3 -m benchexec.benchexec -r SV-COMP21_${RUNDEFINITION} ../benchmark-defs/cpa-seq-validate-violation-witnesses.xml
+cd ..
+
+cd val_cpa-witness2test
+PYTHONPATH=../benchexec python3 -m benchexec.benchexec -r SV-COMP21_${RUNDEFINITION} ../benchmark-defs/cpa-witness2test-validate-violation-witnesses.xml
+cd ..
+
+cd val_fshell-witness2test
+PYTHONPATH=../benchexec python3 -m benchexec.benchexec -r SV-COMP21_${RUNDEFINITION} ../benchmark-defs/fshell-witness2test-validate-violation-witnesses.xml
+cd ..
+
+cd val_metaval
+PYTHONPATH=../benchexec python3 -m benchexec.benchexec -r SV-COMP21_${RUNDEFINITION} ../benchmark-defs/metaval-validate-correctness-witnesses.xml
+PYTHONPATH=../benchexec python3 -m benchexec.benchexec -r SV-COMP21_${RUNDEFINITION} ../benchmark-defs/metaval-validate-violation-witnesses.xml
+cd ..
+
+cd val_nitwit
+PYTHONPATH=../benchexec python3 -m benchexec.benchexec -r SV-COMP21_${RUNDEFINITION} ../benchmark-defs/nitwit-validate-violation-witnesses.xml
+cd ..
+
+cd val_uautomizer
+PYTHONPATH=../benchexec python3 -m benchexec.benchexec -r SV-COMP21_${RUNDEFINITION} ../benchmark-defs/uautomizer-validate-correctness-witnesses.xml
+PYTHONPATH=../benchexec python3 -m benchexec.benchexec -r SV-COMP21_${RUNDEFINITION} ../benchmark-defs/uautomizer-validate-violation-witnesses.xml
+cd ..


### PR DESCRIPTION
This contains various changes that I needed to get `crux-llvm-svcomp`'s witness files accepted by the various witness validators used in SV-COMP, including:

* An option to name witness automaton files as `witness.graphml`, as that works best with `benchexec`.
* A hack to make sure that witness files never print decimals in `creationtime`s, as the witness linter will reject these.
* Some notes on how to factor witness validation into scoring.

Refer to each individual commit message for further details.