### PR TITLE
`crucible-llvm`: Control granularity of reading uninitialized memory

### DIFF
--- a/crucible-llvm/CHANGELOG.md
+++ b/crucible-llvm/CHANGELOG.md
@@ -1,0 +1,15 @@
+# next
+* A new `indeterminateLoadBehavior` flag in `MemOptions` now controls now
+  reading from uninitialized memory works when `laxLoadsAndStores` is enabled.
+  If `StableSymbolic` is chosen, then allocating memory will also initialize it
+  with a fresh symbolic value so that subsequent reads will always return that
+  same value. If `UnstableSymbolic` is chosen, then each read from a section of
+  uninitialized memory will return a distinct symbolic value each time.
+
+  As a result of this change, `?memOpts :: MemOptions` constraints have been
+  added to the following functions:
+  * `Lang.Crucible.LLVM.Globals`:
+    `initializeAllMemory` and `initializeMemoryConstGlobals`
+  * `Lang.Crucible.LLVM.MemModel`:
+    `doAlloca`, `doCalloc`, `doMalloc`, `doMallocUnbounded`, `mallocRaw`,
+    `mallocConstRaw`, `allocGlobals`, and `allocGlobal`

--- a/crucible-llvm/CHANGELOG.md
+++ b/crucible-llvm/CHANGELOG.md
@@ -9,7 +9,8 @@
   As a result of this change, `?memOpts :: MemOptions` constraints have been
   added to the following functions:
   * `Lang.Crucible.LLVM.Globals`:
-    `initializeAllMemory` and `initializeMemoryConstGlobals`
+    `initializeAllMemory`, `initializeMemoryConstGlobals`, `populateGlobals`,
+    `populateAllGlobals`, and `populateConstGlobals`
   * `Lang.Crucible.LLVM.MemModel`:
     `doAlloca`, `doCalloc`, `doMalloc`, `doMallocUnbounded`, `mallocRaw`,
     `mallocConstRaw`, `allocGlobals`, and `allocGlobal`

--- a/crucible-llvm/crucible-llvm.cabal
+++ b/crucible-llvm/crucible-llvm.cabal
@@ -12,6 +12,7 @@ Synopsis:      Support for translating and executing LLVM code in Crucible
 Description:
    Library providing LLVM-specific extensions to the crucible core library
    for Crucible-based simulation and verification of LLVM-compiled applications.
