### PR TITLE
crucible-llvm: Annotate errors with call stacks

### DIFF
--- a/crucible-llvm/crucible-llvm.cabal
+++ b/crucible-llvm/crucible-llvm.cabal
@@ -75,6 +75,7 @@ library
     Lang.Crucible.LLVM.Intrinsics
     Lang.Crucible.LLVM.MalformedLLVMModule
     Lang.Crucible.LLVM.MemModel
+    Lang.Crucible.LLVM.MemModel.CallStack
     Lang.Crucible.LLVM.MemModel.Generic
     Lang.Crucible.LLVM.MemModel.Partial
     Lang.Crucible.LLVM.MemModel.Pointer

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Errors/MemoryError.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Errors/MemoryError.hs
@@ -22,6 +22,7 @@ module Lang.Crucible.LLVM.Errors.MemoryError
 , details
 , ppMemoryError
 , MemoryOp(..)
+, memOpMem
 , ppMemoryOp
 , MemoryErrorReason(..)
 , ppMemoryErrorReason
@@ -60,6 +61,16 @@ data MemoryOp sym w
   | MemLoadHandleOp L.Type (Maybe String) (LLVMPtr sym w) (Mem sym)
   | forall wlen. (1 <= wlen) => MemInvalidateOp
        Text (Maybe String) (LLVMPtr sym w) (SymBV sym wlen) (Mem sym)
+
+memOpMem :: MemoryOp sym w -> Mem sym
+memOpMem =
+  \case
+    MemLoadOp _ _ _ mem -> mem
+    MemStoreOp _ _ _ mem -> mem
+    MemStoreBytesOp _ _ _ mem -> mem
+    MemCopyOp _ _ _ mem -> mem
+    MemLoadHandleOp _ _ _ mem -> mem
+    MemInvalidateOp _ _ _ _ mem -> mem
 
 data MemoryError sym where
   MemoryError :: (1 <= w) =>

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Eval.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Eval.hs
@@ -45,7 +45,7 @@ llvmExtensionEval sym _iTypes _logFn eval e =
   case e of
     X86Expr ex -> X86.eval sym eval ex
 
