### PR TITLE
Add an `Eq` instance for `TypeRepr`

### DIFF
--- a/crucible/src/Lang/Crucible/Types.hs
+++ b/crucible/src/Lang/Crucible/Types.hs
@@ -486,6 +486,8 @@ instance TestEquality TypeRepr where
                      , [|testEquality|])
                    ]
                   )
+instance Eq (TypeRepr tp) where
+  x == y = isJust (testEquality x y)
 
 instance OrdF TypeRepr where
   compareF = $(U.structuralTypeOrd [t|TypeRepr|]


### PR DESCRIPTION
This was prompted by GaloisInc/parameterized-utils#126, but the changes needed on `crucible`'s end can be applied independently.