### PR TITLE
Remove dependency on deprecated `data-binary-ieee754` library

### DIFF
--- a/crux-llvm/crux-llvm.cabal
+++ b/crux-llvm/crux-llvm.cabal
@@ -91,7 +91,6 @@ library
     aeson,
     bv-sized,
     config-schema >= 1.2.2.0,
-    data-binary-ieee754,
     logict,
     llvm-pretty,
     llvm-pretty-bc-parser,


### PR DESCRIPTION
The `data-binary-ieee754` library is deprecated. `crux-llvm` depends on it, but it doesn't actually use this dependency anywhere, so let's just remove it.