### PR TITLE
uc-crux-llvm: Introduce a newtype for pre-simulation memory

### DIFF
--- a/uc-crux-llvm/src/UCCrux/LLVM/Classify.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Classify.hs
@@ -79,6 +79,7 @@ import           UCCrux.LLVM.FullType (FullType(FTPtr), MapToCrucibleType, FullT
 import           UCCrux.LLVM.FullType.MemType (toMemType)
 import           UCCrux.LLVM.Logging (Verbosity(Hi))
 import           UCCrux.LLVM.Module (makeFuncSymbol, makeGlobalSymbol, globalSymbol)
+import           UCCrux.LLVM.Newtypes.PreSimulationMem (PreSimulationMem, getPreSimulationMem)
 import           UCCrux.LLVM.Overrides.Skip (SkipOverrideName)
 import           UCCrux.LLVM.Setup (SymValue)
 import           UCCrux.LLVM.Setup.Monad (TypedSelector(..), mallocLocation)
@@ -208,7 +209,7 @@ classifyBadBehavior ::
   FunctionContext m arch argTypes ->
   sym ->
   -- | Initial LLVM memory (containing globals and functions)
-  LLVMMem.MemImpl sym ->
+  PreSimulationMem sym ->
   -- | Functions skipped during execution
   Set SkipOverrideName ->
   -- | Simulation error (including source position)
@@ -250,7 +251,7 @@ doClassifyBadBehavior ::
   FunctionContext m arch argTypes ->
   sym ->
   -- | Program memory
-  LLVMMem.MemImpl sym ->
+  PreSimulationMem sym ->
   -- | Functions skipped during execution
   Set SkipOverrideName ->
   -- | Simulation error (including source position)
@@ -529,7 +530,7 @@ doClassifyBadBehavior appCtx modCtx funCtx sym memImpl skipped simError (Crucibl
                       then unclass appCtx badBehavior errorLoc
                       else truePositive (ReadUninitializedHeap loc)
                   Just (G.AllocInfo G.GlobalAlloc _sz _mut _align _loc) ->
-                    case flip Map.lookup (LLVMMem.memImplSymbolMap memImpl) =<< blk of
+                    case flip Map.lookup (LLVMMem.memImplSymbolMap (getPreSimulationMem memImpl)) =<< blk of
                       Nothing -> requirePossiblePointer ReadNonPointer ptr
                       Just glob ->
                         case ( makeFuncSymbol glob (modCtx ^. funcTypes),

--- a/uc-crux-llvm/src/UCCrux/LLVM/Newtypes/PreSimulationMem.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Newtypes/PreSimulationMem.hs
@@ -1,0 +1,23 @@
+{-
+Module           : UCCrux.LLVM.Newtypes.PreSimulationMem
+Copyright        : (c) Galois, Inc 2020
+License          : BSD3
+Maintainer       : Langston Barrett <langston@galois.com>
+Stability        : provisional
+-}
+
+module UCCrux.LLVM.Newtypes.PreSimulationMem
+  ( PreSimulationMem
+  , makePreSimulationMem
+  , getPreSimulationMem
+  ) where
+
+import           Lang.Crucible.LLVM.MemModel (MemImpl)
+
+-- | LLVM memory just before symbolic execution. Populated with globals, defined
+-- functions, and arguments to the entry point.
+newtype PreSimulationMem sym =
+  PreSimulationMem { getPreSimulationMem :: MemImpl sym }
+
+makePreSimulationMem :: MemImpl sym -> PreSimulationMem sym
+makePreSimulationMem = PreSimulationMem

--- a/uc-crux-llvm/uc-crux-llvm.cabal
+++ b/uc-crux-llvm/uc-crux-llvm.cabal
@@ -61,6 +61,7 @@ library
     UCCrux.LLVM.Mem
     UCCrux.LLVM.Module
     UCCrux.LLVM.Newtypes.FunctionName
+    UCCrux.LLVM.Newtypes.PreSimulationMem
     UCCrux.LLVM.Newtypes.Seconds
     UCCrux.LLVM.Overrides.Check
     UCCrux.LLVM.Overrides.Polymorphic


### PR DESCRIPTION
This concept was used throughout the codebase, so it's nice to have types act as documentation.

Fixes #912.