### PR TITLE
uc-crux-llvm: Abstract type and operations for tracking symbolic value annotations

### DIFF
--- a/uc-crux-llvm/src/UCCrux/LLVM/ExprTracker.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/ExprTracker.hs
@@ -1,0 +1,110 @@
+{-
+Module       : UCCrux.LLVM.ExprTracker
+Description  : Track sources of annotated symbolic expressions
+Copyright    : (c) Galois, Inc 2022
+License      : BSD3
+Maintainer   : Langston Barrett <langston@galois.com>
+Stability    : provisional
+-}
+
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE PolyKinds #-}
+
+module UCCrux.LLVM.ExprTracker
+  ( TypedSelector(..),
+    ExprTracker,
+    empty,
+    insert,
+    lookup,
+    union
+  )
+where
+
+import           Prelude hiding (lookup)
+
+import           Data.Parameterized.Ctx (Ctx)
+import           Data.Parameterized.Classes (OrdF)
+import           Data.Parameterized.Some (Some(Some))
+
+import qualified What4.Interface as What4
+
+import           Data.Map (Map)
+import qualified Data.Map as Map
+
+import           UCCrux.LLVM.Cursor (Selector, SomeInSelector(..))
+import           UCCrux.LLVM.FullType.Type (FullType, FullTypeRepr)
+
+-- | A 'Selector' together with the type of value it points to.
+--
+-- NOTE(lb): The explicit kind signature here is necessary for GHC 8.8
+-- compatibility.
+data TypedSelector m (argTypes :: Ctx (FullType m)) (ft :: FullType m)
+  = TypedSelector
+      { tsType :: FullTypeRepr m ft,
+        tsSelector :: SomeInSelector m argTypes ft
+      }
+
+-- | Track the origins of What4 expressions.
+--
+-- This map tracks where a given expression originated from, i.e. whether it was
+-- generated as part of an argument of global variable, and if so, where in said
+-- value it resides (via a 'Selector'). This is used by
+-- 'UCCrux.LLVM.Classify.classifyBadBehavior' to deduce new preconditions and
+-- attach constraints in the right place.
+--
+-- For example, if the error is an OOB write and classification looks up the
+-- pointer in this map and it appears in an argument, it will attach a
+-- precondition that that part of the argument gets allocated with more
+-- space. If it looks up the pointer and it's not in this map, it's not clear
+-- how this error could be prevented, and the error will be unclassified.
+--
+-- This is implemented as a @'Map' ('Some' _) ('Some' _)@ instead of a @MapF@
+-- because the relationship between the 'What4.BaseType' and the 'FullType'
+-- isn't one-to-one. For example, a 'Selector' may point to a pointer value,
+-- which can have an annotated block number (natural) or offset (bitvector).
+newtype ExprTracker m sym argTypes =
+  ExprTracker
+    { getExprTracker ::
+        Map (Some (What4.SymAnnotation sym)) (Some (TypedSelector m argTypes))
+    }
+
+empty :: ExprTracker m sym argTypes
+empty = ExprTracker Map.empty
+
+-- | Insert an annotation and the 'Selector' for the annotated value into the
+-- tracker
+insert ::
+  OrdF (What4.SymAnnotation sym) =>
+  -- | Annotation on the value
+  What4.SymAnnotation sym bt ->
+  -- | Path to this value
+  Selector m argTypes inTy atTy ->
+  -- | Type of the annotated value
+  FullTypeRepr m atTy ->
+  ExprTracker m sym argTypes ->
+  ExprTracker m sym argTypes
+insert ann s ftRepr =
+  ExprTracker .
+    Map.insert (Some ann) (Some (TypedSelector ftRepr (SomeInSelector s))) .
+    getExprTracker
+
+-- | Find the origin and type of a symbolic expression
+lookup ::
+  OrdF (What4.SymAnnotation sym) =>
+  -- | Annotation on the value
+  What4.SymAnnotation sym bt ->
+  ExprTracker m sym argTypes ->
+  Maybe (Some (TypedSelector m argTypes))
+lookup ann = Map.lookup (Some ann) . getExprTracker
+
+-- | Union of two 'ExprTracker's.
+--
+-- At runtime, the keys are nonces. They'll never clash, so the bias of the
+-- union is unimportant (technically, it's left-biased).
+union ::
+  OrdF (What4.SymAnnotation sym) =>
+  ExprTracker m sym argTypes ->
+  ExprTracker m sym argTypes ->
+  ExprTracker m sym argTypes
+union et1 et2 = ExprTracker (Map.union (getExprTracker et1) (getExprTracker et2))

--- a/uc-crux-llvm/src/UCCrux/LLVM/FullType/Type.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/FullType/Type.hs
@@ -138,7 +138,7 @@ import qualified Lang.Crucible.Types as CrucibleTypes hiding ((::>))
 import qualified Lang.Crucible.LLVM.DataLayout as Crucible
 import           Lang.Crucible.LLVM.TypeContext (TypeContext (llvmDataLayout), asMemType, lookupAlias)
 
-import           Lang.Crucible.LLVM.Extension (ArchWidth, LLVMArch)
+import           Lang.Crucible.LLVM.Extension (ArchWidth)
 import           Lang.Crucible.LLVM.MemType (MemType(..), SymType(..), FunDecl(..))
 import qualified Lang.Crucible.LLVM.MemType as MemType
 
@@ -270,18 +270,18 @@ type family ToCrucibleType arch (ft :: FullType m) :: CrucibleTypes.CrucibleType
       "LLVM_pointer"
       (Ctx.EmptyCtx Ctx.::> CrucibleTypes.BVType (ArchWidth arch))
 
-type family MapToBaseType (sym :: Type) (arch :: LLVMArch) (ctx :: Ctx (FullType m)) :: Ctx CrucibleTypes.BaseType where
-  MapToBaseType sym arch 'Ctx.EmptyCtx = Ctx.EmptyCtx
-  MapToBaseType sym arch (xs 'Ctx.::> x) =
-    MapToBaseType sym arch xs Ctx.::> ToBaseType sym arch x
+type family MapToBaseType (sym :: Type) (ctx :: Ctx (FullType m)) :: Ctx CrucibleTypes.BaseType where
+  MapToBaseType sym 'Ctx.EmptyCtx = Ctx.EmptyCtx
+  MapToBaseType sym (xs 'Ctx.::> x) =
+    MapToBaseType sym xs Ctx.::> ToBaseType sym x
 
 -- | The type of annotated What4 values that correspond to each 'FullType'
-type family ToBaseType (sym :: Type) (arch :: LLVMArch) (ft :: FullType m) :: CrucibleTypes.BaseType where
-  ToBaseType sym arch ('FTInt n) = CrucibleTypes.BaseBVType n
-  ToBaseType sym arch ('FTPtr _ft) = CrucibleTypes.BaseIntegerType
-  ToBaseType sym arch ('FTFloat flt) = W4IFP.SymInterpretedFloatType sym flt
-  ToBaseType sym arch ('FTStruct _sp ctx) =
-    CrucibleTypes.BaseStructType (MapToBaseType sym arch ctx)
+type family ToBaseType (sym :: Type) (ft :: FullType m) :: CrucibleTypes.BaseType where
+  ToBaseType sym ('FTInt n) = CrucibleTypes.BaseBVType n
+  ToBaseType sym ('FTPtr _ft) = CrucibleTypes.BaseIntegerType
+  ToBaseType sym ('FTFloat flt) = W4IFP.SymInterpretedFloatType sym flt
+  ToBaseType sym ('FTStruct _sp ctx) =
+    CrucibleTypes.BaseStructType (MapToBaseType sym ctx)
 
 -- | A singleton for representing a 'FullType' at the value level.
 --

--- a/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Skip.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Skip.hs
@@ -41,7 +41,6 @@ import qualified Data.Parameterized.Context as Ctx
 import           Data.Parameterized.Some (Some(Some))
 
 -- what4
-import qualified What4.Interface as What4
 import           What4.FunctionName (functionName)
 
 -- crucible
@@ -67,6 +66,7 @@ import           Crux.LLVM.Overrides (ArchOk)
 import           UCCrux.LLVM.Context.Module (ModuleContext, funcTypes, moduleDecls)
 import           UCCrux.LLVM.Errors.Panic (panic)
 import           UCCrux.LLVM.FullType.CrucibleType (SomeAssign'(..),  assignmentToCrucibleType, toCrucibleReturnType)
+import           UCCrux.LLVM.ExprTracker (ExprTracker)
 import           UCCrux.LLVM.FullType.FuncSig (FuncSigRepr(FuncSigRepr))
 import qualified UCCrux.LLVM.FullType.FuncSig as FS
 import           UCCrux.LLVM.FullType.Type (MapToCrucibleType)
@@ -75,7 +75,6 @@ import           UCCrux.LLVM.Overrides.Polymorphic (PolymorphicLLVMOverride, mak
 import           UCCrux.LLVM.Postcondition.Apply (applyPostcond)
 import qualified UCCrux.LLVM.Postcondition.Type as Post
 import           UCCrux.LLVM.Postcondition.Type (UPostcond)
-import           UCCrux.LLVM.Setup.Monad (TypedSelector)
 {- ORMOLU_ENABLE -}
 
 newtype SkipOverrideName = SkipOverrideName {getSkipOverrideName :: Text}
@@ -105,8 +104,8 @@ unsoundSkipOverrides ::
   ModuleTranslation arch ->
   -- | Set of skip overrides encountered during execution
   IORef (Set SkipOverrideName) ->
-  -- | Annotations of created values
-  IORef (Map (Some (What4.SymAnnotation sym)) (Some (TypedSelector m arch argTypes))) ->
+  -- | Origins of created values
+  IORef (ExprTracker m sym argTypes) ->
   -- | Postconditions of each override (constraints on return values,
   -- information about clobbered pointer values such as arguments or global
   -- variables)
@@ -199,8 +198,8 @@ createSkipOverride ::
   ModuleContext m arch ->
   bak ->
   IORef (Set SkipOverrideName) ->
-  -- | Annotations of created values
-  IORef (Map (Some (What4.SymAnnotation sym)) (Some (TypedSelector m arch argTypes))) ->
+  -- | Origins of created values
+  IORef (ExprTracker m sym argTypes) ->
   -- | Constraints on the return value, clobbered pointer values such as
   -- arguments or global variables
   UPostcond m ->

--- a/uc-crux-llvm/src/UCCrux/LLVM/Setup.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Setup.hs
@@ -122,10 +122,10 @@ annotatedTerm ::
   (Crucible.IsSymInterface sym) =>
   sym ->
   FullTypeRepr m atTy ->
-  CrucibleTypes.BaseTypeRepr (ToBaseType sym arch atTy) ->
+  CrucibleTypes.BaseTypeRepr (ToBaseType sym atTy) ->
   -- | Path to this value
   Selector m argTypes inTy atTy ->
-  Setup m arch sym argTypes (W4I.SymExpr sym (ToBaseType sym arch atTy))
+  Setup m arch sym argTypes (W4I.SymExpr sym (ToBaseType sym atTy))
 annotatedTerm sym fullTypeRepr baseTypeRepr selector =
   do
     symbol <- freshSymbol

--- a/uc-crux-llvm/src/UCCrux/LLVM/Setup/Monad.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Setup/Monad.hs
@@ -27,7 +27,6 @@ module UCCrux.LLVM.Setup.Monad
     SetupAssumption (..),
     SetupResult (..),
     setupMem,
-    TypedSelector (..),
     freshSymbol,
     assume,
     getAnnotation,
@@ -47,8 +46,6 @@ import           Control.Monad.Reader (MonadReader, ask)
 import           Control.Monad.State.Strict (MonadState, gets)
 import           Control.Monad.Writer (MonadWriter, tell)
 import           Control.Monad.RWS (RWST, runRWST)
-import           Data.Map (Map)
-import qualified Data.Map as Map
 import           Data.Proxy (Proxy(Proxy))
 import           Data.Text (Text)
 import qualified Data.Text.IO as TextIO
@@ -76,17 +73,13 @@ import           Lang.Crucible.LLVM.TypeContext (TypeContext(llvmDataLayout))
 import           Crux.LLVM.Overrides (ArchOk)
 
 import           UCCrux.LLVM.Context.Module (ModuleContext, moduleTranslation)
-import           UCCrux.LLVM.Cursor (Selector, SomeInSelector(..))
+import           UCCrux.LLVM.Cursor (Selector)
+import           UCCrux.LLVM.ExprTracker as ET
 import           UCCrux.LLVM.FullType.Memory (arraySizeBv)
 import           UCCrux.LLVM.FullType.Type (FullType(FTPtr), FullTypeRepr, ToCrucibleType, ToBaseType, ModuleTypes, DataLayout)
 import           UCCrux.LLVM.Constraints (Constraint)
 import qualified UCCrux.LLVM.Mem as Mem
 {- ORMOLU_ENABLE -}
-
--- NOTE(lb): The explicit kind signature here is necessary for GHC 8.8
--- compatibility.
-data TypedSelector m arch (argTypes :: Ctx (FullType m)) (ft :: FullType m)
-  = TypedSelector (FullTypeRepr m ft) (SomeInSelector m argTypes ft)
 
 data SetupAssumption m sym = SetupAssumption
   { assumptionReason :: Some (Constraint m),
@@ -97,20 +90,20 @@ data SetupAssumption m sym = SetupAssumption
 -- compatibility.
 data SetupState m arch sym (argTypes :: Ctx (FullType m)) = SetupState
   { _setupMem :: LLVMMem.MemImpl sym,
-    -- | This map tracks where a given expression originated from
-    _setupAnnotations :: Map (Some (What4.SymAnnotation sym)) (Some (TypedSelector m arch argTypes)),
+    -- | Track where a given expression originated from
+    _setupTracker :: ExprTracker m sym argTypes,
     -- | Counter for generating unique/fresh symbols
     _symbolCounter :: !Int
   }
 
 makeSetupState :: LLVMMem.MemImpl sym -> SetupState m arch sym argTypes
-makeSetupState mem = SetupState mem Map.empty 0
+makeSetupState mem = SetupState mem ET.empty 0
 
 setupMem :: Simple Lens (SetupState m arch sym argTypes) (LLVMMem.MemImpl sym)
 setupMem = lens _setupMem (\s v -> s {_setupMem = v})
 
-setupAnnotations :: Simple Lens (SetupState m arch sym argTypes) (Map (Some (What4.SymAnnotation sym)) (Some (TypedSelector m arch argTypes)))
-setupAnnotations = lens _setupAnnotations (\s v -> s {_setupAnnotations = v})
+setupTracker :: Simple Lens (SetupState m arch sym argTypes) (ExprTracker m sym argTypes)
+setupTracker = lens _setupTracker (\s v -> s {_setupTracker = v})
 
 symbolCounter :: Simple Lens (SetupState m arch sym argTypes) Int
 symbolCounter = lens _symbolCounter (\s v -> s {_symbolCounter = v})
@@ -141,21 +134,8 @@ instance LJ.HasLog Text (Setup m arch sym argTypes) where
 -- compatibility.
 data SetupResult m arch sym (argTypes :: Ctx (FullType m)) = SetupResult
   { resultMem :: LLVMMem.MemImpl sym,
-    -- | This map tracks where a given expression originated from, i.e. whether
-    -- it was generated as part of an argument of global variable, and if so,
-    -- where in said value it resides (via a 'Selector'). This is used by
-    -- 'UCCrux.LLVM.Classify.classifyBadBehavior' to deduce new preconditions
-    -- and attach constraints in the right place.
-    --
-    -- For example, if the error is an OOB write and classification looks up the
-    -- pointer in this map and it appears in an argument, it will attach a
-    -- precondition that that part of the argument gets allocated with more
-    -- space. If it looks up the pointer and it's not in this map, it's not clear
-    -- how this error could be prevented, and the error will be unclassified.
-    resultAnnotations ::
-      Map (Some (What4.SymAnnotation sym)) (Some (TypedSelector m arch argTypes)),
-    resultAssumptions ::
-      [SetupAssumption m sym]
+    resultTracker :: ExprTracker m sym argTypes,
+    resultAssumptions :: [SetupAssumption m sym]
   }
 
 runSetup ::
@@ -173,7 +153,7 @@ runSetup modCtx mem (Setup computation) = do
       (result', state, assumptions) ->
         ( SetupResult
             (state ^. setupMem)
-            (state ^. setupAnnotations)
+            (state ^. setupTracker)
             assumptions,
           result'
         )
@@ -192,14 +172,13 @@ assume constraint predicate = tell [SetupAssumption (Some constraint) predicate]
 
 addAnnotation ::
   OrdF (What4.SymAnnotation sym) =>
-  Some (What4.SymAnnotation sym) ->
+  What4.SymAnnotation sym bt ->
   -- | Path to this value
   Selector m argTypes inTy atTy ->
   FullTypeRepr m atTy ->
   Setup m arch sym argTypes ()
 addAnnotation ann selector fullTypeRepr =
-  setupAnnotations
-    %= Map.insert ann (Some (TypedSelector fullTypeRepr (SomeInSelector selector)))
+  setupTracker %= ET.insert ann selector fullTypeRepr
 
 -- | Retrieve a pre-existing annotation, or make a new one.
 getAnnotation ::
@@ -221,12 +200,12 @@ getAnnotation sym selector fullTypeRepr expr =
   case What4.getAnnotation sym expr of
     Just annotation ->
       do
-        addAnnotation (Some annotation) selector fullTypeRepr
+        addAnnotation annotation selector fullTypeRepr
         pure (annotation, expr)
     Nothing ->
       do
         (annotation, expr') <- liftIO $ What4.annotateTerm sym expr
-        addAnnotation (Some annotation) selector fullTypeRepr
+        addAnnotation annotation selector fullTypeRepr
         pure (annotation, expr')
 
 annotatePointer ::
@@ -244,23 +223,23 @@ annotatePointer sym selector fullTypeRepr ptr =
       case What4.getAnnotation sym block of
         Just annotation ->
           do
-            addAnnotation (Some annotation) selector fullTypeRepr
+            addAnnotation annotation selector fullTypeRepr
             pure ptr
         Nothing ->
           do
             (annotation, ptr') <- liftIO (LLVMPtr.annotatePointerBlock sym ptr)
-            addAnnotation (Some annotation) selector fullTypeRepr
+            addAnnotation annotation selector fullTypeRepr
             pure ptr'
     let offset = LLVMPtr.llvmPointerOffset ptr'
     case What4.getAnnotation sym offset of
       Just annotation ->
         do
-          addAnnotation (Some annotation) selector fullTypeRepr
+          addAnnotation annotation selector fullTypeRepr
           pure ptr'
       Nothing ->
         do
           (annotation, ptr'') <- liftIO (LLVMPtr.annotatePointerOffset sym ptr)
-          addAnnotation (Some annotation) selector fullTypeRepr
+          addAnnotation annotation selector fullTypeRepr
           pure ptr''
 
 modifyMem ::

--- a/uc-crux-llvm/src/UCCrux/LLVM/Setup/Monad.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Setup/Monad.hs
@@ -208,14 +208,14 @@ getAnnotation ::
   -- | Path to this value
   Selector m argTypes inTy atTy ->
   FullTypeRepr m atTy ->
-  What4.SymExpr sym (ToBaseType sym arch atTy) ->
+  What4.SymExpr sym (ToBaseType sym atTy) ->
   Setup
     m
     arch
     sym
     argTypes
-    ( What4.SymAnnotation sym (ToBaseType sym arch atTy),
-      What4.SymExpr sym (ToBaseType sym arch atTy)
+    ( What4.SymAnnotation sym (ToBaseType sym atTy),
+      What4.SymExpr sym (ToBaseType sym atTy)
     )
 getAnnotation sym selector fullTypeRepr expr =
   case What4.getAnnotation sym expr of

--- a/uc-crux-llvm/test/Postcond.hs
+++ b/uc-crux-llvm/test/Postcond.hs
@@ -37,6 +37,7 @@ import qualified Crux.LLVM.Config as CruxLLVM
 import           UCCrux.LLVM.Constraints (ConstrainedShape(..))
 import           UCCrux.LLVM.Context.Module (moduleTranslation, declTypes)
 import qualified UCCrux.LLVM.Cursor as Cursor
+import qualified UCCrux.LLVM.ExprTracker as ET
 import           UCCrux.LLVM.FullType.CrucibleType (makeSameCrucibleType)
 import qualified UCCrux.LLVM.FullType.Type as FT
 import           UCCrux.LLVM.Module (FuncSymbol(FuncDeclSymbol), makeDeclSymbol)
@@ -76,7 +77,7 @@ postcondTests =
                    return $
                      Sim.SimulatorCallbacks $
                        do nameRef <- IORef.newIORef Set.empty
-                          annRef <- IORef.newIORef Map.empty
+                          annRef <- IORef.newIORef ET.empty
                           return $
                             Sim.SimulatorHooks
                               { Sim.createOverrideHooks =
@@ -130,7 +131,7 @@ postcondTests =
                    return $
                      Sim.SimulatorCallbacks $
                        do nameRef <- IORef.newIORef Set.empty
-                          annRef <- IORef.newIORef Map.empty
+                          annRef <- IORef.newIORef ET.empty
                           return $
                             Sim.SimulatorHooks
                               { Sim.createOverrideHooks =

--- a/uc-crux-llvm/uc-crux-llvm.cabal
+++ b/uc-crux-llvm/uc-crux-llvm.cabal
@@ -50,6 +50,7 @@ library
     UCCrux.LLVM.Errors.MalformedLLVMModule
     UCCrux.LLVM.Errors.Panic
     UCCrux.LLVM.Errors.Unimplemented
+    UCCrux.LLVM.ExprTracker
     UCCrux.LLVM.FullType
     UCCrux.LLVM.FullType.CrucibleType
     UCCrux.LLVM.FullType.FuncSig


### PR DESCRIPTION
Fixes #991. This map type was used ubiquitously throughout the codebase, but its concrete details aren't important/necessary for most clients. Instead, abstract it behind a newtype and only expose a few operations. Helpfully simplifies some type signatures, and makes their intent more clear.

The first commit is a small, only marginally related simplification. Might be helpful to review the commits separately.