### PR TITLE
Add a hook for interpreting simulation results to Crux

### DIFF
--- a/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
@@ -31,18 +31,25 @@ import           Prelude hiding (log)
 import           Control.Lens ((^.), view, to)
 import           Control.Monad (void, unless)
 import           Control.Monad.IO.Class (liftIO)
-import           Data.IORef
+import qualified Data.IORef as IORef
+import           Data.IORef (IORef)
 import           Data.List (isInfixOf)
+import           Data.Map (Map)
 import qualified Data.Map.Strict as Map
+import           Data.Maybe (fromMaybe)
 import qualified Data.Set as Set
 import           Data.Set (Set)
 import qualified Data.Text as Text
 import           Data.Traversable (for)
+import           Data.Void (Void)
 
 import qualified Text.LLVM.AST as L
 
 import           Data.Parameterized.Ctx (Ctx)
+import           Data.Parameterized.Context (Assignment)
+import           Data.Parameterized.Some (Some)
 
+import qualified What4.Expr.Builder as What4
 import qualified What4.Interface as What4
 import qualified What4.ProgramLoc as What4
 
@@ -58,7 +65,7 @@ import qualified Lang.Crucible.Types as CrucibleTypes
 import           Lang.Crucible.LLVM (llvmGlobalsToCtx)
 import qualified Lang.Crucible.LLVM.Errors as LLVMErrors
 import           Lang.Crucible.LLVM.Intrinsics (register_llvm_overrides)
-import           Lang.Crucible.LLVM.MemModel (HasLLVMAnn, LLVMAnnMap)
+import           Lang.Crucible.LLVM.MemModel (HasLLVMAnn, LLVMAnnMap, MemImpl)
 import           Lang.Crucible.LLVM.Translation (transContext, llvmMemVar, llvmTypeCtx)
 import           Lang.Crucible.LLVM.TypeContext (TypeContext)
 
@@ -93,8 +100,10 @@ import           UCCrux.LLVM.Overrides.Unsound (UnsoundOverrideName, unsoundOver
 import           UCCrux.LLVM.FullType.Type (FullType, MapToCrucibleType)
 import           UCCrux.LLVM.PP (ppRegMap)
 import           UCCrux.LLVM.Run.Unsoundness (Unsoundness(Unsoundness))
-import           UCCrux.LLVM.Setup (setupExecution, SetupResult(SetupResult))
+import           UCCrux.LLVM.Setup (setupExecution, SetupResult(SetupResult), SymValue)
 import           UCCrux.LLVM.Setup.Assume (assume)
+import           UCCrux.LLVM.Setup.Monad (TypedSelector)
+import           UCCrux.LLVM.Shape (Shape)
 {- ORMOLU_ENABLE -}
 
 newtype CreateOverrideFn arch =
@@ -108,6 +117,7 @@ newtype CreateOverrideFn arch =
     }
 
 simulateLLVM ::
+  forall m arch argTypes blocks ret msgs.
   ArchOk arch =>
   AppContext ->
   ModuleContext m arch ->
@@ -119,130 +129,181 @@ simulateLLVM ::
   Constraints m argTypes ->
   Crucible.CFG LLVM blocks (MapToCrucibleType arch argTypes) ret ->
   LLVMOptions ->
-  Crux.SimulatorCallback msgs
+  Crux.SimulatorCallbacks msgs Crux.CruxSimulationResult
 simulateLLVM appCtx modCtx funCtx halloc explRef skipOverrideRef overrideFns constraints cfg llvmOpts =
