### PR TITLE
Export `nat` from `Lang.Crucible.Syntax.Concrete`

### DIFF
--- a/crucible-syntax/src/Lang/Crucible/Syntax/Concrete.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Concrete.hs
@@ -38,6 +38,7 @@ module Lang.Crucible.Syntax.Concrete
   , SyntaxState(..)
   , atomName
   , freshAtom
+  , nat
   , operands
   -- * Rules for pretty-printing language syntax
   , printExpr


### PR DESCRIPTION
This export allows `ParserHooks` instances to make use of the parser for
natural numbers.