### PR TITLE
uc-crux-llvm: Feed arguments and memory to result hook

### DIFF
--- a/uc-crux-llvm/test/Check.hs
+++ b/uc-crux-llvm/test/Check.hs
@@ -120,7 +120,7 @@ checkOverrideTests =
                                                      result
                                          ]
                                      , Sim.resultHook =
-                                       \_sym _cruxResult _ucCruxResult ->
+                                       \_sym _mem _args _cruxResult _ucCruxResult ->
                                          -- TODO: Confirm that the values
                                          -- indicate a precondition violation
                                          do mp <- IORef.readIORef ref


### PR DESCRIPTION
Make more data available to be interpreted. Makes the API more flexible overall.