-  Crux.SimulatorCallback $ \sym _maybeOnline ->
-    do
-      let trans = modCtx ^. moduleTranslation
-      let llvmCtxt = trans ^. transContext
-      let memOptions = memOpts llvmOpts
-      bbMapRef <- newIORef (Map.empty :: LLVMAnnMap sym)
-      let ?lc = llvmCtxt ^. llvmTypeCtx
-      let ?recordLLVMAnnotation = \an bb -> modifyIORef bbMapRef (Map.insert an bb)
-      let ?intrinsicsOpts = intrinsicsOpts llvmOpts
-      let ?memOpts = memOptions
-      let simctx =
-            (setupSimCtxt halloc sym memOptions (llvmMemVar llvmCtxt))
-              { Crucible.printHandle = view outputHandle ?outputConfig
-              }
+  Crux.SimulatorCallbacks $
+    do -- References written to during setup
+       memRef <- IORef.newIORef Nothing
+       argRef <- IORef.newIORef Nothing
+       argAnnRef <- IORef.newIORef Nothing
+       argShapeRef <- IORef.newIORef Nothing
+       -- References written to during simulation
+       bbMapRef <- IORef.newIORef (Map.empty :: LLVMAnnMap sym)
+       skipReturnValueAnns <- IORef.newIORef Map.empty
+       return $
+         Crux.SimulatorHooks
+           { Crux.setupHook =
+             \sym _symOnline ->
+               setupHook sym memRef argRef argAnnRef argShapeRef bbMapRef skipReturnValueAnns
+           , Crux.onErrorHook =
+             \sym -> return (onErrorHook sym memRef argRef argAnnRef argShapeRef bbMapRef skipReturnValueAnns)
+           , Crux.resultHook = \_sym result -> return result
+           }
+  where
+    setupHook ::
+      Crux.Logs msgs =>
+      IsSymInterface sym =>
+      sym ->
+      IORef (Maybe (MemImpl sym)) ->
+      IORef (Maybe (Crucible.RegMap sym (MapToCrucibleType arch argTypes))) ->
+      IORef (Maybe (Map (Some (What4.SymAnnotation sym)) (Some (TypedSelector m arch argTypes)))) ->
+      IORef (Maybe (Assignment (Shape m (SymValue sym arch)) argTypes)) ->
+      IORef (LLVMAnnMap sym) ->
+      IORef (Map (Some (What4.SymAnnotation sym)) (Some (TypedSelector m arch argTypes))) ->
+      IO (Crux.RunnableState sym)
+    setupHook sym memRef argRef argAnnRef argShapeRef bbMapRef skipReturnValueAnnotations =
+      do
+        let trans = modCtx ^. moduleTranslation
+        let llvmCtxt = trans ^. transContext
+        let memOptions = memOpts llvmOpts
+        let ?lc = llvmCtxt ^. llvmTypeCtx
+        let ?recordLLVMAnnotation = \an bb -> IORef.modifyIORef bbMapRef (Map.insert an bb)
+        let ?intrinsicsOpts = intrinsicsOpts llvmOpts
+        let ?memOpts = memOptions
+        let simctx =
+              (setupSimCtxt halloc sym memOptions (llvmMemVar llvmCtxt))
+                { Crucible.printHandle = view outputHandle ?outputConfig
+                }
 
-      unless (null (constraints ^. relationalConstraints)) $
-        panic "simulateLLVM" ["Unimplemented: relational constraints"]
+        unless (null (constraints ^. relationalConstraints)) $
+          panic "simulateLLVM" ["Unimplemented: relational constraints"]
 
-      setupResult <-
-        liftIO $ setupExecution appCtx modCtx funCtx sym constraints
-      (mem, argAnnotations, assumptions, argShapes, args) <-
-        case setupResult of
-          (SetupResult mem anns assumptions, (argShapes, args)) ->
-            pure (mem, anns, assumptions, argShapes, args)
+        setupResult <-
+          liftIO $ setupExecution appCtx modCtx funCtx sym constraints
+        (mem, argAnnotations, assumptions, argShapes, args) <-
+          case setupResult of
+            (SetupResult mem anns assumptions, (argShapes, args)) ->
+              pure (mem, anns, assumptions, argShapes, args)
 
-      -- Assume all predicates necessary to satisfy the deduced preconditions
-      assume (funCtx ^. functionName) sym assumptions
+        -- Save initial state so that it can be used during classification
+        IORef.writeIORef memRef (Just mem)
+        IORef.writeIORef argRef (Just args)
+        IORef.writeIORef argAnnRef (Just argAnnotations)
+        IORef.writeIORef argShapeRef (Just argShapes)
 
