### PR TITLE
Pare down the number of CI configurations

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,18 @@
+# GitHub Actions workflows
+
+We currently build and test a subset of the packages in the `crucible` repo
+on CI, whose CI configurations are located here. We use the following
+conventions when picking with operating systems to test:
+
+* For each project, we test the latest LTS release of Ubuntu on all supported
+  versions of GHC.
+* In addition, we also test the previous LTS release of Ubuntu on the
+  `crux-llvm-build.yml` workflow, but only using the latest supported version
+  of GHC.
+* For each project, we test macOS only using the latest
+  supported version of GHC. This is because the turnaround time for macOS
+  builders on GitHub Actions is longer, so we try to avoid
+  bottlenecking CI workflows on macOS builds.
+
+  In the future, we wish to test Windows using the latest supported version
+  of GHC as well.

--- a/.github/workflows/crucible-go-build.yml
+++ b/.github/workflows/crucible-go-build.yml
@@ -21,34 +21,16 @@ env:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.allow-failure }}
     env:
       CI_TEST_LEVEL: "1"
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest] # , macos-10.15] # , windows-latest]
+        os: [ubuntu-latest]
         ghc: ["8.8.4", "8.10.7", "9.0.2"]
-        allow-failure: [false]
         include:
           - os: macos-10.15
-            ghc: 8.8.4
-            allow-failure: true
-          - os: macos-10.15
-            ghc: 8.10.7
-            allow-failure: true
-          - os: macos-10.15
             ghc: 9.0.2
-            allow-failure: true
-        # Windows only seems to work on 8.6.5. Others result in
-        # segfaults or other internal errors.
-        exclude:
-          - os: windows-latest
-            ghc: 9.0.2
-          - os: windows-latest
-            ghc: 8.10.7
-          - os: windows-latest
-            ghc: 8.8.4
     name: crucible-go - GHC v${{ matrix.ghc }} - ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/crucible-go-build.yml
+++ b/.github/workflows/crucible-go-build.yml
@@ -43,6 +43,7 @@ jobs:
           ghc-version: ${{ matrix.ghc }}
 
       - name: Install Nix
+        if: runner.os == 'Linux'
         uses: cachix/install-nix-action@v16
         with:
           nix_path: nixpkgs=channel:21.11
@@ -65,6 +66,7 @@ jobs:
           BUILD_TARGET_OS: ${{ matrix.os }}
 
       - name: Setup Environment Vars
+        if: runner.os == 'Linux'
         run: |
           GHC=haskell.compiler.ghc$(echo ${{ matrix.ghc }} | sed -e s,\\.,,g)
           case ${{ matrix.ghc }} in

--- a/.github/workflows/crucible-jvm-build.yml
+++ b/.github/workflows/crucible-jvm-build.yml
@@ -21,34 +21,16 @@ env:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.allow-failure }}
     env:
       CI_TEST_LEVEL: "1"
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest] # , macos-10.15] # , windows-latest]
+        os: [ubuntu-latest]
         ghc: ["8.8.4", "8.10.7", "9.0.2"]
-        allow-failure: [false]
         include:
           - os: macos-10.15
-            ghc: 8.8.4
-            allow-failure: true
-          - os: macos-10.15
-            ghc: 8.10.7
-            allow-failure: true
-          - os: macos-10.15
             ghc: 9.0.2
-            allow-failure: true
-        # Windows only seems to work on 8.6.5. Others result in
-        # segfaults or other internal errors.
-        exclude:
-          - os: windows-latest
-            ghc: 9.0.2
-          - os: windows-latest
-            ghc: 8.10.7
-          - os: windows-latest
-            ghc: 8.8.4
     name: crucible-jvm - GHC v${{ matrix.ghc }} - ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/crucible-jvm-build.yml
+++ b/.github/workflows/crucible-jvm-build.yml
@@ -43,6 +43,7 @@ jobs:
           ghc-version: ${{ matrix.ghc }}
 
       - name: Install Nix
+        if: runner.os == 'Linux'
         uses: cachix/install-nix-action@v16
         with:
           nix_path: nixpkgs=channel:21.11
@@ -65,6 +66,7 @@ jobs:
           BUILD_TARGET_OS: ${{ matrix.os }}
 
       - name: Setup Environment Vars
+        if: runner.os == 'Linux'
         run: |
           GHC=haskell.compiler.ghc$(echo ${{ matrix.ghc }} | sed -e s,\\.,,g)
           case ${{ matrix.ghc }} in

--- a/.github/workflows/crucible-wasm-build.yml
+++ b/.github/workflows/crucible-wasm-build.yml
@@ -21,34 +21,16 @@ env:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.allow-failure }}
     env:
       CI_TEST_LEVEL: "1"
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest] # , macos-10.15] # , windows-latest]
+        os: [ubuntu-latest]
         ghc: ["8.8.4", "8.10.7", "9.0.2"]
-        allow-failure: [false]
         include:
           - os: macos-10.15
-            ghc: 8.8.4
-            allow-failure: true
-          - os: macos-10.15
-            ghc: 8.10.7
-            allow-failure: true
-          - os: macos-10.15
             ghc: 9.0.2