+extra-source-files: CHANGELOG.md, README.md
 
 common bldflags
   ghc-options: -Wall

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Globals.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Globals.hs
@@ -25,6 +25,7 @@
 {-# LANGUAGE PatternSynonyms       #-}
 {-# LANGUAGE RankNTypes            #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeOperators         #-}
 
 module Lang.Crucible.LLVM.Globals
@@ -50,6 +51,7 @@ import qualified Data.Set as Set
 import           Data.String
 import           Control.Monad.State (StateT, runStateT, get, put)
 import           Data.Maybe (fromMaybe)
+import qualified Data.Parameterized.Context as Ctx
 
 import qualified Text.LLVM.AST as L
 import qualified Text.LLVM.PP as LPP
@@ -253,6 +255,7 @@ allocLLVMFunPtr sym llvm_ctx mem decl =
 --   filtered list transitively reference.
 populateGlobals ::
   ( ?lc :: TypeContext
+  , ?memOpts :: MemOptions
   , 16 <= wptr
   , HasPtrWidth wptr
   , HasLLVMAnn sym
@@ -267,12 +270,13 @@ populateGlobals select sym gimap mem0 = foldM f mem0 (Map.elems gimap)
   f mem (gl, _) | not (select gl)    = return mem
   f _   (_,  Left msg)               = fail msg
   f mem (gl, Right (mty, Just cval)) = populateGlobal sym gl mty cval gimap mem
-  f mem (_ , Right (_, Nothing))     = return mem
+  f mem (gl, Right (mty, Nothing))   = populateExternalGlobal sym gl mty mem
 
 
 -- | Populate all the globals mentioned in the given @GlobalInitializerMap@.
 populateAllGlobals ::
   ( ?lc :: TypeContext
+  , ?memOpts :: MemOptions
   , 16 <= wptr
   , HasPtrWidth wptr
   , HasLLVMAnn sym
@@ -288,6 +292,7 @@ populateAllGlobals = populateGlobals (const True)
 --   given @GlobalInitializerMap@ (and any they transitively refer to).
 populateConstGlobals ::
   ( ?lc :: TypeContext
+  , ?memOpts :: MemOptions
   , 16 <= wptr
   , HasPtrWidth wptr
   , HasLLVMAnn sym
@@ -298,6 +303,40 @@ populateConstGlobals ::
   IO (MemImpl sym)
 populateConstGlobals = populateGlobals f
   where f = L.gaConstant . L.globalAttrs
+
+
+-- | Ordinarily external globals do not receive initalizing writes.  However,
+--   when 'lax-loads-and-stores` is enabled in the `stable-symbolic` mode, we
+--   populate external global variables with fresh bytes.
+populateExternalGlobal :: forall sym wptr.
+  ( ?lc :: TypeContext
+  , 16 <= wptr
+  , HasPtrWidth wptr
+  , IsSymInterface sym
+  , HasLLVMAnn sym
+  , HasCallStack
+  , ?memOpts :: MemOptions
+  ) =>
+  sym ->
+  L.Global {- ^ The global to populate -} ->
+  MemType {- ^ Type of the global -} ->
+  MemImpl sym ->
+  IO (MemImpl sym)
+populateExternalGlobal sym gl memty mem
+  | laxLoadsAndStores ?memOpts
+  , indeterminateLoadBehavior ?memOpts == StableSymbolic
+
+  =  do bytes <- freshConstant sym emptySymbol
+                    (BaseArrayRepr (Ctx.singleton $ BaseBVRepr ?ptrWidth)
+                        (BaseBVRepr (knownNat @8)))
+        let dl = llvmDataLayout ?lc
+        let sz = memTypeSize dl memty
+        let tyAlign = memTypeAlign dl memty
+        sz' <- bvLit sym PtrWidth (bytesToBV PtrWidth sz)
+        ptr <- doResolveGlobal sym mem (L.globalSym gl)
+        doArrayConstStore sym mem ptr tyAlign bytes sz'
+
+  | otherwise = return mem
 
 
 -- | Write the value of the given LLVMConst into the given global variable.

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Globals.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Globals.hs
@@ -148,7 +148,8 @@ makeGlobalMap ctx m = foldl' addAliases globalMap (Map.toList (llvmGlobalAliases
 -- allocates space for global variables, but does not set their
 -- initial values.
 initializeAllMemory
-   :: (IsSymInterface sym, HasPtrWidth wptr)
+   :: ( IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym
+      , ?memOpts :: MemOptions )
    => sym
    -> LLVMContext arch
    -> L.Module
@@ -156,7 +157,8 @@ initializeAllMemory
 initializeAllMemory = initializeMemory (const True)
 
 initializeMemoryConstGlobals
-   :: (IsSymInterface sym, HasPtrWidth wptr)
+   :: ( IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym
+      , ?memOpts :: MemOptions )
    => sym
    -> LLVMContext arch
    -> L.Module
@@ -164,7 +166,8 @@ initializeMemoryConstGlobals
 initializeMemoryConstGlobals = initializeMemory (L.gaConstant . L.globalAttrs)
 
 initializeMemory
-   :: (IsSymInterface sym, HasPtrWidth wptr)
+   :: ( IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym
+      , ?memOpts :: MemOptions )
    => (L.Global -> Bool)
    -> sym
    -> LLVMContext arch
@@ -218,7 +221,8 @@ initializeMemory predicate sym llvm_ctx llvmModl = do
 
 
 allocLLVMFunPtr ::
-  (IsSymInterface sym, HasPtrWidth wptr) =>
+  ( IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym
+  , ?memOpts :: MemOptions ) =>
   sym ->
   LLVMContext arch ->
   MemImpl sym ->

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Globals.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Globals.hs
@@ -350,7 +350,7 @@ populateGlobal sym gl memty cval giMap mem =
                     , show glob
                     ]
                   Just (glob, Right (memty_, Just cval_)) ->
-                    liftIO $ populateGlobal sym glob memty_ cval_ giMap mem
+                    liftIO $ populateGlobal sym glob memty_ cval_ giMap memimpl0
            put memimpl
            liftIO $ doResolveGlobal sym memimpl symbol
 

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libc.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libc.hs
@@ -171,7 +171,8 @@ llvmMemsetChkOverride =
 -- *** Allocation
 
 llvmCallocOverride
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, ?lc :: TypeContext)
+  :: ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
+     , ?lc :: TypeContext, ?memOpts :: MemOptions )
   => LLVMOverride p sym
          (EmptyCtx ::> BVType wptr ::> BVType wptr)
          (LLVMPointerType wptr)
@@ -182,7 +183,8 @@ llvmCallocOverride =
 
 
 llvmReallocOverride
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, ?lc :: TypeContext)
+  :: ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
+     , ?lc :: TypeContext, ?memOpts :: MemOptions )
   => LLVMOverride p sym
          (EmptyCtx ::> LLVMPointerType wptr ::> BVType wptr)
          (LLVMPointerType wptr)
@@ -192,7 +194,8 @@ llvmReallocOverride =
   (\memOps sym args -> Ctx.uncurryAssignment (callRealloc sym memOps alignment) args)
 
 llvmMallocOverride
