### PR TITLE
Add overrides for `ceil` and `floor`

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics.hs
@@ -237,6 +237,10 @@ declare_overrides =
   , basic_llvm_override LLVM.llvmFabsF32
   , basic_llvm_override LLVM.llvmFabsF64
 
+  , basic_llvm_override LLVM.llvmCeilOverride_F32
+  , basic_llvm_override LLVM.llvmCeilOverride_F64
+  , basic_llvm_override LLVM.llvmFloorOverride_F32
+  , basic_llvm_override LLVM.llvmFloorOverride_F64
   , basic_llvm_override LLVM.llvmSqrtOverride_F32
   , basic_llvm_override LLVM.llvmSqrtOverride_F64
   , basic_llvm_override LLVM.llvmSinOverride_F32
@@ -285,6 +289,10 @@ declare_overrides =
   , basic_llvm_override Libc.llvmLAbsOverride_64
   , basic_llvm_override Libc.llvmLLAbsOverride
 
+  , basic_llvm_override Libc.llvmCeilOverride
+  , basic_llvm_override Libc.llvmCeilfOverride
+  , basic_llvm_override Libc.llvmFloorOverride
+  , basic_llvm_override Libc.llvmFloorfOverride
   , basic_llvm_override Libc.llvmSqrtOverride
   , basic_llvm_override Libc.llvmSqrtfOverride
   , basic_llvm_override Libc.llvmSinOverride

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/LLVM.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/LLVM.hs
@@ -615,6 +615,42 @@ llvmFabsF64 =
   [llvmOvr| double @llvm.fabs.f64( double ) |]
   (\_memOps sym (Empty :> (regValue -> x)) -> liftIO (iFloatAbs @_ @DoubleFloat sym x))
 
+llvmCeilOverride_F32 ::
+  IsSymInterface sym =>
+  LLVMOverride p sym
+     (EmptyCtx ::> FloatType SingleFloat)
+     (FloatType SingleFloat)
+llvmCeilOverride_F32 =
+  [llvmOvr| float @llvm.ceil.f32( float ) |]
+  (\_memOps sym args -> Ctx.uncurryAssignment (Libc.callCeil sym) args)
+
+llvmCeilOverride_F64 ::
+  IsSymInterface sym =>
+  LLVMOverride p sym
+     (EmptyCtx ::> FloatType DoubleFloat)
+     (FloatType DoubleFloat)
+llvmCeilOverride_F64 =
+  [llvmOvr| double @llvm.ceil.f64( double ) |]
+  (\_memOps sym args -> Ctx.uncurryAssignment (Libc.callCeil sym) args)
+
+llvmFloorOverride_F32 ::
+  IsSymInterface sym =>
+  LLVMOverride p sym
+     (EmptyCtx ::> FloatType SingleFloat)
+     (FloatType SingleFloat)
+llvmFloorOverride_F32 =
+  [llvmOvr| float @llvm.floor.f32( float ) |]
+  (\_memOps sym args -> Ctx.uncurryAssignment (Libc.callFloor sym) args)
+
+llvmFloorOverride_F64 ::
+  IsSymInterface sym =>
+  LLVMOverride p sym
+     (EmptyCtx ::> FloatType DoubleFloat)
+     (FloatType DoubleFloat)
+llvmFloorOverride_F64 =
+  [llvmOvr| double @llvm.floor.f64( double ) |]
+  (\_memOps sym args -> Ctx.uncurryAssignment (Libc.callFloor sym) args)
+
 llvmSqrtOverride_F32 ::
   IsSymInterface sym =>
   LLVMOverride p sym

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libc.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libc.hs
@@ -680,6 +680,43 @@ printfOps sym valist =
 ------------------------------------------------------------------------
 -- *** Math
 