-    LLVM_SideConditions _tp conds val ->
+    LLVM_SideConditions _ _tp conds val ->
       do conds' <- traverse (traverseF (\x -> RV @sym <$> eval x)) (NE.toList conds)
          forM_ conds' (assertSideCondition sym)
          eval val

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Eval.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Eval.hs
@@ -4,8 +4,10 @@
 {-# LANGUAGE TypeApplications #-}
 module Lang.Crucible.LLVM.Eval
   ( llvmExtensionEval
+  , callStackFromMemVar
   ) where
 
+import           Control.Lens ((^.), view)
 import           Control.Monad (forM_)
 import qualified Data.List.NonEmpty as NE
 import           Data.Parameterized.TraversableF
@@ -13,41 +15,68 @@ import           Data.Parameterized.TraversableF
 import           What4.Interface
 
 import           Lang.Crucible.Backend
+import           Lang.Crucible.CFG.Common (GlobalVar)
+import           Lang.Crucible.Simulator.ExecutionTree (SimState, CrucibleState)
+import           Lang.Crucible.Simulator.ExecutionTree (stateGlobals)
+import           Lang.Crucible.Simulator.GlobalState (lookupGlobal)
 import           Lang.Crucible.Simulator.Intrinsics
 import           Lang.Crucible.Simulator.Evaluation
 import           Lang.Crucible.Simulator.RegValue
 import           Lang.Crucible.Simulator.SimError
+import           Lang.Crucible.Panic (panic)
 
 import qualified Lang.Crucible.LLVM.Arch.X86 as X86
 import qualified Lang.Crucible.LLVM.Errors.UndefinedBehavior as UB
 import           Lang.Crucible.LLVM.Extension
-import           Lang.Crucible.LLVM.MemModel.Pointer
+import           Lang.Crucible.LLVM.MemModel (memImplHeap)
+import           Lang.Crucible.LLVM.MemModel.CallStack (CallStack, getCallStack)
+import           Lang.Crucible.LLVM.MemModel.MemLog (memState)
 import           Lang.Crucible.LLVM.MemModel.Partial
+import           Lang.Crucible.LLVM.MemModel.Pointer
+import           Lang.Crucible.LLVM.Types (Mem)
+
+callStackFromMemVar ::
+  SimState p sym ext rtp lang args ->
+  GlobalVar Mem ->
+  CallStack
+callStackFromMemVar state mvar =
+  getCallStack . view memState . memImplHeap $
+     case lookupGlobal mvar (state ^. stateGlobals) of
+       Just v -> v
+       Nothing ->
+         panic "callStackFromMemVar"
+           [ "Global heap value not initialized."
+           , "*** Global heap variable: " ++ show mvar
+           ]
 
 assertSideCondition ::
   (HasLLVMAnn sym, IsSymInterface sym) =>
   sym ->
+  CallStack ->
   LLVMSideCondition (RegValue' sym) ->
   IO ()
-assertSideCondition sym (LLVMSideCondition (RV p) ub) =
-  do p' <- annotateUB sym ub p
+assertSideCondition sym callStack (LLVMSideCondition (RV p) ub) =
+  do p' <- annotateUB sym callStack ub p
      let err = AssertFailureSimError "Undefined behavior encountered" (show (UB.explain ub))
      assert sym p' err
 
-llvmExtensionEval :: forall sym.
+llvmExtensionEval ::
+  forall sym p ext rtp blocks r ctx.
   (HasLLVMAnn sym, IsSymInterface sym) =>
   sym ->
   IntrinsicTypes sym ->
   (Int -> String -> IO ()) ->
+  CrucibleState p sym ext rtp blocks r ctx ->
   EvalAppFunc sym LLVMExtensionExpr
 
-llvmExtensionEval sym _iTypes _logFn eval e =
+llvmExtensionEval sym _iTypes _logFn state eval e =
   case e of
     X86Expr ex -> X86.eval sym eval ex
 
-    LLVM_SideConditions _ _tp conds val ->
-      do conds' <- traverse (traverseF (\x -> RV @sym <$> eval x)) (NE.toList conds)
-         forM_ conds' (assertSideCondition sym)
+    LLVM_SideConditions mvar _tp conds val ->
+      do let callStack = callStackFromMemVar state mvar
+         conds' <- traverse (traverseF (\x -> RV @sym <$> eval x)) (NE.toList conds)
+         forM_ conds' (assertSideCondition sym callStack)
          eval val
 
     LLVM_PointerExpr _w blk off ->

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Common.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Common.hs
@@ -25,6 +25,7 @@ module Lang.Crucible.LLVM.Intrinsics.Common
   , llvmSSizeT
   , OverrideTemplate(..)
   , TemplateMatcher(..)
+  , callStackFromMemVar'
     -- ** register_llvm_override
   , basic_llvm_override
   , polymorphic1_llvm_override
@@ -65,7 +66,9 @@ import           Lang.Crucible.Types
 import           What4.FunctionName
 
 import           Lang.Crucible.LLVM.Extension
+import           Lang.Crucible.LLVM.Eval (callStackFromMemVar)
 import           Lang.Crucible.LLVM.MemModel
+import           Lang.Crucible.LLVM.MemModel.CallStack (CallStack)
 import           Lang.Crucible.LLVM.Translation.Monad
 import           Lang.Crucible.LLVM.Translation.Types
 
@@ -113,6 +116,11 @@ data TemplateMatcher
 type RegOverrideM p sym arch rtp l a =
   ReaderT (L.Declare, Maybe ABI.DecodedName, LLVMContext arch)
     (MaybeT (OverrideSim p sym LLVM rtp l a))
+
+callStackFromMemVar' ::
+  GlobalVar Mem ->
+  OverrideSim p sym ext r args ret CallStack
+callStackFromMemVar' mvar = use (to (flip callStackFromMemVar mvar))
 
 ------------------------------------------------------------------------
 -- ** register_llvm_override

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/LLVM.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/LLVM.hs
@@ -573,7 +573,9 @@ llvmAbsOverride ::
 llvmAbsOverride w =
   let nm = L.Symbol ("llvm.abs.i" ++ show (natValue w)) in
     [llvmOvr| #w $nm( #w, i1 ) |]
-    (\_memOpts sym args -> Ctx.uncurryAssignment (Libc.callLLVMAbs sym w) args)
+    (\mvar sym args ->
+     do callStack <- callStackFromMemVar' mvar
+        Ctx.uncurryAssignment (Libc.callLLVMAbs sym callStack w) args)
 
 llvmCopysignOverride_F32 ::
   IsSymInterface sym =>

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/CallStack.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/CallStack.hs
@@ -1,0 +1,49 @@
+------------------------------------------------------------------------
+-- |
+-- Module           : Lang.Crucible.LLVM.MemModel.CallStack
+-- Description      : Call stacks from the LLVM memory model
+-- Copyright        : (c) Galois, Inc 2021
+-- License          : BSD3
+-- Maintainer       : Rob Dockins <rdockins@galois.com>
+-- Stability        : provisional
+------------------------------------------------------------------------
+
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Lang.Crucible.LLVM.MemModel.CallStack
+  ( CallStack
+  , getCallStack
+  , ppCallStack
+  ) where
+
+import           Data.Foldable (toList)
+import           Data.Sequence (Seq)
+import qualified Data.Sequence as Seq
+import           Data.Text (Text)
+import qualified Prettyprinter as PP
+
+import           Lang.Crucible.LLVM.MemModel.MemLog (MemState(..))
+
+newtype FunctionName =
+  FunctionName { getFunctionName :: Text }
+  deriving (Eq, Monoid, Ord, Semigroup)
+
+newtype CallStack =
+  CallStack { runCallStack :: Seq FunctionName }
+  deriving (Eq, Monoid, Ord, Semigroup)
+
+cons :: FunctionName -> CallStack -> CallStack
+cons top (CallStack rest) = CallStack (top Seq.<| rest)
+
+getCallStack :: MemState sym -> CallStack
+getCallStack =
+  \case
+    EmptyMem{} -> CallStack mempty
+    StackFrame _ _ nm _ rest -> cons (FunctionName nm) (getCallStack rest)
+    BranchFrame _ _ _ rest -> getCallStack rest
+
+ppCallStack :: CallStack -> PP.Doc ann
+ppCallStack =
+  PP.vsep . toList . fmap (PP.pretty . getFunctionName) . runCallStack

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Generic.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Generic.hs
@@ -103,6 +103,7 @@ import           Lang.Crucible.LLVM.Bytes
 import           Lang.Crucible.LLVM.DataLayout
 import           Lang.Crucible.LLVM.Errors.MemoryError (MemErrContext, MemoryErrorReason(..), MemoryOp(..))
 import qualified Lang.Crucible.LLVM.Errors.UndefinedBehavior as UB
+import           Lang.Crucible.LLVM.MemModel.CallStack (getCallStack)
 import           Lang.Crucible.LLVM.MemModel.Common
 import           Lang.Crucible.LLVM.MemModel.Options
 import           Lang.Crucible.LLVM.MemModel.MemLog
@@ -719,8 +720,9 @@ readMem sym w gsym l tp alignment m = do
     -- Otherwise, fall back to the less-optimized read case
     _ -> readMem' sym w (memEndianForm m) gsym l m tp alignment (memWrites m)
 
+  let stack = getCallStack (m ^. memState)
   part_val' <- applyUnless (laxLoadsAndStores ?memOpts)
-                           (Partial.attachSideCondition sym p2 (UB.ReadBadAlignment (RV l) alignment))
+                           (Partial.attachSideCondition sym stack p2 (UB.ReadBadAlignment (RV l) alignment))
                            part_val
   applyUnless (laxLoadsAndStores ?memOpts)
               (Partial.attachMemoryError sym p1 mop UnreadableRegion)

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Partial.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Partial.hs
@@ -88,6 +88,8 @@ import           Lang.Crucible.Simulator.SimError
 import           Lang.Crucible.Simulator.RegValue (RegValue'(..))
 import           Lang.Crucible.LLVM.Bytes (Bytes)
 import qualified Lang.Crucible.LLVM.Bytes as Bytes
+import           Lang.Crucible.LLVM.MemModel.MemLog (memState)
+import           Lang.Crucible.LLVM.MemModel.CallStack (CallStack, getCallStack)
 import           Lang.Crucible.LLVM.MemModel.Pointer ( pattern LLVMPointer, LLVMPtr )
 import           Lang.Crucible.LLVM.MemModel.Type (StorageType(..), StorageTypeF(..), Field(..))
 import qualified Lang.Crucible.LLVM.MemModel.Type as Type
@@ -95,7 +97,7 @@ import           Lang.Crucible.LLVM.MemModel.Value (LLVMVal(..))
 import qualified Lang.Crucible.LLVM.MemModel.Value as Value
 import           Lang.Crucible.LLVM.Errors
 import qualified Lang.Crucible.LLVM.Errors.UndefinedBehavior as UB
-import           Lang.Crucible.LLVM.Errors.MemoryError (MemoryError(..), MemoryErrorReason(..), MemoryOp(..))
+import           Lang.Crucible.LLVM.Errors.MemoryError (MemoryError(..), MemoryErrorReason(..), MemoryOp(..), memOpMem)
 import           Lang.Crucible.Panic (panic)
 
 import           What4.Expr
@@ -113,12 +115,12 @@ instance IsSymInterface sym => Eq (BoolAnn sym) where
 instance IsSymInterface sym => Ord (BoolAnn sym) where
   compare (BoolAnn x) (BoolAnn y) = toOrdering $ compareF x y
 
-type LLVMAnnMap sym = Map (BoolAnn sym) (BadBehavior sym)
-type HasLLVMAnn sym = (?recordLLVMAnnotation :: BoolAnn sym -> BadBehavior sym -> IO ())
+type LLVMAnnMap sym = Map (BoolAnn sym) (CallStack, BadBehavior sym)
+type HasLLVMAnn sym = (?recordLLVMAnnotation :: CallStack -> BoolAnn sym -> BadBehavior sym -> IO ())
 
 data CexExplanation sym (tp :: BaseType) where
   NoExplanation  :: CexExplanation sym tp
-  DisjOfFailures :: [ BadBehavior sym ] -> CexExplanation sym BaseBoolType
+  DisjOfFailures :: [ (CallStack, BadBehavior sym) ] -> CexExplanation sym BaseBoolType
 
 instance Semigroup (CexExplanation sym BaseBoolType) where
   NoExplanation <> y = y
@@ -148,11 +150,11 @@ explainCex sym bbMap evalFn =
       (asNonceApp -> Just (Annotation BaseBoolRepr annId e')) ->
         case Map.lookup (BoolAnn annId) bbMap of
           Nothing -> evalPos posCache negCache e'
-          Just bb ->
+          Just (callStack, bb) ->
             do bb' <- case evalFn of
                         Just f  -> concBadBehavior sym (groundEval f) bb
                         Nothing -> pure bb
-               pure (DisjOfFailures [ bb' ])
+               pure (DisjOfFailures [ (callStack, bb') ])
 
       (asApp -> Just (BaseIte BaseBoolRepr _ c x y))
          | Just f <- evalFn ->
@@ -233,13 +235,17 @@ explainCex sym bbMap evalFn =
 
 annotateUB :: (IsSymInterface sym, HasLLVMAnn sym) =>
   sym ->
+  CallStack ->
   UB.UndefinedBehavior (RegValue' sym) ->
   Pred sym ->
   IO (Pred sym)
-annotateUB sym ub p =
+annotateUB sym callStack ub p =
   do (n, p') <- annotateTerm sym p
-     ?recordLLVMAnnotation (BoolAnn n) (BBUndefinedBehavior ub)
+     ?recordLLVMAnnotation callStack (BoolAnn n) (BBUndefinedBehavior ub)
      return p'
+
+memOpCallStack :: MemoryOp sym w -> CallStack
+memOpCallStack = getCallStack . view memState . memOpMem
 
 annotateME :: (IsSymInterface sym, HasLLVMAnn sym, 1 <= w) =>
   sym ->
@@ -249,7 +255,10 @@ annotateME :: (IsSymInterface sym, HasLLVMAnn sym, 1 <= w) =>
   IO (Pred sym)
 annotateME sym mop rsn p =
   do (n, p') <- annotateTerm sym p
-     ?recordLLVMAnnotation (BoolAnn n) (BBMemoryError (MemoryError mop rsn))
+     ?recordLLVMAnnotation
+       (memOpCallStack mop)
+       (BoolAnn n)
+       (BBMemoryError (MemoryError mop rsn))
      return p'
 
 -- | Assert that the given LLVM pointer value is actually a raw bitvector and extract its value.
@@ -270,8 +279,12 @@ data PartLLVMVal sym where
   Err :: Pred sym -> PartLLVMVal sym
   NoErr :: Pred sym -> LLVMVal sym -> PartLLVMVal sym
 
-partErr :: (IsSymInterface sym, HasLLVMAnn sym, 1 <= w) =>
-  sym -> MemoryOp sym w -> MemoryErrorReason -> IO (PartLLVMVal sym)
+partErr ::
+  (IsSymInterface sym, HasLLVMAnn sym, 1 <= w) =>
+  sym ->
+  MemoryOp sym w ->
+  MemoryErrorReason ->
+  IO (PartLLVMVal sym)
 partErr sym errCtx rsn =
   do p <- annotateME sym errCtx rsn (falsePred sym)
      pure (Err p)
@@ -279,15 +292,16 @@ partErr sym errCtx rsn =
 attachSideCondition ::
   (IsSymInterface sym, HasLLVMAnn sym) =>
   sym ->
+  CallStack ->
   Pred sym ->
   UB.UndefinedBehavior (RegValue' sym) ->
   PartLLVMVal sym ->
   IO (PartLLVMVal sym)
-attachSideCondition sym pnew ub pv =
+attachSideCondition sym callStack pnew ub pv =
   case pv of
     Err p -> pure (Err p)
     NoErr p v ->
-      do p' <- andPred sym p =<< annotateUB sym ub pnew
+      do p' <- andPred sym p =<< annotateUB sym callStack ub pnew
          return $ NoErr p' v
 
 attachMemoryError ::
@@ -333,7 +347,6 @@ assertSafe sym (Err p) = do
      let err = SimError loc rsn
      addProofObligation sym (LabeledPred p err)
      abortExecBecause (AssertionFailure err)
-
 
 ------------------------------------------------------------------------
 -- ** PartLLVMVal interface
@@ -429,11 +442,11 @@ bvToFloat sym _ (NoErr p (LLVMValZero (StorageType (Bitvector 4) _))) =
     (W4IFP.iFloatFromBinary sym W4IFP.SingleFloatRepr =<<
        W4I.bvLit sym (knownNat @32) (BV.zero knownNat))
 
-bvToFloat sym _ (NoErr p (LLVMValInt blk off))
+bvToFloat sym errCtx (NoErr p (LLVMValInt blk off))
   | Just Refl <- testEquality (bvWidth off) (knownNat @32) = do
       pz <- natEq sym blk =<< natLit sym 0
       let ub = UB.PointerFloatCast (RV (LLVMPointer blk off)) Type.floatType
-      p' <- andPred sym p =<< annotateUB sym ub pz
+      p' <- andPred sym p =<< annotateUB sym (memOpCallStack errCtx) ub pz
       NoErr p' . LLVMValFloat Value.SingleSize <$>
         W4IFP.iFloatFromBinary sym W4IFP.SingleFloatRepr off
 
@@ -457,11 +470,11 @@ bvToDouble sym _ (NoErr p (LLVMValZero (StorageType (Bitvector 8) _))) =
     (W4IFP.iFloatFromBinary sym W4IFP.DoubleFloatRepr =<<
        W4I.bvLit sym (knownNat @64) (BV.zero knownNat))
 
-bvToDouble sym _ (NoErr p (LLVMValInt blk off))
+bvToDouble sym errCtx (NoErr p (LLVMValInt blk off))
   | Just Refl <- testEquality (bvWidth off) (knownNat @64) = do
       pz <- natEq sym blk =<< natLit sym 0
       let ub = UB.PointerFloatCast (RV (LLVMPointer blk off)) Type.doubleType
-      p' <- andPred sym p =<< annotateUB sym ub pz
+      p' <- andPred sym p =<< annotateUB sym (memOpCallStack errCtx) ub pz
       NoErr p' .
         LLVMValFloat Value.DoubleSize <$>
         W4IFP.iFloatFromBinary sym W4IFP.DoubleFloatRepr off
@@ -486,11 +499,11 @@ bvToX86_FP80 sym _ (NoErr p (LLVMValZero (StorageType (Bitvector 10) _))) =
     (W4IFP.iFloatFromBinary sym W4IFP.X86_80FloatRepr =<<
        W4I.bvLit sym (knownNat @80) (BV.zero knownNat))
 
-bvToX86_FP80 sym _ (NoErr p (LLVMValInt blk off))
+bvToX86_FP80 sym errCtx (NoErr p (LLVMValInt blk off))
   | Just Refl <- testEquality (bvWidth off) (knownNat @80) =
       do pz <- natEq sym blk =<< natLit sym 0
          let ub = UB.PointerFloatCast (RV (LLVMPointer blk off)) Type.x86_fp80Type
-         p' <- andPred sym p =<< annotateUB sym ub pz
+         p' <- andPred sym p =<< annotateUB sym (memOpCallStack errCtx) ub pz
          NoErr p' . LLVMValFloat Value.X86_FP80Size <$>
            W4IFP.iFloatFromBinary sym W4IFP.X86_80FloatRepr off
 
@@ -546,8 +559,9 @@ bvConcat sym errCtx (NoErr p1 v1) (NoErr p2 v2) =
          Just LeqProof <- return $ isPosNat (addNat high_w' low_w')
          let ub1 = UB.PointerIntCast (RV (LLVMPointer blk_low low))   low_tp
              ub2 = UB.PointerIntCast (RV (LLVMPointer blk_high high)) high_tp
-         predLow       <- annotateUB sym ub1 =<< natEq sym blk_low blk0
-         predHigh      <- annotateUB sym ub2 =<< natEq sym blk_high blk0
+             annUB = annotateUB sym (memOpCallStack errCtx)
+         predLow       <- annUB ub1 =<< natEq sym blk_low blk0
+         predHigh      <- annUB ub2 =<< natEq sym blk_high blk0
          bv            <- W4I.bvConcat sym high low
 
          p' <- andPred sym p1 =<< andPred sym p2 =<< andPred sym predLow predHigh
@@ -732,7 +746,7 @@ selectLowBv _sym _ low hi (NoErr p (LLVMValZero (StorageType (Bitvector bytes) _
   | low + hi == bytes =
       return $ NoErr p $ LLVMValZero (Type.bitvectorType low)
 
-selectLowBv sym _ low hi (NoErr p (LLVMValInt blk bv))
+selectLowBv sym errCtx low hi (NoErr p (LLVMValInt blk bv))
   | Just (Some (low_w)) <- someNat (Bytes.bytesToBits low)
   , Just (Some (hi_w))  <- someNat (Bytes.bytesToBits hi)
   , Just LeqProof       <- isPosNat low_w
@@ -741,7 +755,7 @@ selectLowBv sym _ low hi (NoErr p (LLVMValInt blk bv))
       do pz  <- natEq sym blk =<< natLit sym 0
          bv' <- bvSelect sym (knownNat :: NatRepr 0) low_w bv
          let ub = UB.PointerIntCast (RV (LLVMPointer blk bv)) tp
-         p' <- andPred sym p =<< annotateUB sym ub pz
+         p' <- andPred sym p =<< annotateUB sym (memOpCallStack errCtx) ub pz
          return $ NoErr p' $ LLVMValInt blk bv'
  where w = bvWidth bv
        tp = Type.bitvectorType (Bytes.bitsToBytes (natValue w))
@@ -768,7 +782,7 @@ selectHighBv _sym _ low hi (NoErr p (LLVMValZero (StorageType (Bitvector bytes) 
   | low + hi == bytes =
       return $ NoErr p $ LLVMValZero (Type.bitvectorType hi)
 
-selectHighBv sym _ low hi (NoErr p (LLVMValInt blk bv))
+selectHighBv sym errCtx low hi (NoErr p (LLVMValInt blk bv))
   | Just (Some (low_w)) <- someNat (Bytes.bytesToBits low)
   , Just (Some (hi_w))  <- someNat (Bytes.bytesToBits hi)
   , Just LeqProof <- isPosNat hi_w
@@ -776,7 +790,7 @@ selectHighBv sym _ low hi (NoErr p (LLVMValInt blk bv))
     do pz <-  natEq sym blk =<< natLit sym 0
        bv' <- bvSelect sym low_w hi_w bv
        let ub = UB.PointerIntCast (RV (LLVMPointer blk bv)) tp
-       p' <- andPred sym p =<< annotateUB sym ub pz
+       p' <- andPred sym p =<< annotateUB sym (memOpCallStack errCtx) ub pz
        return $ NoErr p' $ LLVMValInt blk bv'
   where w = bvWidth bv
         tp = Type.bitvectorType (Bytes.bitsToBytes (natValue w))

--- a/crucible-llvm/test/TestMemory.hs
+++ b/crucible-llvm/test/TestMemory.hs
@@ -66,7 +66,7 @@ withMem ::
 withMem endianess action = withIONonceGenerator $ \nonce_gen ->
   CBO.withZ3OnlineBackend W4B.FloatIEEERepr nonce_gen CBO.NoUnsatFeatures noFeatures $ \sym -> do
     let ?ptrWidth = knownNat @64
-    let ?recordLLVMAnnotation = \_ _ -> pure ()
+    let ?recordLLVMAnnotation = \_ _ _ -> pure ()
     let ?memOpts = LLVMMem.defaultMemOptions
     mem <- LLVMMem.emptyMem endianess
     action sym mem

--- a/crucible-mc/exe/Main.hs
+++ b/crucible-mc/exe/Main.hs
@@ -47,7 +47,7 @@ main =
     Just (AnyCFG cfg) ->
       case (cfgArgTypes cfg, cfgReturnType cfg) of
         (Empty, UnitRepr) ->
-          let ?recordLLVMAnnotation = \_ _ -> pure () in
+          let ?recordLLVMAnnotation = \_ _ _ -> pure () in
                pure Setup
                  { cruxOutput = stdout
                  , cruxBackend = sym

--- a/crucible-wasm/src/Lang/Crucible/Wasm/Extension.hs
+++ b/crucible-wasm/src/Lang/Crucible/Wasm/Extension.hs
@@ -139,7 +139,7 @@ extImpl mo =
   let ?memOpts = mo in
   ExtensionImpl
   { -- There are no interesting extension expression formers
-    extensionEval = \_ _ _ _ -> \case{}
+    extensionEval = \_ _ _ _ _ -> \case{}
   , extensionExec = evalWasmExt
   }
 

--- a/crucible-wasm/tool/Main.hs
+++ b/crucible-wasm/tool/Main.hs
@@ -41,7 +41,7 @@ setupWasmState :: IsSymInterface sym =>
 setupWasmState sym memOptions s =
   do halloc <- newHandleAllocator
 
-     let ?recordLLVMAnnotation = \_ _ -> pure ()
+     let ?recordLLVMAnnotation = \_ _ _ -> pure ()
      let ?memOpts = memOptions
      let globals = emptyGlobals
      let bindings = emptyHandleMap

--- a/crucible/src/Lang/Crucible/Simulator/EvalStmt.hs
+++ b/crucible/src/Lang/Crucible/Simulator/EvalStmt.hs
@@ -117,7 +117,7 @@ evalExpr verb (App a) = ReaderT $ \s ->
      let sym = s^.stateSymInterface
      let logFn = evalLogFn verb s
      r <- evalApp sym iteFns logFn
-            (extensionEval (extensionImpl (s^.stateContext)) sym iteFns logFn)
+            (extensionEval (extensionImpl (s^.stateContext)) sym iteFns logFn s)
             (\r -> runReaderT (evalReg r) s)
             a
      return $! r

--- a/crucible/src/Lang/Crucible/Simulator/ExecutionTree.hs
+++ b/crucible/src/Lang/Crucible/Simulator/ExecutionTree.hs
@@ -986,10 +986,12 @@ type EvalStmtFunc p sym ext =
 data ExtensionImpl p sym ext
   = ExtensionImpl
     { extensionEval ::
+        forall rtp blocks r ctx.
         IsSymInterface sym =>
         sym ->
         IntrinsicTypes sym ->
         (Int -> String -> IO ()) ->
+        CrucibleState p sym ext rtp blocks r ctx ->
         EvalAppFunc sym (ExprExtension ext)
 
     , extensionExec :: EvalStmtFunc p sym ext
@@ -1000,7 +1002,7 @@ data ExtensionImpl p sym ext
 emptyExtensionImpl :: ExtensionImpl p sym ()
 emptyExtensionImpl =
   ExtensionImpl
-  { extensionEval = \_sym _iTypes _log _f -> \case
+  { extensionEval = \_sym _iTypes _log _f _state -> \case
   , extensionExec = \case
   }
 

--- a/crux-llvm/test-data/golden/golden/T847-fail1.good
+++ b/crux-llvm/test-data/golden/golden/T847-fail1.good
@@ -8,6 +8,8 @@
 [Crux]       The C language standard, version C11
 [Crux]       §7.22.6 Integer arithmetic functions, ¶1
 [Crux]       Document URL: http://www.iso-9899.info/n1570.html
+[Crux]     in context:
+[Crux]       main
 [Crux] Found counterexample for verification goal
 [Crux]   internal: error: in main
 [Crux]   Undefined behavior encountered
@@ -18,6 +20,8 @@
 [Crux]       The C language standard, version C11
 [Crux]       §7.22.6 Integer arithmetic functions, ¶1
 [Crux]       Document URL: http://www.iso-9899.info/n1570.html
+[Crux]     in context:
+[Crux]       main
 [Crux] Found counterexample for verification goal
 [Crux]   internal: error: in main
 [Crux]   Undefined behavior encountered
@@ -28,4 +32,6 @@
 [Crux]       The C language standard, version C11
 [Crux]       §7.22.6 Integer arithmetic functions, ¶1
 [Crux]       Document URL: http://www.iso-9899.info/n1570.html
+[Crux]     in context:
+[Crux]       main
 [Crux] Overall status: Invalid.

--- a/crux-llvm/test-data/golden/golden/double_free.good
+++ b/crux-llvm/test-data/golden/golden/double_free.good
@@ -9,4 +9,6 @@
 [Crux]       The C language standard, version C11
 [Crux]       §7.22.3.3 The free function, ¶2
 [Crux]       Document URL: http://www.iso-9899.info/n1570.html
+[Crux]     in context:
+[Crux]       main
 [Crux] Overall status: Invalid.

--- a/crux-llvm/test-data/golden/golden/invoke-test.good
+++ b/crux-llvm/test-data/golden/golden/invoke-test.good
@@ -74,4 +74,7 @@
 [Crux]                      ,base+32 = (10, 0x0:[64])
 [Crux]                      ,base+40 = (11, 0x0:[64])}
 [Crux]             46 |->   *(46, 0x0:[64]) := {base+0 = "\n"}
+[Crux]     in context:
+[Crux]       _ZN3std2rt10lang_start17h4f32aa1279b9079fE
+[Crux]       main
 [Crux] Overall status: Invalid.


### PR DESCRIPTION
Still WIP, since:

- [x] There are probably other projects in this repo that will need changes to typecheck
- [x] The Crux-LLVM golden tests are probably failing
- [x] Most importantly: There's a spot where I could use help on how to proceed (see inline comment)