-  :: (IsSymInterface sym, HasPtrWidth wptr, ?lc :: TypeContext)
+  :: ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
+     , ?lc :: TypeContext, ?memOpts :: MemOptions )
   => LLVMOverride p sym
          (EmptyCtx ::> BVType wptr)
          (LLVMPointerType wptr)
@@ -202,7 +205,8 @@ llvmMallocOverride =
   (\memOps sym args -> Ctx.uncurryAssignment (callMalloc sym memOps alignment) args)
 
 posixMemalignOverride ::
-  (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, ?lc :: TypeContext) =>
+  ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
+  , ?lc :: TypeContext, ?memOpts :: MemOptions ) =>
   LLVMOverride p sym
       (EmptyCtx ::> LLVMPointerType wptr
                 ::> BVType wptr
@@ -280,7 +284,8 @@ llvmStrlenOverride =
 -- *** Allocation
 
 callRealloc
-  :: (IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym)
+  :: ( IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym
+     , ?memOpts :: MemOptions )
   => sym
   -> GlobalVar Mem
   -> Alignment
@@ -321,7 +326,8 @@ callRealloc sym mvar alignment (regValue -> ptr) (regValue -> sz) =
 
 
 callPosixMemalign
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, ?lc :: TypeContext)
+  :: ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
+     , ?lc :: TypeContext, ?memOpts :: MemOptions )
   => sym
   -> GlobalVar Mem
   -> RegEntry sym (LLVMPointerType wptr)
@@ -345,7 +351,8 @@ callPosixMemalign sym mvar (regValue -> outPtr) (regValue -> align) (regValue ->
                 return (z, mem'')
 
 callMalloc
-  :: (IsSymInterface sym, HasPtrWidth wptr)
+  :: ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
+     , ?memOpts :: MemOptions )
   => sym
   -> GlobalVar Mem
   -> Alignment
@@ -358,7 +365,8 @@ callMalloc sym mvar alignment (regValue -> sz) =
        doMalloc sym G.HeapAlloc G.Mutable displayString mem sz alignment
 
 callCalloc
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
+  :: ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
+     , ?memOpts :: MemOptions )
   => sym
   -> GlobalVar Mem
   -> Alignment

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
@@ -706,7 +706,9 @@ doMallocSize sz sym allocType mut loc mem alignment = do
   let heap' = G.allocMem allocType blkNum sz alignment mut loc (memImplHeap mem)
   let ptr   = LLVMPointer blk z
   let mem'  = mem{ memImplHeap = heap' }
-  mem'' <- if laxLoadsAndStores ?memOpts && mut == G.Mutable
+  mem'' <- if laxLoadsAndStores ?memOpts
+                && mut == G.Mutable
+                && allocType == G.HeapAlloc
                 && indeterminateLoadBehavior ?memOpts == StableSymbolic
            then do bytes <- freshConstant sym emptySymbol
                               (BaseArrayRepr (Ctx.singleton $ BaseBVRepr ?ptrWidth)

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
@@ -719,6 +719,8 @@ doMallocSize sz sym allocType mut loc mem alignment = do
            else pure mem'
   return (ptr, mem'')
 
+
+
 bindLLVMFunPtr ::
   (IsSymInterface sym, HasPtrWidth wptr) =>
   sym ->

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
@@ -44,6 +44,7 @@ module Lang.Crucible.LLVM.MemModel
   , BlockSource(..)
   , nextBlock
   , MemOptions(..)
+  , IndeterminateLoadBehavior(..)
   , defaultMemOptions
   , laxPointerMemOptions
 
@@ -547,7 +548,8 @@ ptrMessage msg ptr ty =
 
 -- | Allocate memory on the stack frame of the currently executing function.
 doAlloca ::
-  (IsSymInterface sym, HasPtrWidth wptr) =>
+  ( IsSymInterface sym, HasPtrWidth wptr, Partial.HasLLVMAnn sym
+  , ?memOpts :: MemOptions ) =>
   sym ->
   MemImpl sym ->
   SymBV sym wptr {- ^ allocation size -} ->
@@ -562,7 +564,14 @@ doAlloca sym mem sz alignment loc = do
   let heap' = G.allocMem G.StackAlloc blkNum (Just sz) alignment G.Mutable loc (memImplHeap mem)
   let ptr   = LLVMPointer blk z
   let mem'  = mem{ memImplHeap = heap' }
