### PR TITLE
uc-crux-llvm: Export Aeson options used to derive JSON instances

### DIFF
--- a/uc-crux-llvm/src/UCCrux/LLVM/View.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/View.hs
@@ -26,20 +26,6 @@ The view datatypes are all in modules using the @StrictData@ language extension.
 This is because their primary use is serialization, which will result in
 complete evaluation, eliminating the benefits of laziness.
 
-Note [JSON instance tweaks]: JSON instances for various datatypes are derived
-using 'Data.Aeson.TH.deriveJSON', with some tweaks to
-'Data.Aeson.defaultOptions'. These tweaks remove unnecessary Haskell idioms from
-the JSON representation. For example, it's common in Haskell code for all record
-selectors for the same type to share a common prefix, e.g., "pt" in
-
-> data Point2D = Point2D { ptX :: Int, ptY :: Int }
-
-This idiom is used in part to avoid name clashes due to the lack of namespacing
-for record selectors. There is no need for the JSON representation to reflect
-this implementation detail, and removing such prefixes makes the JSON more terse,
-hopefully making it use less RAM/disk space and network bandwidth, and making
-it easier to write by hand (especially for users not familiar with Haskell
-coding conventions).
 -}
 
 module UCCrux.LLVM.View

--- a/uc-crux-llvm/src/UCCrux/LLVM/View.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/View.hs
@@ -26,6 +26,7 @@ The view datatypes are all in modules using the @StrictData@ language extension.
 This is because their primary use is serialization, which will result in
 complete evaluation, eliminating the benefits of laziness.
 
+See also "UCCrux.LLVM.View.Options".
 -}
 
 module UCCrux.LLVM.View

--- a/uc-crux-llvm/src/UCCrux/LLVM/View/Constraint.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/View/Constraint.hs
@@ -41,7 +41,6 @@ module UCCrux.LLVM.View.Constraint
 where
 
 import           Control.Monad (when)
-import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.TH as Aeson.TH
 import qualified Data.BitVector.Sized as BV
 import           Data.Functor.Compose (Compose(Compose, getCompose))