-      skipReturnValueAnnotations <- newIORef Map.empty
+        -- Assume all predicates necessary to satisfy the deduced preconditions
+        assume (funCtx ^. functionName) sym assumptions
 
-      let globSt = llvmGlobalsToCtx llvmCtxt mem
-      let initSt =
-            Crucible.InitialState simctx globSt Crucible.defaultAbortHandler CrucibleTypes.UnitRepr $
-              Crucible.runOverrideSim CrucibleTypes.UnitRepr $
-                do
-                  -- TODO(lb): This could be more lazy: We could install only
-                  -- those functions that are used by the program. It's an open
-                  -- question whether this would be faster: it would mean more
-                  -- superfluous errors when the program inevitably calls
-                  -- functions that haven't yet been installed, but would mean
-                  -- faster startup time generally, especially for large
-                  -- programs where the vast majority of functions wouldn't be
-                  -- called from any particular function. Needs some
-                  -- benchmarking.
-                  registerFunctions llvmOpts (modCtx ^. llvmModule . to getModule) trans Nothing
-                  overrides <- liftIO $ for overrideFns (($ sym) . runCreateOverrideFn)
-                  sOverrides <-
-                    unsoundSkipOverrides
-                      modCtx
-                      sym
-                      trans
-                      skipOverrideRef
-                      skipReturnValueAnnotations
-                      (constraints ^. returnConstraints)
-                      (L.modDeclares (modCtx ^. llvmModule . to getModule))
-                  register_llvm_overrides
-                    (modCtx ^. llvmModule . to getModule)
-                    []
-                    (map getPolymorphicLLVMOverride (overrides ++ sOverrides))
-                    llvmCtxt
-                  liftIO $ (appCtx ^. log) Hi $ "Running " <> funCtx ^. functionName <> " on arguments..."
-                  printed <- ppRegMap modCtx funCtx sym mem args
-                  mapM_ (liftIO . (appCtx ^. log) Hi . Text.pack . show) printed
-                  void $ Crucible.callCFG cfg args
-
-      -- Diagnose errors and write back the results so they can be read in the
-      -- outer loop
-      let explainFailure _ gl =
-            do
-              bb <- readIORef bbMapRef
-              let loc = gl ^. Crucible.labeledPredMsg . to Crucible.simErrorLoc
-              case flip Map.lookup bb . BoolAnn
-                =<< What4.getAnnotation sym (gl ^. Crucible.labeledPred) of
-                Nothing ->
-                  case What4.getAnnotation sym (gl ^. Crucible.labeledPred) of
-                    Just _ ->
-                      panic "simulateLLVM" ["Unexplained error: no error for annotation."]
-                    Nothing ->
-                      modifyIORef explRef . (:) $
-                        case gl ^. Crucible.labeledPredMsg . to Crucible.simErrorReason of
-                          Crucible.ResourceExhausted msg ->
-                            Located loc (ExExhaustedBounds msg)
-                          Crucible.AssertFailureSimError msg _ ->
-                            if "Call to assert" `isInfixOf` msg -- HACK
-                              then
-                                classifyAssertion
-                                  sym
-                                  (gl ^. Crucible.labeledPred)
-                                  loc
-                              else
-                                Located
-                                  loc
-                                  (ExUncertain (UMissingAnnotation (gl ^. Crucible.labeledPredMsg)))
-                          _ ->
-                            Located
-                              loc
-                              (ExUncertain (UMissingAnnotation (gl ^. Crucible.labeledPredMsg)))
-                Just badBehavior ->
+        let globSt = llvmGlobalsToCtx llvmCtxt mem
+        let initSt =
+              Crucible.InitialState simctx globSt Crucible.defaultAbortHandler CrucibleTypes.UnitRepr $
+                Crucible.runOverrideSim CrucibleTypes.UnitRepr $
                   do
