### PR TITLE
LLVM lazy load

### DIFF
--- a/crucible-llvm/CHANGELOG.md
+++ b/crucible-llvm/CHANGELOG.md
@@ -4,6 +4,18 @@
     `storeConstRaw`
   * `Lang.Crucible.LLVM.Globals`: `populateGlobal`
   * `Lang.Crucible.LLVM.MemModel.Generic`: `writeMem` and `writeConstMem`
+* `Lang.Crucible.LLVM`: `registerModuleFn` has changed type to
+  accomodate lazy loading of Crucible IR.
+* `Lang.Crucible.LLVM.Translation` : The `ModuleTranslation` record is
+  now opaque, the `cfgMap` is no longer exported and `globalInitMap`
+  and `modTransNonce` have become lens-style getters instead of record
+  accessors. CFGs should be retrieved using the new `getTranslatedCFG`
+  or `getTranslatedCFGForHandle` functions.
+* `Lang.Crucible.LLVM` : new functions `registerLazyModuleFn` and
+  `registerLazyModule`, which delay the building of Crucible CFGs until
+  the functions in question are actually called.
+
+
 
 # 0.4
 * A new `indeterminateLoadBehavior` flag in `MemOptions` now controls now

--- a/crucible-llvm/crucible-llvm.cabal
+++ b/crucible-llvm/crucible-llvm.cabal
@@ -138,6 +138,7 @@ test-suite crucible-llvm-tests
     lens,
     llvm-pretty,
     llvm-pretty-bc-parser,
+    lens,
     mtl,
     parameterized-utils,
     process,

--- a/crucible-llvm/src/Lang/Crucible/LLVM.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM.hs
@@ -20,6 +20,8 @@ module Lang.Crucible.LLVM
   ( LLVM
   , registerModule
   , registerModuleFn
+  , registerLazyModule
+  , registerLazyModuleFn
   , llvmGlobalsToCtx
   , llvmGlobals
   , register_llvm_overrides
@@ -29,13 +31,19 @@ module Lang.Crucible.LLVM
 import           Control.Lens
 import           Control.Monad (when)
 import           Control.Monad.IO.Class
+import qualified Data.Text as Text
 import qualified Text.LLVM.AST as L
+import qualified Text.LLVM.PP as L
 
 import           Lang.Crucible.Analysis.Postdom
 import           Lang.Crucible.Backend
 import           Lang.Crucible.CFG.Core
-import           Lang.Crucible.FunctionHandle (lookupHandleMap)
+import           Lang.Crucible.FunctionHandle
+                   (lookupHandleMap, SomeHandle(..), mkHandle'
+                   , handleArgTypes, handleReturnType
+                   )
 import           Lang.Crucible.LLVM.Eval (llvmExtensionEval)
+import           Lang.Crucible.Panic (panic)
 import           Lang.Crucible.LLVM.Extension (ArchWidth)
 import           Lang.Crucible.LLVM.Intrinsics
 import           Lang.Crucible.LLVM.MemModel
@@ -43,16 +51,20 @@ import           Lang.Crucible.LLVM.MemModel
                    , bindLLVMFunPtr, Mem
                    )
 import           Lang.Crucible.LLVM.Translation
+import           Lang.Crucible.Simulator (FnVal(..), regValue)
 import           Lang.Crucible.Simulator.ExecutionTree
 import           Lang.Crucible.Simulator.GlobalState
 import           Lang.Crucible.Simulator.OverrideSim
+
+
 import           What4.Interface (getCurrentProgramLoc)
 import           What4.ProgramLoc (plSourceLoc)
+import           What4.FunctionName (functionNameFromText)
 
 
--- | Register all the functions defined in the LLVM module
-registerModule
-   :: (1 <= ArchWidth arch, HasPtrWidth (ArchWidth arch), IsSymInterface sym) =>
+-- | Register all the functions defined in the LLVM module.
+registerModule ::
+   (1 <= ArchWidth arch, HasPtrWidth (ArchWidth arch), IsSymInterface sym) =>
    (LLVMTranslationWarning -> IO ()) ->
    LLVMContext arch ->
    ModuleTranslation arch ->
@@ -60,13 +72,15 @@ registerModule
 registerModule handleWarning llvm_ctx mtrans =
    mapM_ (registerModuleFn handleWarning llvm_ctx mtrans) (map L.decName (mtrans ^. modTransDefs))
 