-  pure (ptr, mem')
+  mem'' <- if laxLoadsAndStores ?memOpts
+                && indeterminateLoadBehavior ?memOpts == StableSymbolic
+           then do bytes <- freshConstant sym emptySymbol
+                              (BaseArrayRepr (Ctx.singleton $ BaseBVRepr ?ptrWidth)
+                                             (BaseBVRepr (knownNat @8)))
+                   doArrayStore sym mem' ptr alignment bytes sz
+           else pure mem'
+  pure (ptr, mem'')
 
 -- | Load a 'RegValue' from memory. Both the 'StorageType' and 'TypeRepr'
 -- arguments should be computed from a single 'MemType' using
@@ -630,7 +639,8 @@ sextendBVTo sym w w' x
 --
 -- Precondition: the multiplication /size * number/ does not overflow.
 doCalloc ::
-  (IsSymInterface sym, HasPtrWidth wptr, Partial.HasLLVMAnn sym) =>
+  ( IsSymInterface sym, HasPtrWidth wptr, Partial.HasLLVMAnn sym
+  , ?memOpts :: MemOptions ) =>
   sym ->
   MemImpl sym ->
   SymBV sym wptr {- ^ size   -} ->
@@ -653,7 +663,8 @@ doCalloc sym mem sz num alignment = do
 
 -- | Allocate a memory region.
 doMalloc
-  :: (IsSymInterface sym, HasPtrWidth wptr)
+  :: ( IsSymInterface sym, HasPtrWidth wptr, Partial.HasLLVMAnn sym
+     , ?memOpts :: MemOptions )
   => sym
   -> G.AllocType {- ^ stack, heap, or global -}
   -> G.Mutability {- ^ whether region is read-only -}
@@ -666,7 +677,8 @@ doMalloc sym allocType mut loc mem sz alignment = doMallocSize (Just sz) sym all
 
 -- | Allocate a memory region of unbounded size.
 doMallocUnbounded
-  :: (IsSymInterface sym, HasPtrWidth wptr)
+  :: ( IsSymInterface sym, HasPtrWidth wptr, Partial.HasLLVMAnn sym
+     , ?memOpts :: MemOptions )
   => sym
   -> G.AllocType {- ^ stack, heap, or global -}
   -> G.Mutability {- ^ whether region is read-only -}
@@ -677,7 +689,8 @@ doMallocUnbounded
 doMallocUnbounded = doMallocSize Nothing
 
 doMallocSize
-  :: (IsSymInterface sym, HasPtrWidth wptr)
+  :: ( IsSymInterface sym, HasPtrWidth wptr, Partial.HasLLVMAnn sym
+     , ?memOpts :: MemOptions )
   => Maybe (SymBV sym wptr) {- ^ allocation size -}
   -> sym
   -> G.AllocType {- ^ stack, heap, or global -}
@@ -692,7 +705,17 @@ doMallocSize sz sym allocType mut loc mem alignment = do
   z      <- bvLit sym PtrWidth (BV.zero PtrWidth)
   let heap' = G.allocMem allocType blkNum sz alignment mut loc (memImplHeap mem)
   let ptr   = LLVMPointer blk z
-  return (ptr, mem{ memImplHeap = heap' })
+  let mem'  = mem{ memImplHeap = heap' }
+  mem'' <- if laxLoadsAndStores ?memOpts && mut == G.Mutable
+                && indeterminateLoadBehavior ?memOpts == StableSymbolic
+           then do bytes <- freshConstant sym emptySymbol
+                              (BaseArrayRepr (Ctx.singleton $ BaseBVRepr ?ptrWidth)
+                                             (BaseBVRepr (knownNat @8)))
+                   case sz of
+                     Just sz' -> doArrayStore sym mem' ptr alignment bytes sz'
+                     Nothing  -> doArrayStoreUnbounded sym mem' ptr alignment bytes
+           else pure mem'
+  return (ptr, mem'')
 
 bindLLVMFunPtr ::
   (IsSymInterface sym, HasPtrWidth wptr) =>
@@ -1300,7 +1323,8 @@ storeConstRaw sym mem ptr valType alignment val = do
 
 -- | Allocate a memory region on the heap, with no source location info.
 mallocRaw
-  :: (IsSymInterface sym, HasPtrWidth wptr)
+  :: ( IsSymInterface sym, HasPtrWidth wptr, Partial.HasLLVMAnn sym
+     , ?memOpts :: MemOptions )
   => sym
   -> MemImpl sym
   -> SymBV sym wptr {- ^ size in bytes -}
@@ -1311,7 +1335,8 @@ mallocRaw sym mem sz alignment =
 
 -- | Allocate a read-only memory region on the heap, with no source location info.
 mallocConstRaw
-  :: (IsSymInterface sym, HasPtrWidth wptr)
+  :: ( IsSymInterface sym, HasPtrWidth wptr, Partial.HasLLVMAnn sym
+     , ?memOpts :: MemOptions )
   => sym
   -> MemImpl sym
   -> SymBV sym wptr
@@ -1683,14 +1708,16 @@ registerGlobal (MemImpl blockSource gMap sMap hMap mem) symbols ptr =
 
 -- | Allocate memory for each global, and register all the resulting
 -- pointers in the global map.
-allocGlobals :: (IsSymInterface sym, HasPtrWidth wptr)
+allocGlobals :: ( IsSymInterface sym, HasPtrWidth wptr, Partial.HasLLVMAnn sym
+                , ?memOpts :: MemOptions )
              => sym
              -> [(L.Global, [L.Symbol], Bytes, Alignment)]
              -> MemImpl sym
              -> IO (MemImpl sym)
 allocGlobals sym gs mem = foldM (allocGlobal sym) mem gs
 
-allocGlobal :: (IsSymInterface sym, HasPtrWidth wptr)
+allocGlobal :: ( IsSymInterface sym, HasPtrWidth wptr, Partial.HasLLVMAnn sym
+               , ?memOpts :: MemOptions )
             => sym
             -> MemImpl sym
             -> (L.Global, [L.Symbol], Bytes, Alignment)

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Generic.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Generic.hs
@@ -773,13 +773,16 @@ readMem' sym w end gsym l0 origMem tp0 alignment (MemWrites ws) =
       LLVMPtr sym w ->
       ReadMem sym (PartLLVMVal sym)
     fallback0 tp _l =
-      do -- We're playing a trick here.  By making a fresh constant a proof obligation, we can be
-         -- sure it always fails.  But, because it's a variable, it won't be constant-folded away
-         -- and we can be relatively sure the annotation will survive.
-         liftIO $ do
-           b <- freshConstant sym emptySymbol BaseBoolRepr
-           Partial.Err <$>
-             Partial.annotateME sym mop (NoSatisfyingWrite tp) b
+      liftIO $
+        if laxLoadsAndStores ?memOpts
+           && indeterminateLoadBehavior ?memOpts == UnstableSymbolic
+        then Partial.totalLLVMVal sym <$> freshLLVMVal sym tp
+        else do -- We're playing a trick here.  By making a fresh constant a proof obligation, we can be
+                -- sure it always fails.  But, because it's a variable, it won't be constant-folded away
+                -- and we can be relatively sure the annotation will survive.
+                b <- freshConstant sym emptySymbol BaseBoolRepr
+                Partial.Err <$>
+                  Partial.annotateME sym mop (NoSatisfyingWrite tp) b
 
     go :: (StorageType -> LLVMPtr sym w -> ReadMem sym (PartLLVMVal sym)) ->
           LLVMPtr sym w ->

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Generic.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Generic.hs
@@ -1270,7 +1270,17 @@ writeMemWithAllocationCheck is_allocated sym w gsym ptr tp alignment val mem = d
                   idx <- bvAdd sym (llvmPointerOffset ptr)
                     =<< bvLit sym w (bytesToBV w off)
                   arrayUpdate sym acc_arr (Ctx.singleton idx) byte
-              _ -> return acc_arr
+
+              LLVMValZero _ -> do
+                  byte <- bvLit sym knownRepr (BV.zero knownRepr)
+                  idx <- bvAdd sym (llvmPointerOffset ptr)
+                    =<< bvLit sym w (bytesToBV w off)
+                  arrayUpdate sym acc_arr (Ctx.singleton idx) byte
+
+              _ -> panic "wrietMemWithAllocationCheck"
+                         [ "Expected byte value when updating SMT array, but got:"
+                         , show v
+                         ]
       res_arr <- foldM storeArrayByteFn arr [0 .. (sz - 1)]
       overwriteArrayMem sym w ptr res_arr arr_sz mem
 

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Generic.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Generic.hs
@@ -773,15 +773,13 @@ readMem' sym w end gsym l0 origMem tp0 alignment (MemWrites ws) =
       LLVMPtr sym w ->
       ReadMem sym (PartLLVMVal sym)
     fallback0 tp _l =
-      liftIO $
-        if laxLoadsAndStores ?memOpts
-        then Partial.totalLLVMVal sym <$> freshLLVMVal sym tp
-        else do -- We're playing a trick here.  By making a fresh constant a proof obligation, we can be
-                -- sure it always fails.  But, because it's a variable, it won't be constant-folded away
-                -- and we can be relatively sure the annotation will survive.
-                b <- freshConstant sym emptySymbol BaseBoolRepr
-                Partial.Err <$>
-                  Partial.annotateME sym mop (NoSatisfyingWrite tp) b
+      do -- We're playing a trick here.  By making a fresh constant a proof obligation, we can be
+         -- sure it always fails.  But, because it's a variable, it won't be constant-folded away
+         -- and we can be relatively sure the annotation will survive.
+         liftIO $ do
+           b <- freshConstant sym emptySymbol BaseBoolRepr
+           Partial.Err <$>
+             Partial.annotateME sym mop (NoSatisfyingWrite tp) b
 
     go :: (StorageType -> LLVMPtr sym w -> ReadMem sym (PartLLVMVal sym)) ->
           LLVMPtr sym w ->

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Options.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Options.hs
@@ -92,6 +92,12 @@ data IndeterminateLoadBehavior
     --   distinct. That is, the symbolic values are \"unstable\". Contrast this
     --   with 'StableSymbolic', in which multiple reads from the same section
     --   of uninitialized memory will all yield the same symbolic value.
+    --
+    --   One consequence of the 'UnstableSymbolic' approach is that any
+    --   pointer can be derefenced, even if it does not actually point to
+    --   anything. Dereferencing such a pointer will simply yield a fresh
+    --   symbolic value. On the other hand, dereferencing such a pointer
+    --   continues to be a Crucible error in 'StableSymbolic'.
   deriving (Eq, Show)
 
 -- | The default memory model options:

--- a/crucible-llvm/test/MemSetup.hs
+++ b/crucible-llvm/test/MemSetup.hs
@@ -73,7 +73,7 @@ withLLVMCtx mod' action =
         case assertLeq (knownNat @16) width of { LeqProof      -> do
           let ?ptrWidth = width
           let ?lc = LLVMTr._llvmTypeCtx ctx
-          let ?recordLLVMAnnotation = \_ _ -> pure ()
+          let ?recordLLVMAnnotation = \_ _ _ -> pure ()
           action ctx sym
         }}}
   in withIONonceGenerator $ \nonceGen ->