-                    -- Helpful for debugging:
-                    -- putStrLn "~~~~~~~~~~~"
-                    -- putStrLn (show (LLVMErrors.ppBB badBehavior))
+                    -- TODO(lb): This could be more lazy: We could install only
+                    -- those functions that are used by the program. It's an open
+                    -- question whether this would be faster: it would mean more
+                    -- superfluous errors when the program inevitably calls
+                    -- functions that haven't yet been installed, but would mean
+                    -- faster startup time generally, especially for large
+                    -- programs where the vast majority of functions wouldn't be
+                    -- called from any particular function. Needs some
+                    -- benchmarking.
+                    registerFunctions llvmOpts (modCtx ^. llvmModule . to getModule) trans Nothing
+                    overrides <- liftIO $ for overrideFns (($ sym) . runCreateOverrideFn)
+                    sOverrides <-
+                      unsoundSkipOverrides
+                        modCtx
+                        sym
+                        trans
+                        skipOverrideRef
+                        skipReturnValueAnnotations
+                        (constraints ^. returnConstraints)
+                        (L.modDeclares (modCtx ^. llvmModule . to getModule))
+                    register_llvm_overrides
+                      (modCtx ^. llvmModule . to getModule)
+                      []
+                      (map getPolymorphicLLVMOverride (overrides ++ sOverrides))
+                      llvmCtxt
+                    liftIO $ (appCtx ^. log) Hi $ "Running " <> funCtx ^. functionName <> " on arguments..."
+                    printed <- ppRegMap modCtx funCtx sym mem args
+                    mapM_ (liftIO . (appCtx ^. log) Hi . Text.pack . show) printed
+                    void $ Crucible.callCFG cfg args
 
-                    liftIO $ (appCtx ^. log) Hi ("Explaining error: " <> Text.pack (show (LLVMErrors.explainBB badBehavior)))
-                    skipped <- readIORef skipOverrideRef
-                    retAnns <- readIORef skipReturnValueAnnotations
-                    classifyBadBehavior
-                      appCtx
-                      modCtx
-                      funCtx
-                      sym
-                      mem
-                      skipped
-                      (gl ^. Crucible.labeledPredMsg)
-                      args
-                      (Map.union argAnnotations retAnns)
-                      argShapes
-                      badBehavior
-                      >>= modifyIORef explRef . (:)
-              return mempty
+        return (Crux.RunnableState initSt)
 
-      return (Crux.RunnableState initSt, explainFailure)
+    -- | Classify errors and write back the results to an IORef so they can be
+    -- read in the outer loop
+    onErrorHook ::
+      IsSymInterface sym =>
+      (sym ~ What4.ExprBuilder t st fs) =>
+      sym ->
+      IORef (Maybe (MemImpl sym)) ->
+      IORef (Maybe (Crucible.RegMap sym (MapToCrucibleType arch argTypes))) ->
+      IORef (Maybe (Map (Some (What4.SymAnnotation sym)) (Some (TypedSelector m arch argTypes)))) ->
+      IORef (Maybe (Assignment (Shape m (SymValue sym arch)) argTypes)) ->
+      IORef (LLVMAnnMap sym) ->
+      IORef (Map.Map (Some (What4.SymAnnotation sym)) (Some (TypedSelector m arch argTypes))) ->
+      Crux.Explainer sym t Void
+    onErrorHook sym memRef argRef argAnnRef argShapeRef bbMapRef skipReturnValueAnnotations _groundEvalFn gl =
+      do
+        let rd = panic "onErrorHook" []
+        -- Read info from initial state
+        mem <- fromMaybe rd <$> IORef.readIORef memRef
+        args <- fromMaybe rd <$> IORef.readIORef argRef
+        argAnnotations <- fromMaybe rd <$> IORef.readIORef argAnnRef
+        argShapes <- fromMaybe rd <$> IORef.readIORef argShapeRef
+        -- Read info from execution
+        bb <- IORef.readIORef bbMapRef
+        let loc = gl ^. Crucible.labeledPredMsg . to Crucible.simErrorLoc
+        case flip Map.lookup bb . BoolAnn
+          =<< What4.getAnnotation sym (gl ^. Crucible.labeledPred) of
+          Nothing ->
+            case What4.getAnnotation sym (gl ^. Crucible.labeledPred) of
+              Just _ ->
+                panic "simulateLLVM" ["Unexplained error: no error for annotation."]
+              Nothing ->
+                IORef.modifyIORef explRef . (:) $
+                  case gl ^. Crucible.labeledPredMsg . to Crucible.simErrorReason of
+                    Crucible.ResourceExhausted msg ->
+                      Located loc (ExExhaustedBounds msg)
+                    Crucible.AssertFailureSimError msg _ ->
+                      if "Call to assert" `isInfixOf` msg -- HACK
+                        then
+                          classifyAssertion
+                            sym
+                            (gl ^. Crucible.labeledPred)
+                            loc
+                        else
+                          Located
+                            loc
+                            (ExUncertain (UMissingAnnotation (gl ^. Crucible.labeledPredMsg)))
+                    _ ->
+                      Located
+                        loc
+                        (ExUncertain (UMissingAnnotation (gl ^. Crucible.labeledPredMsg)))
+          Just badBehavior ->
+            do
+              -- Helpful for debugging:
+              -- putStrLn "~~~~~~~~~~~"
+              -- putStrLn (show (LLVMErrors.ppBB badBehavior))
+
+              liftIO $ (appCtx ^. log) Hi ("Explaining error: " <> Text.pack (show (LLVMErrors.explainBB badBehavior)))
+              skipped <- IORef.readIORef skipOverrideRef
+              retAnns <- IORef.readIORef skipReturnValueAnnotations
+              classifyBadBehavior
+                appCtx
+                modCtx
+                funCtx
+                sym
+                mem
+                skipped
+                (gl ^. Crucible.labeledPredMsg)
+                args
+                (Map.union argAnnotations retAnns)
+                argShapes
+                badBehavior
+                >>= IORef.modifyIORef explRef . (:)
+        return mempty
 
 -- NOTE(lb): The explicit kind signature here is necessary for GHC 8.6
 -- compatibility.