-registerModuleFn
-   :: (1 <= ArchWidth arch, HasPtrWidth (ArchWidth arch), IsSymInterface sym) =>
+-- | Register a specific named function that is defined in the given
+--   module translation.
+registerModuleFn ::
+   (1 <= ArchWidth arch, HasPtrWidth (ArchWidth arch), IsSymInterface sym) =>
    (LLVMTranslationWarning -> IO ()) ->
    LLVMContext arch ->
    ModuleTranslation arch ->
    L.Symbol ->
-   OverrideSim p sym LLVM rtp l a ()
+   OverrideSim p sym LLVM rtp l a SomeHandle
 registerModuleFn handleWarning llvm_ctx mtrans sym =
   liftIO (getTranslatedCFG mtrans sym) >>= \case
     Nothing ->
@@ -89,6 +103,86 @@ registerModuleFn handleWarning llvm_ctx mtrans sym =
         do loc <- liftIO . getCurrentProgramLoc =<< getSymInterface
            liftIO (handleWarning (LLVMTranslationWarning sym (plSourceLoc loc) "LLVM function handle registered twice"))
       liftIO $ mapM_ handleWarning warns
+      return (SomeHandle h)
+
+-- | Lazily register all the functions defined in the LLVM module.  See
+--   'registerLazyModuleFn' for a description.
+registerLazyModule ::
+   (1 <= ArchWidth arch, HasPtrWidth (ArchWidth arch), IsSymInterface sym) =>
+   (LLVMTranslationWarning -> IO ()) ->
+   LLVMContext arch ->
+   ModuleTranslation arch ->
+   OverrideSim p sym LLVM rtp l a ()
+registerLazyModule handleWarning llvm_ctx mtrans =
+   mapM_ (registerLazyModuleFn handleWarning llvm_ctx mtrans) (map L.decName (mtrans ^. modTransDefs))
+
+-- | Lazily register the named function that is defnied in the given module
+--   translation. This will delay actually translating the function until it
+--   is called. This done by first installing a bootstrapping override that
+--   will peform the actual translation when first invoked, and then will backpatch
+--   its own references to point to the translated function.
+registerLazyModuleFn ::
+   (1 <= ArchWidth arch, HasPtrWidth (ArchWidth arch), IsSymInterface sym) =>
+   (LLVMTranslationWarning -> IO ()) ->
+   LLVMContext arch ->
+   ModuleTranslation arch ->
+   L.Symbol ->
+   OverrideSim p sym LLVM rtp l a ()
+registerLazyModuleFn handleWarning llvm_ctx mtrans sym =
+  case filter (\def -> L.defName def == sym) (L.modDefines (mtrans ^. modTransModule)) of
+    [def] ->
+      let ?lc = llvm_ctx^.llvmTypeCtx in
+      let decl = declareFromDefine def
+          (L.Symbol fstr) = L.decName decl
+          halloc = mtrans ^. modTransHalloc
+       in llvmDeclToFunHandleRepr' decl $ \argTys retTy ->
+           do let fn_name = functionNameFromText $ Text.pack (fstr ++ "_bootstrap")
+              h <- liftIO $ mkHandle' halloc fn_name argTys retTy
+
+              -- Bind the function handle we just created to the following bootstrapping code,
+              -- which actually translates the function on its first execution and patches up
+              -- behind itself.
+              bindFnHandle h
+                $ UseOverride
+                $ mkOverride' fn_name retTy
+                $ -- This inner action defines what to do when this function is called for the
+                  -- first time.  We actually translate the function and install it, which
+                  -- overrites the global symbol.
+                  do SomeHandle h' <- registerModuleFn handleWarning llvm_ctx mtrans sym
+                     case (testEquality argTys (handleArgTypes h'),
+                           testEquality retTy (handleReturnType h')) of
+                        (Nothing, _) -> panic ("Argument type mismatch when bootstraping function: " ++ fstr)
+                                               [ show argTys, show h ]
+                        (_, Nothing) -> panic ("Return type mismatch when bootstrapping function: " ++ fstr)
+                                               [ show retTy, show h ]
+                        (Just Refl, Just Refl) ->
+                           do -- Rebind the old handle to call directly into the new handle.
+                              -- This makes sure that even if the handle related to the global symbol
+                              -- has previously been resolved, the actual code for this function
+                              -- is correctly executed.
+                              bindFnHandle h
+                                $ UseOverride
+                                $ mkOverride' fn_name retTy
+                                $ (regValue <$> (callFnVal (HandleFnVal h') =<< getOverrideArgs))
+                              -- Now, call the new handle
+                              regValue <$> (callFnVal (HandleFnVal h') =<< getOverrideArgs)
+
+              -- Bind the bootstrapping function handle to the global symbol
+              let mvar = llvmMemVar llvm_ctx
+              mem <- readGlobal mvar
+              mem' <- ovrWithBackend $ \bak ->
+                        liftIO $ bindLLVMFunPtr bak decl h mem
+              writeGlobal mvar mem'
+
+
+    [] -> fail $ unlines
+            [ "Could not find definition for function"
+            , show sym
+            ]
+
+    ds -> panic ("More than one LLVM definition found for " ++ show (L.ppSymbol sym))
+                (map (show . L.ppDeclare . declareFromDefine) ds)
+
 
 llvmGlobalsToCtx
    :: LLVMContext arch

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation.hs
@@ -80,6 +80,7 @@ module Lang.Crucible.LLVM.Translation
   , globalInitMap
   , modTransDefs
   , modTransModule
+  , modTransHalloc
   , LLVMContext(..)
   , llvmTypeCtx
   , translateModule
@@ -173,6 +174,9 @@ modTransDefs = to _modTransDefs
 
 modTransModule :: Getter (ModuleTranslation arch) L.Module
 modTransModule = to _modTransModule
+
+modTransHalloc :: Getter (ModuleTranslation arch) HandleAllocator
+modTransHalloc = to _modTransHalloc
 
 typeToRegExpr :: MemType -> LLVMGenerator s arch ret (Some (Reg s))
 typeToRegExpr tp = do

--- a/crucible-llvm/test/MemSetup.hs
+++ b/crucible-llvm/test/MemSetup.hs
@@ -12,6 +12,7 @@ module MemSetup
   )
   where
 
+import           Control.Lens ( (^.) )
 import           Data.Parameterized.NatRepr
 import           Data.Parameterized.Nonce
 import           Data.Parameterized.Some
@@ -71,7 +72,8 @@ withLLVMCtx mod' action =
         let ?memOpts = LLVMMem.defaultMemOptions
         let ?transOpts = LLVMTr.defaultTranslationOptions
         memVar <- LLVMM.mkMemVar "test_llvm_memory" halloc
-        (Some (LLVMTr.ModuleTranslation _ ctx _ _), _warns) <- LLVMTr.translateModule halloc memVar mod'
+        Some mtrans <- LLVMTr.translateModule halloc memVar mod'
+        let ctx = mtrans ^. LLVMTr.transContext
         case LLVMTr.llvmArch ctx            of { LLVME.X86Repr width ->
         case assertLeq (knownNat @1)  width of { LeqProof      ->
         case assertLeq (knownNat @16) width of { LeqProof      -> do

--- a/crux-llvm/CHANGELOG.md
+++ b/crux-llvm/CHANGELOG.md
@@ -1,3 +1,13 @@
+# next
+
+## New features
+
+* When loading bitcode to execute, we now make use of a new feature
+of `crucible-llvm` which delays the translation of the LLVM bitcode
+until functions are actually called. This should speed up startup
+times and reduce memory usage for verification tasks where a small
+subset of functions in a bitcode module are actually executed.
+
 # 0.6
 
 ## New features

--- a/crux-llvm/src/Crux/LLVM/Simulate.hs
+++ b/crux-llvm/src/Crux/LLVM/Simulate.hs
@@ -59,7 +59,7 @@ import Lang.Crucible.Simulator.Profiling ( Metric(Metric) )
 
 
 -- crucible-llvm
-import Lang.Crucible.LLVM(llvmExtensionImpl, llvmGlobals, registerModule )
+import Lang.Crucible.LLVM(llvmExtensionImpl, llvmGlobals, registerLazyModule )
 import Lang.Crucible.LLVM.Bytes ( bytesToBV )
 import Lang.Crucible.LLVM.Globals
         ( initializeAllMemory, populateAllGlobals )
@@ -149,7 +149,7 @@ registerFunctions llvmOpts llvm_module mtrans fs0 =
        llvm_ctx
 
      -- register all the functions defined in the LLVM module
-     registerModule sayTranslationWarning llvm_ctx mtrans
+     registerLazyModule sayTranslationWarning llvm_ctx mtrans
 
 simulateLLVMFile ::
   Crux.Logs msgs =>

--- a/uc-crux-llvm/CHANGELOG.md
+++ b/uc-crux-llvm/CHANGELOG.md
@@ -3,6 +3,17 @@
   * `UCCrux.LLVM.Setup`: `generate` and `setupExecution`
   * `UCCrux.LLVM.Setup.Monad`: `malloc`
 
+* When loading bitcode to execute, we now make use of a new feature
+of `crucible-llvm` which delays the translation of the LLVM bitcode
+until functions are actually called. This should speed up startup
+times and reduce memory usage for verification tasks where a small
+subset of functions in a bitcode module are actually executed.
+
+* The types of `UCCrux.LLVM.Context.Module.findFun` and
+  `UCCrux.LLVM.FullType.Translation.translateModuleDefines` have
+  changed to accomodate the new lazy-loading feature.
+
+
 # 0.2
 * Add `?memOpts :: MemOptions` constraints to the following functions:
   * `UCCrux.LLVM.Mem`: `store`, `store'`, `storeGlobal`, and `storeGlobal'`

--- a/uc-crux-llvm/src/UCCrux/LLVM/Main.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Main.hs
@@ -13,6 +13,7 @@ Stability    : provisional
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PolyKinds #-}
@@ -250,7 +251,7 @@ translateLLVMModule llOpts halloc memVar moduleFilePath llvmMod =
       ( \ptrW ->
           withPtrWidth
             ptrW
-            ( case makeModuleContext moduleFilePath llvmMod trans of
+            ( makeModuleContext moduleFilePath llvmMod trans >>= \case
                 SomeModuleContext modCtx -> pure (SomeModuleContext' modCtx)
             )
       )

--- a/uc-crux-llvm/src/UCCrux/LLVM/Main.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Main.hs
@@ -243,7 +243,7 @@ translateLLVMModule ::
   IO SomeModuleContext'
 translateLLVMModule llOpts halloc memVar moduleFilePath llvmMod =
   do
-    (Some trans, _warns) <- -- TODO? should we do something with these warnings?
+    Some trans <-
       let ?transOpts = transOpts llOpts
        in translateModule halloc memVar llvmMod
     llvmPtrWidth

--- a/uc-crux-llvm/src/UCCrux/LLVM/Run/Check.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Run/Check.hs
@@ -201,7 +201,7 @@ checkInferredContracts appCtx modCtx funCtx halloc cruxOpts llOpts constraints c
         (Map.toList contracts)
         (\(func, Some (TypedPreconds tcs types)) ->
            do CFGWithTypes ovCfg argFTys _retTy _varArgs <-
-                pure (findFun modCtx (FuncDefnSymbol func))
+                findFun modCtx (FuncDefnSymbol func)
               let argCTys = Crucible.cfgArgTypes ovCfg
               let ovFunCtx = makeFunctionContext modCtx func argFTys argCTys
               let ?memOpts = CruxLLVM.memOpts llOpts
@@ -253,7 +253,7 @@ checkInferredContractsFromEntryPoints appCtx modCtx halloc cruxOpts llOpts entri
     for (getEntryPoints entries) $
       \entry ->
         do CFGWithTypes cfg argFTys _retTy _varArgs <-
-             pure (findFun modCtx (FuncDefnSymbol entry))
+             findFun modCtx (FuncDefnSymbol entry)
 
            let funCtx =
                  makeFunctionContext modCtx entry argFTys (Crucible.cfgArgTypes cfg)

--- a/uc-crux-llvm/src/UCCrux/LLVM/Run/Loop.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Run/Loop.hs
@@ -236,7 +236,7 @@ loopOnFunction appCtx modCtx halloc cruxOpts llOpts fn =
             ptrW
             ( do
                 CFGWithTypes cfg argFTys _retTy _varArgs <-
-                  pure (findFun modCtx (FuncDefnSymbol fn))
+                  findFun modCtx (FuncDefnSymbol fn)
                 let funCtx =
                       makeFunctionContext modCtx fn argFTys (Crucible.cfgArgTypes cfg)
                 (appCtx ^. log) Hi $ "Checking function " <> (funCtx ^. functionName)

--- a/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
@@ -268,7 +268,6 @@ registerDefinedFns ::
   Crucible.OverrideSim (personality sym) sym LLVM rtp l a ()
 registerDefinedFns appCtx modCtx =
   do let trans = modCtx ^. moduleTranslation
-     let llvmCtxt = trans ^. transContext
      for_ (trans ^. modTransDefs) $
        \decl ->
          do let s@(L.Symbol symb) = L.decName decl
@@ -277,7 +276,7 @@ registerDefinedFns appCtx modCtx =
                 Text.unwords ["Registering definition of", Text.pack symb]
             -- TODO? handle these warnings?
             let handleTranslationWarning _warn = return ()
-            registerLazyModuleFn handleTranslationWarning llvmCtxt trans s
+            registerLazyModuleFn handleTranslationWarning trans s
 
 mkCallbacks ::
   forall r m arch argTypes blocks ret msgs.

--- a/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
@@ -269,7 +269,7 @@ registerDefinedFns ::
 registerDefinedFns appCtx modCtx =
   do let trans = modCtx ^. moduleTranslation
      for_ (trans ^. modTransDefs) $
-       \decl ->
+       \(decl, _) ->
          do let s@(L.Symbol symb) = L.decName decl
             liftIO $
               (appCtx ^. log) Hi $

--- a/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
@@ -77,7 +77,7 @@ import qualified Lang.Crucible.Simulator as Crucible
 import qualified Lang.Crucible.Types as CrucibleTypes
 
 -- crucible-llvm
-import           Lang.Crucible.LLVM (llvmGlobalsToCtx, registerModuleFn)
+import           Lang.Crucible.LLVM (llvmGlobalsToCtx, registerLazyModuleFn)
 import qualified Lang.Crucible.LLVM.Errors as LLVMErrors
 import qualified Lang.Crucible.LLVM.Intrinsics as LLVMIntrinsics
 import           Lang.Crucible.LLVM.MemModel.CallStack (ppCallStack)
@@ -277,7 +277,7 @@ registerDefinedFns appCtx modCtx =
                 Text.unwords ["Registering definition of", Text.pack symb]
             -- TODO? handle these warnings?
             let handleTranslationWarning _warn = return ()
-            registerModuleFn handleTranslationWarning llvmCtxt trans s
+            registerLazyModuleFn handleTranslationWarning llvmCtxt trans s
 
 mkCallbacks ::
   forall r m arch argTypes blocks ret msgs.

--- a/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
@@ -275,7 +275,9 @@ registerDefinedFns appCtx modCtx =
             liftIO $
               (appCtx ^. log) Hi $
                 Text.unwords ["Registering definition of", Text.pack symb]
-            registerModuleFn llvmCtxt trans s
+            -- TODO? handle these warnings?
+            let handleTranslationWarning _warn = return ()
+            registerModuleFn handleTranslationWarning llvmCtxt trans s
 
 mkCallbacks ::
   forall r m arch argTypes blocks ret msgs.

--- a/uc-crux-llvm/src/UCCrux/LLVM/Setup.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Setup.hs
@@ -474,7 +474,7 @@ setupExecution appCtx modCtx funCtx bak constraints = do
   mem <-
     withTypeContext modCtx $
       liftIO $
-        LLVMGlobals.populateConstGlobals bak (LLVMTrans.globalInitMap moduleTrans)
+        LLVMGlobals.populateConstGlobals bak (moduleTrans ^. LLVMTrans.globalInitMap)
           =<< LLVMGlobals.initializeAllMemory bak llvmCtxt (modCtx ^. llvmModule . to getModule)
   runSetup modCtx mem $
     do

--- a/uc-crux-llvm/test/Check.hs
+++ b/uc-crux-llvm/test/Check.hs
@@ -85,7 +85,7 @@ checkOverrideTests =
                     modCtx
                     ( do
                         CFGWithTypes fcgf fArgFTys _retTy _varArgs <-
-                          pure (findFun modCtx (FuncDefnSymbol f))
+                          findFun modCtx (FuncDefnSymbol f)
 
                         let funCtxF = makeFunctionContext modCtx f fArgFTys (Crucible.cfgArgTypes fcgf)
 
@@ -146,7 +146,7 @@ checkOverrideTests =
                         -- Additional checks happen in the result hook,
                         -- see 'callbacks'.
                         CFGWithTypes gcfg gArgFTys _retTy _varArgs <-
-                          pure (findFun modCtx (FuncDefnSymbol g))
+                          findFun modCtx (FuncDefnSymbol g)
 
                         let funCtxG = makeFunctionContext modCtx g gArgFTys (Crucible.cfgArgTypes gcfg)
 

--- a/uc-crux-llvm/test/Utils.hs
+++ b/uc-crux-llvm/test/Utils.hs
@@ -222,7 +222,7 @@ simulateFunc file func makeCallbacks =
                 [functionNameFromString func]
            withModulePtrWidth modCtx $
              do CFGWithTypes cfg argFTys _retTy _varArgs <-
-                   pure (findFun modCtx (FuncDefnSymbol entry))
+                   findFun modCtx (FuncDefnSymbol entry)
                 let funCtx =
                       makeFunctionContext modCtx entry argFTys (Crucible.cfgArgTypes cfg)
                 -- TODO(lb): also provide these


### PR DESCRIPTION
This sets up the `ModuleTranslation` to perform translation to Crucible IR on-demand, instead of eagerly doing all the translation steps in the beginning. Hopefully, this will help with startup times and memory usage when loading large bitcode files.