-            allow-failure: true
-        # Windows only seems to work on 8.6.5. Others result in
-        # segfaults or other internal errors.
-        exclude:
-          - os: windows-latest
-            ghc: 9.0.2
-          - os: windows-latest
-            ghc: 8.10.7
-          - os: windows-latest
-            ghc: 8.8.4
     name: crucible-wasm - GHC v${{ matrix.ghc }} - ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/crucible-wasm-build.yml
+++ b/.github/workflows/crucible-wasm-build.yml
@@ -43,6 +43,7 @@ jobs:
           ghc-version: ${{ matrix.ghc }}
 
       - name: Install Nix
+        if: runner.os == 'Linux'
         uses: cachix/install-nix-action@v16
         with:
           nix_path: nixpkgs=channel:21.11
@@ -65,6 +66,7 @@ jobs:
           BUILD_TARGET_OS: ${{ matrix.os }}
 
       - name: Setup Environment Vars
+        if: runner.os == 'Linux'
         run: |
           GHC=haskell.compiler.ghc$(echo ${{ matrix.ghc }} | sed -e s,\\.,,g)
           case ${{ matrix.ghc }} in

--- a/.github/workflows/crux-llvm-build.yml
+++ b/.github/workflows/crux-llvm-build.yml
@@ -38,34 +38,18 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     needs: [outputs]
-    continue-on-error: ${{ matrix.allow-failure }}
     env:
       CI_TEST_LEVEL: "1"
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-18.04] # , macos-10.15] # , windows-latest]
+        os: [ubuntu-20.04]
         ghc: ["8.8.4", "8.10.7", "9.0.2"]
-        allow-failure: [false]
         include:
-          - os: macos-10.15
-            ghc: 8.8.4
-            allow-failure: true
-          - os: macos-10.15
-            ghc: 8.10.7
-            allow-failure: true
+          - os: ubuntu-18.04
+            ghc: 9.0.2
           - os: macos-10.15
             ghc: 9.0.2
-            allow-failure: true
-        # Windows only seems to work on 8.6.5. Others result in
-        # segfaults or other internal errors.
-        exclude:
-          - os: windows-latest
-            ghc: 9.0.2
-          - os: windows-latest
-            ghc: 8.10.7
-          - os: windows-latest
-            ghc: 8.8.4
     name: crux-llvm - GHC v${{ matrix.ghc }} - ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/crux-llvm-build.yml
+++ b/.github/workflows/crux-llvm-build.yml
@@ -62,6 +62,7 @@ jobs:
           ghc-version: ${{ matrix.ghc }}
 
       - name: Install Nix
+        if: runner.os == 'Linux'
         uses: cachix/install-nix-action@v16
         with:
           nix_path: nixpkgs=channel:21.11
@@ -84,6 +85,7 @@ jobs:
           BUILD_TARGET_OS: ${{ matrix.os }}
 
       - name: Setup Environment Vars
+        if: runner.os == 'Linux'
         run: |
           GHC=haskell.compiler.ghc$(echo ${{ matrix.ghc }} | sed -e s,\\.,,g)
           case ${{ matrix.ghc }} in

--- a/.github/workflows/crux-mir-build.yml
+++ b/.github/workflows/crux-mir-build.yml
@@ -40,18 +40,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # We want Windows soon, but it doesn't need to be now
-        os: [ubuntu-latest, macos-10.15] #, windows-latest]
+        os: [ubuntu-latest]
         ghc: ["8.8.4", "8.10.7", "9.0.2"]
-        # Windows only seems to work on 8.6.5. Others result in
-        # segfaults or other internal errors.
-        exclude:
-          - os: windows-latest
+        include:
+          - os: macos-10.15
             ghc: 9.0.2
-          - os: windows-latest
-            ghc: 8.10.7
-          - os: windows-latest
-            ghc: 8.8.4
+          # We want Windows soon, but it doesn't need to be now
     name: crux-mir - GHC v${{ matrix.ghc }} - ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/crux-mir-build.yml
+++ b/.github/workflows/crux-mir-build.yml
@@ -58,6 +58,7 @@ jobs:
           ghc-version: ${{ matrix.ghc }}
 
       - name: Install Nix
+        if: runner.os == 'Linux'
         uses: cachix/install-nix-action@v16
         with:
           nix_path: nixpkgs=channel:21.11
@@ -87,6 +88,7 @@ jobs:
           BUILD_TARGET_OS: ${{ matrix.os }}
 
       - name: Setup Environment Vars
+        if: runner.os == 'Linux'
         run: |
           GHC=haskell.compiler.ghc$(echo ${{ matrix.ghc }} | sed -e s,\\.,,g)
           case ${{ matrix.ghc }} in


### PR DESCRIPTION
Currently, we have a whopping 36 (!) different number of CI configurations. This is mainly because we test every supported version of GHC across both Linux and macOS, and in the case of `crux-llvm-build`, we even test multiple versions of Linux. I believe this is a bit overkill, so this patch attempts to trim down the number of configurations to something more manageable:

* For each project, we test the latest LTS release of Ubuntu on all supported versions of GHC.
* In addition, we also test the previous LTS release of Ubuntu on the `crux-llvm-build.yml` workflow, but only using the latest supported version of GHC.
* For each project, we test macOS only using the latest supported version of GHC. This is because the turnaround time for macOS builders on GitHub Actions is longer, so we try to avoid bottlenecking CI workflows on macOS builds.

  In the future, we wish to test Windows using the latest supported version of GHC as well.

I've written this up in `.github/workflows/README.md`.