@@ -63,7 +62,7 @@ import           UCCrux.LLVM.Constraints (Constraint(..), ConstrainedShape(..), 
 import           UCCrux.LLVM.FullType.PP (ppFullTypeRepr)
 import           UCCrux.LLVM.FullType.Type (FullTypeRepr(..), SomeFullTypeRepr(..), ModuleTypes)
 import           UCCrux.LLVM.View.FullType (FullTypeReprView, FullTypeReprViewError, fullTypeReprView, viewFullTypeRepr, ppFullTypeReprViewError)
-import qualified UCCrux.LLVM.View.Idioms as Idioms
+import qualified UCCrux.LLVM.View.Options.Constraint as Opts
 import           UCCrux.LLVM.View.Shape (ShapeView, ViewShapeError, shapeView, viewShape, ppViewShapeError)
 import           UCCrux.LLVM.View.Util () -- Alignment, ICmpOp instance
 
@@ -244,13 +243,6 @@ viewConstrainedTypedValue mts (ConstrainedTypedValueView vty vval) =
        liftError ViewConstrainedShapeError (viewConstrainedShape mts ft vval)
      return (ConstrainedTypedValue ft shape)
 
--- See module docs for "UCCrux.LLVM.View.Idioms".
-$(Aeson.TH.deriveJSON
-  (Idioms.constructorSuffix "View" Aeson.defaultOptions)
-  ''ConstraintView)
-$(Aeson.TH.deriveJSON
-  Aeson.defaultOptions { Aeson.unwrapUnaryRecords = True }
-  ''ConstrainedShapeView)
-$(Aeson.TH.deriveJSON
-  (Idioms.recordSelectorPrefix "vConstrained" Aeson.defaultOptions)
-  ''ConstrainedTypedValueView)
+$(Aeson.TH.deriveJSON Opts.constraint ''ConstraintView)
+$(Aeson.TH.deriveJSON Opts.constrainedShape ''ConstrainedShapeView)
+$(Aeson.TH.deriveJSON Opts.constrainedTypedValue ''ConstrainedTypedValueView)

--- a/uc-crux-llvm/src/UCCrux/LLVM/View/Constraint.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/View/Constraint.hs
@@ -63,6 +63,7 @@ import           UCCrux.LLVM.Constraints (Constraint(..), ConstrainedShape(..), 
 import           UCCrux.LLVM.FullType.PP (ppFullTypeRepr)
 import           UCCrux.LLVM.FullType.Type (FullTypeRepr(..), SomeFullTypeRepr(..), ModuleTypes)
 import           UCCrux.LLVM.View.FullType (FullTypeReprView, FullTypeReprViewError, fullTypeReprView, viewFullTypeRepr, ppFullTypeReprViewError)
+import qualified UCCrux.LLVM.View.Idioms as Idioms
 import           UCCrux.LLVM.View.Shape (ShapeView, ViewShapeError, shapeView, viewShape, ppViewShapeError)
 import           UCCrux.LLVM.View.Util () -- Alignment, ICmpOp instance
 
@@ -243,17 +244,13 @@ viewConstrainedTypedValue mts (ConstrainedTypedValueView vty vval) =
        liftError ViewConstrainedShapeError (viewConstrainedShape mts ft vval)
      return (ConstrainedTypedValue ft shape)
 
--- See Note [JSON instance tweaks].
+-- See module docs for "UCCrux.LLVM.View.Idioms".
 $(Aeson.TH.deriveJSON
-  Aeson.defaultOptions
-    { Aeson.constructorTagModifier =
-        reverse . drop (length ("View" :: String)) . reverse
-    }
+  (Idioms.constructorSuffix "View" Aeson.defaultOptions)
   ''ConstraintView)
 $(Aeson.TH.deriveJSON
   Aeson.defaultOptions { Aeson.unwrapUnaryRecords = True }
   ''ConstrainedShapeView)
 $(Aeson.TH.deriveJSON
-  Aeson.defaultOptions
-    { Aeson.fieldLabelModifier = drop (length ("vConstrained" :: String)) }
+  (Idioms.recordSelectorPrefix "vConstrained" Aeson.defaultOptions)
   ''ConstrainedTypedValueView)

--- a/uc-crux-llvm/src/UCCrux/LLVM/View/Cursor.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/View/Cursor.hs
@@ -25,7 +25,6 @@ where
 
 import           Control.Lens ((^.))
 import           Control.Monad (when)
-import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.TH as Aeson.TH
 import           GHC.Generics (Generic)
 import           Numeric.Natural (Natural)
@@ -41,7 +40,7 @@ import           Data.Parameterized.Some (Some(Some))
 import           UCCrux.LLVM.Cursor (Cursor(..))
 import           UCCrux.LLVM.FullType.Type (FullTypeRepr(..), SomeFullTypeRepr(..), ModuleTypes, asFullType)
 import           UCCrux.LLVM.FullType.PP (ppFullTypeRepr)
-import qualified UCCrux.LLVM.View.Idioms as Idioms
+import qualified UCCrux.LLVM.View.Options.Cursor as Opts
 
 data ViewCursorError
   = StructBadIndex !Int
@@ -130,7 +129,4 @@ viewCursor mts ft vcur =
         Nothing -> Left err
         Just v -> Right v
 
--- See module docs for "UCCrux.LLVM.View.Idioms".
-$(Aeson.TH.deriveJSON
-  (Idioms.constructorSuffix "View" Aeson.defaultOptions)
-  ''CursorView)
+$(Aeson.TH.deriveJSON Opts.cursor ''CursorView)

--- a/uc-crux-llvm/src/UCCrux/LLVM/View/Cursor.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/View/Cursor.hs
@@ -40,7 +40,8 @@ import           Data.Parameterized.Some (Some(Some))
 
 import           UCCrux.LLVM.Cursor (Cursor(..))
 import           UCCrux.LLVM.FullType.Type (FullTypeRepr(..), SomeFullTypeRepr(..), ModuleTypes, asFullType)
-import UCCrux.LLVM.FullType.PP (ppFullTypeRepr)
+import           UCCrux.LLVM.FullType.PP (ppFullTypeRepr)
+import qualified UCCrux.LLVM.View.Idioms as Idioms
 
 data ViewCursorError
   = StructBadIndex !Int
@@ -129,5 +130,7 @@ viewCursor mts ft vcur =
         Nothing -> Left err
         Just v -> Right v
 
--- See Note [JSON instance tweaks].
-$(Aeson.TH.deriveJSON Aeson.defaultOptions ''CursorView)
+-- See module docs for "UCCrux.LLVM.View.Idioms".
+$(Aeson.TH.deriveJSON
+  (Idioms.constructorSuffix "View" Aeson.defaultOptions)
+  ''CursorView)

--- a/uc-crux-llvm/src/UCCrux/LLVM/View/FullType.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/View/FullType.hs
@@ -36,7 +36,6 @@ module UCCrux.LLVM.View.FullType
   )
 where
 
-import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.TH as Aeson.TH
 import qualified Data.Text as Text
 import           GHC.Generics (Generic)
@@ -59,7 +58,7 @@ import           What4.InterpretedFloatingPoint (FloatInfoRepr)
 import           UCCrux.LLVM.FullType.Type (FullTypeRepr(..), PartTypeRepr, aliasOrFullType, ModuleTypes, toPartType, makePartTypeRepr, StructPackedRepr(PackedStructRepr, UnpackedStructRepr))
 import           UCCrux.LLVM.View.Util (TypeName(..), Width (Width))
 import           UCCrux.LLVM.FullType.VarArgs (VarArgsRepr(IsVarArgsRepr, NotVarArgsRepr))
-import qualified UCCrux.LLVM.View.Idioms as Idioms
+import qualified UCCrux.LLVM.View.Options.FullType as Opts
 import           UCCrux.LLVM.View.TH (deriveMutualJSON)
 
 data VarArgsReprView
@@ -242,25 +241,10 @@ viewPartTypeRepr mts =
            Just spt -> Right spt
            Nothing -> Left (BadAlias iden)
 
--- See module docs for "UCCrux.LLVM.View.Idioms".
-$(Aeson.TH.deriveJSON
-  (Idioms.constructorSuffix "ReprView" Aeson.defaultOptions)
-  ''StructPackedReprView)
-$(Aeson.TH.deriveJSON
-  (Idioms.constructorSuffix "ReprView" Aeson.defaultOptions)
-  ''VarArgsReprView)
-$(Aeson.TH.deriveJSON
-  (Idioms.constructorSuffix "ReprView" Aeson.defaultOptions)
-  ''FloatInfoReprView)
+$(Aeson.TH.deriveJSON Opts.structPackedRepr ''StructPackedReprView)
+$(Aeson.TH.deriveJSON Opts.varArgsRepr ''VarArgsReprView)
+$(Aeson.TH.deriveJSON Opts.floatInfoRepr ''FloatInfoReprView)
 $(deriveMutualJSON
-  [ ( Idioms.constructorSuffix "ReprView" $
-        Idioms.constructorPrefix "FT" $
-        Aeson.defaultOptions
-    , ''FullTypeReprView
-    )
-  , ( Idioms.constructorSuffix "ReprView" $
-        Idioms.constructorPrefix "PT" $
-        Aeson.defaultOptions
-    , ''PartTypeReprView
-    )
+  [ (Opts.fullTypeRepr, ''FullTypeReprView)
+  , (Opts.partTypeRepr, ''PartTypeReprView)
   ])

--- a/uc-crux-llvm/src/UCCrux/LLVM/View/FullType.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/View/FullType.hs
@@ -253,7 +253,14 @@ $(Aeson.TH.deriveJSON
   (Idioms.constructorSuffix "ReprView" Aeson.defaultOptions)
   ''FloatInfoReprView)
 $(deriveMutualJSON
-  (Idioms.constructorSuffix "ReprView" $
-    Idioms.constructorPrefix "FT" $  -- or "PT"
-    Aeson.defaultOptions)
-  [''FullTypeReprView, ''PartTypeReprView])
+  [ ( Idioms.constructorSuffix "ReprView" $
+        Idioms.constructorPrefix "FT" $
+        Aeson.defaultOptions
+    , ''FullTypeReprView
+    )
+  , ( Idioms.constructorSuffix "ReprView" $
+        Idioms.constructorPrefix "PT" $
+        Aeson.defaultOptions
+    , ''PartTypeReprView
+    )
+  ])

--- a/uc-crux-llvm/src/UCCrux/LLVM/View/FullType.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/View/FullType.hs
@@ -59,6 +59,7 @@ import           What4.InterpretedFloatingPoint (FloatInfoRepr)
 import           UCCrux.LLVM.FullType.Type (FullTypeRepr(..), PartTypeRepr, aliasOrFullType, ModuleTypes, toPartType, makePartTypeRepr, StructPackedRepr(PackedStructRepr, UnpackedStructRepr))
 import           UCCrux.LLVM.View.Util (TypeName(..), Width (Width))
 import           UCCrux.LLVM.FullType.VarArgs (VarArgsRepr(IsVarArgsRepr, NotVarArgsRepr))
+import qualified UCCrux.LLVM.View.Idioms as Idioms
 import           UCCrux.LLVM.View.TH (deriveMutualJSON)
 
 data VarArgsReprView
@@ -241,16 +242,18 @@ viewPartTypeRepr mts =
            Just spt -> Right spt
            Nothing -> Left (BadAlias iden)
 
--- See Note [JSON instance tweaks].
-$(Aeson.TH.deriveJSON Aeson.defaultOptions ''StructPackedReprView)
-$(Aeson.TH.deriveJSON Aeson.defaultOptions ''VarArgsReprView)
-$(Aeson.TH.deriveJSON Aeson.defaultOptions ''FloatInfoReprView)
+-- See module docs for "UCCrux.LLVM.View.Idioms".
+$(Aeson.TH.deriveJSON
+  (Idioms.constructorSuffix "ReprView" Aeson.defaultOptions)
+  ''StructPackedReprView)
+$(Aeson.TH.deriveJSON
+  (Idioms.constructorSuffix "ReprView" Aeson.defaultOptions)
+  ''VarArgsReprView)
+$(Aeson.TH.deriveJSON
+  (Idioms.constructorSuffix "ReprView" Aeson.defaultOptions)
+  ''FloatInfoReprView)
 $(deriveMutualJSON
-  Aeson.defaultOptions
-    { Aeson.constructorTagModifier =
-        reverse .
-          drop (length ("ReprView" :: String)) .
-          reverse .
-          drop (length ("FT" :: String))  -- or "PT"
-    }
+  (Idioms.constructorSuffix "ReprView" $
+    Idioms.constructorPrefix "FT" $  -- or "PT"
+    Aeson.defaultOptions)
   [''FullTypeReprView, ''PartTypeReprView])

--- a/uc-crux-llvm/src/UCCrux/LLVM/View/Idioms.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/View/Idioms.hs
@@ -1,0 +1,68 @@
+{-
+Module      : UCCrux.LLVM.View.Idioms
+Description : Tweak 'Aeson.Options' to remove Haskell idioms from JSON instances.
+Copyright   : (c) Galois, Inc 2022
+License     : BSD3
+Maintainer  : Langston Barrett <langston@galois.com>
+Stability   : provisional
+
+This module contains helper functions for tweaking 'Aeson.Options' to remove
+unnecessary Haskell idioms from the JSON representations. There is no need for
+the JSON representation to reflect implementation details, and removing such can
+make the JSON more terse, hopefully making it use less RAM/disk space and
+network bandwidth, and making it easier to write by hand (especially for users
+not familiar with Haskell coding conventions).
+
+The helpers in this module post-compose their modifications with those already
+specified in the 'Aeson.fieldLabelModifier' and 'Aeson.constructorTagModifier'
+fields of 'Aeson.Options'.
+-}
+
+module UCCrux.LLVM.View.Idioms
+  ( constructorPrefix
+  , constructorSuffix
+  , recordSelectorPrefix
+  )
+where
+
+import qualified Data.Aeson as Aeson
+
+-- | Drop shared prefixes from sum type constructors.
+--
+-- It's common in Haskell code for all constructors of a type to share a common
+-- prefix, e.g., "Color" in
+--
+-- > data Color = ColorGreen | ColorBlue
+constructorPrefix :: String -> Aeson.Options -> Aeson.Options
+constructorPrefix s opts =
+  opts { Aeson.constructorTagModifier =
+           drop (length s) . Aeson.constructorTagModifier opts
+       }
+
+-- | Drop shared suffixes from sum type constructors.
+--
+-- It's common in Haskell code for all constructors of a type to share a common
+-- suffix, e.g., "Box" in
+--
+-- > data Box = BigBox | SmallBox
+constructorSuffix :: String -> Aeson.Options -> Aeson.Options
+constructorSuffix s opts =
+  opts { Aeson.constructorTagModifier =
+           dropSuffix (length s) . Aeson.constructorTagModifier opts
+       }
+  where dropSuffix l = reverse . drop l . reverse
+
+-- | Drop shared prefixes from record selector (i.e., field) names.
+--
+-- It's common in Haskell code for all record selectors for the same type to
+-- share a common prefix, e.g., "pt" in
+--
+-- > data Point2D = Point2D { ptX :: Int, ptY :: Int }
+--
+-- This idiom is used in part to avoid name clashes due to the lack of
+-- namespacing for record selectors.
+recordSelectorPrefix :: String -> Aeson.Options -> Aeson.Options
+recordSelectorPrefix s opts =
+  opts { Aeson.fieldLabelModifier =
+           drop (length s) . Aeson.fieldLabelModifier opts
+       }

--- a/uc-crux-llvm/src/UCCrux/LLVM/View/Options.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/View/Options.hs
@@ -1,0 +1,23 @@
+{-
+Module           : UCCrux.LLVM.View.Options
+Description      : 'Data.Aeson.Options' used to derive JSON instances
+Copyright        : (c) Galois, Inc 2022
+License          : BSD3
+Maintainer       : Langston Barrett <langston@galois.com>
+Stability        : provisional
+
+These modules export the 'Data.Aeson.Options' passed to
+'Data.Aeson.TH.deriveJSON' for each "view" type. Since these influence the
+serialized representation, these details are necessarily public. Also, they are
+useful to library clients such as those using the aeson-typescript package,
+which requires that its @TypeScript@ instances be generated using the same
+'Data.Aeson.Options' as the corresponding JSON instances.
+
+These must be in separate modules from the corresponding types due to staging
+restrictions from the use of Template Haskell to generate the JSON instances.
+
+For details on how these options are constructed, see
+"UCCrux.LLVM.View.Options.Idioms".
+-}
+
+module UCCrux.LLVM.View.Options () where

--- a/uc-crux-llvm/src/UCCrux/LLVM/View/Options/Constraint.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/View/Options/Constraint.hs
@@ -1,0 +1,37 @@
+{-
+Module           : UCCrux.LLVM.View.Options.Constraint
+Description      : 'Aeson.Options' used in "UCCrux.LLVM.View.Constraint"
+Copyright        : (c) Galois, Inc 2022
+License          : BSD3
+Maintainer       : Langston Barrett <langston@galois.com>
+Stability        : provisional
+
+This module is intended to be imported qualified as \"Opts\".
+-}
+
+module UCCrux.LLVM.View.Options.Constraint
+  ( constraint
+  , constrainedShape
+  , constrainedTypedValue
+  )
+where
+
+import qualified Data.Aeson as Aeson
+
+import qualified UCCrux.LLVM.View.Options.Idioms as Idioms
+
+-- | Options used to derive JSON instances for
+-- 'UCCrux.LLVM.View.Constraint.ConstraintView'.
+constraint :: Aeson.Options
+constraint = Idioms.constructorSuffix "View" Aeson.defaultOptions
+
+-- | Options used to derive JSON instances for
+-- 'UCCrux.LLVM.View.Constraint.ConstrainedShapeView'.
+constrainedShape :: Aeson.Options
+constrainedShape = Aeson.defaultOptions { Aeson.unwrapUnaryRecords = True }
+
+-- | Options used to derive JSON instances for
+-- 'UCCrux.LLVM.View.Constraint.ConstrainedTypedValue'.
+constrainedTypedValue :: Aeson.Options
+constrainedTypedValue =
+  Idioms.recordSelectorPrefix "vConstrained" Aeson.defaultOptions

--- a/uc-crux-llvm/src/UCCrux/LLVM/View/Options/Cursor.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/View/Options/Cursor.hs
@@ -1,0 +1,24 @@
+{-
+Module           : UCCrux.LLVM.View.Options.Cursor
+Description      : 'Aeson.Options' used in "UCCrux.LLVM.View.Cursor"
+Copyright        : (c) Galois, Inc 2022
+License          : BSD3
+Maintainer       : Langston Barrett <langston@galois.com>
+Stability        : provisional
+
+This module is intended to be imported qualified as \"Opts\".
+-}
+
+module UCCrux.LLVM.View.Options.Cursor
+  ( cursor
+  )
+where
+
+import qualified Data.Aeson as Aeson
+
+import qualified UCCrux.LLVM.View.Options.Idioms as Idioms
+
+-- | Options used to derive JSON instances for
+-- 'UCCrux.LLVM.View.Cursor.CursorView'.
+cursor :: Aeson.Options
+cursor = Idioms.constructorSuffix "View" Aeson.defaultOptions

--- a/uc-crux-llvm/src/UCCrux/LLVM/View/Options/FullType.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/View/Options/FullType.hs
@@ -1,0 +1,52 @@
+{-
+Module           : UCCrux.LLVM.View.Options.FullType
+Description      : 'Aeson.Options' used in "UCCrux.LLVM.View.FullType"
+Copyright        : (c) Galois, Inc 2022
+License          : BSD3
+Maintainer       : Langston Barrett <langston@galois.com>
+Stability        : provisional
+
+This module is intended to be imported qualified as \"Opts\".
+-}
+
+module UCCrux.LLVM.View.Options.FullType
+  ( structPackedRepr
+  , varArgsRepr
+  , floatInfoRepr
+  , fullTypeRepr
+  , partTypeRepr
+  )
+where
+
+import qualified Data.Aeson as Aeson
+
+import qualified UCCrux.LLVM.View.Options.Idioms as Idioms
+
+-- | Options used to derive JSON instances for
+-- 'UCCrux.LLVM.View.FullType.StructPackedReprView'.
+structPackedRepr :: Aeson.Options
+structPackedRepr = Idioms.constructorSuffix "ReprView" Aeson.defaultOptions
+
+-- | Options used to derive JSON instances for
+-- 'UCCrux.LLVM.View.FullType.VarArgsReprView'.
+varArgsRepr :: Aeson.Options
+varArgsRepr = Idioms.constructorSuffix "ReprView" Aeson.defaultOptions
+
+-- | Options used to derive JSON instances for
+-- 'UCCrux.LLVM.View.FullType.FloatInfoReprView'.
+floatInfoRepr :: Aeson.Options
+floatInfoRepr = Idioms.constructorSuffix "ReprView" Aeson.defaultOptions
+
+-- | Options used to derive JSON instances for
+-- 'UCCrux.LLVM.View.FullType.FullTypeReprView'.
+fullTypeRepr :: Aeson.Options
+fullTypeRepr =
+  Idioms.constructorSuffix "ReprView" $
+    Idioms.constructorPrefix "FT" Aeson.defaultOptions
+
+-- | Options used to derive JSON instances for
+-- 'UCCrux.LLVM.View.PartType.PartTypeReprView'.
+partTypeRepr :: Aeson.Options
+partTypeRepr =
+  Idioms.constructorSuffix "ReprView" $
+    Idioms.constructorPrefix "PT" Aeson.defaultOptions

--- a/uc-crux-llvm/src/UCCrux/LLVM/View/Options/Idioms.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/View/Options/Idioms.hs
@@ -18,7 +18,7 @@ specified in the 'Aeson.fieldLabelModifier' and 'Aeson.constructorTagModifier'
 fields of 'Aeson.Options'.
 -}
 
