### PR TITLE
Add overrides for `pow`, `powf`, and `llvm.pow.*`

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics.hs
@@ -243,6 +243,8 @@ declare_overrides =
   , basic_llvm_override LLVM.llvmSinOverride_F64
   , basic_llvm_override LLVM.llvmCosOverride_F32
   , basic_llvm_override LLVM.llvmCosOverride_F64
+  , basic_llvm_override LLVM.llvmPowOverride_F32
+  , basic_llvm_override LLVM.llvmPowOverride_F64
   , basic_llvm_override LLVM.llvmExpOverride_F32
   , basic_llvm_override LLVM.llvmExpOverride_F64
   , basic_llvm_override LLVM.llvmLogOverride_F32
@@ -313,6 +315,8 @@ declare_overrides =
   , basic_llvm_override Libc.llvmHypotfOverride
   , basic_llvm_override Libc.llvmAtan2Override
   , basic_llvm_override Libc.llvmAtan2fOverride
+  , basic_llvm_override Libc.llvmPowfOverride
+  , basic_llvm_override Libc.llvmPowOverride
   , basic_llvm_override Libc.llvmExpOverride
   , basic_llvm_override Libc.llvmExpfOverride
   , basic_llvm_override Libc.llvmLogOverride

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/LLVM.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/LLVM.hs
@@ -669,6 +669,24 @@ llvmCosOverride_F64 =
   [llvmOvr| double @llvm.cos.f64( double ) |]
   (\_memOps sym args -> Ctx.uncurryAssignment (Libc.callSpecialFunction1 sym W4.Cos) args)
 
+llvmPowOverride_F32 ::
+  IsSymInterface sym =>
+  LLVMOverride p sym
+     (EmptyCtx ::> FloatType SingleFloat ::> FloatType SingleFloat)
+     (FloatType SingleFloat)
+llvmPowOverride_F32 =
+  [llvmOvr| float @llvm.pow.f32( float, float ) |]
+  (\_memOps sym args -> Ctx.uncurryAssignment (Libc.callSpecialFunction2 sym W4.Pow) args)
+
+llvmPowOverride_F64 ::
+  IsSymInterface sym =>
+  LLVMOverride p sym
+     (EmptyCtx ::> FloatType DoubleFloat ::> FloatType DoubleFloat)
+     (FloatType DoubleFloat)
+llvmPowOverride_F64 =
+  [llvmOvr| double @llvm.pow.f64( double, double ) |]
+  (\_memOps sym args -> Ctx.uncurryAssignment (Libc.callSpecialFunction2 sym W4.Pow) args)
+
 llvmExpOverride_F32 ::
   IsSymInterface sym =>
   LLVMOverride p sym

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libc.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libc.hs
@@ -1017,7 +1017,27 @@ llvmAtan2fOverride =
   (\_memOps sym args -> Ctx.uncurryAssignment (callSpecialFunction2 sym W4.Arctan2) args)
 
 ------------------------------------------------------------------------
--- **** Natural exponential and logarithm
+-- **** Exponential and logarithm functions
+
+-- pow(f)
+
+llvmPowfOverride ::
+  IsSymInterface sym =>
+  LLVMOverride p sym
+     (EmptyCtx ::> FloatType SingleFloat ::> FloatType SingleFloat)
+     (FloatType SingleFloat)
+llvmPowfOverride =
+  [llvmOvr| float @powf( float, float ) |]
+  (\_memOps sym args -> Ctx.uncurryAssignment (callSpecialFunction2 sym W4.Pow) args)
+
+llvmPowOverride ::
+  IsSymInterface sym =>
+  LLVMOverride p sym
+     (EmptyCtx ::> FloatType DoubleFloat ::> FloatType DoubleFloat)
+     (FloatType DoubleFloat)
+llvmPowOverride =
+  [llvmOvr| double @pow( double, double ) |]
+  (\_memOps sym args -> Ctx.uncurryAssignment (callSpecialFunction2 sym W4.Pow) args)
 
 -- exp(f)
 

--- a/crux-llvm/test-data/golden/special-functions-fast-math.c
+++ b/crux-llvm/test-data/golden/special-functions-fast-math.c
@@ -7,6 +7,7 @@ int main() {
   // doubles //
   /////////////
   double dx = crucible_double("dx");
+  double dy = crucible_double("dy");
 
   double d01 = exp(dx);
   double d02 = exp2(dx);
@@ -15,6 +16,7 @@ int main() {
   double d05 = log10(dx);
   double d06 = sin(dx);
   double d07 = cos(dx);
+  double d08 = pow(dx, dy);
 
   // sqrt unit tests
   check(sqrt(+0) == +0);
@@ -26,7 +28,8 @@ int main() {
   ////////////
   // floats //
   ////////////
-  float fx = crucible_double("fx");
+  float fx = crucible_float("fx");
+  float fy = crucible_float("fy");
 
   float f01 = expf(fx);
   float f02 = exp2f(fx);
@@ -35,6 +38,7 @@ int main() {
   float f05 = log10f(fx);
   float f06 = sinf(fx);
   float f07 = cosf(fx);
+  float f08 = powf(dx, dy);
 
   // sqrt unit tests
   check(sqrtf(+0) == +0);

--- a/crux-llvm/test-data/golden/special-functions.c
+++ b/crux-llvm/test-data/golden/special-functions.c
@@ -47,6 +47,7 @@ int main() {
   double d20 = acosh(dx);
   double d21 = hypot(dx, dy);
   double d22 = atan2(dx, dy);
+  double d23 = pow(dx, dy);
 
   // sqrt unit tests
   check(sqrt(+0) == +0);
@@ -57,8 +58,8 @@ int main() {
   ////////////
   // floats //
   ////////////
-  float fx = crucible_double("fx");
-  float fy = crucible_double("fy");
+  float fx = crucible_float("fx");
+  float fy = crucible_float("fy");
 
   float f01 = expf(fx);
   float f02 = expm1f(fx);
@@ -82,6 +83,7 @@ int main() {
   float f20 = acoshf(fx);
   float f21 = hypotf(fx, fy);
   float f22 = atan2f(fx, fy);
+  float f23 = powf(dx, dy);
 
   // sqrt unit tests
   check(sqrtf(+0) == +0);


### PR DESCRIPTION
Bumps the `what4` submodule to include GaloisInc/what4#163.