### PR TITLE
uc-crux-llvm: Prefer using 'toEnum' over 'fromIntegral'

### DIFF
--- a/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Unsound.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Unsound.hs
@@ -126,7 +126,7 @@ callGetHostName _proxy sym mvar (regValue -> ptr) (regValue -> len) =
     -- the ArchOk constraint guarantees that the pointer width is at least 16.
     -- if this override is changed to e.g. use really long hostnames it might
     -- be necessary to check that mkBV doesn't truncate the length here.
-    lenSmall <- lenLt (BV.mkBV ?ptrWidth (fromIntegral (BS.length hostname)))
+    lenSmall <- lenLt (BV.mkBV ?ptrWidth (toEnum (BS.length hostname)))
     Override.symbolicBranches
       emptyRegMap
       [ ( lenNeg,
@@ -178,7 +178,7 @@ callGetEnv _proxy sym mvar _ptr =
         do
           let val = LLVMMem.LLVMValString value
           let ty = LLVMMem.llvmValStorableType val
-          let lenBv = BV.mkBV ?ptrWidth (fromIntegral $ BS.length value)
+          let lenBv = BV.mkBV ?ptrWidth (toEnum (BS.length value))
           sz <- What4.bvLit sym ?ptrWidth lenBv
           (ptr', mem1) <-
             LLVMMem.doMalloc sym G.GlobalAlloc G.Mutable "getenv" mem sz noAlignment

--- a/uc-crux-llvm/src/UCCrux/LLVM/Setup.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Setup.hs
@@ -215,19 +215,19 @@ generate sym modCtx ftRepr selector (ConstrainedShape shape) =
           <$> annotatedLLVMPtr sym ?ptrWidth ftRepr selector
       (Shape.ShapePtr _constraints (Shape.ShapeAllocated n), FTPtrRepr _ptdTo) ->
         Shape.ShapePtr
-          <$> (SymValue <$> malloc sym ftRepr selector (fromIntegral n))
+          <$> (SymValue <$> malloc sym ftRepr selector (toEnum n))
           <*> pure (Shape.ShapeAllocated n)
       (Shape.ShapePtr _constraints (Shape.ShapeInitialized vec), FTPtrRepr ptPtdTo) ->
         do
           let num = Seq.length vec
           Some numRepr <-
-            case NatRepr.mkNatRepr (fromIntegral num) of
+            case NatRepr.mkNatRepr (toEnum num) of
               Some nr ->
                 -- pointerRange adds 1 to the size, so we have to subtract 1.
                 case NatRepr.isZeroNat nr of
                   NatRepr.ZeroNat -> panic "generate" ["Empty vector"]
                   NatRepr.NonZeroNat -> return (Some (NatRepr.predNat nr))
-          ptr <- malloc sym ftRepr selector (fromIntegral num)
+          ptr <- malloc sym ftRepr selector (toEnum num)
           let ftPtdTo = asFullType (modCtx ^. moduleTypes) ptPtdTo
           size <- liftIO $ sizeBv modCtx sym ftPtdTo 1
           -- For each offset, generate a value and store it there.

--- a/uc-crux-llvm/src/UCCrux/LLVM/Stats.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Stats.hs
@@ -57,9 +57,9 @@ getStats :: BugfindingResult m arch argTypes -> Stats
 getStats result =
   let (missingAnns, failedAsserts, unimplementeds, unclass, unfixed, unfixable, timeouts') = partitionUncertainty (uncertainResults result)
    in Stats
-        { missingAnnotation = fromIntegral $ length missingAnns,
-          symbolicallyFailedAssert = fromIntegral $ length failedAsserts,
-          timeouts = fromIntegral $ length timeouts',
+        { missingAnnotation = toEnum $ length missingAnns,
+          symbolicallyFailedAssert = toEnum $ length failedAsserts,
+          timeouts = toEnum $ length timeouts',
           truePositiveFreq =
             case Result.summary result of
               Result.FoundBugs bugs -> frequencies (toList bugs)


### PR DESCRIPTION
As @kquick pointed out to me, [`toEnum`](https://hackage.haskell.org/package/base-4.15.0.0/docs/Prelude.html#v:toEnum) has a number of advantages:

- It has a fixed domain type, and so aids the reader in figuring out the types of expressions
- It is intended to throw an error when the result is unrepresentable, rather than silently wrapping
- It's shorter :smile: 

