### PR TITLE
uc-crux-llvm: Overrides that check inferred function contracts

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Common.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Common.hs
@@ -77,11 +77,11 @@ data LLVMOverride p sym args ret =
   , llvmOverride_args    :: CtxRepr args -- ^ A representation of the argument types
   , llvmOverride_ret     :: TypeRepr ret -- ^ A representation of the return type
   , llvmOverride_def ::
-       forall ext rtp args' ret'.
+       forall rtp args' ret'.
          GlobalVar Mem ->
          sym ->
          Ctx.Assignment (RegEntry sym) args ->
-         OverrideSim p sym ext rtp args' ret' (RegValue sym ret)
+         OverrideSim p sym LLVM rtp args' ret' (RegValue sym ret)
     -- ^ The implementation of the intrinsic in the simulator monad
     -- (@OverrideSim@).
   }

--- a/uc-crux-llvm/.hlint.yaml
+++ b/uc-crux-llvm/.hlint.yaml
@@ -60,7 +60,7 @@
     within: ["UCCrux.LLVM.Config"]
 - ignore:  # No need for this in the test suite
     name: "Use panic"
-    within: ["Main", "Utils"]
+    within: ["Check", "Main", "Utils"]
 - ignore:  # Guide to further implementation
     name: "Redundant if"
     within: ["UCCrux.LLVM.Classify.Poison"]

--- a/uc-crux-llvm/src/UCCrux/LLVM/Errors/Unimplemented.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Errors/Unimplemented.hs
@@ -36,6 +36,9 @@ data Unimplemented
   | GetHostNameSmallSize
   | NonEmptyUnboundedSizeArrays
   | CastIntegerToPointer
+  | CheckConstraintsPtrArray
+  | CheckConstraintsStruct
+  | CheckConstraintsGlobal
   deriving (Eq, Ord)
 
 ppUnimplemented :: Unimplemented -> String
@@ -50,6 +53,9 @@ ppUnimplemented =
     GetHostNameSmallSize -> "`gethostname` called with a small length"
     NonEmptyUnboundedSizeArrays -> "Generating arrays with unbounded size"
     CastIntegerToPointer -> "Value of integer type treated as/cast to a pointer"
+    CheckConstraintsPtrArray -> "Checking inferred precondition on an array"
+    CheckConstraintsStruct -> "Checking inferred precondition on a struct"
+    CheckConstraintsGlobal -> "Checking inferred precondition on a global"
 
 instance PanicComponent Unimplemented where
   panicComponentName _ = "uc-crux-llvm"

--- a/uc-crux-llvm/src/UCCrux/LLVM/FullType/Type.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/FullType/Type.hs
@@ -70,6 +70,7 @@ module UCCrux.LLVM.FullType.Type
     asFullType',
     asFullType,
     pointedToType,
+    arrayElementType,
   )
 where
 