-module UCCrux.LLVM.View.Idioms
+module UCCrux.LLVM.View.Options.Idioms
   ( constructorPrefix
   , constructorSuffix
   , recordSelectorPrefix

--- a/uc-crux-llvm/src/UCCrux/LLVM/View/Options/Postcond.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/View/Options/Postcond.hs
@@ -1,0 +1,36 @@
+{-
+Module           : UCCrux.LLVM.View.Options.Postcond
+Description      : 'Aeson.Options' used in "UCCrux.LLVM.View.Postcond"
+Copyright        : (c) Galois, Inc 2022
+License          : BSD3
+Maintainer       : Langston Barrett <langston@galois.com>
+Stability        : provisional
+
+This module is intended to be imported qualified as \"Opts\".
+-}
+
+module UCCrux.LLVM.View.Options.Postcond
+  ( clobberValue
+  , clobberArg
+  , uPostcond
+  )
+where
+
+import qualified Data.Aeson as Aeson
+
+import qualified UCCrux.LLVM.View.Options.Idioms as Idioms
+
+-- | Options used to derive JSON instances for
+-- 'UCCrux.LLVM.View.Postcond.ClobberValueView'.
+clobberValue :: Aeson.Options
+clobberValue = Idioms.recordSelectorPrefix "vClobber" Aeson.defaultOptions
+
+-- | Options used to derive JSON instances for
+-- 'UCCrux.LLVM.View.Postcond.ClobberArgView'.
+clobberArg :: Aeson.Options
+clobberArg = Idioms.constructorSuffix "View" Aeson.defaultOptions
+
+-- | Options used to derive JSON instances for
+-- 'UCCrux.LLVM.View.Postcond.UPostcondView'.
+uPostcond :: Aeson.Options
+uPostcond = Idioms.recordSelectorPrefix "vU" Aeson.defaultOptions

--- a/uc-crux-llvm/src/UCCrux/LLVM/View/Options/Precond.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/View/Options/Precond.hs
@@ -1,0 +1,24 @@
+{-
+Module           : UCCrux.LLVM.View.Options.Precond
+Description      : 'Aeson.Options' used in "UCCrux.LLVM.View.Precond"
+Copyright        : (c) Galois, Inc 2022
+License          : BSD3
+Maintainer       : Langston Barrett <langston@galois.com>
+Stability        : provisional
+
+This module is intended to be imported qualified as \"Opts\".
+-}
+
+module UCCrux.LLVM.View.Options.Precond
+  ( preconds
+  )
+where
+
+import qualified Data.Aeson as Aeson
+
+import qualified UCCrux.LLVM.View.Options.Idioms as Idioms
+
+-- | Options used to derive JSON instances for
+-- 'UCCrux.LLVM.View.Precond.PrecondsView'.
+preconds :: Aeson.Options
+preconds = Idioms.recordSelectorPrefix "v" Aeson.defaultOptions

--- a/uc-crux-llvm/src/UCCrux/LLVM/View/Options/Shape.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/View/Options/Shape.hs
@@ -1,0 +1,34 @@
+{-
+Module           : UCCrux.LLVM.View.Options.Shape
+Description      : 'Aeson.Options' used in "UCCrux.LLVM.View.Shape"
+Copyright        : (c) Galois, Inc 2022
+License          : BSD3
+Maintainer       : Langston Barrett <langston@galois.com>
+Stability        : provisional
+
+This module is intended to be imported qualified as \"Opts\".
+-}
+
+module UCCrux.LLVM.View.Options.Shape
+  ( ptrShape
+  , shape
+  )
+where
+
+import qualified Data.Aeson as Aeson
+
+import qualified UCCrux.LLVM.View.Options.Idioms as Idioms
+
+-- | Options used to derive JSON instances for
+-- 'UCCrux.LLVM.View.Shape.PtrShapeView'.
+ptrShape :: Aeson.Options
+ptrShape =
+  Idioms.constructorSuffix "View" $
+    Idioms.constructorPrefix "Shape" Aeson.defaultOptions
+
+-- | Options used to derive JSON instances for
+-- 'UCCrux.LLVM.View.Shape.ShapeView'.
+shape :: Aeson.Options
+shape =
+  Idioms.constructorSuffix "View" $
+    Idioms.constructorPrefix "Shape" Aeson.defaultOptions

--- a/uc-crux-llvm/src/UCCrux/LLVM/View/Options/Specs.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/View/Options/Specs.hs
@@ -1,0 +1,42 @@
+{-
+Module           : UCCrux.LLVM.View.Options.Specs
+Description      : 'Aeson.Options' used in "UCCrux.LLVM.View.Specs"
+Copyright        : (c) Galois, Inc 2022
+License          : BSD3
+Maintainer       : Langston Barrett <langston@galois.com>
+Stability        : provisional
+
+This module is intended to be imported qualified as \"Opts\".
+-}
+
+module UCCrux.LLVM.View.Options.Specs
+  ( specPreconds
+  , specSoundness
+  , spec
+  , specs
+  )
+where
+
+import qualified Data.Aeson as Aeson
+
+import qualified UCCrux.LLVM.View.Options.Idioms as Idioms
+
+-- | Options used to derive JSON instances for
+-- 'UCCrux.LLVM.View.Specs.SpecPrecondsView'.
+specPreconds :: Aeson.Options
+specPreconds = Idioms.recordSelectorPrefix "vSpec" Aeson.defaultOptions
+
+-- | Options used to derive JSON instances for
+-- 'UCCrux.LLVM.View.Specs.SpecSoundnessView'.
+specSoundness :: Aeson.Options
+specSoundness = Idioms.constructorSuffix "View" Aeson.defaultOptions
+
+-- | Options used to derive JSON instances for
+-- 'UCCrux.LLVM.View.Specs.SpecView'.
+spec :: Aeson.Options
+spec = Idioms.recordSelectorPrefix "vSpec" Aeson.defaultOptions
+
+-- | Options used to derive JSON instances for
+-- 'UCCrux.LLVM.View.Specss.SpecsView'.
+specs :: Aeson.Options
+specs = Aeson.defaultOptions { Aeson.unwrapUnaryRecords = True }

--- a/uc-crux-llvm/src/UCCrux/LLVM/View/Postcond.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/View/Postcond.hs
@@ -37,7 +37,6 @@ module UCCrux.LLVM.View.Postcond
 where
 
 import           Control.Lens ((^.), itraverse)
-import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.TH as Aeson.TH
 import           Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap
@@ -67,9 +66,9 @@ import           UCCrux.LLVM.FullType.Type (FullTypeRepr(..), SomeFullTypeRepr(.
 import           UCCrux.LLVM.Module (globalSymbolToString, makeGlobalSymbol, moduleGlobalMap, globalSymbol)
 import           UCCrux.LLVM.View.Constraint (ViewConstrainedShapeError, ConstrainedShapeView, ConstrainedTypedValueViewError, ConstrainedTypedValueView, constrainedShapeView, viewConstrainedShape, ppViewConstrainedShapeError, viewConstrainedTypedValue, constrainedTypedValueView, ppConstrainedTypedValueViewError)
 import           UCCrux.LLVM.View.Cursor (ViewCursorError, CursorView, cursorView, viewCursor, ppViewCursorError)
+import qualified UCCrux.LLVM.View.Options.Postcond as Opts
 import           UCCrux.LLVM.View.Shape (ViewShapeError, ppViewShapeError)
 import           UCCrux.LLVM.View.FullType (FullTypeReprView, FullTypeReprViewError, fullTypeReprView, viewFullTypeRepr, ppFullTypeReprViewError)
-import qualified UCCrux.LLVM.View.Idioms as Idioms
 import           UCCrux.LLVM.View.Util (GlobalVarName(..))
 
 -- Helper, not exported. Equivalent to Data.Bifunctor.first.
@@ -285,13 +284,6 @@ viewUPostcond modCtx fs vup =
          cv <- liftError ViewClobberValueError (viewClobberValue mts gTy vcv)
          return (gSymb, SomeClobberValue cv)
 
--- See module docs for "UCCrux.LLVM.View.Idioms".
-$(Aeson.TH.deriveJSON
-  (Idioms.recordSelectorPrefix "vClobber" Aeson.defaultOptions)
-  ''ClobberValueView)
-$(Aeson.TH.deriveJSON
-  (Idioms.constructorSuffix "View" Aeson.defaultOptions)
-  ''ClobberArgView)
-$(Aeson.TH.deriveJSON
-  (Idioms.recordSelectorPrefix "vU" Aeson.defaultOptions)
-  ''UPostcondView)
+$(Aeson.TH.deriveJSON Opts.clobberValue ''ClobberValueView)
+$(Aeson.TH.deriveJSON Opts.clobberArg ''ClobberArgView)
+$(Aeson.TH.deriveJSON Opts.uPostcond ''UPostcondView)

--- a/uc-crux-llvm/src/UCCrux/LLVM/View/Postcond.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/View/Postcond.hs
@@ -69,6 +69,7 @@ import           UCCrux.LLVM.View.Constraint (ViewConstrainedShapeError, Constra
 import           UCCrux.LLVM.View.Cursor (ViewCursorError, CursorView, cursorView, viewCursor, ppViewCursorError)
 import           UCCrux.LLVM.View.Shape (ViewShapeError, ppViewShapeError)
 import           UCCrux.LLVM.View.FullType (FullTypeReprView, FullTypeReprViewError, fullTypeReprView, viewFullTypeRepr, ppFullTypeReprViewError)
+import qualified UCCrux.LLVM.View.Idioms as Idioms
 import           UCCrux.LLVM.View.Util (GlobalVarName(..))
 
 -- Helper, not exported. Equivalent to Data.Bifunctor.first.
@@ -284,18 +285,13 @@ viewUPostcond modCtx fs vup =
          cv <- liftError ViewClobberValueError (viewClobberValue mts gTy vcv)
          return (gSymb, SomeClobberValue cv)
 
--- See Note [JSON instance tweaks].
+-- See module docs for "UCCrux.LLVM.View.Idioms".
 $(Aeson.TH.deriveJSON
-  Aeson.defaultOptions
-    { Aeson.fieldLabelModifier = drop (length ("vClobber" :: String)) }
+  (Idioms.recordSelectorPrefix "vClobber" Aeson.defaultOptions)
   ''ClobberValueView)
 $(Aeson.TH.deriveJSON
-  Aeson.defaultOptions
-    { Aeson.constructorTagModifier =
-        reverse . drop (length ("View" :: String)) . reverse
-    }
+  (Idioms.constructorSuffix "View" Aeson.defaultOptions)
   ''ClobberArgView)
 $(Aeson.TH.deriveJSON
-  Aeson.defaultOptions
-    { Aeson.fieldLabelModifier = drop (length ("vU" :: String)) }
+  (Idioms.recordSelectorPrefix "vU" Aeson.defaultOptions)
   ''UPostcondView)

--- a/uc-crux-llvm/src/UCCrux/LLVM/View/Precond.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/View/Precond.hs
@@ -30,7 +30,6 @@ module UCCrux.LLVM.View.Precond
 where
 
 import           Control.Lens ((^.))
-import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.TH as Aeson.TH
 import           Data.Map (Map)
 import qualified Data.Map as Map
@@ -57,9 +56,9 @@ import qualified UCCrux.LLVM.FullType.FuncSig as FS
 import           UCCrux.LLVM.FullType.Type (FullTypeRepr(..), ModuleTypes)
 import           UCCrux.LLVM.Module (funcSymbolToString, globalSymbolToString, makeFuncSymbol, makeGlobalSymbol, moduleGlobalMap, funcSymbol)
 import           UCCrux.LLVM.View.Constraint (ViewConstrainedShapeError, ConstrainedShapeView, ConstrainedTypedValueViewError, ConstrainedTypedValueView, constrainedShapeView, viewConstrainedShape, ppViewConstrainedShapeError, viewConstrainedTypedValue, constrainedTypedValueView, ppConstrainedTypedValueViewError)
+import qualified UCCrux.LLVM.View.Options.Precond as Opts
 import           UCCrux.LLVM.View.Shape (ViewShapeError, ppViewShapeError)
 import           UCCrux.LLVM.View.Postcond (UPostcondView(..), uPostcondView, viewUPostcond, ViewUPostcondError, ppViewUPostcondError)
-import qualified UCCrux.LLVM.View.Idioms as Idioms
 import           UCCrux.LLVM.View.Util (FuncName(..), GlobalVarName(..))
 
 -- Helper, not exported. Equivalent to Data.Bifunctor.first.
@@ -216,7 +215,4 @@ viewPreconds modCtx fs vpres =
              (viewUPostcond modCtx fsRep vpost)
          return (fSymb, post)
 
--- See module docs for "UCCrux.LLVM.View.Idioms".
-$(Aeson.TH.deriveJSON
-  (Idioms.recordSelectorPrefix "v" Aeson.defaultOptions)
-  ''PrecondsView)
+$(Aeson.TH.deriveJSON Opts.preconds ''PrecondsView)

--- a/uc-crux-llvm/src/UCCrux/LLVM/View/Precond.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/View/Precond.hs
@@ -59,6 +59,7 @@ import           UCCrux.LLVM.Module (funcSymbolToString, globalSymbolToString, m
 import           UCCrux.LLVM.View.Constraint (ViewConstrainedShapeError, ConstrainedShapeView, ConstrainedTypedValueViewError, ConstrainedTypedValueView, constrainedShapeView, viewConstrainedShape, ppViewConstrainedShapeError, viewConstrainedTypedValue, constrainedTypedValueView, ppConstrainedTypedValueViewError)
 import           UCCrux.LLVM.View.Shape (ViewShapeError, ppViewShapeError)
 import           UCCrux.LLVM.View.Postcond (UPostcondView(..), uPostcondView, viewUPostcond, ViewUPostcondError, ppViewUPostcondError)
+import qualified UCCrux.LLVM.View.Idioms as Idioms
 import           UCCrux.LLVM.View.Util (FuncName(..), GlobalVarName(..))
 
 -- Helper, not exported. Equivalent to Data.Bifunctor.first.
@@ -215,5 +216,7 @@ viewPreconds modCtx fs vpres =
              (viewUPostcond modCtx fsRep vpost)
          return (fSymb, post)
 
--- See Note [JSON instance tweaks].
-$(Aeson.TH.deriveJSON Aeson.defaultOptions ''PrecondsView)
+-- See module docs for "UCCrux.LLVM.View.Idioms".
+$(Aeson.TH.deriveJSON
+  (Idioms.recordSelectorPrefix "v" Aeson.defaultOptions)
+  ''PrecondsView)

--- a/uc-crux-llvm/src/UCCrux/LLVM/View/Shape.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/View/Shape.hs
@@ -55,6 +55,7 @@ import           UCCrux.LLVM.Errors.Panic (panic)
 import           UCCrux.LLVM.FullType.PP (ppFullTypeRepr)
 import           UCCrux.LLVM.FullType.Type (FullTypeRepr(..), SomeFullTypeRepr(..), viewSomeFullTypeRepr, ModuleTypes, asFullType)
 import           UCCrux.LLVM.Shape (PtrShape(..), Shape(..))
+import qualified UCCrux.LLVM.View.Idioms as Idioms
 import           UCCrux.LLVM.View.TH (deriveMutualJSON)
 
 data ViewShapeError e
@@ -269,17 +270,15 @@ viewShape mts tag ft vshape =
     check cond err = when cond (Left err)
     getTag vtag = liftErr (tag ft vtag)
 
--- See Note [JSON instance tweaks].
+-- See module docs for "UCCrux.LLVM.View.Idioms".
 $(deriveMutualJSON
-  Aeson.defaultOptions
-    { Aeson.constructorTagModifier =
-        \s ->
-        reverse $
-          drop (length ("View" :: String)) $
-          reverse $
-          (if "Shape" `isPrefixOf` s
-           then drop (length ("Shape" :: String))
-           else drop (length ("PtrShape" :: String)))
-          s
-    }
+  (Idioms.constructorSuffix "View" $
+    Aeson.defaultOptions
+      { Aeson.constructorTagModifier =
+          \s ->
+            (if "Shape" `isPrefixOf` s
+            then drop (length ("Shape" :: String))
+            else drop (length ("PtrShape" :: String)))
+            s
+    })
   [''PtrShapeView, ''ShapeView])

--- a/uc-crux-llvm/src/UCCrux/LLVM/View/Shape.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/View/Shape.hs
@@ -31,7 +31,6 @@ module UCCrux.LLVM.View.Shape
 where
 
 import           Control.Monad (when)
-import qualified Data.Aeson as Aeson
 import           Data.Foldable (toList)
 import           Data.List.NonEmpty (NonEmpty, nonEmpty)
 import           Data.Sequence (Seq)
@@ -54,7 +53,7 @@ import           UCCrux.LLVM.Errors.Panic (panic)
 import           UCCrux.LLVM.FullType.PP (ppFullTypeRepr)
 import           UCCrux.LLVM.FullType.Type (FullTypeRepr(..), SomeFullTypeRepr(..), viewSomeFullTypeRepr, ModuleTypes, asFullType)
 import           UCCrux.LLVM.Shape (PtrShape(..), Shape(..))
-import qualified UCCrux.LLVM.View.Idioms as Idioms
+import qualified UCCrux.LLVM.View.Options.Shape as Opts
 import           UCCrux.LLVM.View.TH (deriveMutualJSON)
 
 data ViewShapeError e
@@ -271,14 +270,6 @@ viewShape mts tag ft vshape =
 
 -- See module docs for "UCCrux.LLVM.View.Idioms".
 $(deriveMutualJSON
-  [ ( Idioms.constructorSuffix "View" $
-        Idioms.constructorPrefix "PtrShape" $
-        Aeson.defaultOptions
-    , ''PtrShapeView
-    )
-  , ( Idioms.constructorSuffix "View" $
-        Idioms.constructorPrefix "Shape" $
-        Aeson.defaultOptions
-    , ''ShapeView
-    )
+  [ (Opts.ptrShape, ''PtrShapeView)
+  , (Opts.shape, ''ShapeView)
   ])

--- a/uc-crux-llvm/src/UCCrux/LLVM/View/Shape.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/View/Shape.hs
@@ -33,7 +33,6 @@ where
 import           Control.Monad (when)
 import qualified Data.Aeson as Aeson
 import           Data.Foldable (toList)
-import           Data.List (isPrefixOf)
 import           Data.List.NonEmpty (NonEmpty, nonEmpty)
 import           Data.Sequence (Seq)
 import           Data.Vector (Vector)
@@ -272,13 +271,14 @@ viewShape mts tag ft vshape =
 
 -- See module docs for "UCCrux.LLVM.View.Idioms".
 $(deriveMutualJSON
-  (Idioms.constructorSuffix "View" $
-    Aeson.defaultOptions
-      { Aeson.constructorTagModifier =
-          \s ->
-            (if "Shape" `isPrefixOf` s
-            then drop (length ("Shape" :: String))
-            else drop (length ("PtrShape" :: String)))
-            s
-    })
-  [''PtrShapeView, ''ShapeView])
+  [ ( Idioms.constructorSuffix "View" $
+        Idioms.constructorPrefix "PtrShape" $
+        Aeson.defaultOptions
+    , ''PtrShapeView
+    )
+  , ( Idioms.constructorSuffix "View" $
+        Idioms.constructorPrefix "Shape" $
+        Aeson.defaultOptions
+    , ''ShapeView
+    )
+  ])

--- a/uc-crux-llvm/src/UCCrux/LLVM/View/Specs.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/View/Specs.hs
@@ -43,7 +43,6 @@ where
 
 import           Control.Lens ((^.))
 import           Control.Monad (foldM)
-import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.TH as Aeson.TH
 import           Data.Data (Data)
 import           Data.List.NonEmpty (NonEmpty)
@@ -71,7 +70,7 @@ import           UCCrux.LLVM.Postcondition.Type (toUPostcond, typecheckPostcond,
 import qualified UCCrux.LLVM.Specs.Type as Spec
 import           UCCrux.LLVM.Specs.Type (SpecPreconds, SpecSoundness(..), Spec (Spec), Specs (Specs), SomeSpecs (SomeSpecs))
 import           UCCrux.LLVM.View.Constraint (ConstrainedShapeView, constrainedShapeView)
-import qualified UCCrux.LLVM.View.Idioms as Idioms
+import qualified UCCrux.LLVM.View.Options.Specs as Opts
 import           UCCrux.LLVM.View.Postcond (UPostcondView, uPostcondView, viewUPostcond, ViewUPostcondError, ppViewUPostcondError)
 import           UCCrux.LLVM.View.Precond (ArgError, viewArgPreconds, ppArgError)
 
@@ -236,16 +235,7 @@ parseSpecs modCtx =
              specs <- viewSpecs modCtx fsRepr vspecs
              return (Map.insert funcSymb (SomeSpecs fsRepr specs) mp, missingFuns)
 
--- See module docs for "UCCrux.LLVM.View.Idioms".
-$(Aeson.TH.deriveJSON
-  (Idioms.recordSelectorPrefix "vSpec" Aeson.defaultOptions)
-  ''SpecPrecondsView)
-$(Aeson.TH.deriveJSON
-  (Idioms.constructorSuffix "View" Aeson.defaultOptions)
-  ''SpecSoundnessView)
-$(Aeson.TH.deriveJSON
-  (Idioms.recordSelectorPrefix "vSpec" Aeson.defaultOptions)
-  ''SpecView)
-$(Aeson.TH.deriveJSON
-  Aeson.defaultOptions { Aeson.unwrapUnaryRecords = True }
-  ''SpecsView)
+$(Aeson.TH.deriveJSON Opts.specPreconds ''SpecPrecondsView)
+$(Aeson.TH.deriveJSON Opts.specSoundness ''SpecSoundnessView)
+$(Aeson.TH.deriveJSON Opts.spec ''SpecView)
+$(Aeson.TH.deriveJSON Opts.specs ''SpecsView)

--- a/uc-crux-llvm/src/UCCrux/LLVM/View/Specs.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/View/Specs.hs
@@ -71,6 +71,7 @@ import           UCCrux.LLVM.Postcondition.Type (toUPostcond, typecheckPostcond,
 import qualified UCCrux.LLVM.Specs.Type as Spec
 import           UCCrux.LLVM.Specs.Type (SpecPreconds, SpecSoundness(..), Spec (Spec), Specs (Specs), SomeSpecs (SomeSpecs))
 import           UCCrux.LLVM.View.Constraint (ConstrainedShapeView, constrainedShapeView)
+import qualified UCCrux.LLVM.View.Idioms as Idioms
 import           UCCrux.LLVM.View.Postcond (UPostcondView, uPostcondView, viewUPostcond, ViewUPostcondError, ppViewUPostcondError)
 import           UCCrux.LLVM.View.Precond (ArgError, viewArgPreconds, ppArgError)
 
@@ -235,20 +236,15 @@ parseSpecs modCtx =
              specs <- viewSpecs modCtx fsRepr vspecs
              return (Map.insert funcSymb (SomeSpecs fsRepr specs) mp, missingFuns)
 
--- See Note [JSON instance tweaks].
+-- See module docs for "UCCrux.LLVM.View.Idioms".
 $(Aeson.TH.deriveJSON
-  Aeson.defaultOptions
-    { Aeson.fieldLabelModifier = drop (length ("vSpec" :: String)) }
+  (Idioms.recordSelectorPrefix "vSpec" Aeson.defaultOptions)
   ''SpecPrecondsView)
 $(Aeson.TH.deriveJSON
-  Aeson.defaultOptions
-    { Aeson.constructorTagModifier =
-        reverse . drop (length ("View" :: String)) . reverse
-    }
+  (Idioms.constructorSuffix "View" Aeson.defaultOptions)
   ''SpecSoundnessView)
 $(Aeson.TH.deriveJSON
-  Aeson.defaultOptions
-    { Aeson.fieldLabelModifier = drop (length ("vSpec" :: String)) }
+  (Idioms.recordSelectorPrefix "vSpec" Aeson.defaultOptions)
   ''SpecView)
 $(Aeson.TH.deriveJSON
   Aeson.defaultOptions { Aeson.unwrapUnaryRecords = True }

--- a/uc-crux-llvm/src/UCCrux/LLVM/View/TH.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/View/TH.hs
@@ -20,8 +20,7 @@ import           Language.Haskell.TH (Dec, Q, Name)
 -- | Like 'Aeson.TH.deriveJSON' but processes mutliple types in the same splice,
 -- and so can be used for mutually recursive types.
 deriveMutualJSON ::
-  Options ->
-  [Name] ->
+  [(Options, Name)] ->
   Q [Dec]
-deriveMutualJSON opts =
-  foldM (\decs nm -> (decs ++) <$> Aeson.TH.deriveJSON opts nm) []
+deriveMutualJSON =
+  foldM (\decs (opts, nm) -> (decs ++) <$> Aeson.TH.deriveJSON opts nm) []

--- a/uc-crux-llvm/uc-crux-llvm.cabal
+++ b/uc-crux-llvm/uc-crux-llvm.cabal
@@ -101,6 +101,7 @@ library
     UCCrux.LLVM.View.Constraint
     UCCrux.LLVM.View.Cursor
     UCCrux.LLVM.View.FullType
+    UCCrux.LLVM.View.Idioms
     UCCrux.LLVM.View.Postcond
     UCCrux.LLVM.View.Precond
     UCCrux.LLVM.View.Shape

--- a/uc-crux-llvm/uc-crux-llvm.cabal
+++ b/uc-crux-llvm/uc-crux-llvm.cabal
@@ -101,7 +101,14 @@ library
     UCCrux.LLVM.View.Constraint
     UCCrux.LLVM.View.Cursor
     UCCrux.LLVM.View.FullType
-    UCCrux.LLVM.View.Idioms
+    UCCrux.LLVM.View.Options.Constraint
+    UCCrux.LLVM.View.Options.Cursor
+    UCCrux.LLVM.View.Options.FullType
+    UCCrux.LLVM.View.Options.Idioms
+    UCCrux.LLVM.View.Options.Postcond
+    UCCrux.LLVM.View.Options.Precond
+    UCCrux.LLVM.View.Options.Shape
+    UCCrux.LLVM.View.Options.Specs
     UCCrux.LLVM.View.Postcond
     UCCrux.LLVM.View.Precond
     UCCrux.LLVM.View.Shape


### PR DESCRIPTION
Fixes #1019. Also, factor out and document some helpers for tweaking the `Options`.