--- a/crucible-llvm/test/TestMemory.hs
+++ b/crucible-llvm/test/TestMemory.hs
@@ -149,7 +149,8 @@ testArrayStride = testCase "array stride" $ withMem LLVMD.BigEndian $ \sym mem0 
 
 
 allocFreshArray ::
-  (CB.IsSymInterface sym, LLVMMem.HasLLVMAnn sym, LLVMMem.HasPtrWidth wptr) =>
+  ( CB.IsSymInterface sym, LLVMMem.HasLLVMAnn sym, LLVMMem.HasPtrWidth wptr
+  , ?memOpts :: LLVMMem.MemOptions ) =>
   sym ->
   LLVMMem.MemImpl sym ->
   Integer ->

--- a/crux-llvm/CHANGELOG.md
+++ b/crux-llvm/CHANGELOG.md
@@ -1,0 +1,6 @@
+# next
+* `LLVMConfig` now has an `indeterminateLoadBehavior` flag to control the
+  `MemOptions` option of the same name. Refer to the `crucible-llvm` changelog
+  for more details.
+* A `?memOpts :: MemOptions` constraint has been added to
+  `Crux.LLVM.Simulate.checkFun`.

--- a/crux-llvm/crux-llvm.cabal
+++ b/crux-llvm/crux-llvm.cabal
@@ -39,6 +39,7 @@ data-files:
    c-src/print-model.c
    c-src/libcxx-3.6.2.bc
    c-src/libcxx-7.1.0.bc
