### PR TITLE
Invalidate memory properly with laxLoadsAndStores

### DIFF
--- a/crucible-llvm/CHANGELOG.md
+++ b/crucible-llvm/CHANGELOG.md
@@ -12,5 +12,5 @@
     `initializeAllMemory`, `initializeMemoryConstGlobals`, `populateGlobals`,
     `populateAllGlobals`, and `populateConstGlobals`
   * `Lang.Crucible.LLVM.MemModel`:
-    `doAlloca`, `doCalloc`, `doMalloc`, `doMallocUnbounded`, `mallocRaw`,
-    `mallocConstRaw`, `allocGlobals`, and `allocGlobal`
+    `doAlloca`, `doCalloc`, `doInvalidate`, `doMalloc`, `doMallocUnbounded`,
+    `mallocRaw`, `mallocConstRaw`, `allocGlobals`, and `allocGlobal`


### PR DESCRIPTION
Prior to this change, invalidated memory would always result in an error when read from. This isn't quite the semantics that we would want when `laxLoadsAndStores` is enabled, however, since reading should always result in a symbolic value of some sort. This patch changes the mechanics of `doInvalidate` and `readMemInvalidate` such that when `laxLoadsAndStores` is enabled, the memory is given the appropriate semantics depending on whether `indeterminateLoadBehavior` is `StableSymbolic` or `UnstableSymbolic`.

This adds a `?memOpts :: MemOptions` constraint to `doInvalidate`, which is a breaking API change. That being said, the only call site that I am aware of for the `doInvalidate` function is SAW, so the breakage should be relatively minor. Furthermore, there were no test cases for `doInvalidate` before this, so this patch adds some.