### PR TITLE
uc-crux-llvm: Check inferred contracts from callsites

### DIFF
--- a/uc-crux-llvm/src/UCCrux/LLVM/Callgraph.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Callgraph.hs
@@ -1,0 +1,177 @@
+{-
+Module           : UCCrux.LLVM.Callgraph
+Description      : Callgraph data type and utilities
+Copyright        : (c) Galois, Inc 2022
+License          : BSD3
+Maintainer       : Langston Barrett <langston@galois.com>
+Stability        : provisional
+-}
+
+{-# LANGUAGE DeriveFunctor #-}
+
+module UCCrux.LLVM.Callgraph
+  ( PartEdge
+  , peTag
+  , peEndpoint
+  , Callgraph
+  , edges
+  , check
+  , empty
+  , singleton
+  , outgoing
+  , incoming
+  , callees
+  , callers
+  , cgBimap
+  , Edge(..)
+  , insertEdge
+  , fromList
+  )
+where
+
+import           Data.Bifunctor (Bifunctor(bimap))
+import qualified Data.Bifunctor as Bi
+import           Data.Map (Map)
+import qualified Data.Map as Map
+import           Data.Maybe (fromMaybe)
+import           Data.Set (Set)
+import qualified Data.Set as Set
+
+import           UCCrux.LLVM.Errors.Panic (panic)
+
+-- | Two thirds of a labeled edge: a label and one endpoint
+data PartEdge tag a
+  = PartEdge
+      { -- | Edge label
+        peTag :: tag
+        -- | Edge endpoint
+      , peEndpoint :: a
+      }
+  deriving (Eq, Ord, Functor, Show)
+
+instance Bifunctor PartEdge where
+  bimap f g e =
+    e { peTag = f (peTag e)
+      , peEndpoint = g (peEndpoint e)
+      }
+
+-- | A program callgraph.
+--
+-- This type has three parameters:
+--
+-- * @tag@ is the type of edge labels (e.g., weights, control-flow contexts)
+-- * @ee@ is the type of callees (e.g., functions)
+-- * @er@ is the type of callers (e.g., functions, instructions, or expressions)
+data Callgraph tag ee er
+  = Callgraph
+      { cgCallees :: Map er (Set (PartEdge tag ee))
+      , cgCallers :: Map ee (Set (PartEdge tag er))
+      }
+  deriving (Eq, Ord, Show)
+
+-- Utility, not exported
+setFold :: Ord a => (k -> v -> Set a) -> Map k v -> Set a
+setFold f = Map.foldrWithKey (\k v acc -> Set.union (f k v) acc) Set.empty
+
+-- | Edges from the perspective of 'cgCallees'. Should be identical to
+-- 'calleeEdges'.
+callerEdges ::
+  (Ord ee, Ord er, Ord tag) =>
+  Callgraph tag ee er ->
+  Set (Edge tag ee er)
+callerEdges cg = setFold (\er es -> mkCallerEdges er es) (cgCallees cg)
+  where
+    mkCallerEdges ee partEdges =
+      Set.map (\er -> Edge (peEndpoint er) ee (peTag er)) partEdges
+
+-- | Edges from the perspective of 'cgCallers'. Should be identical to
+-- 'callerEdges'.
+calleeEdges ::
+  (Ord ee, Ord er, Ord tag) =>
+  Callgraph tag ee er ->
+  Set (Edge tag ee er)
+calleeEdges cg = setFold (\ee es -> mkCalleeEdges ee es) (cgCallers cg)
+  where
+    mkCalleeEdges er partEdges =
+      Set.map (\ee -> Edge er (peEndpoint ee) (peTag ee)) partEdges
+
+-- | All of the edges in the callgraph.
+edges :: (Ord ee, Ord er, Ord tag) => Callgraph tag ee er -> Set (Edge tag ee er)
+edges = callerEdges
+
+-- | Panic if this 'Callgraph' violates its invariants
+--
+-- Invariant: For each edge from a caller to a callee, there is a corresponding
+-- edge from a callee to its caller.
+check :: (Ord ee, Ord er, Ord tag) => Callgraph tag ee er -> ()
+check cg =
+  if callerEdges cg == calleeEdges cg
+  then ()
+  else panic "UCCrux.LLVM.Callgraph.check" ["Invariant violation"]
+
+-- | A 'Callgraph' with no edges.
+empty :: Callgraph tag ee er
+empty =
+  Callgraph
+    { cgCallees = Map.empty
+    , cgCallers = Map.empty
+    }
+
+-- | /O(log n)/.
+outgoing :: (Ord ee, Ord er) => Callgraph tag ee er -> er -> Set (PartEdge tag ee)
+outgoing cg caller = fromMaybe Set.empty (Map.lookup caller (cgCallees cg))
+
+-- | /O(log n)/.
+incoming :: (Ord ee, Ord er) => Callgraph tag ee er -> ee -> Set (PartEdge tag er)
+incoming cg callee = fromMaybe Set.empty (Map.lookup callee (cgCallers cg))
+
+-- | /O(log n)/.
+callees :: (Ord ee, Ord er) => Callgraph tag ee er -> er -> Set ee
+callees cg callee = Set.map peEndpoint (outgoing cg callee)
+
+-- | /O(log n)/.
+callers :: (Ord ee, Ord er) => Callgraph tag ee er -> ee -> Set er
+callers cg caller = Set.map peEndpoint (incoming cg caller)
+
+cgBimap ::
+  (Ord tag, Ord ee', Ord er') =>
+  (er -> er') ->
+  (ee -> ee') ->
+  Callgraph tag ee er ->
+  Callgraph tag ee' er'
+cgBimap f g cg =
+  Callgraph
+    { cgCallees = fmap (Set.map (Bi.second g)) (Map.mapKeys f (cgCallees cg))
+    , cgCallers = fmap (Set.map (Bi.second f)) (Map.mapKeys g (cgCallers cg))
+    }
+
+-- | A callgraph edge, with two endpoints and a label/tag.
+data Edge tag ee er
+  = Edge
+      { edgeCallee :: ee
+      , edgeCaller :: er
+      , edgeTag :: tag
+      }
+  deriving (Eq, Ord, Show)
+
+-- | /O(log n)/.
+insertEdge ::
+  (Ord tag, Ord ee, Ord er) =>
+  Edge tag ee er ->
+  Callgraph tag ee er ->
+  Callgraph tag ee er
+insertEdge (Edge eCallee eCaller eTag) cg =
+  cg
+    { cgCallees = setInsert eCaller (PartEdge eTag eCallee) (cgCallees cg)
+    , cgCallers = setInsert eCallee (PartEdge eTag eCaller) (cgCallers cg)
+    }
+  where
+    setInsert :: Ord k => Ord v => k -> v -> Map k (Set v) -> Map k (Set v)
+    setInsert k v = Map.insertWith Set.union k (Set.singleton v)
+
+singleton :: (Ord tag, Ord ee, Ord er) => Edge tag ee er -> Callgraph tag ee er
+singleton e = insertEdge e empty
+
+-- | /O(n log n)/.
+fromList :: (Ord tag, Ord ee, Ord er) => [Edge tag ee er] -> Callgraph tag ee er
+fromList = foldr insertEdge empty

--- a/uc-crux-llvm/src/UCCrux/LLVM/Callgraph/LLVM.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Callgraph/LLVM.hs
@@ -1,0 +1,64 @@
+{-
+Module           : UCCrux.LLVM.Callgraph.LLVM
+Description      : Callgraph of LLVM functions
+Copyright        : (c) Galois, Inc 2022
+License          : BSD3
+Maintainer       : Langston Barrett <langston@galois.com>
+Stability        : provisional
+-}
+
+{-# LANGUAGE LambdaCase #-}
+
+module UCCrux.LLVM.Callgraph.LLVM
+  ( LLVMFuncCallgraph
+  , directCalls
+  , funcCallees
+  , funcCallers
+  )
+where
+
+import           Data.Maybe (mapMaybe)
+import           Data.Set (Set)
+
+import qualified Text.LLVM.AST as L
+
+import           UCCrux.LLVM.Callgraph (Callgraph)
+import qualified UCCrux.LLVM.Callgraph as CG
+
+-- | Function-level callgraph of an LLVM module
+newtype LLVMFuncCallgraph
+  = LLVMFuncCallgraph
+      { getLLVMCallgraph :: Callgraph () L.Symbol L.Symbol }
+  deriving (Eq, Ord, Show)
+
+-- | Create a callgraph consisting of the direct calls found in the LLVM module.
+directCalls :: L.Module -> LLVMFuncCallgraph
+directCalls m =
+  LLVMFuncCallgraph (CG.fromList (concatMap defEdges (L.modDefines m)))
+  where
+    defEdges def =
+      mapMaybe (fmap (mkEdge def) . stmtCalls) (concatMap L.bbStmts (L.defBody def))
+
+    mkEdge def symb =
+      CG.Edge
+        { CG.edgeCaller = L.defName def
+        , CG.edgeCallee = symb
+        , CG.edgeTag = ()
+        }
+
+    stmtCalls =
+      \case
+        L.Result _ instr _ -> instrDirectlyCalls instr
+        L.Effect instr _ -> instrDirectlyCalls instr
+
+    instrDirectlyCalls =
+      \case
+        L.Call _ _ (L.ValSymbol f) _args -> Just f
+        L.Invoke _ (L.ValSymbol f) _args _ _ -> Just f
+        _ -> Nothing
+
+funcCallees :: LLVMFuncCallgraph -> L.Symbol -> Set L.Symbol
+funcCallees cg symb = CG.callees (getLLVMCallgraph cg) symb
+
+funcCallers :: LLVMFuncCallgraph -> L.Symbol -> Set L.Symbol
+funcCallers cg symb = CG.callers (getLLVMCallgraph cg) symb

--- a/uc-crux-llvm/src/UCCrux/LLVM/Main/Config/Type.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Main/Config/Type.hs
@@ -29,7 +29,8 @@ import qualified UCCrux.LLVM.Run.Explore.Config as ExConfig
 
 data RunConfig
   = Explore ExConfig.ExploreConfig
-  | RunOn (NonEmpty FunctionName) [FunctionName]
+  -- | The 'Bool' is whether or not to check contracts from callers
+  | RunOn (NonEmpty FunctionName) [FunctionName] Bool
   | CrashEquivalence EqConfig.EquivalenceConfig
   deriving (Eq, Ord, Show)
 

--- a/uc-crux-llvm/test/Callgraph.hs
+++ b/uc-crux-llvm/test/Callgraph.hs
@@ -1,0 +1,26 @@
+module Callgraph (callgraphTests) where
+
+import qualified Data.Set as Set
+
+import qualified Test.Tasty as TT
+import qualified Test.Tasty.HUnit as TH
+
+import qualified UCCrux.LLVM.Callgraph as CG
+
+callgraphTests :: TT.TestTree
+callgraphTests = TT.testGroup "callgraph"
+  [ TH.testCase "insert one edge" $
+      let cg = CG.insertEdge (CG.Edge () () ()) CG.empty
+      in TH.assertEqual "insert one edge" 1 (length (CG.edges cg))
+  , TH.testCase "callees" $
+      let cg = CG.singleton (CG.Edge "callee" "caller" ())
+      in TH.assertEqual "callees" (Set.singleton "callee") (CG.callees cg "caller")
+  , TH.testCase "outgoing" $
+      let cg = CG.fromList [ CG.Edge "callee1" "caller" ()
+                           , CG.Edge "callee2" "caller" ()
+                           ]
+      in TH.assertEqual
+           "outgoing"
+           (Set.fromList ["callee1", "callee2"])
+           (Set.map CG.peEndpoint (CG.outgoing cg "caller"))
+  ]

--- a/uc-crux-llvm/test/Test.hs
+++ b/uc-crux-llvm/test/Test.hs
@@ -6,8 +6,8 @@ License          : BSD3
 Maintainer       : Langston Barrett <langston@galois.com>
 Stability        : provisional
 
-For now, this test suite only has \"acceptance tests\", i.e. tests that describe
-very high-level behavior.
+For now, this test suite mostly has \"acceptance tests\", i.e. tests that
+describe very high-level behavior.
 
 There are two ways to add such tests:
 
@@ -86,6 +86,7 @@ import           UCCrux.LLVM.Run.Result (SomeBugfindingResult', DidHitBounds(Did
 import qualified UCCrux.LLVM.Run.Result as Result
 import           UCCrux.LLVM.Run.Unsoundness (Unsoundness(..))
 
+import qualified Callgraph
 import qualified Check
 import qualified Clobber
 import qualified Utils
@@ -1531,7 +1532,8 @@ main =
   TT.defaultMain $
     TT.testGroup
       "uc-crux-llvm"
-      [ Check.checkOverrideTests,
+      [ Callgraph.callgraphTests,
+        Check.checkOverrideTests,
         Clobber.clobberTests,
         inFileTests,
         moduleTests,

--- a/uc-crux-llvm/uc-crux-llvm.cabal
+++ b/uc-crux-llvm/uc-crux-llvm.cabal
@@ -35,6 +35,8 @@ library
   exposed-modules:
     UCCrux.LLVM.Bug
     UCCrux.LLVM.Bug.UndefinedBehaviorTag
+    UCCrux.LLVM.Callgraph
+    UCCrux.LLVM.Callgraph.LLVM
     UCCrux.LLVM.Classify
     UCCrux.LLVM.Classify.Poison
     UCCrux.LLVM.Classify.Types
@@ -157,6 +159,7 @@ test-suite uc-crux-llvm-test
 
   main-is: Test.hs
   other-modules:
+    Callgraph
     Check
     Clobber
     Logging


### PR DESCRIPTION
Allow checking inferred contracts from all (direct) callsites in the program. This should give better assurance that the contracts are necessary (not just sufficient), or at least show when they aren't.

It also paves the way for checking contracts at link-time, where we might have inferred contracts for one module and want to check that they're respected at callsites in another module it's linked with.

Here's what it looks like, c.f. #913.