+extra-source-files: CHANGELOG.md, README.md
 
 common bldflags
   ghc-options: -Wall

--- a/crux-llvm/src/Crux/LLVM/Simulate.hs
+++ b/crux-llvm/src/Crux/LLVM/Simulate.hs
@@ -264,7 +264,9 @@ sayTranslationWarning = Log.sayCruxLLVM . f
 
 checkFun ::
   forall arch msgs personality sym.
-  (IsSymInterface sym, ArchOk arch) =>
+  IsSymInterface sym =>
+  HasLLVMAnn sym =>
+  ArchOk arch =>
   Crux.Logs msgs =>
   Log.SupportsCruxLLVMLogMessage msgs =>
   LLVMOptions ->
@@ -320,6 +322,7 @@ checkFun llvmOpts trans memVar =
       OverM personality sym LLVM ()
     checkMainWithArguments anyCfg = do
       ctx <- getContext
+      let ?memOpts  = memOpts llvmOpts
       let w         = knownNat @32
           sym       = ctx^.ctxSymInterface
           dl        = llvmDataLayout (trans^.transContext.llvmTypeCtx)

--- a/crux-llvm/test-data/golden/T844-stable.c
+++ b/crux-llvm/test-data/golden/T844-stable.c
@@ -1,6 +1,9 @@
 #include <stdlib.h>
 
