### PR TITLE
Export integer and rational formatters from printf override

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/Printf.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Printf.hs
@@ -26,6 +26,8 @@ module Lang.Crucible.LLVM.Printf
 , ConversionDirective(..)
 , PrintfOperations(..)
 , executeDirectives
+, formatInteger
+, formatRational
 ) where
 
 import           Data.Char (toUpper)


### PR DESCRIPTION
This change exports `formatInteger` and `formatRational` from `Lang.Crucible.LLVM.Printf` so that library users may use them to implement more overrides in the printf family. 