### PR TITLE
uc-crux-llvm: Improve representation of LLVM types

### DIFF
--- a/uc-crux-llvm/src/UCCrux/LLVM/Classify.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Classify.hs
@@ -126,7 +126,7 @@ elemsFromOffset ::
   Int
 elemsFromOffset mts offset partType =
   let pointedTo = asFullType mts partType
-      typeSize = sizeInBytes mts pointedTo 1 -- 1 = array length
+      typeSize = sizeInBytes mts pointedTo
    in 1 + fromIntegral (BV.asUnsigned (What4.fromConcreteBV offset) `div` typeSize)
 
 unclass ::

--- a/uc-crux-llvm/src/UCCrux/LLVM/Context/Module.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Context/Module.hs
@@ -25,7 +25,6 @@ module UCCrux.LLVM.Context.Module
     declTypes,
     moduleTranslation,
     moduleDecls,
-    dataLayout,
     withTypeContext,
     withModulePtrWidth,
 
@@ -36,7 +35,7 @@ module UCCrux.LLVM.Context.Module
 where
 
 {- ORMOLU_DISABLE -}
-import           Control.Lens ((^.), Simple, Getter, Lens, lens, to, at)
+import           Control.Lens ((^.), Simple, Lens, lens, to, at)
 import           Data.Type.Equality ((:~:)(Refl))
 import           GHC.Stack (HasCallStack)
 
@@ -48,12 +47,11 @@ import           Data.Parameterized.Some (Some(Some))
 
 import qualified Lang.Crucible.CFG.Core as Crucible
 
-import           Lang.Crucible.LLVM.DataLayout (DataLayout)
 import           Lang.Crucible.LLVM.Extension (ArchWidth, LLVM)
 import           Lang.Crucible.LLVM.MemModel (HasPtrWidth, withPtrWidth)
 import           Lang.Crucible.LLVM.Translation (ModuleTranslation)
 import qualified Lang.Crucible.LLVM.Translation as LLVMTrans
-import           Lang.Crucible.LLVM.TypeContext (TypeContext, llvmDataLayout)
+import           Lang.Crucible.LLVM.TypeContext (TypeContext)
 
 import           Crux.LLVM.Overrides (ArchOk)
 
@@ -105,9 +103,6 @@ moduleTranslation = lens _moduleTranslation (\s v -> s {_moduleTranslation = v})
 
 moduleDecls :: Simple Lens (ModuleContext m arch) (FuncMap m L.Declare)
 moduleDecls = lens _moduleDecls (\s v -> s {_moduleDecls = v})
-
-dataLayout :: Getter (ModuleContext m arch) DataLayout
-dataLayout = moduleTranslation . LLVMTrans.transContext . LLVMTrans.llvmTypeCtx . to llvmDataLayout
 
 withTypeContext :: ModuleContext m arch -> ((?lc :: TypeContext) => a) -> a
 withTypeContext context computation =

--- a/uc-crux-llvm/src/UCCrux/LLVM/Cursor.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Cursor.hs
@@ -57,7 +57,7 @@ import           Data.Parameterized.Classes (OrdF(compareF), ixF', fromOrdering)
 import           Data.Parameterized.NatRepr (NatRepr, type (<=), type (+))
 import qualified Data.Parameterized.TH.GADT as U
 
-import           UCCrux.LLVM.FullType.Type (FullType(..), FullTypeRepr(..), ModuleTypes, asFullType)
+import           UCCrux.LLVM.FullType.Type (FullType(..), FullTypeRepr(..), ModuleTypes, asFullType, StructPacked)
 import           UCCrux.LLVM.Module (GlobalSymbol, FuncSymbol, getGlobalSymbol, getFuncSymbol)
 {- ORMOLU_ENABLE -}
 
@@ -91,7 +91,7 @@ data Cursor m (inTy :: FullType m) (atTy :: FullType m) where
     -- | Which field?
     Ctx.Index fields inTy ->
     Cursor m inTy atTy ->
-    Cursor m ('FTStruct fields) atTy
+    Cursor m ('FTStruct sp fields) atTy
 
 $(return [])
 
@@ -113,6 +113,9 @@ instance TestEquality (Cursor m inTy) where
                    [|testEquality|]
                  ),
                  ( appAny (appAny (U.ConType [t|Ctx.Index|])),
+                   [|testEquality|]
+                 ),
+                 ( appAny (U.ConType [t|StructPacked|]),
                    [|testEquality|]
                  )
                ]
@@ -137,6 +140,9 @@ instance OrdF (Cursor m inTy) where
                    [|compareF|]
                  ),
                  ( appAny (appAny (U.ConType [t|Ctx.Index|])),
+                   [|compareF|]
+                 ),
+                 ( appAny (U.ConType [t|StructPacked|]),
                    [|compareF|]
                  )
                ]