+llvmCeilOverride ::
+  IsSymInterface sym =>
+  LLVMOverride p sym
+     (EmptyCtx ::> FloatType DoubleFloat)
+     (FloatType DoubleFloat)
+llvmCeilOverride =
+  [llvmOvr| double @ceil( double ) |]
+  (\_memOps sym args -> Ctx.uncurryAssignment (callCeil sym) args)
+
+llvmCeilfOverride ::
+  IsSymInterface sym =>
+  LLVMOverride p sym
+     (EmptyCtx ::> FloatType SingleFloat)
+     (FloatType SingleFloat)
+llvmCeilfOverride =
+  [llvmOvr| float @ceilf( float ) |]
+  (\_memOps sym args -> Ctx.uncurryAssignment (callCeil sym) args)
+
+
+llvmFloorOverride ::
+  IsSymInterface sym =>
+  LLVMOverride p sym
+     (EmptyCtx ::> FloatType DoubleFloat)
+     (FloatType DoubleFloat)
+llvmFloorOverride =
+  [llvmOvr| double @floor( double ) |]
+  (\_memOps sym args -> Ctx.uncurryAssignment (callFloor sym) args)
+
+llvmFloorfOverride ::
+  IsSymInterface sym =>
+  LLVMOverride p sym
+     (EmptyCtx ::> FloatType SingleFloat)
+     (FloatType SingleFloat)
+llvmFloorfOverride =
+  [llvmOvr| float @floorf( float ) |]
+  (\_memOps sym args -> Ctx.uncurryAssignment (callFloor sym) args)
+
 llvmSqrtOverride ::
   IsSymInterface sym =>
   LLVMOverride p sym
@@ -718,6 +755,22 @@ callSpecialFunction2 ::
   OverrideSim p sym ext r args ret (RegValue sym (FloatType fi))
 callSpecialFunction2 sym fn (regValue -> x) (regValue -> y) = liftIO $
   iFloatSpecialFunction2 sym (knownRepr :: FloatInfoRepr fi) fn x y
+
+callCeil ::
+  forall fi p sym ext r args ret.
+  IsSymInterface sym =>
+  sym ->
+  RegEntry sym (FloatType fi) ->
+  OverrideSim p sym ext r args ret (RegValue sym (FloatType fi))
+callCeil sym (regValue -> x) = liftIO $ iFloatRound @_ @fi sym RTP x
+
+callFloor ::
+  forall fi p sym ext r args ret.
+  IsSymInterface sym =>
+  sym ->
+  RegEntry sym (FloatType fi) ->
+  OverrideSim p sym ext r args ret (RegValue sym (FloatType fi))
+callFloor sym (regValue -> x) = liftIO $ iFloatRound @_ @fi sym RTN x
 
 callSqrt ::
   forall fi p sym ext r args ret.