@@ -257,7 +318,7 @@ createUnsoundOverrides ::
   proxy arch ->
   IO (IORef (Set UnsoundOverrideName), [CreateOverrideFn arch])
 createUnsoundOverrides proxy =
-  do unsoundOverrideRef <- newIORef Set.empty
+  do unsoundOverrideRef <- IORef.newIORef Set.empty
      return
        ( unsoundOverrideRef
        , map (\ov ->
@@ -283,8 +344,8 @@ runSimulator ::
   IO (UCCruxSimulationResult m arch argTypes)
 runSimulator appCtx modCtx funCtx halloc overrideFns preconditions cfg cruxOpts llvmOpts =
   do
-    explRef <- newIORef []
-    skipOverrideRef <- newIORef Set.empty
+    explRef <- IORef.newIORef []
+    skipOverrideRef <- IORef.newIORef Set.empty
     let ?lc = modCtx ^. moduleTranslation . transContext . llvmTypeCtx
     (unsoundOverrideRef, mkUnsoundOverrides) <-
       createUnsoundOverrides modCtx
@@ -305,8 +366,8 @@ runSimulator appCtx modCtx funCtx halloc overrideFns preconditions cfg cruxOpts 
         )
     unsoundness' <-
       Unsoundness
-        <$> readIORef unsoundOverrideRef
-          <*> readIORef skipOverrideRef
+        <$> IORef.readIORef unsoundOverrideRef
+          <*> IORef.readIORef skipOverrideRef
     UCCruxSimulationResult unsoundness'
       <$> case cruxResult of
         Crux.CruxSimulationResult Crux.ProgramIncomplete _ ->
@@ -315,4 +376,4 @@ runSimulator appCtx modCtx funCtx halloc overrideFns preconditions cfg cruxOpts 
                 What4.initializationLoc
                 (ExUncertain (UTimeout (funCtx ^. functionName)))
             ]
-        _ -> readIORef explRef
+        _ -> IORef.readIORef explRef


### PR DESCRIPTION
This was inspired by a need in UC-Crux. In that tool, I need to register some overrides that will put some `Pred sym` away in an `IORef` when they're executed. I'd like to be able to consider whether or not those predicates are satisfiable after execution ends.

The general idea is to allow for an "interpreting results" step that has access to the symbolic backend (`ExprBuilder`). If this feature seems helpful and ergonomic to others, I'm happy to update all the tools in this repo at least to be compatible with it (at least).