@@ -218,7 +224,7 @@ deepenPtr mts =
 -- points to that field.
 deepenStruct ::
   Ctx.Index fields atTy ->
-  Cursor m inTy ('FTStruct fields) ->
+  Cursor m inTy ('FTStruct sp fields) ->
   Cursor m inTy atTy
 deepenStruct idx =
   \case

--- a/uc-crux-llvm/src/UCCrux/LLVM/FullType/MemType.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/FullType/MemType.hs
@@ -24,44 +24,52 @@ import           Data.Parameterized.TraversableFC (toListFC)
 
 import qualified What4.InterpretedFloatingPoint as W4IFP
 
-import           Lang.Crucible.LLVM.MemType (MemType(..), SymType(..), FunDecl(..))
+import           Lang.Crucible.LLVM.MemType (MemType(..), SymType(..), FunDecl(..), mkStructInfo)
 
 import           UCCrux.LLVM.Errors.Panic (panic)
-import           UCCrux.LLVM.FullType.Type (FullTypeRepr(..), aliasOrFullType)
+import           UCCrux.LLVM.FullType.Type (FullTypeRepr(..), aliasOrFullType, DataLayout, crucibleDataLayout, structPackedReprToBool)
 import           UCCrux.LLVM.FullType.VarArgs (varArgsReprToBool)
 {- ORMOLU_ENABLE -}
 
 -- | Postcondition: The returned 'MemType' will not be a metadata type.
 --
 -- @toStorageType@ depends on this.
-toMemType :: FullTypeRepr m ft -> MemType
-toMemType =
+toMemType :: DataLayout m -> FullTypeRepr m ft -> MemType
+toMemType dl =
   \case
     FTIntRepr natRepr -> IntType (natValue natRepr)
     FTPtrRepr ptRepr ->
       case aliasOrFullType ptRepr of
         Left ident -> PtrType (Alias ident)
-        Right ftRepr -> PtrType (MemType (toMemType ftRepr))
+        Right ftRepr -> PtrType (MemType (toMemType dl ftRepr))
     FTFloatRepr W4IFP.SingleFloatRepr -> FloatType
     FTFloatRepr W4IFP.DoubleFloatRepr -> DoubleType
     FTFloatRepr W4IFP.X86_80FloatRepr -> X86_FP80Type
     FTFloatRepr floatInfo -> panic "toMemType" ["Illegal float type: ", show floatInfo]
     FTVoidFuncPtrRepr varArgs argsRepr ->
-      funType Nothing argsRepr (varArgsReprToBool varArgs)
+      funType dl Nothing argsRepr (varArgsReprToBool varArgs)
     FTNonVoidFuncPtrRepr varArgs retRepr argsRepr ->
-      funType (Just retRepr) argsRepr (varArgsReprToBool varArgs)
+      funType dl (Just retRepr) argsRepr (varArgsReprToBool varArgs)
     FTOpaquePtrRepr _ident -> PtrType OpaqueType
-    FTArrayRepr natRepr fullTypeRepr -> ArrayType (natValue natRepr) (toMemType fullTypeRepr)
-    FTUnboundedArrayRepr fullTypeRepr -> ArrayType 0 (toMemType fullTypeRepr)
-    FTStructRepr structInfo _ -> StructType structInfo
+    FTArrayRepr natRepr fullTypeRepr -> ArrayType (natValue natRepr) (toMemType dl fullTypeRepr)
+    FTUnboundedArrayRepr fullTypeRepr -> ArrayType 0 (toMemType dl fullTypeRepr)
+    FTStructRepr sp fields ->
+      let cdl = crucibleDataLayout dl
+          memFields = toListFC (toMemType dl) fields
+      in StructType (mkStructInfo cdl (structPackedReprToBool sp) memFields)
   where
-    funType :: Maybe (FullTypeRepr m ft) -> Ctx.Assignment (FullTypeRepr m) argTypes -> Bool -> MemType
-    funType maybeRetRepr argsRepr isVarArgs =
+    funType ::
+      DataLayout m ->
+      Maybe (FullTypeRepr m ft) ->
+      Ctx.Assignment (FullTypeRepr m) argTypes ->
+      Bool ->
+      MemType
+    funType dl_ maybeRetRepr argsRepr isVarArgs =
       PtrType
         ( FunType
             ( FunDecl
-                (toMemType <$> maybeRetRepr)
-                (toListFC toMemType argsRepr)
+                (toMemType dl_ <$> maybeRetRepr)
+                (toListFC (toMemType dl_) argsRepr)
                 isVarArgs
             )
         )

--- a/uc-crux-llvm/src/UCCrux/LLVM/FullType/Memory.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/FullType/Memory.hs
@@ -20,7 +20,7 @@ module UCCrux.LLVM.FullType.Memory
 where
 
 {- ORMOLU_DISABLE -}
-import           Control.Lens ((^.), to)
+import           Control.Lens ((^.))
 import           Data.BitVector.Sized (mkBV)
 
 import           Data.Parameterized.NatRepr (NatRepr, type (+))
@@ -37,33 +37,27 @@ import           Lang.Crucible.LLVM.Bytes (bytesToInteger)
 import           Lang.Crucible.LLVM.Extension (ArchWidth)
 import qualified Lang.Crucible.LLVM.MemModel as LLVMMem
 import           Lang.Crucible.LLVM.MemType (memTypeSize)
-import qualified Lang.Crucible.LLVM.Translation as LLVMTrans
-import           Lang.Crucible.LLVM.TypeContext (TypeContext(llvmDataLayout))
 
 -- crux
 import           Crux.LLVM.Overrides (ArchOk)
 
-import           UCCrux.LLVM.Context.Module (ModuleContext, moduleTranslation)
+import           UCCrux.LLVM.Context.Module (ModuleContext, moduleTypes)
 import           UCCrux.LLVM.FullType.MemType (toMemType)
-import           UCCrux.LLVM.FullType.Type (FullTypeRepr)
+import           UCCrux.LLVM.FullType.Type (FullTypeRepr, ModuleTypes, dataLayout, crucibleDataLayout)
 {- ORMOLU_ENABLE -}
 
 
 -- | Size in bytes of an array of a given type with a given length.
 sizeInBytes ::
-  ModuleContext m arch ->
+  ModuleTypes m ->
   FullTypeRepr m ft ->
   -- | Array length
   Integer ->
   Integer
-sizeInBytes modCtx ftRepr size =
-  let dl =
-        modCtx
-          ^. moduleTranslation
-            . LLVMTrans.transContext
-            . LLVMTrans.llvmTypeCtx
-            . to llvmDataLayout
-  in size * bytesToInteger (memTypeSize dl (toMemType ftRepr))
+sizeInBytes mts ftRepr size =
+  let dl = dataLayout mts
+      cdl = crucibleDataLayout dl
+  in size * bytesToInteger (memTypeSize cdl (toMemType dl ftRepr))
 
 -- | A concrete bitvector representing the size (in bytes) of an array of data
 -- of a given type in memory.
@@ -78,7 +72,7 @@ sizeBv ::
   Integer ->
   IO (What4.SymExpr sym (What4.BaseBVType (ArchWidth arch)))
 sizeBv modCtx sym ftRepr size =
-  What4.bvLit sym ?ptrWidth (mkBV ?ptrWidth (sizeInBytes modCtx ftRepr size))
+  What4.bvLit sym ?ptrWidth (mkBV ?ptrWidth (sizeInBytes (modCtx ^. moduleTypes) ftRepr size))
 
 -- | A vector of pointers created by repeatedly adding an offset to a given base
 -- pointer.

--- a/uc-crux-llvm/src/UCCrux/LLVM/FullType/StorageType.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/FullType/StorageType.hs
@@ -18,14 +18,18 @@ where
 import           Lang.Crucible.LLVM.MemModel (HasPtrWidth, StorageType)
 import qualified Lang.Crucible.LLVM.MemModel as LLVMMem (toStorableType)
 
-import           UCCrux.LLVM.FullType.Type (FullTypeRepr)
+import           UCCrux.LLVM.FullType.Type (FullTypeRepr, DataLayout)
 import           UCCrux.LLVM.FullType.MemType (toMemType)
 import           UCCrux.LLVM.Errors.Panic (panic)
 {- ORMOLU_ENABLE -}
 
-toStorageType :: HasPtrWidth wptr => FullTypeRepr m ft -> StorageType
-toStorageType fullTypeRepr =
-  let memType = toMemType fullTypeRepr
+toStorageType ::
+  HasPtrWidth wptr =>
+  DataLayout m ->
+  FullTypeRepr m ft ->
+  StorageType
+toStorageType dl fullTypeRepr =
+  let memType = toMemType dl fullTypeRepr
   in case LLVMMem.toStorableType memType of
        Nothing ->
          panic

--- a/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Check.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Check.hs
@@ -46,7 +46,7 @@ where
 
 {- ORMOLU_DISABLE -}
 import           Prelude hiding (log)
-import           Control.Lens ((^.), (%~))
+import           Control.Lens ((^.), (%~), to)
 import           Control.Monad (foldM, unless)
 import           Control.Monad.IO.Class (liftIO)
 import           Data.Function ((&))
@@ -99,7 +99,7 @@ import           UCCrux.LLVM.Cursor (Selector, selectorCursor)
 import qualified UCCrux.LLVM.Cursor as Cursor
 import qualified UCCrux.LLVM.Errors.Unimplemented as Unimplemented
 import           UCCrux.LLVM.FullType.CrucibleType (SomeIndex(SomeIndex), translateIndex)
-import           UCCrux.LLVM.FullType.Type (FullType, FullTypeRepr, MapToCrucibleType, ToCrucibleType, pointedToType, arrayElementType)
+import           UCCrux.LLVM.FullType.Type (FullType, FullTypeRepr, MapToCrucibleType, ToCrucibleType, pointedToType, arrayElementType, dataLayout)
 import           UCCrux.LLVM.Logging (Verbosity(Hi))
 import qualified UCCrux.LLVM.Mem as Mem
 import           UCCrux.LLVM.Module (FuncSymbol, funcSymbol, getGlobalSymbol)
@@ -407,7 +407,8 @@ createCheckOverride appCtx modCtx usedRef argFTys constraints cfg funcSym =
            do -- 'loadGlobal' will make some safety assertions, but if they fail
               -- that indicates a bug in UC-Crux or the constraints themselves
               -- rather than a constraint failure, so we don't collect them.
-              glob <- Mem.loadGlobal modCtx bak mem globTy (getGlobalSymbol gSymb)
+              let dl = modCtx ^. moduleTypes . to dataLayout
+              glob <- Mem.loadGlobal modCtx dl bak mem globTy (getGlobalSymbol gSymb)
               fmap (viewSome SomeCheckedConstraint) <$>
                 checkPreconds
                   modCtx

--- a/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Skip.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Skip.hs
@@ -88,7 +88,7 @@ import           UCCrux.LLVM.Errors.Panic (panic)
 import           UCCrux.LLVM.Errors.Unimplemented (unimplemented, Unimplemented(SometimesClobber, ClobberGlobal))
 import           UCCrux.LLVM.FullType.CrucibleType (testCompatibility, testCompatibilityReturn)
 import           UCCrux.LLVM.FullType.FuncSig (FuncSigRepr(FuncSigRepr), ReturnTypeRepr(NonVoidRepr, VoidRepr))
-import           UCCrux.LLVM.FullType.Type (ModuleTypes, FullType(FTPtr), FullTypeRepr(..), ToCrucibleType, pointedToType)
+import           UCCrux.LLVM.FullType.Type (ModuleTypes, FullType(FTPtr), FullTypeRepr(..), ToCrucibleType, pointedToType, dataLayout)
 import qualified UCCrux.LLVM.Mem as Mem
 import           UCCrux.LLVM.Module (GlobalSymbol, FuncSymbol, funcSymbol, makeFuncSymbol, isDebug, funcSymbolToString)
 import           UCCrux.LLVM.Overrides.Polymorphic (PolymorphicLLVMOverride, makePolymorphicLLVMOverride)
@@ -440,7 +440,8 @@ createSkipOverride modCtx bak usedRef annotationRef clobbers postcondition funcS
          ptr <- Mem.seekPtr modCtx bak mem (clobberType spec) container cursor
          let mem' = resultMem result
          let val = value ^. Shape.tag . to getSymValue
-         Mem.store modCtx bak mem' (clobberAtType mts spec) ptr val
+         let dl = modCtx ^. moduleTypes . to dataLayout
+         Mem.store modCtx dl bak mem' (clobberAtType mts spec) ptr val
 
     applyClobbers ::
       MemImpl sym ->

--- a/uc-crux-llvm/src/UCCrux/LLVM/Setup.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Setup.hs
@@ -234,7 +234,7 @@ generate bak modCtx ftRepr selector (ConstrainedShape shape) =
                   NatRepr.NonZeroNat -> return (Some (NatRepr.predNat nr))
           ptr <- malloc bak ftRepr selector (toEnum num)
           let ftPtdTo = asFullType (modCtx ^. moduleTypes) ptPtdTo
-          size <- liftIO $ sizeBv modCtx sym ftPtdTo 1
+          size <- liftIO $ sizeBv modCtx sym ftPtdTo
           -- For each offset, generate a value and store it there.
           pointers <- liftIO $ pointerRange proxy sym ptr size numRepr
           pointedTos <-

--- a/uc-crux-llvm/src/UCCrux/LLVM/Setup.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Setup.hs
@@ -79,7 +79,7 @@ import qualified UCCrux.LLVM.Errors.Unimplemented as Unimplemented
 import           UCCrux.LLVM.FullType.CrucibleType (toCrucibleType)
 import qualified UCCrux.LLVM.FullType.CrucibleType as FTCT
 import           UCCrux.LLVM.FullType.Memory (pointerRange, sizeBv)
-import           UCCrux.LLVM.FullType.Type (FullTypeRepr(..), ToCrucibleType, MapToCrucibleType, ToBaseType, asFullType)
+import           UCCrux.LLVM.FullType.Type (FullTypeRepr(..), ToCrucibleType, MapToCrucibleType, ToBaseType, asFullType, dataLayout)
 import           UCCrux.LLVM.Cursor (Selector(..), Cursor(..), selectorCursor, deepenStruct, deepenArray, deepenPtr)
 import           UCCrux.LLVM.Module (GlobalSymbol, globalSymbol, makeGlobalSymbol, getModule)
 import           UCCrux.LLVM.Precondition (Preconds, argPreconds, globalPreconds)
@@ -424,6 +424,7 @@ populateNonConstGlobals modCtx bak constrainedGlobals =
                     )
                 void $
                   storeGlobal
+                    (modCtx ^. moduleTypes . to dataLayout)
                     bak
                     fullTy
                     (SelectGlobal gSymb (Here fullTy))

--- a/uc-crux-llvm/src/UCCrux/LLVM/Setup/Monad.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Setup/Monad.hs
@@ -77,7 +77,7 @@ import           Crux.LLVM.Overrides (ArchOk)
 
 import           UCCrux.LLVM.Context.Module (ModuleContext, moduleTranslation)
 import           UCCrux.LLVM.Cursor (Selector, SomeInSelector(..))
-import           UCCrux.LLVM.FullType.Memory (sizeBv)
+import           UCCrux.LLVM.FullType.Memory (arraySizeBv)
 import           UCCrux.LLVM.FullType.Type (FullType(FTPtr), FullTypeRepr, ToCrucibleType, ToBaseType, ModuleTypes, DataLayout)
 import           UCCrux.LLVM.Constraints (Constraint)
 import qualified UCCrux.LLVM.Mem as Mem
@@ -313,7 +313,7 @@ malloc bak fullTypeRepr selector size =
       modifyMem $
         \mem ->
           do
-            sz <- liftIO $ sizeBv modCtx sym fullTypeRepr size
+            sz <- liftIO $ arraySizeBv modCtx sym fullTypeRepr size
             (p, mem') <-
               liftIO $
                 do

--- a/uc-crux-llvm/src/UCCrux/LLVM/Setup/Monad.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Setup/Monad.hs
@@ -78,7 +78,7 @@ import           Crux.LLVM.Overrides (ArchOk)
 import           UCCrux.LLVM.Context.Module (ModuleContext, moduleTranslation)
 import           UCCrux.LLVM.Cursor (Selector, SomeInSelector(..))
 import           UCCrux.LLVM.FullType.Memory (sizeBv)
-import           UCCrux.LLVM.FullType.Type (FullType(FTPtr), FullTypeRepr, ToCrucibleType, ToBaseType, ModuleTypes)
+import           UCCrux.LLVM.FullType.Type (FullType(FTPtr), FullTypeRepr, ToCrucibleType, ToBaseType, ModuleTypes, DataLayout)
 import           UCCrux.LLVM.Constraints (Constraint)
 import qualified UCCrux.LLVM.Mem as Mem
 {- ORMOLU_ENABLE -}
@@ -359,6 +359,7 @@ storeGlobal ::
     LLVMMem.HasLLVMAnn sym,
     ArchOk arch
   ) =>
+  DataLayout m ->
   bak ->
   FullTypeRepr m ft ->
   -- | Path to this pointer
@@ -366,7 +367,7 @@ storeGlobal ::
   L.Symbol ->
   Crucible.RegValue sym (ToCrucibleType arch ft) ->
   Setup m arch sym argTypes (LLVMMem.LLVMPtr sym (ArchWidth arch))
-storeGlobal bak ftRepr selector symb regValue =
+storeGlobal dl bak ftRepr selector symb regValue =
   do
     let sym = Crucible.backendGetSym bak
     mem <- gets (view setupMem)
@@ -376,5 +377,5 @@ storeGlobal bak ftRepr selector symb regValue =
       \mem' ->
         do
           mem'' <-
-            liftIO $ Mem.store (Proxy @arch) bak mem' ftRepr ptr' regValue
+            liftIO $ Mem.store (Proxy @arch) dl bak mem' ftRepr ptr' regValue
           pure (ptr', mem'')

--- a/uc-crux-llvm/src/UCCrux/LLVM/Shape.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Shape.hs
@@ -112,8 +112,8 @@ data Shape (m :: Type) (tag :: FullType m -> Type) (ft :: FullType m) where
   -- | Opaque pointers don't have any sub-shapes because they can't be
   -- dereferenced.
   ShapeOpaquePtr ::
-    tag 'FTOpaquePtr ->
-    Shape m tag 'FTOpaquePtr
+    tag ('FTOpaquePtr nm) ->
+    Shape m tag ('FTOpaquePtr nm)
   ShapeArray ::
     tag ('FTArray ('Just n) ft) ->
     NatRepr n ->

--- a/uc-crux-llvm/src/UCCrux/LLVM/Shape.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Shape.hs
@@ -124,9 +124,9 @@ data Shape (m :: Type) (tag :: FullType m -> Type) (ft :: FullType m) where
     Seq (Shape m tag ft) ->
     Shape m tag ('FTArray 'Nothing ft)
   ShapeStruct ::
-    tag ('FTStruct fields) ->
+    tag ('FTStruct sp fields) ->
     Ctx.Assignment (Shape m tag) fields ->
-    Shape m tag ('FTStruct fields)
+    Shape m tag ('FTStruct sp fields)
 
 -- TODO: Introduce a "detail limit", either via depth, max array length, or both.
 -- TODO: Drop the ":" when the "tag" is empty

--- a/uc-crux-llvm/test/Test.hs
+++ b/uc-crux-llvm/test/Test.hs
@@ -76,7 +76,7 @@ import           UCCrux.LLVM.Equivalence (NonEmptyCrashDiff, reportDiffs, getCra
 import           UCCrux.LLVM.Errors.Unimplemented (catchUnimplemented)
 import           UCCrux.LLVM.Cursor (Cursor(..))
 import           UCCrux.LLVM.Classify.Types (partitionUncertainty)
-import           UCCrux.LLVM.FullType (FullType(..), FullTypeRepr(..))
+import           UCCrux.LLVM.FullType (FullType(..), FullTypeRepr(..), type StructPacked(UnpackedStruct))
 import           UCCrux.LLVM.Module (defnSymbolToString)
 import           UCCrux.LLVM.Newtypes.FunctionName (FunctionName, functionNameFromString)
 import           UCCrux.LLVM.Overrides.Skip (SkipOverrideName(..))
@@ -103,7 +103,7 @@ _exampleArray = Index (knownNat :: NatRepr 7) knownNat exampleHere
 _exampleStruct ::
   Cursor
     m
-    ('FTStruct ('Ctx.EmptyCtx Ctx.::> 'FTInt 32 Ctx.::> 'FTInt 64))
+    ('FTStruct 'UnpackedStruct ('Ctx.EmptyCtx Ctx.::> 'FTInt 32 Ctx.::> 'FTInt 64))
     ('FTInt 64)
 _exampleStruct =
   Field


### PR DESCRIPTION
For opaque pointers, replaces value-level representation of type names with value-and-type level representation with a `SymbolRepr`.

For structs, represents packed-ness at the type-level and remove `StructInfo` field. This hs three nice effects:

* Makes `FullTypeRepr` into a true singleton, making its `TestEquality` instances lawful.
* Reflects the fact that packed and non-packed structs are not the same at the type level.
* Reduces redundant storage, instead recomputing `StructInfo`s on demand.

Also introduces a wrapper around Crucible's `DataLayout` with an additional phantom type parameter that marks it as corresponding to a particular LLVM module.