### PR TITLE
`crucible-llvm`: Export `ConversionDirective`

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/Printf.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Printf.hs
@@ -23,6 +23,7 @@ module Lang.Crucible.LLVM.Printf
 , PrintfConversionType(..)
 , PrintfDirective(..)
 , parseDirectives
+, ConversionDirective(..)
 , PrintfOperations(..)
 , executeDirectives
 ) where


### PR DESCRIPTION
While we currently export `PrintfDirective`, we do not export the `ConversionDirective` data type that is used in the data constructor of the same name in `PrintfDirective`. This makes it difficult to write custom `printf`-like overrides that need to perform analysis over the types of modifiers used in the format string. Since we export `PrintfDirective`, we might as well export `ConversionDirective` as well.