### PR TITLE
uc-crux-llvm: Improve error handling in cases of a malformed LLVM module

### DIFF
--- a/uc-crux-llvm/src/UCCrux/LLVM/Context/Function.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Context/Function.hs
@@ -121,20 +121,16 @@ ppFunctionContextError =
     BadMemType _ -> "Bad MemType"
 
 throwFunctionContextError :: FunctionContextError -> a
-throwFunctionContextError =
-  \case
-    err@(BadMemType {}) ->
-      malformedLLVMModule
-        "loopOnFunction"
-        (PP.pretty (ppFunctionContextError err))
-        []
-    err@(BadLift {}) ->
-      malformedLLVMModule
-        "loopOnFunction"
-        (PP.pretty (ppFunctionContextError err))
-        []
-    err@(BadLiftArgs {}) ->
-      panic "loopOnFunction" [Text.unpack (ppFunctionContextError err)]
+throwFunctionContextError err =
+  case err of
+    BadMemType {} -> isMalformed
+    BadLift {} -> isMalformed
+    BadLiftArgs {} -> doPanic
+  where
+    nm = "throwFunctionContextError"
+    doPanic = panic nm [Text.unpack (ppFunctionContextError err)]
+    isMalformed =
+      malformedLLVMModule nm (PP.pretty (ppFunctionContextError err)) []
 
 withPtrWidthOf ::
   LLVMTrans.ModuleTranslation arch ->

