### PR TITLE
CI: Use macOS 12

### DIFF
--- a/.github/workflows/crucible-go-build.yml
+++ b/.github/workflows/crucible-go-build.yml
@@ -29,7 +29,7 @@ jobs:
         os: [ubuntu-20.04]
         ghc: ["8.10.7", "9.0.2", "9.2.3"]
         include:
-          - os: macos-10.15
+          - os: macos-12
             ghc: 9.2.2
           - os: windows-2019
             ghc: 9.2.2
@@ -64,7 +64,7 @@ jobs:
       - shell: bash
         run: .github/ci.sh install_system_deps
         env:
-          SOLVER_PKG_VERSION: "snapshot-20210917"
+          SOLVER_PKG_VERSION: "snapshot-20220721"
           BUILD_TARGET_OS: ${{ matrix.os }}
 
       - name: Setup Environment Vars

--- a/.github/workflows/crucible-jvm-build.yml
+++ b/.github/workflows/crucible-jvm-build.yml
@@ -29,7 +29,7 @@ jobs:
         os: [ubuntu-20.04]
         ghc: ["8.10.7", "9.0.2", "9.2.3"]
         include:
-          - os: macos-10.15
+          - os: macos-12
             ghc: 9.2.2
           - os: windows-2019
             ghc: 9.2.2
@@ -64,7 +64,7 @@ jobs:
       - shell: bash
         run: .github/ci.sh install_system_deps
         env:
-          SOLVER_PKG_VERSION: "snapshot-20210917"
+          SOLVER_PKG_VERSION: "snapshot-20220721"
           BUILD_TARGET_OS: ${{ matrix.os }}
 
       - name: Setup Environment Vars

--- a/.github/workflows/crucible-wasm-build.yml
+++ b/.github/workflows/crucible-wasm-build.yml
@@ -29,7 +29,7 @@ jobs:
         os: [ubuntu-20.04]
         ghc: ["8.10.7", "9.0.2", "9.2.3"]
         include:
-          - os: macos-10.15
+          - os: macos-12
             ghc: 9.2.2
           - os: windows-2019
             ghc: 9.2.2
@@ -64,7 +64,7 @@ jobs:
       - shell: bash
         run: .github/ci.sh install_system_deps
         env:
-          SOLVER_PKG_VERSION: "snapshot-20210917"
+          SOLVER_PKG_VERSION: "snapshot-20220721"
           BUILD_TARGET_OS: ${{ matrix.os }}
 
       - name: Setup Environment Vars

--- a/.github/workflows/crux-llvm-build.yml
+++ b/.github/workflows/crux-llvm-build.yml
@@ -50,7 +50,7 @@ jobs:
             ghc: 8.8.4
           - os: ubuntu-18.04
             ghc: 9.2.2
-          - os: macos-10.15
+          - os: macos-12
             ghc: 9.2.2
           - os: windows-2019
             ghc: 9.2.2
@@ -85,7 +85,7 @@ jobs:
       - shell: bash
         run: .github/ci.sh install_system_deps
         env:
-          SOLVER_PKG_VERSION: "snapshot-20210917"
+          SOLVER_PKG_VERSION: "snapshot-20220721"
           BUILD_TARGET_OS: ${{ matrix.os }}
 
       - name: Setup Environment Vars

--- a/.github/workflows/crux-mir-build.yml
+++ b/.github/workflows/crux-mir-build.yml
@@ -43,7 +43,7 @@ jobs:
         os: [ubuntu-20.04]
         ghc: ["8.10.7", "9.0.2", "9.2.3"]
         include:
-          - os: macos-10.15
+          - os: macos-12
             ghc: 9.2.2
           # We want Windows soon, but it doesn't need to be now
     name: crux-mir - GHC v${{ matrix.ghc }} - ${{ matrix.os }}
@@ -84,7 +84,7 @@ jobs:
       - shell: bash
         run: .github/ci.sh install_system_deps
         env:
-          SOLVER_PKG_VERSION: "snapshot-20210917"
+          SOLVER_PKG_VERSION: "snapshot-20220721"
           BUILD_TARGET_OS: ${{ matrix.os }}
 
       - name: Setup Environment Vars


### PR DESCRIPTION
GitHub is deprecating (and eventually removing) its macOS 10.15 runners. See actions/virtual-environments#5583. Let's upgrade to a newer version in the CI. This proves relatively straightforward—the only other change required is to upgrade to a newer version of `what4-solvers`.