### PR TITLE
`crucible-syntax`: Export `isType`

### DIFF
--- a/crucible-syntax/src/Lang/Crucible/Syntax/Concrete.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Concrete.hs
@@ -40,6 +40,7 @@ module Lang.Crucible.Syntax.Concrete
   , atomName
   , freshAtom
   , nat
+  , isType
   , operands
   -- * Rules for pretty-printing language syntax
   , printExpr


### PR DESCRIPTION
This is needed to write parsers for `crucible-syntax` extensions that accept types as arguments, similar to how the `the` function takes a type as its first argument.