### PR TITLE
uc-crux-llvm: Split the test suite into more modules

### DIFF
--- a/uc-crux-llvm/.hlint.yaml
+++ b/uc-crux-llvm/.hlint.yaml
@@ -60,7 +60,7 @@
     within: ["UCCrux.LLVM.Config"]
 - ignore:  # No need for this in the test suite
     name: "Use panic"
-    within: ["Main"]
+    within: ["Main", "Utils"]
 - ignore:  # Guide to further implementation
     name: "Redundant if"
     within: ["UCCrux.LLVM.Classify.Poison"]

--- a/uc-crux-llvm/test/Logging.hs
+++ b/uc-crux-llvm/test/Logging.hs
@@ -1,0 +1,88 @@
+{-
+Copyright        : (c) Galois, Inc 2021
+License          : BSD3
+Maintainer       : Langston Barrett <langston@galois.com>
+Stability        : provisional
+-}
+
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Logging
+  ( Log.Logs,
+    UCCruxLLVMTestLogging,
+    withUCCruxLLVMTestLogging,
+    ucCruxLLVMTestLoggingToSayWhat,
+    sayUCCruxLLVMTest,
+    UCCruxLLVMTestLogMessage(ClangTrouble)
+  ) where
+
+{- ORMOLU_DISABLE -}
+import           Data.Aeson (ToJSON)
+import           GHC.Generics (Generic)
+
+import qualified Crux
+import qualified Crux.Log as Log
+
+import qualified Crux.LLVM.Log as Log
+
+import qualified UCCrux.LLVM.Main as Main
+import qualified UCCrux.LLVM.Logging as Log
+{- ORMOLU_ENABLE -}
+
+-- | Extra logging messages specific to this test suite
+
+data UCCruxLLVMTestLogMessage
+  = ClangTrouble
+  deriving (Generic, ToJSON)
+
+type SupportsUCCruxLLVMTestLogMessage msgs =
+  (?injectUCCruxLLVMTestLogMessage :: UCCruxLLVMTestLogMessage -> msgs)
+
+sayUCCruxLLVMTest ::
+  Crux.Logs msgs =>
+  (?injectUCCruxLLVMTestLogMessage :: UCCruxLLVMTestLogMessage -> msgs) =>
+  UCCruxLLVMTestLogMessage ->
+  IO ()
+sayUCCruxLLVMTest msg =
+  let ?injectMessage = ?injectUCCruxLLVMTestLogMessage
+   in Crux.say msg
+
+ucCruxLLVMTestLogMessageToSayWhat ::
+  UCCruxLLVMTestLogMessage ->
+  Crux.SayWhat
+ucCruxLLVMTestLogMessageToSayWhat ClangTrouble =
+  Crux.SayWhat Crux.Fail Log.ucCruxLLVMTag "Trouble when running Clang:"
+
+-- | Logging data type joining test log messages and uc-crux-llvm log messages
+
+data UCCruxLLVMTestLogging
+  = LoggingViaUCCruxLLVM Main.UCCruxLLVMLogging
+  | LoggingUCCruxLLVMTest UCCruxLLVMTestLogMessage
+  deriving (Generic, ToJSON)
+
+ucCruxLLVMTestLoggingToSayWhat :: UCCruxLLVMTestLogging -> Log.SayWhat
+ucCruxLLVMTestLoggingToSayWhat (LoggingViaUCCruxLLVM msg) =
+  Main.ucCruxLLVMLoggingToSayWhat msg
+ucCruxLLVMTestLoggingToSayWhat (LoggingUCCruxLLVMTest msg) =
+  ucCruxLLVMTestLogMessageToSayWhat msg
+
+withUCCruxLLVMTestLogging ::
+  ( ( Log.SupportsCruxLogMessage UCCruxLLVMTestLogging,
+      Log.SupportsCruxLLVMLogMessage UCCruxLLVMTestLogging,
+      Log.SupportsUCCruxLLVMLogMessage UCCruxLLVMTestLogging,
+      SupportsUCCruxLLVMTestLogMessage UCCruxLLVMTestLogging
+    ) =>
+    computation
+  ) ->
+  computation
+withUCCruxLLVMTestLogging computation =
+  let ?injectCruxLogMessage = LoggingViaUCCruxLLVM . Main.LoggingCrux
+      ?injectCruxLLVMLogMessage = LoggingViaUCCruxLLVM . Main.LoggingCruxLLVM
+      ?injectUCCruxLLVMLogMessage = LoggingViaUCCruxLLVM . Main.LoggingUCCruxLLVM
+      ?injectUCCruxLLVMTestLogMessage = LoggingUCCruxLLVMTest
+   in computation

