### PR TITLE
`crucible-syntax`: Add forward declarations

### DIFF
--- a/crucible-concurrency/src/Cruces/CrucesMain.hs
+++ b/crucible-concurrency/src/Cruces/CrucesMain.hs
@@ -14,8 +14,10 @@ Maintainer       : Alexander Bakst <abakst@galois.com>
 module Cruces.CrucesMain (run, defaultCrucesOptions, cruciblesConfig) where
 
 import Control.Lens
+import Control.Monad (unless)
 import Data.Foldable (toList)
 import Data.List (find)
+import qualified Data.Map as Map
 import Data.Text (pack)
 import Data.String (IsString(..))
 import System.Exit
@@ -140,7 +142,10 @@ run (cruxOpts, opts) =
                        Right (ParsedProgram
                                { parsedProgGlobals = gs
                                , parsedProgCFGs = cs
-                               }) ->
+                               , parsedProgForwardDecs = fds
+                               }) -> do
+                         unless (Map.null fds) $
+                           error "Forward declarations not currently supported"
                          return ( findMain (fromString "main") cs
                                 , crucibleSyntaxPrims
                                 , toList gs

--- a/crucible-concurrency/src/Cruces/CrucesMain.hs
+++ b/crucible-concurrency/src/Cruces/CrucesMain.hs
@@ -137,7 +137,10 @@ run (cruxOpts, opts) =
                      case parseResult of
                        Left (SyntaxParseError e) -> error $ show $ printSyntaxError e
                        Left err -> error $ show err
-                       Right (gs, cs) ->
+                       Right (ParsedProgram
+                               { parsedProgGlobals = gs
+                               , parsedProgCFGs = cs
+                               }) ->
                          return ( findMain (fromString "main") cs
                                 , crucibleSyntaxPrims
                                 , toList gs

--- a/crucible-syntax/CHANGELOG.md
+++ b/crucible-syntax/CHANGELOG.md
@@ -1,3 +1,21 @@
+# next
+
+* The return type of `prog`:
+
+  ```hs
+  TopParser s (Map GlobalName (Pair TypeRepr GlobalVar), [ACFG ext])
+  ```
+
+  Has been changed to:
+
+  ```hs
+  TopParser s (ParsedProgram ext)
+  ```
+
+  Where the `parsedProgGlobals :: Map GlobalName (Pair TypeRepr GlobalVar)` and
+  `parsedProgCFGs :: [ACFG ext]` fields of `ParsedProgram` now serve the roles
+  previously filled by the first and second fields of the returned tuple.
+
 # 0.2
 
 * Various functions now take a `?parserHooks :: ParserHooks ext` implicit

--- a/crucible-syntax/CHANGELOG.md
+++ b/crucible-syntax/CHANGELOG.md
@@ -15,6 +15,27 @@
   Where the `parsedProgGlobals :: Map GlobalName (Pair TypeRepr GlobalVar)` and
   `parsedProgCFGs :: [ACFG ext]` fields of `ParsedProgram` now serve the roles
   previously filled by the first and second fields of the returned tuple.
+* The type of `simulateProgram`'s last argument:
+
+  ```hs
+  simulateProgram
+    :: ...
+    -> (forall p sym ext t st fs. (IsSymInterface sym, sym ~ (ExprBuilder t st fs)) =>
+          sym -> HandleAllocator -> IO [(FnBinding p sym ext,Position)])
+    -> ...
+  ```
+
+  Has changed to the following:
+
+  ```hs
+  simulateProgram
+    :: ...
+    -> SimulateProgramHooks
+    -> ...
+  ```
+
+  Where the `setupOverridesHook` field of `SimulateProgramHooks` now serves the
+  role previously filled by the function argument.
 
 # 0.2
 

--- a/crucible-syntax/README.txt
+++ b/crucible-syntax/README.txt
@@ -77,6 +77,16 @@ statement. The first block must begin with "start" instead of
 "defblock". In the future, the restriction that the start block comes
 first may be relaxed.
 
+Forward declarations
+
+A forward declaration is a form that begins with the keyword "declare",
+followed by a function name, argument list, and return type. A forward
+declaration is like a function but without the function body. Forward
+declarations are useful in situations where you do not know the definition
+of a function ahead of time, but you will know it at some point after parsing
+the program. It is the responsibility of the client to ensure that forward
+declarations are resolved to Crucible definitions before being invoked.
+
 Types
 
 si ::= 'Unicode' | 'Char16' | 'Char8'

--- a/crucible-syntax/crucible-syntax.cabal
+++ b/crucible-syntax/crucible-syntax.cabal
@@ -82,6 +82,7 @@ test-suite crucible-syntax-tests
     Overrides
   build-depends:
     base,
+    containers,
     crucible,
     crucible-syntax,
     directory,

--- a/crucible-syntax/crucible-syntax/Main.hs
+++ b/crucible-syntax/crucible-syntax/Main.hs
@@ -69,7 +69,7 @@ command =
 
 profFile :: Opt.Parser ProfCmd
 profFile =
-  ProfCmd <$> input <*> output 
+  ProfCmd <$> input <*> output
 
 simFile :: Opt.Parser SimCmd
 simFile =
@@ -101,15 +101,20 @@ main =
          do contents <- T.readFile inputFile
             case out of
               Nothing ->
-                simulateProgram inputFile contents stdout Nothing configOptions setupOverrides
+                simulateProgram inputFile contents stdout Nothing configOptions simulationHooks
               Just (TheFile outputFile) ->
                 withFile outputFile WriteMode
-                  (\outh -> simulateProgram inputFile contents outh Nothing configOptions setupOverrides)
+                  (\outh -> simulateProgram inputFile contents outh Nothing configOptions simulationHooks)
 
        ProfileCommand (ProfCmd (TheFile inputFile) (TheFile outputFile)) ->
          do contents <- T.readFile inputFile
             withFile outputFile WriteMode
-               (\outh -> simulateProgram inputFile contents stdout (Just outh) configOptions setupOverrides)
+               (\outh -> simulateProgram inputFile contents stdout (Just outh) configOptions simulationHooks)
 
   where info = Opt.info (command <**> Opt.helper) (Opt.fullDesc)
         prefs = Opt.prefs $ Opt.showHelpOnError <> Opt.showHelpOnEmpty
+
+        simulationHooks =
+          defaultSimulateProgramHooks
+            { setupOverridesHook = setupOverrides
+            }

--- a/crucible-syntax/src/Lang/Crucible/Syntax/Atoms.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Atoms.hs
@@ -40,7 +40,7 @@ newtype FunName = FunName Text deriving (Eq, Ord, Show)
 newtype GlobalName = GlobalName Text deriving (Eq, Ord, Show)
 
 -- | Individual language keywords (reserved identifiers)
-data Keyword = Defun | DefBlock | DefGlobal
+data Keyword = Defun | DefBlock | DefGlobal | Declare
              | Registers
              | Start
              | SetGlobal
@@ -92,6 +92,7 @@ keywords =
   , ("start" , Start)
   , ("defblock", DefBlock)
   , ("defglobal", DefGlobal)
+  , ("declare", Declare)
   , ("registers", Registers)
 
     -- statements

--- a/crucible-syntax/src/Lang/Crucible/Syntax/Prog.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Prog.hs
@@ -14,7 +14,9 @@ module Lang.Crucible.Syntax.Prog
 import Control.Lens (view)
 import Control.Monad
 
-import Data.List (find)
+import Data.Foldable
+import qualified Data.Map as Map
+import Data.Map (Map)
 import Data.Text (Text)
 import Data.String (IsString(..))
 import qualified Data.Text.IO as T
@@ -45,6 +47,7 @@ import Lang.Crucible.Simulator.Profiling
 import What4.Config
 import What4.Interface (getConfiguration,notPred)
 import What4.Expr (ExprBuilder, newExprBuilder, EmptyExprBuilderState(..))
+import What4.FunctionName
 import What4.ProgramLoc
 import What4.SatResult
 import What4.Solver (defaultLogData, runZ3InOverride)
@@ -69,11 +72,14 @@ doParseCheck fn theInput pprint outh =
               forM_ v $
                 \e -> T.hPutStrLn outh (printExpr e) >> hPutStrLn outh ""
             let ?parserHooks = defaultParserHooks
-            cs <- top ng ha [] $ cfgs v
+            cs <- top ng ha [] $ prog v
             case cs of
               Left (SyntaxParseError e) -> T.hPutStrLn outh $ printSyntaxError e
               Left err -> hPutStrLn outh $ show err
-              Right ok ->
+              Right (ParsedProgram{ parsedProgCFGs = ok
+                                  , parsedProgForwardDecs = fds
+                                  }) -> do
+                assertNoForwardDecs fds
                 forM_ ok $
                  \(ACFG _ _ theCfg) ->
                    do C.SomeCFG ssa <- return $ toSSA theCfg
@@ -81,19 +87,38 @@ doParseCheck fn theInput pprint outh =
                       hPutStrLn outh $ show $ C.ppCFG' True (postdomInfo ssa) ssa
 
 -- | Allows users to hook into the various stages of 'simulateProgram'.
-newtype SimulateProgramHooks = SimulateProgramHooks
+data SimulateProgramHooks = SimulateProgramHooks
   { setupOverridesHook ::
       forall p sym ext t st fs. (IsSymInterface sym, sym ~ (ExprBuilder t st fs)) =>
          sym -> HandleAllocator -> IO [(FnBinding p sym ext,Position)]
     -- ^ Action to set up overrides before parsing a program.
+  , resolveForwardDeclarationsHook ::
+      forall p sym ext t st fs. (IsSymInterface sym, sym ~ (ExprBuilder t st fs)) =>
+        Map FunctionName SomeHandle -> IO (FunctionBindings p sym ext)
+    -- ^ Action to resolve forward declarations before simulating a program.
+    --   If you do not intend to support forward declarations, this is an
+    --   appropriate place to error if a program contains one or more forward
+    --   declarations.
   }
 
--- | A sensible default set of hooks for 'simulateProgram' that sets up no
--- additional overrides.
+-- | A sensible default set of hooks for 'simulateProgram' that:
+--
+-- * Sets up no additional overrides.
+--
+-- * Errors out if a program contains one or more forward declarations.
 defaultSimulateProgramHooks :: SimulateProgramHooks
 defaultSimulateProgramHooks = SimulateProgramHooks
   { setupOverridesHook = \_sym _ha -> pure []
+  , resolveForwardDeclarationsHook = \fds ->
+    do assertNoForwardDecs fds
+       pure $ FnBindings emptyHandleMap
   }
+
+assertNoForwardDecs :: Map FunctionName SomeHandle -> IO ()
+assertNoForwardDecs fds =
+  unless (Map.null fds) $
+  do putStrLn "Forward declarations not currently supported"
+     exitFailure
 
 simulateProgram
    :: FilePath -- ^ The name of the input (appears in source locations)
@@ -118,20 +143,26 @@ simulateProgram fn theInput outh profh opts hooks =
             ovrs <- setupOverridesHook hooks @() @_ @() sym ha
             let hdls = [ (SomeHandle h, p) | (FnBinding h _,p) <- ovrs ]
             let ?parserHooks = defaultParserHooks
-            parseResult <- top ng ha hdls $ cfgs v
+            parseResult <- top ng ha hdls $ prog v
             case parseResult of
               Left (SyntaxParseError e) -> T.hPutStrLn outh $ printSyntaxError e
               Left err -> hPutStrLn outh $ show err
-              Right cs ->
+              Right (ParsedProgram{ parsedProgCFGs = cs
+                                  , parsedProgForwardDecs = fds
+                                  }) -> do
                 case find isMain cs of
                   Just (ACFG Ctx.Empty retType mn) ->
-                    do let mainHdl = cfgHandle mn
-                       let fns = fnBindingsFromList
-                             [ case toSSA g of
-                                 C.SomeCFG ssa ->
-                                   FnBinding (cfgHandle g) (UseCFG ssa (postdomInfo ssa))
-                             | ACFG _ _ g <- cs
-                             ]
+                    do fwdDecFnBindings <- resolveForwardDeclarationsHook hooks fds
+                       let mainHdl = cfgHandle mn
+                       let fns = foldl' (\(FnBindings m) (ACFG _ _ g) ->
+                                          case toSSA g of
+                                            C.SomeCFG ssa ->
+                                              FnBindings $
+                                                insertHandleMap
+                                                  (cfgHandle g)
+                                                  (UseCFG ssa (postdomInfo ssa))
+                                                  m)
+                                        fwdDecFnBindings cs
                        let simCtx = initSimContext bak emptyIntrinsicTypes ha outh fns emptyExtensionImpl ()
                        let simSt  = InitialState simCtx emptyGlobals defaultAbortHandler retType $
                                       runOverrideSim retType $

--- a/crucible-syntax/test-data/declare-tests/main.cbl
+++ b/crucible-syntax/test-data/declare-tests/main.cbl
@@ -1,0 +1,8 @@
+(declare @foo () Integer)
+
+(defun @main () Unit
+  (start start:
+    (let foo-res (funcall @foo))
+    (assert! (equal? foo-res 42) "@foo returns 42")
+    (return ()))
+)

--- a/crucible-syntax/test-data/declare-tests/main.out.good
+++ b/crucible-syntax/test-data/declare-tests/main.out.good
@@ -1,0 +1,4 @@
+==== Begin Simulation ====
+
+==== Finish Simulation ====
+==== No proof obligations ====

--- a/crucible-syntax/test/Tests.hs
+++ b/crucible-syntax/test/Tests.hs
@@ -80,11 +80,13 @@ testSimulator :: FilePath -> FilePath -> IO ()
 testSimulator inFile outFile =
   do contents <- T.readFile inFile
      withFile outFile WriteMode $ \outh ->
-       simulateProgram inFile contents outh Nothing testOptions
-         (\sym ha ->
-           do os1 <- SyntaxOvrs.setupOverrides sym ha
-              os2 <- TestOvrs.setupOverrides sym ha
-              return $ concat [os1,os2])
+       simulateProgram inFile contents outh Nothing testOptions $
+         defaultSimulateProgramHooks
+           { setupOverridesHook =  \sym ha ->
+               do os1 <- SyntaxOvrs.setupOverrides sym ha
+                  os2 <- TestOvrs.setupOverrides sym ha
+                  return $ concat [os1,os2]
+           }
 
 
 data Lam = Lam [Text] (Datum TrivialAtom) deriving (Eq, Show)


### PR DESCRIPTION
This adds a `(declare ...)` form to the `crucible-syntax` language for forward declarations. A forward declaration is like a function, but lacking a body, and is useful for situations where one does not know what the implementation of a function will be until after the `.cbl` file is parsed.

Implementation-wise, this is accomplished by adding a new `parsedProgForwardDecs :: Map FunctionName SomeHandle` field to `ParsedProgram` that maps the name of each forward declaration to its handle. It is the responsibility of the caller to register each handle with a suitable `FnState`, or else invoking the forward declaration will result in a simulation error.

I've added a basic test case to ensure that this plan works as intended. This involved adding another field to `SimulateProgramHooks` (named `resolveForwardDeclarationsHook`) to allow resolving forward declarations before simulation begins.

Note that neither `crucibler` nor `cruces`, two of the current consumers of `crucible-syntax` in the `crucible` repo, support forward declarations at the moment, and trying to use forward declarations in the context of `crucibler` or `cruces` will result in an error. One could imagine adding support, although there would be some UX design questions to work out first.

Fixes #996.