### PR TITLE
CI: Use modern GPG keys

### DIFF
--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -94,6 +94,8 @@ install_system_deps() {
 }
 
 sign() {
+  # This is surrounded with `set +x; ...; set -x` to disable printing out
+  # statements that could leak GPG-related secrets.
   set +x
   gpg --yes --quiet --batch --import <(echo "$SIGNING_KEY")
   fingerprint="$(gpg --list-keys | grep Galois -a1 | head -n1 | awk '{$1=$1};1')"

--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -96,7 +96,7 @@ install_system_deps() {
 sign() {
   set +x
   gpg --yes --quiet --batch --import <(echo "$SIGNING_KEY")
-  fingerprint="$(gpg --list-keys | grep galois -a1 | head -n1 | awk '{$1=$1};1')"
+  fingerprint="$(gpg --list-keys | grep Galois -a1 | head -n1 | awk '{$1=$1};1')"
   echo "$fingerprint:6" | gpg --import-ownertrust
   gpg --yes --no-tty --batch --pinentry-mode loopback --default-key "$fingerprint" --detach-sign -o "$1".sig --passphrase-file <(echo "$SIGNING_PASSPHRASE") "$1"
   set -x


### PR DESCRIPTION
Most of the changes are in GitHub's secret values. The only thing that must change in the code is the name of the key we search for.

Fixes #990.