@@ -463,6 +464,14 @@ pointedToType ::
   FullTypeRepr m ('FTPtr ft) ->
   FullTypeRepr m ft
 pointedToType mts (FTPtrRepr ptRepr) = asFullType mts ptRepr
+
+arrayElementType ::
+  FullTypeRepr m ('FTArray sz ft) ->
+  FullTypeRepr m ft
+arrayElementType =
+  \case
+    FTArrayRepr _ subRepr -> subRepr
+    FTUnboundedArrayRepr subRepr -> subRepr
 
 -- ------------------------------------------------------------------------------
 -- Instances

--- a/uc-crux-llvm/src/UCCrux/LLVM/Module.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Module.hs
@@ -61,6 +61,7 @@ module UCCrux.LLVM.Module
     moduleDeclMap,
     moduleDefnMap,
     moduleGlobalMap,
+    allModuleDeclMap,
   )
 where
 
@@ -79,6 +80,7 @@ import qualified Text.LLVM as L
 import           Data.Parameterized.Some (Some(Some))
 
 import           Lang.Crucible.LLVM.MalformedLLVMModule (malformedLLVMModule)
+import           Lang.Crucible.LLVM.Translation (declareFromDefine)
 
 import           UCCrux.LLVM.Errors.Panic (panic)
 
@@ -418,3 +420,13 @@ moduleGlobalMap (Module m) =
     (SymbolMap
       (Map.fromList
         [(Symbol (L.globalSym glob), glob) | glob <- L.modGlobals m]))
+
+-- | A map of declarations for every declaration and definition in the module.
+--
+-- This function will exclude debug intrinsics because debug types are not yet
+-- supported.
+allModuleDeclMap :: Module m -> FuncMap m L.Declare
+allModuleDeclMap m =
+  makeFuncMap
+    (moduleDeclMap m)
+    (fmap declareFromDefine (moduleDefnMap m))

--- a/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Check.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Check.hs
@@ -62,6 +62,7 @@ import qualified Prettyprinter.Render.Text as PP
 import qualified Text.LLVM.AST as L
 
 import           Data.Parameterized.Classes (IndexF)
+import           Data.Parameterized.Ctx (Ctx)
 import qualified Data.Parameterized.Context as Ctx
 import qualified Data.Parameterized.Fin as Fin
 import           Data.Parameterized.TraversableFC.WithIndex (FoldableFCWithIndex, ifoldrMFC)
@@ -115,7 +116,10 @@ declName decl =
 
 -- | A constraint, together with where it was applied and the resulting 'Pred'
 -- it was \"compiled\" to.
-data CheckedConstraint m sym argTypes inTy atTy
+--
+-- NOTE(lb): The explicit kind signature here is necessary for GHC 8.8/8.6
+-- compatibility.
+data CheckedConstraint m sym (argTypes :: Ctx (FullType m)) inTy atTy
   = CheckedConstraint
       { -- | The 'Constraint' that was applied at this 'Selector' to yield this
         -- 'Pred'
@@ -127,7 +131,9 @@ data CheckedConstraint m sym argTypes inTy atTy
         checkedPred :: Pred sym
       }
 
-data SomeCheckedConstraint m sym argTypes =
+-- NOTE(lb): The explicit kind signature here is necessary for GHC 8.8/8.6
+-- compatibility.
+data SomeCheckedConstraint m sym (argTypes :: Ctx (FullType m)) =
   forall inTy atTy.
     SomeCheckedConstraint (CheckedConstraint m sym argTypes inTy atTy)
 

--- a/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Check.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Check.hs
@@ -1,0 +1,358 @@
+{-
+Module       : UCCrux.LLVM.Overrides.Check
+Description  : Overrides that check that deduced preconditions are met.
+Copyright    : (c) Galois, Inc 2021
+License      : BSD3
+Maintainer   : Langston Barrett <langston@galois.com>
+Stability    : provisional
+
+After UC-Crux-LLVM has deduced the preconditions of a function, it can install
+an override that checks that the preconditions are met at callsites.
+
+In particular, creating a check override takes the result of contract inference
+on a function f (namely, 'Constraints') and makes an override that has the same
+signature as f, and when called will:
+
+- Create a bunch of predicates that represent whether or not the constraints
+  were violated at this call
+- Stash them away in an 'IORef'
+- Call the original implementation of f
+
+The hope is that this will be useful for refining overly pessimistic (sufficient
+but unnecessary) preconditions in inferred contracts, or for indicating the
+presence of bugs (when the contract really *should* hold).
+-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+
+module UCCrux.LLVM.Overrides.Check
+  ( CheckOverrideName (..),
+    createCheckOverride,
+    checkOverrideFromResult
+  )
+where
+
+{- ORMOLU_DISABLE -}
+import           Prelude hiding (log)
+import           Control.Lens ((^.))
+import           Control.Monad (foldM, unless)
+import           Control.Monad.IO.Class (liftIO)
+import           Data.Foldable.WithIndex (FoldableWithIndex, ifoldrM)
+import           Data.Functor.Compose (Compose(Compose))
+import           Data.IORef (IORef, modifyIORef)
+import           Data.Map (Map)
+import qualified Data.Map as Map
+import           Data.Sequence (Seq)
+import qualified Data.Sequence as Seq
+import           Data.Text (Text)
+import qualified Data.Text as Text
+import           Data.Type.Equality ((:~:)(Refl))
+import qualified Data.Vector as Vec
+
+import qualified Prettyprinter as PP
+import qualified Prettyprinter.Render.Text as PP
+
+import qualified Text.LLVM.AST as L
+
+import           Data.Parameterized.Classes (IndexF)
+import qualified Data.Parameterized.Context as Ctx
+import qualified Data.Parameterized.Fin as Fin
+import           Data.Parameterized.TraversableFC.WithIndex (FoldableFCWithIndex, ifoldrMFC)
+
+-- what4
+import           What4.Interface (Pred)
+
+-- crucible
+import qualified Lang.Crucible.CFG.Core as Crucible
+import           Lang.Crucible.Backend (IsSymInterface)
+import qualified Lang.Crucible.Simulator as Crucible
+import qualified Lang.Crucible.Simulator.OverrideSim as Override
+
+-- crucible-llvm
+import           Lang.Crucible.LLVM.DataLayout (noAlignment)
+import           Lang.Crucible.LLVM.MemModel (HasLLVMAnn)
+import qualified Lang.Crucible.LLVM.MemModel as LLVMMem
+import           Lang.Crucible.LLVM.Intrinsics (LLVM, LLVMOverride(..), basic_llvm_override)
+
+-- crux-llvm
+import           Crux.LLVM.Overrides (ArchOk)
+
+-- uc-crux-llvm
+import           UCCrux.LLVM.Constraints (Constraint, Constraints, ConstrainedShape(..), argConstraints, globalConstraints, ppConstraints)
+import           UCCrux.LLVM.Context.App (AppContext, log)
+import           UCCrux.LLVM.Context.Module (ModuleContext, moduleDecls, moduleTypes)
+import qualified UCCrux.LLVM.Errors.Unimplemented as Unimplemented
+import           UCCrux.LLVM.FullType.CrucibleType (SomeIndex(SomeIndex), translateIndex, toCrucibleType)
+import           UCCrux.LLVM.FullType.StorageType (toStorageType)
+import           UCCrux.LLVM.FullType.Type (FullType(FTPtr), FullTypeRepr, MapToCrucibleType, ToCrucibleType, pointedToType, arrayElementType)
+import           UCCrux.LLVM.Logging (Verbosity(Hi))
+import           UCCrux.LLVM.Module (FuncSymbol, funcSymbol)
+import           UCCrux.LLVM.Overrides.Polymorphic (PolymorphicLLVMOverride, makePolymorphicLLVMOverride)
+import           UCCrux.LLVM.Run.Result (BugfindingResult)
+import qualified UCCrux.LLVM.Run.Result as Result
+import           UCCrux.LLVM.Setup.Constraints (constraintToPred)
+import qualified UCCrux.LLVM.Shape as Shape
+{- ORMOLU_ENABLE -}
+
+newtype CheckOverrideName = CheckOverrideName {getCheckOverrideName :: Text}
+  deriving (Eq, Ord, Show)
+
+declName :: L.Declare -> Text
+declName decl =
+  let L.Symbol name = L.decName decl
+   in Text.pack name
+
+-- TODO: Alignment...?
+doLoad ::
+  forall arch m sym ft.
+  IsSymInterface sym =>
+  HasLLVMAnn sym =>
+  ArchOk arch =>
+  (?memOpts :: LLVMMem.MemOptions) =>
+  ModuleContext m arch ->
+  sym ->
+  LLVMMem.MemImpl sym ->
+  Crucible.RegValue sym (ToCrucibleType arch ('FTPtr ft)) ->
+  FullTypeRepr m ('FTPtr ft) ->
+  IO (Pred sym, Maybe (Crucible.RegValue sym (ToCrucibleType arch ft)))
+doLoad modCtx sym mem val fullTypeRepr =
+  do let pointedToRepr = pointedToType (modCtx ^. moduleTypes) fullTypeRepr
+         typeRepr = toCrucibleType modCtx pointedToRepr
+     -- TODO Is this alignment right?
+     partVal <-
+       LLVMMem.loadRaw sym mem val (toStorageType pointedToRepr) noAlignment
+     case partVal of
+       LLVMMem.Err p -> return (p, Nothing)
+       LLVMMem.NoErr p ptdToVal ->
+         (p,) . Just <$> LLVMMem.unpackMemValue sym typeRepr ptdToVal
+
+
+ifoldMapM ::
+  FoldableWithIndex i t =>
+  Monoid m =>
+  Monad f =>
+  (i -> a -> f m) ->
+  t a ->
+  f m
+ifoldMapM f = ifoldrM (\i x acc -> fmap (<> acc) (f i x)) mempty
+
+ifoldMapMFC ::
+  FoldableFCWithIndex t =>
+  Monoid m =>
+  Monad g =>
+  (forall x. IndexF (t f z) x -> f x -> g m) ->
+  t f z ->
+  g m
+ifoldMapMFC f = ifoldrMFC (\i x acc -> fmap (<> acc) (f i x)) mempty
+
+-- | Create a predicate that checks that a Crucible(-LLVM) value conforms to the
+-- 'ConstrainedShape'.
+--
+-- TODO: Add selector for provenance
+checkConstraints ::
+  forall arch m sym ft.
+  IsSymInterface sym =>
+  HasLLVMAnn sym =>
+  ArchOk arch =>
+  (?memOpts :: LLVMMem.MemOptions) =>
+  ModuleContext m arch ->
+  sym ->
+  LLVMMem.MemImpl sym ->
+  ConstrainedShape m ft ->
+  FullTypeRepr m ft ->
+  Crucible.RegValue sym (ToCrucibleType arch ft) ->
+  IO (Seq (Pred sym))
+checkConstraints modCtx sym mem cShape fullTypeRepr val =
+  case getConstrainedShape cShape of
+    Shape.ShapeInt (Compose cs) -> constraintsToPreds fullTypeRepr cs val
+    Shape.ShapeFloat (Compose cs) -> constraintsToPreds fullTypeRepr cs val
+    Shape.ShapePtr (Compose cs) Shape.ShapeUnallocated ->
+      constraintsToPreds fullTypeRepr cs val
+    Shape.ShapePtr (Compose cs) Shape.ShapeAllocated{} ->
+      constraintsToPreds fullTypeRepr cs val
+    Shape.ShapePtr (Compose cs) (Shape.ShapeInitialized subShapes) ->
+      do -- TODO: Is there code from Setup that helps with the other addresses?
+         unless (Seq.length subShapes == 1) $
+           Unimplemented.unimplemented
+             "checkConstraints"
+             Unimplemented.CheckConstraintsPtrArray
+         (ptdToPred, mbPtdToVal) <- doLoad modCtx sym mem val fullTypeRepr
+         let shape = ConstrainedShape (subShapes `Seq.index` 0)
+         let ptdToRepr = pointedToType (modCtx ^. moduleTypes) fullTypeRepr
+         subs <-
+           case mbPtdToVal of
+             Nothing -> pure Seq.empty
+             Just ptdToVal ->
+               checkConstraints modCtx sym mem shape ptdToRepr ptdToVal
+         here <- constraintsToPreds fullTypeRepr cs val
+         return (ptdToPred Seq.<| here <> subs)
+    Shape.ShapeFuncPtr (Compose cs) -> constraintsToPreds fullTypeRepr cs val
+    Shape.ShapeOpaquePtr (Compose cs) -> constraintsToPreds fullTypeRepr cs val
+    Shape.ShapeArray (Compose cs) _ subShapes ->
+      (<>)
+      <$> constraintsToPreds fullTypeRepr cs val
+      <*> ifoldMapM
+            (\i shape ->
+               checkConstraints
+                 modCtx
+                 sym
+                 mem
+                 (ConstrainedShape shape)
+                 (arrayElementType fullTypeRepr)
+                 (val Vec.! fromIntegral (Fin.finToNat i)))
+            subShapes
+    Shape.ShapeUnboundedArray (Compose cs) subShapes ->
+      (<>)
+      <$> constraintsToPreds fullTypeRepr cs val
+      <*> ifoldMapM
+            (\i shape ->
+               checkConstraints
+                 modCtx
+                 sym
+                 mem
+                 (ConstrainedShape shape)
+                 (arrayElementType fullTypeRepr)
+                 (val Vec.! i))
+            subShapes
+    Shape.ShapeStruct (Compose cs) _ ->
+      (<>)
+      <$> constraintsToPreds fullTypeRepr cs val
+      <*> Unimplemented.unimplemented
+            "checkConstraints"
+            Unimplemented.CheckConstraintsStruct
+
+  where
+    foldMapM :: forall t f m' a. Foldable t => Monoid m' => Monad f => (a -> f m') -> t a -> f m'
+    foldMapM f = foldM (\acc -> fmap (<> acc) . f) mempty
+
+    constraintsToPreds ::
+      forall ft'.
+      FullTypeRepr m ft' ->
+      [Constraint m ft'] ->
+      Crucible.RegValue sym (ToCrucibleType arch ft') ->
+      IO (Seq (Pred sym))
+    constraintsToPreds ftRepr cs v =
+      foldMapM (\c -> Seq.singleton <$> constraintToPred modCtx sym c ftRepr v) cs
+
+createCheckOverride ::
+  forall arch p sym m argTypes ret blocks.
+  IsSymInterface sym =>
+  HasLLVMAnn sym =>
+  ArchOk arch =>
+  (?memOpts :: LLVMMem.MemOptions) =>
+  AppContext ->
+  ModuleContext m arch ->
+  -- | Set of check overrides encountered during execution
+  --
+  -- TODO: Add constraint, selector for provenance
+  IORef (Map CheckOverrideName [Pred sym]) ->
+  -- | Function argument types
+  Ctx.Assignment (FullTypeRepr m) argTypes ->
+  -- | Function contract to check
+  Constraints m argTypes ->
+  -- | Function implementation
+  Crucible.CFG LLVM blocks (MapToCrucibleType arch argTypes) ret ->
+  -- | Name of function to override
+  FuncSymbol m ->
+  PolymorphicLLVMOverride arch p sym
+createCheckOverride appCtx modCtx usedRef argFTys constraints cfg funcSym =
+  let decl = modCtx ^. moduleDecls . funcSymbol funcSym
+      name = declName decl
+  in makePolymorphicLLVMOverride $
+       basic_llvm_override $
+         LLVMOverride
+           { llvmOverride_declare = decl,
+             llvmOverride_args = Crucible.cfgArgTypes cfg,
+             llvmOverride_ret = Crucible.cfgReturnType cfg,
+             llvmOverride_def =
+               \mvar (sym :: sym) args ->
+                 Override.modifyGlobal mvar $ \mem ->
+                   do
+                     liftIO $ (appCtx ^. log) Hi $ "Checking preconditions of " <> name
+                     let pp = PP.renderStrict . PP.layoutPretty PP.defaultLayoutOptions
+                     liftIO $ (appCtx ^. log) Hi "Constraints:"
+                     liftIO $ (appCtx ^. log) Hi $ pp (ppConstraints constraints)
+
+                     argCs <- liftIO $ getArgConstraints sym mem args
+                     globCs <- liftIO $ getGlobalConstraints sym mem
+                     let cs = argCs <> globCs
+                     let nm = CheckOverrideName name
+                     liftIO $
+                       modifyIORef usedRef $
+                         \m -> foldr (Map.insertWith (++) nm . (:[])) m cs
+                     retEntry <- Crucible.callCFG cfg (Crucible.RegMap args)
+                     return (Crucible.regValue retEntry, mem)
+           }
+  where
+    getArgConstraints ::
+      IsSymInterface sym =>
+      sym ->
+      LLVMMem.MemImpl sym ->
+      Ctx.Assignment (Crucible.RegEntry sym) (MapToCrucibleType arch argTypes) ->
+      IO (Seq (Pred sym))
+    getArgConstraints sym mem args =
+      ifoldMapMFC
+         (\idx constraint ->
+           do SomeIndex idx' Refl <-
+                pure $
+                  let sz = Ctx.size (constraints ^. argConstraints)
+                  in translateIndex modCtx sz idx
+              let arg = args Ctx.! idx'
+              checkConstraints
+                modCtx
+                sym
+                mem
+                constraint
+                (argFTys Ctx.! idx)
+                (Crucible.regValue arg))
+         (constraints ^. argConstraints)
+
+    getGlobalConstraints ::
+      IsSymInterface sym =>
+      sym ->
+      LLVMMem.MemImpl sym ->
+      IO (Seq (Pred sym))
+    getGlobalConstraints _sym _mem =
+      ifoldMapM
+        (Unimplemented.unimplemented
+          "createCheckOverride"
+          Unimplemented.CheckConstraintsGlobal)
+        (constraints ^. globalConstraints)
+
+-- | Create an override for checking deduced preconditions
+checkOverrideFromResult ::
+  IsSymInterface sym =>
+  HasLLVMAnn sym =>
+  ArchOk arch =>
+  (?memOpts :: LLVMMem.MemOptions) =>
+  AppContext ->
+  ModuleContext m arch ->
+  IORef (Map CheckOverrideName [Pred sym]) ->
+  -- | Function argument types
+  Ctx.Assignment (FullTypeRepr m) argTypes ->
+  -- | Function implementation
+  Crucible.CFG LLVM blocks (MapToCrucibleType arch argTypes) ret ->
+  -- | Name of function to override
+  FuncSymbol m ->
+  -- | Result from which to take constraints
+  BugfindingResult m arch argTypes ->
+  Maybe (PolymorphicLLVMOverride arch p sym)
+checkOverrideFromResult appCtx modCtx ref argFTys cfg f result =
+  case Result.summary result of
+    Result.SafeWithPreconditions _bounds _unsound constraints ->
+      Just $
+        createCheckOverride
+          appCtx
+          modCtx
+          ref
+          argFTys
+          constraints
+          cfg
+          f
+    _ -> Nothing

--- a/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Skip.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Skip.hs
@@ -110,7 +110,7 @@ unsoundSkipOverrides ::
   -- | Postconditions of each override (constraints on return values)
   Map (FuncSymbol m) (ConstrainedTypedValue m) ->
   [L.Declare] ->
-  OverM personality sym LLVM [PolymorphicLLVMOverride (personality sym) sym arch]
+  OverM personality sym LLVM [PolymorphicLLVMOverride arch (personality sym) sym]
 unsoundSkipOverrides modCtx sym mtrans usedRef annotationRef postconditions decls =
   do
     let llvmCtx = mtrans ^. transContext
@@ -163,7 +163,7 @@ createSkipOverride ::
   Maybe (ConstrainedTypedValue m) ->
   L.Declare ->
   FuncSymbol m ->
-  Maybe (PolymorphicLLVMOverride (personality sym) sym arch)
+  Maybe (PolymorphicLLVMOverride arch (personality sym) sym)
 createSkipOverride modCtx sym usedRef annotationRef postcondition decl funcSym =
   llvmDeclToFunHandleRepr' decl $
     \args ret ->

--- a/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
@@ -20,7 +20,10 @@ Stability    : provisional
 module UCCrux.LLVM.Run.Simulate
   ( UCCruxSimulationResult (..),
     CreateOverrideFn(..),
+    SimulatorHooks(..),
+    SimulatorCallbacks(..),
     createUnsoundOverrides,
+    runSimulatorWithCallbacks,
     runSimulator,
   )
 where
@@ -131,23 +134,49 @@ symCreateOverrideFn ::
   SymCreateOverrideFn sym arch
 symCreateOverrideFn = SymCreateOverrideFn . runCreateOverrideFn
 
+-- NOTE(lb): The explicit kind signature here is necessary for GHC 8.6
+-- compatibility.
+data UCCruxSimulationResult m arch (argTypes :: Ctx (FullType m)) = UCCruxSimulationResult
+  { unsoundness :: Unsoundness,
+    explanations :: [Located (Explanation m arch argTypes)]
+  }
+
 -- | Based on 'Crux.SimulatorHooks'
-data SimulatorHooks sym arch r =
+data SimulatorHooks sym m arch argTypes r =
   SimulatorHooks
     { createOverrideHooks :: [SymCreateOverrideFn sym arch]
-    , resultHook :: sym -> Crux.CruxSimulationResult -> IO r
+    , resultHook ::
+        sym ->
+        Crux.CruxSimulationResult ->
+        UCCruxSimulationResult m arch argTypes ->
+        IO r
     }
 
 -- | Based on 'Crux.SimulatorCallbacks'
-newtype SimulatorCallbacks arch r =
+newtype SimulatorCallbacks m arch argTypes r =
   SimulatorCallbacks
     { getSimulatorCallbacks ::
         forall sym t st fs.
           IsSymInterface sym =>
           (sym ~ What4.ExprBuilder t st fs) =>
           HasLLVMAnn sym =>
-          IO (SimulatorHooks sym arch r)
+          IO (SimulatorHooks sym m arch argTypes r)
     }
+
+createUnsoundOverrides ::
+  (?lc :: TypeContext) =>
+  ArchOk arch =>
+  proxy arch ->
+  IO (IORef (Set UnsoundOverrideName), [CreateOverrideFn arch])
+createUnsoundOverrides proxy =
+  do unsoundOverrideRef <- IORef.newIORef Set.empty
+     return
+       ( unsoundOverrideRef
+       , map (\ov ->
+                CreateOverrideFn
+                  (\_sym -> pure (getForAllSymArch ov proxy)))
+             (unsoundOverrides unsoundOverrideRef)
+       )
 
 registerOverrides ::
   (?intrinsicsOpts :: LLVMIntrinsics.IntrinsicsOptions) =>
@@ -157,7 +186,7 @@ registerOverrides ::
   HasLLVMAnn sym =>
   AppContext ->
   ModuleContext m arch ->
-  [PolymorphicLLVMOverride p sym arch] ->
+  [PolymorphicLLVMOverride arch p sym] ->
   Crucible.OverrideSim p sym LLVM rtp l a ()
 registerOverrides appCtx modCtx overrides =
   do for_ overrides $
@@ -184,21 +213,19 @@ registerOverrides appCtx modCtx overrides =
         LLVMIntrinsics.SubstringsMatch nms ->
           "functions with names containing " <> Text.pack (show nms)
 
-simulateLLVM ::
+mkCallbacks ::
   forall r m arch argTypes blocks ret msgs.
   ArchOk arch =>
   AppContext ->
   ModuleContext m arch ->
   FunctionContext m arch argTypes ->
   Crucible.HandleAllocator ->
-  IORef [Located (Explanation m arch argTypes)] ->
-  IORef (Set SkipOverrideName) ->
-  SimulatorCallbacks arch r ->
+  SimulatorCallbacks m arch argTypes r ->
   Constraints m argTypes ->
   Crucible.CFG LLVM blocks (MapToCrucibleType arch argTypes) ret ->
   LLVMOptions ->
   Crux.SimulatorCallbacks msgs r
-simulateLLVM appCtx modCtx funCtx halloc explRef skipOverrideRef callbacks constraints cfg llvmOpts =
+mkCallbacks appCtx modCtx funCtx halloc callbacks constraints cfg llvmOpts =
   Crux.SimulatorCallbacks $
     do -- References written to during setup
        memRef <- IORef.newIORef Nothing
@@ -208,22 +235,32 @@ simulateLLVM appCtx modCtx funCtx halloc explRef skipOverrideRef callbacks const
 
        -- References written to during simulation
        bbMapRef <- IORef.newIORef (Map.empty :: LLVMAnnMap sym)
+       explRef <- IORef.newIORef []
        skipReturnValueAnns <- IORef.newIORef Map.empty
+       skipOverrideRef <- IORef.newIORef Set.empty
+       let ?lc = modCtx ^. moduleTranslation . transContext . llvmTypeCtx
+       (unsoundOverrideRef, mkUnsoundOverrides) <-
+         createUnsoundOverrides modCtx
 
        -- Hooks
        let ?recordLLVMAnnotation =
              \an bb -> IORef.modifyIORef bbMapRef (Map.insert an bb)
        SimulatorHooks overrides resHook <-
          getSimulatorCallbacks callbacks
+       let overrides' =
+             map symCreateOverrideFn mkUnsoundOverrides ++ overrides
 
        return $
          Crux.SimulatorHooks
            { Crux.setupHook =
              \sym _symOnline ->
-               setupHook sym overrides memRef argRef argAnnRef argShapeRef skipReturnValueAnns
+               setupHook sym overrides' skipOverrideRef memRef argRef argAnnRef argShapeRef skipReturnValueAnns
            , Crux.onErrorHook =
-             \sym -> return (onErrorHook sym memRef argRef argAnnRef argShapeRef bbMapRef skipReturnValueAnns)
-           , Crux.resultHook = resHook
+             \sym ->
+               return (onErrorHook sym skipOverrideRef memRef argRef argAnnRef argShapeRef bbMapRef explRef skipReturnValueAnns)
+           , Crux.resultHook =
+             \sym result ->
+               mkResultHook sym skipOverrideRef unsoundOverrideRef explRef result resHook
            }
   where
     setupHook ::
@@ -232,13 +269,14 @@ simulateLLVM appCtx modCtx funCtx halloc explRef skipOverrideRef callbacks const
       HasLLVMAnn sym =>
       sym ->
       [SymCreateOverrideFn sym arch] ->
+      IORef (Set SkipOverrideName) ->
       IORef (Maybe (MemImpl sym)) ->
       IORef (Maybe (Crucible.RegMap sym (MapToCrucibleType arch argTypes))) ->
       IORef (Maybe (Map (Some (What4.SymAnnotation sym)) (Some (TypedSelector m arch argTypes)))) ->
       IORef (Maybe (Assignment (Shape m (SymValue sym arch)) argTypes)) ->
       IORef (Map (Some (What4.SymAnnotation sym)) (Some (TypedSelector m arch argTypes))) ->
       IO (Crux.RunnableState sym)
-    setupHook sym overrideFns memRef argRef argAnnRef argShapeRef skipReturnValueAnnotations =
+    setupHook sym overrideFns skipOverrideRef memRef argRef argAnnRef argShapeRef skipReturnValueAnnotations =
       do
         let trans = modCtx ^. moduleTranslation
         let llvmCtxt = trans ^. transContext
@@ -310,14 +348,16 @@ simulateLLVM appCtx modCtx funCtx halloc explRef skipOverrideRef callbacks const
       IsSymInterface sym =>
       (sym ~ What4.ExprBuilder t st fs) =>
       sym ->
+      IORef (Set SkipOverrideName) ->
       IORef (Maybe (MemImpl sym)) ->
       IORef (Maybe (Crucible.RegMap sym (MapToCrucibleType arch argTypes))) ->
       IORef (Maybe (Map (Some (What4.SymAnnotation sym)) (Some (TypedSelector m arch argTypes)))) ->
       IORef (Maybe (Assignment (Shape m (SymValue sym arch)) argTypes)) ->
       IORef (LLVMAnnMap sym) ->
+      IORef [Located (Explanation m arch argTypes)] ->
       IORef (Map.Map (Some (What4.SymAnnotation sym)) (Some (TypedSelector m arch argTypes))) ->
       Crux.Explainer sym t Void
-    onErrorHook sym memRef argRef argAnnRef argShapeRef bbMapRef skipReturnValueAnnotations _groundEvalFn gl =
+    onErrorHook sym skipOverrideRef memRef argRef argAnnRef argShapeRef bbMapRef explRef skipReturnValueAnnotations _groundEvalFn gl =
       do
         let rd = panic "onErrorHook" []
         -- Read info from initial state
@@ -378,33 +418,69 @@ simulateLLVM appCtx modCtx funCtx halloc explRef skipOverrideRef callbacks const
                 >>= IORef.modifyIORef explRef . (:)
         return mempty
 
--- NOTE(lb): The explicit kind signature here is necessary for GHC 8.6
--- compatibility.
-data UCCruxSimulationResult m arch (argTypes :: Ctx (FullType m)) = UCCruxSimulationResult
-  { unsoundness :: Unsoundness,
-    explanations :: [Located (Explanation m arch argTypes)]
-  }
+    mkResultHook ::
+      IsSymInterface sym =>
+      (sym ~ What4.ExprBuilder t st fs) =>
+      sym ->
+      IORef (Set SkipOverrideName) ->
+      IORef (Set UnsoundOverrideName) ->
+      IORef [Located (Explanation m arch argTypes)] ->
+      Crux.CruxSimulationResult ->
+      (sym ->
+        Crux.CruxSimulationResult ->
+        UCCruxSimulationResult m arch argTypes ->
+        IO r) ->
+      IO r
+    mkResultHook sym skipOverrideRef unsoundOverrideRef explRef cruxResult resHook =
+      do unsoundness' <-
+           Unsoundness
+             <$> IORef.readIORef unsoundOverrideRef
+               <*> IORef.readIORef skipOverrideRef
+         ucCruxResult <-
+           UCCruxSimulationResult unsoundness'
+             <$> case cruxResult of
+               Crux.CruxSimulationResult Crux.ProgramIncomplete _ ->
+                 pure
+                   [ Located
+                       What4.initializationLoc
+                       (ExUncertain (UTimeout (funCtx ^. functionName)))
+                   ]
+               _ -> IORef.readIORef explRef
+         resHook sym cruxResult ucCruxResult
 
-createUnsoundOverrides ::
-  (?lc :: TypeContext) =>
+
+runSimulatorWithCallbacks ::
+  Crux.Logs msgs =>
+  Crux.SupportsCruxLogMessage msgs =>
   ArchOk arch =>
-  proxy arch ->
-  IO (IORef (Set UnsoundOverrideName), [CreateOverrideFn arch])
-createUnsoundOverrides proxy =
-  do unsoundOverrideRef <- IORef.newIORef Set.empty
-     return
-       ( unsoundOverrideRef
-       , map (\ov ->
-                CreateOverrideFn
-                  (\_sym -> pure (getForAllSymArch ov proxy)))
-             (unsoundOverrides unsoundOverrideRef)
-       )
+  AppContext ->
+  ModuleContext m arch ->
+  FunctionContext m arch argTypes ->
+  Crucible.HandleAllocator ->
+  Constraints m argTypes ->
+  Crucible.CFG LLVM blocks (MapToCrucibleType arch argTypes) ret ->
+  CruxOptions ->
+  LLVMOptions ->
+  SimulatorCallbacks m arch argTypes r ->
+  IO r
+runSimulatorWithCallbacks appCtx modCtx funCtx halloc preconditions cfg cruxOpts llvmOpts callbacks =
+  Crux.runSimulator
+    cruxOpts
+    ( mkCallbacks
+        appCtx
+        modCtx
+        funCtx
+        halloc
+        callbacks
+        preconditions
+        cfg
+        llvmOpts
+    )
 
 runSimulator ::
-  ( Crux.Logs msgs,
-    Crux.SupportsCruxLogMessage msgs,
-    ArchOk arch
-  ) =>
+  Crux.Logs msgs =>
+  Crux.SupportsCruxLogMessage msgs =>
+  ArchOk arch =>
   AppContext ->
   ModuleContext m arch ->
   FunctionContext m arch argTypes ->
@@ -415,46 +491,19 @@ runSimulator ::
   CruxOptions ->
   LLVMOptions ->
   IO (UCCruxSimulationResult m arch argTypes)
-runSimulator appCtx modCtx funCtx halloc overrideFns preconditions cfg cruxOpts llvmOpts =
-  do
-    explRef <- IORef.newIORef []
-    skipOverrideRef <- IORef.newIORef Set.empty
-    let ?lc = modCtx ^. moduleTranslation . transContext . llvmTypeCtx
-    (unsoundOverrideRef, mkUnsoundOverrides) <-
-      createUnsoundOverrides modCtx
-    let callbacks =
-          SimulatorCallbacks $
-           return $
-             SimulatorHooks
-               { createOverrideHooks =
-                   (map symCreateOverrideFn (mkUnsoundOverrides ++ overrideFns))
-               , resultHook =
-                   \_sym cruxResult ->
-                     do unsoundness' <-
-                          Unsoundness
-                            <$> IORef.readIORef unsoundOverrideRef
-                              <*> IORef.readIORef skipOverrideRef
-                        UCCruxSimulationResult unsoundness'
-                          <$> case cruxResult of
-                            Crux.CruxSimulationResult Crux.ProgramIncomplete _ ->
-                              pure
-                                [ Located
-                                    What4.initializationLoc
-                                    (ExUncertain (UTimeout (funCtx ^. functionName)))
-                                ]
-                            _ -> IORef.readIORef explRef
-               }
-    Crux.runSimulator
-      cruxOpts
-      ( simulateLLVM
-          appCtx
-          modCtx
-          funCtx
-          halloc
-          explRef
-          skipOverrideRef
-          callbacks
-          preconditions
-          cfg
-          llvmOpts
-      )
+runSimulator appCtx modCtx funCtx halloc overrides preconditions cfg cruxOpts llvmOpts =
+  runSimulatorWithCallbacks
+    appCtx
+    modCtx
+    funCtx
+    halloc
+    preconditions
+    cfg
+    cruxOpts
+    llvmOpts
+    (SimulatorCallbacks $
+      return $
+        SimulatorHooks
+          { createOverrideHooks = map symCreateOverrideFn overrides
+          , resultHook = \_sym _cruxResult ucCruxResult -> return ucCruxResult
+          })

--- a/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
@@ -129,6 +129,7 @@ newtype CreateOverrideFn arch =
         IO (PolymorphicLLVMOverride arch (Crux.Crux sym) sym)
     }
 
+-- | Used in 'SimulatorHooks' to register caller-specified overrides.
 newtype SymCreateOverrideFn sym arch =
   SymCreateOverrideFn
     { runSymCreateOverrideFn ::
@@ -150,7 +151,10 @@ data UCCruxSimulationResult m arch (argTypes :: Ctx (FullType m)) = UCCruxSimula
   }
 
 -- | Based on 'Crux.SimulatorHooks'
-data SimulatorHooks sym m arch argTypes r =
+--
+-- NOTE(lb): The explicit kind signature here is necessary for GHC 8.6
+-- compatibility.
+data SimulatorHooks sym m arch (argTypes :: Ctx (FullType m)) r =
   SimulatorHooks
     { createOverrideHooks :: [SymCreateOverrideFn sym arch]
     , resultHook ::
@@ -162,7 +166,7 @@ data SimulatorHooks sym m arch argTypes r =
   deriving Functor
 
 -- | Based on 'Crux.SimulatorCallbacks'
-newtype SimulatorCallbacks m arch argTypes r =
+newtype SimulatorCallbacks m arch (argTypes :: Ctx (FullType m)) r =
   SimulatorCallbacks
     { getSimulatorCallbacks ::
         forall sym t st fs.

--- a/uc-crux-llvm/src/UCCrux/LLVM/Setup/Monad.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Setup/Monad.hs
@@ -76,9 +76,9 @@ import           Crux.LLVM.Overrides (ArchOk)
 import           UCCrux.LLVM.Context.Module (ModuleContext, moduleTranslation)
 import           UCCrux.LLVM.Cursor (Selector, SomeInSelector(..))
 import           UCCrux.LLVM.FullType.CrucibleType (toCrucibleType)
-import           UCCrux.LLVM.FullType.Type (FullType(FTPtr), FullTypeRepr(FTPtrRepr), ToCrucibleType, ToBaseType, ModuleTypes, asFullType)
 import           UCCrux.LLVM.FullType.Memory (sizeBv)
 import           UCCrux.LLVM.FullType.StorageType (toStorageType)
+import           UCCrux.LLVM.FullType.Type (FullType(FTPtr), FullTypeRepr(FTPtrRepr), ToCrucibleType, ToBaseType, ModuleTypes, asFullType)
 import           UCCrux.LLVM.Constraints (Constraint)
 {- ORMOLU_ENABLE -}
 

--- a/uc-crux-llvm/test/Check.hs
+++ b/uc-crux-llvm/test/Check.hs
@@ -1,0 +1,167 @@
+{-
+Copyright        : (c) Galois, Inc 2021
+License          : BSD3
+Maintainer       : Langston Barrett <langston@galois.com>
+Stability        : provisional
+-}
+
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{-# OPTIONS_GHC -fno-warn-partial-type-signatures #-}
+
+module Check (checkOverrideTests) where
+
+{- ORMOLU_DISABLE -}
+import           Control.Lens ((^.))
+import qualified Data.IORef as IORef
+import qualified Data.Map as Map
+import           Data.Maybe (fromMaybe)
+import qualified Data.Set as Set
+import qualified Data.Text as Text
+
+import qualified Lang.Crucible.CFG.Core as Crucible
+
+import qualified Crux.LLVM.Config as CruxLLVM
+
+import qualified Test.Tasty as TT
+import qualified Test.Tasty.HUnit as TH
+
+import           UCCrux.LLVM.Constraints (emptyConstraints)
+import           UCCrux.LLVM.Context.Function (makeFunctionContext, ppFunctionContextError)
+import           UCCrux.LLVM.Context.Module (ModuleContext, CFGWithTypes(..), defnTypes, findFun, withModulePtrWidth)
+import           UCCrux.LLVM.Module (FuncSymbol(FuncDefnSymbol))
+import           UCCrux.LLVM.Newtypes.FunctionName (functionNameFromString)
+import qualified UCCrux.LLVM.Overrides.Check as Check
+import qualified UCCrux.LLVM.Run.EntryPoints as EntryPoints
+import           UCCrux.LLVM.Run.Loop (bugfindingLoop)
+import qualified UCCrux.LLVM.Run.Simulate as Sim
+
+-- Tests
+import qualified Utils
+{- ORMOLU_ENABLE -}
+
+checkOverrideTests :: TT.TestTree
+checkOverrideTests =
+  TT.testGroup
+    "check overrides"
+    [ TH.testCase
+        "disjunctive generalization"
+        (Utils.withOptions
+          Nothing
+          "check_disjunctive_generalization.c"
+          (\appCtx (modCtx :: ModuleContext m arch) halloc cruxOpts llOpts ->
+             do [f] <-
+                  EntryPoints.getEntryPoints <$>
+                    EntryPoints.makeEntryPointsOrThrow
+                      (modCtx ^. defnTypes)
+                      [functionNameFromString "f"]
+                [g] <-
+                  EntryPoints.getEntryPoints <$>
+                    EntryPoints.makeEntryPointsOrThrow
+                      (modCtx ^. defnTypes)
+                      [functionNameFromString "g"]
+
+                -- Without something explicit here to fix a type, GHC will get
+                -- mad about leaking existentials (of which there are many - the
+                -- pointer width, the CFG argument types...)
+                () <-
+                  withModulePtrWidth
+                    modCtx
+                    ( do
+                        CFGWithTypes fcgf fArgFTys _retTy _varArgs <-
+                          pure (findFun modCtx (FuncDefnSymbol f))
+
+                        funCtxF <-
+                          case makeFunctionContext modCtx f fArgFTys (Crucible.cfgArgTypes fcgf) of
+                            Left err ->
+                              error (Text.unpack (ppFunctionContextError err))
+                            Right funCtxF -> return funCtxF
+
+                        -- Run main loop on f, to deduce the precondition
+                        -- that y should be nonnull
+                        (result, _) <-
+                          bugfindingLoop
+                            appCtx
+                            modCtx
+                            funCtxF
+                            fcgf
+                            cruxOpts
+                            llOpts
+                            halloc
+
+                        -- Construct override that checks that y is nonnull
+
+                        let ?memOpts = CruxLLVM.memOpts llOpts
+                        let
+                          -- This type signature is necessary for some
+                          -- reason...
+                          msg = "Test failure: 'f' should have been safe with preconditions"
+                          callbacks :: Sim.SimulatorCallbacks m _ _ _
+                          callbacks =
+                            Sim.SimulatorCallbacks $
+                              do ref <- IORef.newIORef Map.empty
+                                 return $
+                                   Sim.SimulatorHooks
+                                     { Sim.createOverrideHooks =
+                                         [ Sim.SymCreateOverrideFn $
+                                             \_sym ->
+                                               return $
+                                                 fromMaybe (error msg) $
+                                                   Check.checkOverrideFromResult
+                                                     appCtx
+                                                     modCtx
+                                                     ref
+                                                     fArgFTys
+                                                     fcgf
+                                                     (FuncDefnSymbol f)
+                                                     result
+                                         ]
+                                     , Sim.resultHook =
+                                       \_sym _cruxResult _ucCruxResult ->
+                                         -- TODO: Confirm that the values
+                                         -- indicate a precondition violation
+                                         do mp <- IORef.readIORef ref
+                                            TH.assertEqual
+                                              "The override for 'f' was exec'd"
+                                              (Set.singleton
+                                               (Check.CheckOverrideName "f"))
+                                              (Map.keysSet mp)
+                                            return ()
+                                     }
+
+                        -- Simulate g, but with override that checks the
+                        -- inferred preconditions of f
+                        --
+                        -- Additional checks happen in the result hook,
+                        -- see 'callbacks'.
+                        CFGWithTypes gcfg gArgFTys _retTy _varArgs <-
+                          pure (findFun modCtx (FuncDefnSymbol g))
+
+                        funCtxG <-
+                          case makeFunctionContext modCtx g gArgFTys (Crucible.cfgArgTypes gcfg) of
+                            Left err ->
+                              error (Text.unpack (ppFunctionContextError err))
+                            Right funCtxG -> return funCtxG
+
+                        () <-
+                          Sim.runSimulatorWithCallbacks
+                            appCtx
+                            modCtx
+                            funCtxG
+                            halloc
+                            (emptyConstraints gArgFTys)
+                            gcfg
+                            cruxOpts
+                            llOpts
+                            callbacks
+
+                        return ()
+                    )
+                return ()
+          )
+        )
+
+    ]

--- a/uc-crux-llvm/test/Test.hs
+++ b/uc-crux-llvm/test/Test.hs
@@ -85,6 +85,7 @@ import           UCCrux.LLVM.Run.Result (DidHitBounds(DidHitBounds, DidntHitBoun
 import qualified UCCrux.LLVM.Run.Result as Result
 import           UCCrux.LLVM.Run.Unsoundness (Unsoundness(..))
 
+import qualified Check
 import qualified Utils
 {- ORMOLU_ENABLE -}
 
@@ -1524,7 +1525,8 @@ main =
   TT.defaultMain $
     TT.testGroup
       "uc-crux-llvm"
-      [ inFileTests,
+      [ Check.checkOverrideTests,
+        inFileTests,
         moduleTests,
         isUnimplemented
           "read_extern_global_unsized_array.c"

--- a/uc-crux-llvm/test/programs/check_disjunctive_generalization.c
+++ b/uc-crux-llvm/test/programs/check_disjunctive_generalization.c
@@ -1,0 +1,21 @@
+// This function demonstrates a pretty fundamental limitation of UC-Crux-LLVM:
+// Since y is dereferenced along *one* path through f, UC-Crux-LLVM will add a
+// precondition that it's non-null, instead of a precondition that it's non-null
+// when x is non-zero.
+int f(int p, int x, int* y) __attribute__((noinline))  {
+  printf("%i", p);  // Just to make sure there's something dynamic here
+  if (x) {
+    return *y;
+  }
+  return x;
+}
+
+int g(int x) __attribute__((noinline))  {
+  // No problem
+  return f(x, 0, 0);
+}
+
+int h(int x) __attribute__((noinline))  {
+  // Null pointer dereference
+  return f(x, 1, 0);
+}

--- a/uc-crux-llvm/uc-crux-llvm.cabal
+++ b/uc-crux-llvm/uc-crux-llvm.cabal
@@ -47,10 +47,10 @@ library
     UCCrux.LLVM.FullType.CrucibleType
     UCCrux.LLVM.FullType.MemType
     UCCrux.LLVM.FullType.Memory
-    UCCrux.LLVM.FullType.Translation
-    UCCrux.LLVM.FullType.Type
     UCCrux.LLVM.FullType.ReturnType
     UCCrux.LLVM.FullType.StorageType
+    UCCrux.LLVM.FullType.Translation
+    UCCrux.LLVM.FullType.Type
     UCCrux.LLVM.FullType.VarArgs
     UCCrux.LLVM.Logging
     UCCrux.LLVM.Main
@@ -59,6 +59,7 @@ library
     UCCrux.LLVM.Module
     UCCrux.LLVM.Newtypes.FunctionName
     UCCrux.LLVM.Newtypes.Seconds
+    UCCrux.LLVM.Overrides.Check
     UCCrux.LLVM.Overrides.Polymorphic
     UCCrux.LLVM.Overrides.Skip
     UCCrux.LLVM.Overrides.Unsound
@@ -95,6 +96,10 @@ library
     crucible-llvm,
     crux,
     crux-llvm,
+    -- crucible-llvm depends on 'extra', but this package uses just a few
+    -- functions from it; so if crucible-llvm ever drops that dependency, it
+    -- might be worth working around it here.
+    extra,
     directory,
     filepath,
     indexed-traversable,
@@ -143,6 +148,7 @@ test-suite uc-crux-llvm-test
 
   main-is: Test.hs
   other-modules:
+    Check
     Logging
     Paths_uc_crux_llvm
     Utils


### PR DESCRIPTION
'Check' overrides take the result of contract inference on a function f
(namely, 'Constraints') and create an override that has the same
signature as f, and when called will

- Create a bunch of predicates that represent whether or not the
  constraints were violated at this call
- Stash them away in an IORef
- Call the original implementation of f

The hope is that this will be useful for refining overly pessimistic
(sufficient but unnecessary) preconditions in inferred contracts, or for
indicating the presence of bugs (when the contract really *should*
hold).

This is not currently integrated with other functionality (i.e., it's
not reachable from the CLI), but is instead a minimal prototype.