--- a/crux-llvm/test-data/golden/special-functions-fast-math.c
+++ b/crux-llvm/test-data/golden/special-functions-fast-math.c
@@ -18,6 +18,32 @@ int main() {
   double d07 = cos(dx);
   double d08 = pow(dx, dy);
 
+  // ceil unit tests
+  check(ceil(-0.4) == 0);
+  check(ceil(-0.5) == 0);
+  check(ceil(-0.6) == 0);
+  check(ceil(0.4) == 1);
+  check(ceil(0.5) == 1);
+  check(ceil(0.6) == 1);
+  check(ceil(+0) == +0);
+  check(ceil(-0) == -0);
+  check(ceil(+INFINITY) == +INFINITY);
+  check(ceil(-INFINITY) == -INFINITY);
+  check(isnan(ceil(NAN)));
+
+  // floor unit tests
+  check(floor(-0.4) == -1);
+  check(floor(-0.5) == -1);
+  check(floor(-0.6) == -1);
+  check(floor(0.4) == 0);
+  check(floor(0.5) == 0);
+  check(floor(0.6) == 0);
+  check(floor(+0) == +0);
+  check(floor(-0) == -0);
+  check(floor(+INFINITY) == +INFINITY);
+  check(floor(-INFINITY) == -INFINITY);
+  check(isnan(floor(NAN)));
+
   // sqrt unit tests
   check(sqrt(+0) == +0);
   check(sqrt(-0) == -0);
@@ -40,7 +66,33 @@ int main() {
   float f07 = cosf(fx);
   float f08 = powf(dx, dy);
 
-  // sqrt unit tests
+  // ceilf unit tests
+  check(ceilf(-0.4) == 0);
+  check(ceilf(-0.5) == 0);
+  check(ceilf(-0.6) == 0);
+  check(ceilf(0.4) == 1);
+  check(ceilf(0.5) == 1);
+  check(ceilf(0.6) == 1);
+  check(ceilf(+0) == +0);
+  check(ceilf(-0) == -0);
+  check(ceilf(+INFINITY) == +INFINITY);
+  check(ceilf(-INFINITY) == -INFINITY);
+  check(isnan(ceilf(NAN)));
+
+  // floorf unit tests
+  check(floorf(-0.4) == -1);
+  check(floorf(-0.5) == -1);
+  check(floorf(-0.6) == -1);
+  check(floorf(0.4) == 0);
+  check(floorf(0.5) == 0);
+  check(floorf(0.6) == 0);
+  check(floorf(+0) == +0);
+  check(floorf(-0) == -0);
+  check(floorf(+INFINITY) == +INFINITY);
+  check(floorf(-INFINITY) == -INFINITY);
+  check(isnan(floorf(NAN)));
+
+  // sqrtf unit tests
   check(sqrtf(+0) == +0);
   check(sqrtf(-0) == -0);
   check(sqrtf(INFINITY) == INFINITY);

--- a/crux-llvm/test-data/golden/special-functions.c
+++ b/crux-llvm/test-data/golden/special-functions.c
@@ -49,6 +49,32 @@ int main() {
   double d22 = atan2(dx, dy);
   double d23 = pow(dx, dy);
 
+  // ceil unit tests
+  check(ceil(-0.4) == 0);
+  check(ceil(-0.5) == 0);
+  check(ceil(-0.6) == 0);
+  check(ceil(0.4) == 1);
+  check(ceil(0.5) == 1);
+  check(ceil(0.6) == 1);
+  check(ceil(+0) == +0);
+  check(ceil(-0) == -0);
+  check(ceil(+INFINITY) == +INFINITY);
+  check(ceil(-INFINITY) == -INFINITY);
+  check(isnan(ceil(NAN)));
+
+  // floor unit tests
+  check(floor(-0.4) == -1);
+  check(floor(-0.5) == -1);
+  check(floor(-0.6) == -1);
+  check(floor(0.4) == 0);
+  check(floor(0.5) == 0);
+  check(floor(0.6) == 0);
+  check(floor(+0) == +0);
+  check(floor(-0) == -0);
+  check(floor(+INFINITY) == +INFINITY);
+  check(floor(-INFINITY) == -INFINITY);
+  check(isnan(floor(NAN)));
+
   // sqrt unit tests
   check(sqrt(+0) == +0);
   check(sqrt(-0) == -0);
@@ -85,7 +111,33 @@ int main() {
   float f22 = atan2f(fx, fy);
   float f23 = powf(dx, dy);
 
-  // sqrt unit tests
+  // ceilf unit tests
+  check(ceilf(-0.4) == 0);
+  check(ceilf(-0.5) == 0);
+  check(ceilf(-0.6) == 0);
+  check(ceilf(0.4) == 1);
+  check(ceilf(0.5) == 1);
+  check(ceilf(0.6) == 1);
+  check(ceilf(+0) == +0);
+  check(ceilf(-0) == -0);
+  check(ceilf(+INFINITY) == +INFINITY);
+  check(ceilf(-INFINITY) == -INFINITY);
+  check(isnan(ceilf(NAN)));
+
+  // floorf unit tests
+  check(floorf(-0.4) == -1);
+  check(floorf(-0.5) == -1);
+  check(floorf(-0.6) == -1);
+  check(floorf(0.4) == 0);
+  check(floorf(0.5) == 0);
+  check(floorf(0.6) == 0);
+  check(floorf(+0) == +0);
+  check(floorf(-0) == -0);
+  check(floorf(+INFINITY) == +INFINITY);
+  check(floorf(-INFINITY) == -INFINITY);
+  check(isnan(floorf(NAN)));
+
+  // sqrtf unit tests
   check(sqrtf(+0) == +0);
   check(sqrtf(-0) == -0);
   check(sqrtf(INFINITY) == INFINITY);


### PR DESCRIPTION
These are implemented by means of `what4`'s `iFloatRound`.