### PR TITLE
Export SymIO open/close/read/write overrides

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/SymIO.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/SymIO.hs
@@ -53,6 +53,10 @@ module Lang.Crucible.LLVM.SymIO
   , LLVMFileSystem
   , SomeOverrideSim(..)
   , initialLLVMFileSystem
+  , openFile
+  , closeFile
+  , readFileHandle
+  , writeFileHandle
   )
   where
 


### PR DESCRIPTION
This change adds `openFile`, `closeFile`, `readFileHandle`, and
`writeFileHandle` to the exports from `Lang.Crucible.LLVM.SymIO` so that
they may be used directly rather than through the existing
`symio_overrides` list.