### PR TITLE
uc-crux-llvm: Use a fixed configuration in test suite

### DIFF
--- a/uc-crux-llvm/uc-crux-llvm.cabal
+++ b/uc-crux-llvm/uc-crux-llvm.cabal
@@ -157,4 +157,6 @@ test-suite uc-crux-llvm-test
                 tasty-hunit      >= 0.10,
                 tasty-quickcheck >= 0.10,
                 text,
-                uc-crux-llvm
+                time,
+                uc-crux-llvm,
+                what4


### PR DESCRIPTION
Uses #832 to stop grabbing the configuration from the environment and instead fix its values. This is substantially cleaner and more flexible, if a bit more verbose.