### PR TITLE
Add crucible-syntax support for arbitrary syntax extensions

### DIFF
--- a/crucible-concurrency/src/Cruces/CrucesMain.hs
+++ b/crucible-concurrency/src/Cruces/CrucesMain.hs
@@ -93,7 +93,7 @@ cruciblesConfig = Crux.Config
       ]
   }
 
-findMain :: FunctionName -> [ACFG] -> FnVal sym Ctx.EmptyCtx C.UnitType
+findMain :: FunctionName -> [ACFG ()] -> FnVal sym Ctx.EmptyCtx C.UnitType
 findMain mainName cs =
   case find (isFn mainName) cs of
     Just (ACFG Ctx.Empty C.UnitRepr m) ->
@@ -130,6 +130,7 @@ run (cruxOpts, opts) =
                 mkSym _sym =
                   do exploreBuiltins <- mkExplorePrims ha (pedantic opts) (Some nonceGen)
                      let builtins = [ (SomeHandle h, InternalPos) | FnBinding h _ <- exploreBuiltins ]
+                     let ?parserHooks = defaultParserHooks
                      parseResult <- top nonceGen ha builtins $ prog v
                      case parseResult of
                        Left (SyntaxParseError e) -> error $ show $ printSyntaxError e

--- a/crucible-syntax/src/Lang/Crucible/Syntax/Concrete.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Concrete.hs
@@ -284,7 +284,7 @@ repUntilLast sp = describe "zero or more followed by one" $ repUntilLast' sp
 _isBaseType :: MonadSyntax Atomic m => ParserHooks ext -> m (Some BaseTypeRepr)
 _isBaseType hooks =
   describe "base type" $
-  do Some tp <- (isType hooks)
+  do Some tp <- isType hooks
      case asBaseType tp of
        NotBaseType -> empty
        AsBaseType bt -> return (Some bt)
@@ -294,7 +294,7 @@ _isFloatingType :: MonadSyntax Atomic m
                 -> m (Some FloatInfoRepr)
 _isFloatingType hooks =
   describe "floating-point type" $
-  do Some tp <- (isType hooks)
+  do Some tp <- isType hooks
      case tp of
        FloatRepr fi -> return (Some fi)
        _ -> empty

--- a/crucible-syntax/src/Lang/Crucible/Syntax/Concrete.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Concrete.hs
@@ -1878,7 +1878,7 @@ data ACFG ext :: * where
           CFG ext s init ret ->
           ACFG ext
 
-deriving instance Show (ACFG ())
+deriving instance Show (ACFG ext)
 
 data Arg t = Arg AtomName Position (TypeRepr t)
 

--- a/crucible-syntax/src/Lang/Crucible/Syntax/Prog.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Prog.hs
@@ -62,7 +62,7 @@ doParseCheck fn theInput pprint outh =
          do when pprint $
               forM_ v $
                 \e -> T.hPutStrLn outh (printExpr e) >> hPutStrLn outh ""
-            cs <- top ng ha [] $ (cfgs defaultParserHooks) v
+            cs <- top ng ha [] $ cfgs defaultParserHooks v
             case cs of
               Left (SyntaxParseError e) -> T.hPutStrLn outh $ printSyntaxError e
               Left err -> hPutStrLn outh $ show err
@@ -95,7 +95,7 @@ simulateProgram fn theInput outh profh opts setup =
             extendConfig opts (getConfiguration sym)
             ovrs <- setup @() @_ @() sym ha
             let hdls = [ (SomeHandle h, p) | (FnBinding h _,p) <- ovrs ]
-            parseResult <- top ng ha hdls $ (cfgs defaultParserHooks) v
+            parseResult <- top ng ha hdls $ cfgs defaultParserHooks v
             case parseResult of
               Left (SyntaxParseError e) -> T.hPutStrLn outh $ printSyntaxError e
               Left err -> hPutStrLn outh $ show err

--- a/crucible-syntax/src/Lang/Crucible/Syntax/Prog.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Prog.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeApplications #-}
@@ -62,7 +63,8 @@ doParseCheck fn theInput pprint outh =
          do when pprint $
               forM_ v $
                 \e -> T.hPutStrLn outh (printExpr e) >> hPutStrLn outh ""
-            cs <- top ng ha [] $ cfgs defaultParserHooks v
+            let ?parserHooks = defaultParserHooks
+            cs <- top ng ha [] $ cfgs v
             case cs of
               Left (SyntaxParseError e) -> T.hPutStrLn outh $ printSyntaxError e
               Left err -> hPutStrLn outh $ show err
@@ -95,7 +97,8 @@ simulateProgram fn theInput outh profh opts setup =
             extendConfig opts (getConfiguration sym)
             ovrs <- setup @() @_ @() sym ha
             let hdls = [ (SomeHandle h, p) | (FnBinding h _,p) <- ovrs ]
-            parseResult <- top ng ha hdls $ cfgs defaultParserHooks v
+            let ?parserHooks = defaultParserHooks
+            parseResult <- top ng ha hdls $ cfgs v
             case parseResult of
               Left (SyntaxParseError e) -> T.hPutStrLn outh $ printSyntaxError e
               Left err -> hPutStrLn outh $ show err

--- a/crucible-syntax/src/Lang/Crucible/Syntax/Prog.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Prog.hs
@@ -62,7 +62,7 @@ doParseCheck fn theInput pprint outh =
          do when pprint $
               forM_ v $
                 \e -> T.hPutStrLn outh (printExpr e) >> hPutStrLn outh ""
-            cs <- top ng ha [] $ cfgs v
+            cs <- top ng ha [] $ (cfgs defaultParserHooks) v
             case cs of
               Left (SyntaxParseError e) -> T.hPutStrLn outh $ printSyntaxError e
               Left err -> hPutStrLn outh $ show err
@@ -95,7 +95,7 @@ simulateProgram fn theInput outh profh opts setup =
             extendConfig opts (getConfiguration sym)
             ovrs <- setup @() @_ @() sym ha
             let hdls = [ (SomeHandle h, p) | (FnBinding h _,p) <- ovrs ]
-            parseResult <- top ng ha hdls $ cfgs v
+            parseResult <- top ng ha hdls $ (cfgs defaultParserHooks) v
             case parseResult of
               Left (SyntaxParseError e) -> T.hPutStrLn outh $ printSyntaxError e
               Left err -> hPutStrLn outh $ show err


### PR DESCRIPTION
This change adds a `ParserHooks` datatype that library users can
leverage to define parsing rules for additional types and syntax
extensions.  It also provides a `defaultParserHooks` instance that
existing crucible-syntax client code can use to preserve the current
behavior of the library.