--- a/uc-crux-llvm/src/UCCrux/LLVM/Context/Function.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Context/Function.hs
@@ -17,9 +17,11 @@ Stability    : provisional
 
 module UCCrux.LLVM.Context.Function
   ( FunctionContext (..),
-    FunctionContextError (..),
+    FunctionContextError,
     ppFunctionContextError,
+    throwFunctionContextError,
     makeFunctionContext,
+    tryMakeFunctionContext,
     functionName,
     argumentNames,
     argumentCrucibleTypes,
@@ -39,6 +41,8 @@ import           Data.Monoid (getFirst, First(First))
 import           Data.Text (Text)
 import qualified Data.Text as Text
 
+import qualified Prettyprinter as PP
+
 import qualified Text.LLVM.AST as L
 
 import           Data.Parameterized.Ctx (Ctx)
@@ -53,6 +57,8 @@ import qualified Lang.Crucible.LLVM.Translation as LLVMTrans
 import           Crux.LLVM.Overrides (ArchOk)
 
 import           UCCrux.LLVM.Context.Module (ModuleContext, withTypeContext, llvmModule, moduleTranslation)
+import           UCCrux.LLVM.Errors.MalformedLLVMModule (malformedLLVMModule)
+import           UCCrux.LLVM.Errors.Panic (panic)
 import           UCCrux.LLVM.Errors.Unimplemented (unimplemented, Unimplemented(VarArgsFunction))
 import           UCCrux.LLVM.FullType.Type (FullType, FullTypeRepr, MapToCrucibleType)
 import           UCCrux.LLVM.Module (DefnSymbol, defnSymbol, getDefnSymbol, moduleDefnMap, getModule)
@@ -88,9 +94,7 @@ argumentStorageTypes :: Simple Lens (FunctionContext m arch argTypes) (Ctx.Assig
 argumentStorageTypes = lens _argumentStorageTypes (\s v -> s {_argumentStorageTypes = v})
 
 data FunctionContextError
-  = -- | Couldn't find 'L.Define' of entrypoint
-    MissingEntrypoint Text
-  | -- | Couldn't lift types in declaration to 'MemType'
+  = -- | Couldn't lift types in declaration to 'MemType'
     BadLift Text
   | -- | Wrong number of arguments after lifting declaration
     BadLiftArgs !Int !Int !Int
@@ -100,7 +104,6 @@ data FunctionContextError
 ppFunctionContextError :: FunctionContextError -> Text
 ppFunctionContextError =
   \case
-    MissingEntrypoint name -> "Couldn't find definition of function " <> name
     BadLift name -> "Couldn't lift argument/return types to MemTypes for " <> name
     BadLiftArgs decl tys idx ->
       Text.unwords
@@ -117,6 +120,22 @@ ppFunctionContextError =
         ]
     BadMemType _ -> "Bad MemType"
 
+throwFunctionContextError :: FunctionContextError -> a
+throwFunctionContextError =
+  \case
+    err@(BadMemType {}) ->
+      malformedLLVMModule
+        "loopOnFunction"
+        (PP.pretty (ppFunctionContextError err))
+        []
+    err@(BadLift {}) ->
+      malformedLLVMModule
+        "loopOnFunction"
+        (PP.pretty (ppFunctionContextError err))
+        []
+    err@(BadLiftArgs {}) ->
+      panic "loopOnFunction" [Text.unpack (ppFunctionContextError err)]
+
 withPtrWidthOf ::
   LLVMTrans.ModuleTranslation arch ->
   (ArchOk arch => b) ->
@@ -124,8 +143,10 @@ withPtrWidthOf ::
 withPtrWidthOf trans k =
   LLVMTrans.llvmPtrWidth (trans ^. LLVMTrans.transContext) (\ptrW -> withPtrWidth ptrW k)
 
--- | This function does some precomputation of ubiquitously used values, and
--- some handling of what should generally be very rare errors.
+-- | This function does some precomputation of ubiquitously used values.
+--
+-- Any errors encountered in this process are bugs in UC-Crux or results of a
+-- malformed LLVM module, and are thrown as exceptions.
 makeFunctionContext ::
   forall m arch fullTypes.
   ArchOk arch =>
@@ -133,8 +154,21 @@ makeFunctionContext ::
   DefnSymbol m ->
   Ctx.Assignment (FullTypeRepr m) fullTypes ->
   Ctx.Assignment CrucibleTypes.TypeRepr (MapToCrucibleType arch fullTypes) ->
-  Either FunctionContextError (FunctionContext m arch fullTypes)
+  FunctionContext m arch fullTypes
 makeFunctionContext modCtx defnSymb argFullTypes argTypes =
+  case tryMakeFunctionContext modCtx defnSymb argFullTypes argTypes of
+    Left err -> throwFunctionContextError err
+    Right funCtx -> funCtx
+
+tryMakeFunctionContext ::
+  forall m arch fullTypes.
+  ArchOk arch =>
+  ModuleContext m arch ->
+  DefnSymbol m ->
+  Ctx.Assignment (FullTypeRepr m) fullTypes ->
+  Ctx.Assignment CrucibleTypes.TypeRepr (MapToCrucibleType arch fullTypes) ->
+  Either FunctionContextError (FunctionContext m arch fullTypes)
+tryMakeFunctionContext modCtx defnSymb argFullTypes argTypes =
   do
     let llvmMod = modCtx ^. llvmModule
     let L.Symbol strName = getDefnSymbol defnSymb

--- a/uc-crux-llvm/src/UCCrux/LLVM/Context/Module.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Context/Module.hs
@@ -40,6 +40,7 @@ where
 import           Control.Lens ((^.), Simple, Getter, Lens, lens, to, at)
 import           Data.Proxy (Proxy(Proxy))
 import           Data.Type.Equality ((:~:)(Refl), testEquality)
+import           GHC.Stack (HasCallStack)
 
 import           Text.LLVM.AST (Symbol(Symbol))
 import qualified Text.LLVM.AST as L
@@ -119,6 +120,7 @@ withTypeContext context computation =
 -- | Any errors encountered in this function are bugs in UC-Crux or results of a
 -- malformed LLVM module, and are thrown as exceptions.
 makeModuleContext ::
+  HasCallStack =>
   ArchOk arch =>
   FilePath ->
   L.Module ->

--- a/uc-crux-llvm/src/UCCrux/LLVM/Errors/MalformedLLVMModule.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Errors/MalformedLLVMModule.hs
@@ -14,6 +14,7 @@ where
 
 {- ORMOLU_DISABLE -}
 import           Data.Void (Void)
+import           GHC.Stack (HasCallStack, prettyCallStack, callStack)
 
 import           Prettyprinter (Doc, pretty)
 
@@ -23,17 +24,18 @@ import qualified Lang.Crucible.LLVM.MalformedLLVMModule as M
 -- | Throw a 'Lang.Crucible.LLVM.MalformedLLVMModule.MalformedLLVMModule'
 -- exception.
 malformedLLVMModule ::
-  -- | Function name
-  String ->
+  HasCallStack =>
   -- | Short explanation
   Doc Void ->
   -- | Details
   [Doc Void] ->
   a
-malformedLLVMModule nm short details =
+malformedLLVMModule short details =
   M.malformedLLVMModule short $
     concat
-      [ [ pretty ("In function: " ++ nm) ]
+      [ [ pretty "Call stack:"
+        , pretty (prettyCallStack callStack)
+        ]
       , details
       , map
           pretty

--- a/uc-crux-llvm/src/UCCrux/LLVM/Errors/MalformedLLVMModule.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Errors/MalformedLLVMModule.hs
@@ -1,0 +1,46 @@
+{-
+Module       : UCCrux.LLVM.Errors.MalformedLLVMModule
+Description  : Problems with the (our assumptions about) the input program(s)
+Copyright    : (c) Galois, Inc 2021
+License      : BSD3
+Maintainer   : Langston Barrett <langston@galois.com>
+Stability    : provisional
+-}
+
+module UCCrux.LLVM.Errors.MalformedLLVMModule
+  ( malformedLLVMModule,
+  )
+where
+
+{- ORMOLU_DISABLE -}
+import           Data.Void (Void)
+
+import           Prettyprinter (Doc, pretty)
+
+import qualified Lang.Crucible.LLVM.MalformedLLVMModule as M
+{- ORMOLU_ENABLE -}
+
+-- | Throw a 'Lang.Crucible.LLVM.MalformedLLVMModule.MalformedLLVMModule'
+-- exception.
+malformedLLVMModule ::
+  -- | Function name
+  String ->
+  -- | Short explanation
+  Doc Void ->
+  -- | Details
+  [Doc Void] ->
+  a
+malformedLLVMModule nm short details =
+  M.malformedLLVMModule short $
+    concat
+      [ [ pretty ("In function: " ++ nm) ]
+      , details
+      , map
+          pretty
+          [ "This is either a bug in the compiler that produced the LLVM module",
+            "or in UC-Crux's assumptions about the form of valid LLVM modules.",
+            "Try running `opt -disable-output -verify < your-module.bc`.",
+            "If opt reports no problems, please report this error here:",
+            "https://github.com/GaloisInc/crucible/issues"
+          ]
+      ]

--- a/uc-crux-llvm/src/UCCrux/LLVM/FullType/Translation.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/FullType/Translation.hs
@@ -24,9 +24,10 @@ module UCCrux.LLVM.FullType.Translation
   ( FunctionTypes (..),
     MatchingAssign (..),
     TranslatedTypes (..),
-    TypeTranslationError (..),
+    TypeTranslationError,
     translateModuleDefines,
     ppTypeTranslationError,
+    throwTypeTranslationError,
   )
 where
 
@@ -39,6 +40,9 @@ import           Control.Monad.State (State, runState)
 import           Data.Functor ((<&>))
 import           Data.Proxy (Proxy(Proxy))
 import qualified Data.Map as Map
+
+import           Prettyprinter (Doc)
+import qualified Prettyprinter as PP
 
 import qualified Text.LLVM.AST as L
 
@@ -55,6 +59,7 @@ import qualified Lang.Crucible.LLVM.Translation as LLVMTrans
 import           Lang.Crucible.LLVM.TypeContext (TypeContext)
 
 import           Crux.LLVM.Overrides (ArchOk)
+import           UCCrux.LLVM.Errors.MalformedLLVMModule (malformedLLVMModule)
 import           UCCrux.LLVM.Errors.Panic (panic)
 import           UCCrux.LLVM.FullType.CrucibleType (SomeAssign'(..), testCompatibilityAssign, assignmentToCrucibleType)
 import           UCCrux.LLVM.FullType.Type
@@ -102,15 +107,29 @@ data TypeTranslationError
     BadLiftArgs !L.Symbol
   | FullTypeTranslation L.Ident
 
-ppTypeTranslationError :: TypeTranslationError -> String
+ppTypeTranslationError :: TypeTranslationError -> Doc ann
 ppTypeTranslationError =
-  \case
-    NoCFG (L.Symbol name) -> "Couldn't find definition of function " <> name
-    BadLift name -> "Couldn't lift argument/return types to MemTypes for " <> name
-    BadLiftArgs (L.Symbol name) ->
-      "Wrong number of arguments after lifting declaration of " <> name
-    FullTypeTranslation (L.Ident ident) ->
-      "Couldn't find or couldn't translate type: " <> ident
+  PP.pretty .
+    \case
+      NoCFG (L.Symbol name) -> "Couldn't find definition of function " <> name
+      BadLift name -> "Couldn't lift argument/return types to MemTypes for " <> name
+      BadLiftArgs (L.Symbol name) ->
+        "Wrong number of arguments after lifting declaration of " <> name
+      FullTypeTranslation (L.Ident ident) ->
+        "Couldn't find or couldn't translate type: " <> ident
+
+throwTypeTranslationError :: TypeTranslationError -> a
+throwTypeTranslationError err =
+  case err of
+    NoCFG {} -> doPanic
+    BadLift {} -> isMalformed
+    BadLiftArgs {} -> doPanic
+    FullTypeTranslation {} -> doPanic
+  where
+    nm = "throwTypeTranslationError"
+    doPanic = panic nm [show (ppTypeTranslationError err)]
+    isMalformed = malformedLLVMModule nm (ppTypeTranslationError err) []
+
 
 -- | Precondition: The 'TypeContext' must correspond to the 'L.Module'.
 translateModuleDefines ::

--- a/uc-crux-llvm/src/UCCrux/LLVM/Main.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Main.hs
@@ -85,8 +85,6 @@ import           UCCrux.LLVM.Context.App (AppContext)
 import           UCCrux.LLVM.Context.Module (ModuleContext, SomeModuleContext(..), makeModuleContext, defnTypes, withModulePtrWidth)
 import           UCCrux.LLVM.Equivalence (checkEquiv)
 import qualified UCCrux.LLVM.Equivalence.Config as EqConfig
-import           UCCrux.LLVM.Errors.Panic (panic)
-import           UCCrux.LLVM.FullType.Translation (ppTypeTranslationError)
 import qualified UCCrux.LLVM.Logging as Log
 import qualified UCCrux.LLVM.Main.Config.FromEnv as Config.FromEnv
 import           UCCrux.LLVM.Main.Config.Type (TopLevelConfig)
@@ -237,14 +235,7 @@ translateLLVMModule llOpts halloc memVar moduleFilePath llvmMod =
           withPtrWidth
             ptrW
             ( case makeModuleContext moduleFilePath llvmMod trans of
-                Left err ->
-                  panic
-                    "translateLLVMModule"
-                    [ "Type translation failed",
-                      ppTypeTranslationError err
-                    ]
-                Right (SomeModuleContext modCtx) ->
-                  pure (SomeModuleContext' modCtx)
+                SomeModuleContext modCtx -> pure (SomeModuleContext' modCtx)
             )
       )
 

--- a/uc-crux-llvm/test/Check.hs
+++ b/uc-crux-llvm/test/Check.hs
@@ -19,7 +19,6 @@ import           Control.Lens ((^.))
 import           Data.Foldable (toList)
 import qualified Data.IORef as IORef
 import           Data.Maybe (fromMaybe)
-import qualified Data.Text as Text
 
 import qualified Lang.Crucible.CFG.Core as Crucible
 
@@ -31,7 +30,7 @@ import qualified Test.Tasty.HUnit as TH
 import qualified What4.Interface as What4
 
 import           UCCrux.LLVM.Constraints (emptyConstraints)
-import           UCCrux.LLVM.Context.Function (makeFunctionContext, ppFunctionContextError)
+import           UCCrux.LLVM.Context.Function (makeFunctionContext)
 import           UCCrux.LLVM.Context.Module (ModuleContext, CFGWithTypes(..), defnTypes, findFun, withModulePtrWidth)
 import           UCCrux.LLVM.Module (FuncSymbol(FuncDefnSymbol), DefnSymbol, defnSymbolToString)
 import           UCCrux.LLVM.Newtypes.FunctionName (functionNameFromString)
@@ -87,11 +86,7 @@ checkOverrideTests =
                         CFGWithTypes fcgf fArgFTys _retTy _varArgs <-
                           pure (findFun modCtx (FuncDefnSymbol f))
 
-                        funCtxF <-
-                          case makeFunctionContext modCtx f fArgFTys (Crucible.cfgArgTypes fcgf) of
-                            Left err ->
-                              error (Text.unpack (ppFunctionContextError err))
-                            Right funCtxF -> return funCtxF
+                        let funCtxF = makeFunctionContext modCtx f fArgFTys (Crucible.cfgArgTypes fcgf)
 
                         -- Run main loop on f, to deduce the precondition
                         -- that y should be nonnull
@@ -152,11 +147,7 @@ checkOverrideTests =
                         CFGWithTypes gcfg gArgFTys _retTy _varArgs <-
                           pure (findFun modCtx (FuncDefnSymbol g))
 
-                        funCtxG <-
-                          case makeFunctionContext modCtx g gArgFTys (Crucible.cfgArgTypes gcfg) of
-                            Left err ->
-                              error (Text.unpack (ppFunctionContextError err))
-                            Right funCtxG -> return funCtxG
+                        let funCtxG = makeFunctionContext modCtx g gArgFTys (Crucible.cfgArgTypes gcfg)
 
                         () <-
                           Sim.runSimulatorWithCallbacks

--- a/uc-crux-llvm/test/Utils.hs
+++ b/uc-crux-llvm/test/Utils.hs
@@ -21,7 +21,6 @@ module Utils
 import           Control.Lens ((^.))
 import           Control.Exception (try)
 import           Data.Maybe (fromMaybe, isNothing)
-import qualified Data.Text as Text
 import           System.Environment (lookupEnv)
 import           System.FilePath ((</>))
 import           System.IO (IOMode(WriteMode), withFile)
@@ -50,7 +49,7 @@ import           Crux.LLVM.Overrides (ArchOk)
 import           UCCrux.LLVM.Constraints (emptyConstraints)
 import           UCCrux.LLVM.Context.App (AppContext, makeAppContext)
 import           UCCrux.LLVM.Context.Module (ModuleContext, CFGWithTypes(..), defnTypes, findFun, withModulePtrWidth)
-import           UCCrux.LLVM.Context.Function (FunctionContext, makeFunctionContext, ppFunctionContextError)
+import           UCCrux.LLVM.Context.Function (FunctionContext, makeFunctionContext)
 import           UCCrux.LLVM.Module (FuncSymbol(FuncDefnSymbol))
 import           UCCrux.LLVM.Newtypes.FunctionName (functionNameFromString)
 import qualified UCCrux.LLVM.Logging as Log
@@ -224,11 +223,8 @@ simulateFunc file func makeCallbacks =
            withModulePtrWidth modCtx $
              do CFGWithTypes cfg argFTys _retTy _varArgs <-
                    pure (findFun modCtx (FuncDefnSymbol entry))
-                funCtx <-
-                  case makeFunctionContext modCtx entry argFTys (Crucible.cfgArgTypes cfg) of
-                    Left err ->
-                      error (Text.unpack (ppFunctionContextError err))
-                    Right funCtx -> return funCtx
+                let funCtx =
+                      makeFunctionContext modCtx entry argFTys (Crucible.cfgArgTypes cfg)
                 -- TODO(lb): also provide these
                 -- let ?memOpts = CruxLLVM.memOpts llOpts
                 -- let ?lc = modCtx ^. moduleTranslation . transContext . llvmTypeCtx
@@ -244,4 +240,3 @@ simulateFunc file func makeCallbacks =
                   llOpts
                   cbs
     )
-  

--- a/uc-crux-llvm/uc-crux-llvm.cabal
+++ b/uc-crux-llvm/uc-crux-llvm.cabal
@@ -45,6 +45,7 @@ library
     UCCrux.LLVM.Cursor
     UCCrux.LLVM.Equivalence
     UCCrux.LLVM.Equivalence.Config
+    UCCrux.LLVM.Errors.MalformedLLVMModule
     UCCrux.LLVM.Errors.Panic
     UCCrux.LLVM.Errors.Unimplemented
     UCCrux.LLVM.FullType


### PR DESCRIPTION
Previously, UC-Crux `panic`ed in a few places that could potentially indicate malformed LLVM modules. This change makes it more clear what might be Clang/rustc/whatever bugs.