+int a = 0;
+
 int main() {
+  a++;
   int x;
   if (x && !x) {
     abort();

--- a/crux-llvm/test-data/golden/T844-stable.c
+++ b/crux-llvm/test-data/golden/T844-stable.c
@@ -1,0 +1,10 @@
+#include <stdlib.h>
+
+int main() {
+  int x;
+  if (x && !x) {
+    abort();
+  }
+
+  return 0;
+}

--- a/crux-llvm/test-data/golden/T844-stable.config
+++ b/crux-llvm/test-data/golden/T844-stable.config
@@ -1,0 +1,3 @@
+lax-loads-and-stores: yes
+indeterminate-load-behavior: stable-symbolic
+opt-level: 0

--- a/crux-llvm/test-data/golden/T844-stable.good
+++ b/crux-llvm/test-data/golden/T844-stable.good
@@ -1,0 +1,1 @@
+[Crux] Overall status: Valid.

--- a/crux-llvm/test-data/golden/T844-unstable.c
+++ b/crux-llvm/test-data/golden/T844-unstable.c
@@ -1,6 +1,9 @@
 #include <stdlib.h>
 
+int a = 0;
+
 int main() {
+  a++;
   int x;
   if (x && !x) {
     abort();

--- a/crux-llvm/test-data/golden/T844-unstable.c
+++ b/crux-llvm/test-data/golden/T844-unstable.c
@@ -1,0 +1,10 @@
+#include <stdlib.h>
+
+int main() {
+  int x;
+  if (x && !x) {
+    abort();
+  }
+
+  return 0;
+}

--- a/crux-llvm/test-data/golden/T844-unstable.config
+++ b/crux-llvm/test-data/golden/T844-unstable.config
@@ -1,0 +1,3 @@
+lax-loads-and-stores: yes
+indeterminate-load-behavior: unstable-symbolic
+opt-level: 0

--- a/crux-llvm/test-data/golden/T844-unstable.good
+++ b/crux-llvm/test-data/golden/T844-unstable.good
@@ -1,4 +1,4 @@
 [Crux] Found counterexample for verification goal
-[Crux]   test-data/golden/T844-unstable.c:6:5: error: in main
+[Crux]   test-data/golden/T844-unstable.c:9:5: error: in main
 [Crux]   Call to abort
 [Crux] Overall status: Invalid.

--- a/crux-llvm/test-data/golden/T844-unstable.good
+++ b/crux-llvm/test-data/golden/T844-unstable.good
@@ -1,0 +1,4 @@
+[Crux] Found counterexample for verification goal
+[Crux]   test-data/golden/T844-unstable.c:6:5: error: in main
+[Crux]   Call to abort
+[Crux] Overall status: Invalid.

--- a/uc-crux-llvm/CHANGELOG.md
+++ b/uc-crux-llvm/CHANGELOG.md
@@ -1,0 +1,4 @@
+# next
+* Add `?memOpts :: MemOptions` constraints to the following functions:
+  * `UCCrux.LLVM.Setup`: `generate` and `setupExecution`
+  * `UCCrux.LLVM.Setup.Monad`: `malloc`

--- a/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Skip.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Skip.hs
@@ -53,7 +53,7 @@ import qualified Lang.Crucible.Types as CrucibleTypes
 
 -- crucible-llvm
 import           Lang.Crucible.LLVM.Extension (LLVM)
-import           Lang.Crucible.LLVM.MemModel (HasLLVMAnn, MemImpl)
+import           Lang.Crucible.LLVM.MemModel (HasLLVMAnn, MemImpl, MemOptions)
 import           Lang.Crucible.LLVM.Translation (ModuleTranslation, transContext, llvmTypeCtx, llvmDeclToFunHandleRepr')
 import           Lang.Crucible.LLVM.TypeContext (TypeContext)
 import           Lang.Crucible.LLVM.Intrinsics (LLVMOverride(..), basic_llvm_override)
@@ -98,7 +98,8 @@ unsoundSkipOverrides ::
   ( IsSymInterface sym,
     HasLLVMAnn sym,
     ArchOk arch,
-    ?lc :: TypeContext
+    ?lc :: TypeContext,
+    ?memOpts :: MemOptions
   ) =>
   ModuleContext m arch ->
   sym ->
@@ -153,7 +154,8 @@ createSkipOverride ::
   ( IsSymInterface sym,
     HasLLVMAnn sym,
     ArchOk arch,
-    ?lc :: TypeContext
+    ?lc :: TypeContext,
+    ?memOpts :: MemOptions
   ) =>
   ModuleContext m arch ->
   sym ->

--- a/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Unsound.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Unsound.hs
@@ -74,7 +74,7 @@ newtype UnsoundOverrideName = UnsoundOverrideName {getUnsoundOverrideName :: Tex
 -- verification. They unsoundly under-approximate the environment. This helps
 -- symbolic execution reach more code.
 unsoundOverrides ::
-  (?lc :: TypeContext) =>
+  (?lc :: TypeContext, ?memOpts :: LLVMMem.MemOptions) =>
   IORef (Set UnsoundOverrideName) ->
   [ForAllSymArch PolymorphicLLVMOverride]
 unsoundOverrides usedRef =
@@ -165,7 +165,8 @@ callGetEnv ::
     HasLLVMAnn sym,
     wptr ~ ArchWidth arch,
     ArchOk arch,
-    ?lc :: TypeContext
+    ?lc :: TypeContext,
+    ?memOpts :: LLVMMem.MemOptions
   ) =>
   proxy arch ->
   sym ->

--- a/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
@@ -216,6 +216,7 @@ addOverrides newOverrides cbs =
 
 createUnsoundOverrides ::
   (?lc :: TypeContext) =>
+  (?memOpts :: MemOptions) =>
   ArchOk arch =>
   proxy arch ->
   IO (IORef (Set UnsoundOverrideName), [CreateOverrideFn arch])
@@ -231,7 +232,6 @@ createUnsoundOverrides proxy =
 
 registerOverrides ::
   (?intrinsicsOpts :: LLVMIntrinsics.IntrinsicsOptions) =>
-  (?memOpts :: MemOptions) =>
   ArchOk arch =>
   IsSymInterface sym =>
   HasLLVMAnn sym =>
@@ -265,7 +265,6 @@ registerOverrides appCtx modCtx kind overrides =
 
 registerDefinedFns ::
   (?intrinsicsOpts :: LLVMIntrinsics.IntrinsicsOptions) =>
-  (?memOpts :: MemOptions) =>
   ArchOk arch =>
   IsSymInterface sym =>
   HasLLVMAnn sym =>
@@ -308,6 +307,7 @@ mkCallbacks appCtx modCtx funCtx halloc callbacks constraints cfg llvmOpts =
        skipReturnValueAnns <- IORef.newIORef Map.empty
        skipOverrideRef <- IORef.newIORef Set.empty
        let ?lc = modCtx ^. moduleTranslation . transContext . llvmTypeCtx
+           ?memOpts = memOpts llvmOpts
        (unsoundOverrideRef, uOverrides) <-
          createUnsoundOverrides modCtx
 

--- a/uc-crux-llvm/src/UCCrux/LLVM/Setup.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Setup.hs
@@ -179,7 +179,8 @@ generate ::
   forall arch sym m atTy inTy argTypes.
   ( ArchOk arch,
     LLVMMem.HasLLVMAnn sym,
-    Crucible.IsSymInterface sym
+    Crucible.IsSymInterface sym,
+    ?memOpts :: LLVMMem.MemOptions
   ) =>
   sym ->
   ModuleContext m arch ->
@@ -322,7 +323,8 @@ generateArgs ::
   forall m arch sym argTypes.
   ( Crucible.IsSymInterface sym,
     LLVMMem.HasLLVMAnn sym,
-    ArchOk arch
+    ArchOk arch,
+    ?memOpts :: LLVMMem.MemOptions
   ) =>
   AppContext ->
   ModuleContext m arch ->
@@ -371,7 +373,8 @@ populateNonConstGlobals ::
   forall m arch sym argTypes.
   ( Crucible.IsSymInterface sym,
     LLVMMem.HasLLVMAnn sym,
-    ArchOk arch
+    ArchOk arch,
+    ?memOpts :: LLVMMem.MemOptions
   ) =>
   ModuleContext m arch ->
   sym ->
@@ -436,7 +439,8 @@ setupExecution ::
   ( Crucible.IsSymInterface sym,
     LLVMMem.HasLLVMAnn sym,
     ArchOk arch,
-    MonadIO f
+    MonadIO f,
+    ?memOpts :: LLVMMem.MemOptions
   ) =>
   AppContext ->
   ModuleContext m arch ->

--- a/uc-crux-llvm/src/UCCrux/LLVM/Setup/Monad.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Setup/Monad.hs
@@ -11,6 +11,7 @@ Stability    : provisional
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PolyKinds #-}
@@ -287,7 +288,9 @@ mallocLocation = "uc-crux-llvm bugfinding auto-setup"
 malloc ::
   forall m sym arch argTypes inTy atTy.
   ( Crucible.IsSymInterface sym,
-    ArchOk arch
+    LLVMMem.HasLLVMAnn sym,
+    ArchOk arch,
+    ?memOpts :: LLVMMem.MemOptions
   ) =>
   sym ->
   FullTypeRepr m ('FTPtr atTy) ->

--- a/uc-crux-llvm/uc-crux-llvm.cabal
+++ b/uc-crux-llvm/uc-crux-llvm.cabal
@@ -9,6 +9,7 @@ License-file:  LICENSE
 Build-type:    Simple
 Category:      Language
 Synopsis:      A bugfinding tool for C programs, using under-constrained symbolic execution.
+extra-source-files: CHANGELOG.md, README.md
 
 common bldflags
   ghc-options: -Wall


### PR DESCRIPTION
Previously, `laxLoadsAndStores` would make it so that all reads from uninitialized memory would return a new, fresh value. This isn't always what you want, however, as this implies that consecutive reads from the same, uninititalized variable would return different results. This patch adds another knob in the form of the `indeterminateLoadBehavior` field of `MemOptions`, which has two settings:

* `unstable-symbolic`: The previous behavior, in which each read from uninitialized memory will return a fresh symbolic value each time.
* `stable-symbolic` (now the default): After memory is allocated (be it through `alloca`, `malloc`, `calloc`, etc.), it is written with a fresh symbolic value. This makes it so that reading from the same section of uninitialized memory multiple times will always return the same symbolic value.

Note that `indeterminateLoadBehavior` only takes effect when `laxLoadsAndStores` is enabled.

Fixes #844.