--- a/uc-crux-llvm/test/Utils.hs
+++ b/uc-crux-llvm/test/Utils.hs
@@ -1,0 +1,182 @@
+{-
+Copyright        : (c) Galois, Inc 2021
+License          : BSD3
+Maintainer       : Langston Barrett <langston@galois.com>
+Stability        : provisional
+-}
+
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Utils
+  ( testDir,
+    withOptions
+  ) where
+
+{- ORMOLU_DISABLE -}
+import           Control.Exception (try)
+import           Data.Maybe (fromMaybe, isNothing)
+import           System.Environment (lookupEnv)
+import           System.FilePath ((</>))
+import           System.IO (IOMode(WriteMode), withFile)
+
+import qualified Text.LLVM.AST as L
+
+import qualified What4.ProblemFeatures as What4 (noFeatures)
+
+import           Lang.Crucible.FunctionHandle (HandleAllocator, newHandleAllocator)
+
+import           Lang.Crucible.LLVM.Intrinsics as CLLVM (defaultIntrinsicsOptions)
+import qualified Lang.Crucible.LLVM.MemModel as CLLVM
+import           Lang.Crucible.LLVM.Translation as CLLVM (defaultTranslationOptions)
+
+import qualified Crux
+import qualified Crux.Config.Common as Crux
+import qualified Crux.Log as Log
+
+import           Crux.LLVM.Config (LLVMOptions)
+import qualified Crux.LLVM.Config as CruxLLVM
+import           Crux.LLVM.Compile (genBitCode)
+
+import           UCCrux.LLVM.Context.App (AppContext, makeAppContext)
+import           UCCrux.LLVM.Context.Module (ModuleContext)
+import qualified UCCrux.LLVM.Logging as Log
+import qualified UCCrux.LLVM.Main as Main
+
+import qualified Logging as Log
+{- ORMOLU_ENABLE -}
+
+testDir :: FilePath
+testDir = "test/programs"
+
+withOptions ::
+  Maybe L.Module ->
+  FilePath ->
+  ( forall m arch.
+    Log.Logs Log.UCCruxLLVMTestLogging =>
+    Log.SupportsCruxLogMessage Log.UCCruxLLVMTestLogging =>
+    AppContext ->
+    ModuleContext m arch ->
+    HandleAllocator ->
+    Crux.CruxOptions ->
+    LLVMOptions ->
+    IO a
+  ) ->
+  IO a
+withOptions llvmModule file k =
+  Log.withUCCruxLLVMTestLogging $
+  do
+    withFile (testDir </> file <> ".output") WriteMode $ \h ->
+      do
+        let appCtx = makeAppContext Log.Low
+        llOpts <- (\ll -> ll { CruxLLVM.noCompile = False }) <$> mkLLOpts ""
+        let cruxOpts = mkCruxOpts [testDir </> file]
+        let ?outputConfig =
+              Crux.mkOutputConfig
+                (h, False)
+                (h, False)
+                Log.ucCruxLLVMTestLoggingToSayWhat
+                (Just cruxOpts)
+        _ <- Crux.postprocessOptions cruxOpts -- Validate, create build directory
+        path <-
+          let complain exc = do
+                Log.sayUCCruxLLVMTest Log.ClangTrouble
+                Log.logException exc
+                error ("aborting: " ++ show exc)
+           in if isNothing llvmModule
+              then try (genBitCode cruxOpts llOpts) >>= either complain return
+              else return "<fake-path>"
+        cruxOpts' <- Crux.postprocessOptions (mkCruxOpts [path])
+
+        -- TODO(lb): It would be nice to print this only when the test fails
+        -- putStrLn
+        --   ( unwords
+        --       [ "\nReproduce with:\n",
+        --         "cabal v2-run exe:uc-crux-llvm -- ",
+        --         "--entry-points",
+        --         intercalate " --entry-points " (map show fns),
+        --         testDir </> file
+        --       ]
+        --   )
+
+        halloc <- newHandleAllocator
+        memVar <- CLLVM.mkMemVar "uc-crux-llvm:test_llvm_memory" halloc
+        Main.SomeModuleContext' modCtx <-
+          case llvmModule of
+            Just lMod -> Main.translateLLVMModule llOpts halloc memVar path lMod
+            Nothing -> Main.translateFile llOpts halloc memVar path
+
+        k appCtx modCtx halloc cruxOpts' llOpts
+
+  where
+    mkLLOpts :: FilePath -> IO CruxLLVM.LLVMOptions
+    mkLLOpts libDir =
+      do clang <- fromMaybe "clang" <$> lookupEnv "CLANG"
+         llvmLink <- fromMaybe "llvm-link" <$> lookupEnv "LLVM_LINK"
+         return $
+           CruxLLVM.LLVMOptions
+             { CruxLLVM.clangBin = clang
+             , CruxLLVM.linkBin = llvmLink
+             -- NB(lb): The -fno-wrapv here ensures that Clang will emit 'nsw' flags
+             -- even on platforms using nixpkgs, which injects -fno-strict-overflow
+             -- by default.
+             , CruxLLVM.clangOpts = ["-fno-wrapv"]
+             , CruxLLVM.libDir = libDir
+             , CruxLLVM.incDirs = []
+             , CruxLLVM.targetArch = Nothing
+             , CruxLLVM.ubSanitizers = []
+             , CruxLLVM.intrinsicsOpts = CLLVM.defaultIntrinsicsOptions
+             , CruxLLVM.memOpts = CLLVM.defaultMemOptions
+             , CruxLLVM.transOpts = CLLVM.defaultTranslationOptions
+             , CruxLLVM.entryPoint = "main"
+             , CruxLLVM.lazyCompile = False
+             , CruxLLVM.noCompile = True
+             , CruxLLVM.optLevel = 1
+             , CruxLLVM.symFSRoot = Nothing
+             , CruxLLVM.supplyMainArguments = CruxLLVM.NoArguments
+             }
+
+    mkCruxOpts :: [FilePath] -> Crux.CruxOptions
+    mkCruxOpts files =
+      Crux.CruxOptions
+        { Crux.inputFiles = files
+        , Crux.outDir = "" -- no reports
+        , Crux.bldDir = "crux-build"
+        , Crux.checkPathSat = True
+        , Crux.profileCrucibleFunctions = False
+        , Crux.profileSolver = False
+        , Crux.branchCoverage = False
+        , Crux.pathStrategy = Crux.SplitAndExploreDepthFirst
+        , Crux.globalTimeout =
+            Just (fromRational (toRational (5 :: Int)))
+        , Crux.goalTimeout =
+            Just (fromRational (toRational (5 :: Int)))
+        , Crux.profileOutputInterval =
+            fromRational (toRational (1.0 :: Double))
+        , Crux.loopBound = Just 8
+        , Crux.recursionBound = Just 8
+        , Crux.makeCexes = False
+        , Crux.unsatCores = False
+        , Crux.simVerbose = 0
+        -- With Yices, cast_float_to_pointer_write.c hangs
+        , Crux.solver = "z3"
+        , Crux.pathSatSolver = Just "z3"
+        , Crux.forceOfflineGoalSolving = False
+        , Crux.pathSatSolverOutput = Nothing
+        , Crux.onlineSolverOutput = Nothing
+        , Crux.yicesMCSat = False
+        , Crux.floatMode = "default"
+        , Crux.quietMode = True
+        , Crux.proofGoalsFailFast = False
+        , Crux.skipReport = True
+        , Crux.skipSuccessReports = True
+        , Crux.skipIncompleteReports = True
+        , Crux.hashConsing = False
+        , Crux.onlineProblemFeatures = What4.noFeatures
+        , Crux.printFailures = False
+        , Crux.printSymbolicVars = False
+        , Crux.noColorsOut = False
+        , Crux.noColorsErr = False
+        }

--- a/uc-crux-llvm/uc-crux-llvm.cabal
+++ b/uc-crux-llvm/uc-crux-llvm.cabal
@@ -137,7 +137,10 @@ test-suite uc-crux-llvm-test
   hs-source-dirs: test
 
   main-is: Test.hs
-  other-modules: Paths_uc_crux_llvm
+  other-modules:
+    Logging
+    Paths_uc_crux_llvm
+    Utils
   autogen-modules: Paths_uc_crux_llvm
 
   build-depends:


### PR DESCRIPTION
This will make the code in Utils easier to reuse in new tests in new modules.