### PR TITLE
CI: Use Ubuntu 22.04, drop 18.04

### DIFF
--- a/.github/Dockerfile-crux-llvm
+++ b/.github/Dockerfile-crux-llvm
@@ -1,12 +1,34 @@
-FROM haskell:8.8.4 AS build
+FROM ubuntu:22.04 AS build
 
-RUN echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
-RUN apt-get update && apt-get install -y wget libncurses-dev unzip clang-11 llvm-11-tools
+RUN apt-get update && \
+    apt-get install -y \
+      # ghcup requirements
+      build-essential curl libffi-dev libffi8 libgmp-dev libgmp10 libncurses-dev libncurses6 libtinfo6 \
+      # Crux dependencies \
+      zlib1g-dev \
+      # LLVM toolchain
+      clang-12 llvm-12-tools \
+      # Miscellaneous
+      locales unzip wget
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && \
+    locale-gen
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
 
 WORKDIR /usr/local/bin
-RUN curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20210917/ubuntu-18.04-bin.zip"
+RUN curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20220812/ubuntu-22.04-bin.zip"
 RUN unzip solvers.zip && rm solvers.zip && chmod +x *
 
+ENV PATH=/root/ghcup-download/bin:/root/.ghcup/bin:$PATH
+RUN mkdir -p /root/ghcup-download/bin && \
+    curl -L https://downloads.haskell.org/~ghcup/0.1.17.7/x86_64-linux-ghcup-0.1.17.7 -o /root/ghcup-download/bin/ghcup && \
+    chmod +x /root/ghcup-download/bin/ghcup
+RUN mkdir -p /root/.ghcup && \
+    ghcup --version && \
+    ghcup install cabal 3.6.2.0 && \
+    ghcup install ghc 8.8.4 && \
+    ghcup set ghc 8.8.4
 RUN cabal v2-update
 
 ARG DIR=/crux-llvm
@@ -20,24 +42,24 @@ ADD crux-llvm ${DIR}/build/crux-llvm
 ADD dependencies ${DIR}/build/dependencies
 ADD .github/cabal.project.crux-llvm ${DIR}/build/cabal.project
 ADD cabal.GHC-8.8.4.config ${DIR}/build/cabal.project.freeze
-# Workaround until we have an LLVM 11 build available
-RUN cp $DIR/build/crux-llvm/c-src/libcxx-7.1.0.bc $DIR/build/crux-llvm/c-src/libcxx-11.0.1.bc
+# Workaround until we have an LLVM 12 build available
+RUN cp $DIR/build/crux-llvm/c-src/libcxx-7.1.0.bc $DIR/build/crux-llvm/c-src/libcxx-12.0.1.bc
 
 WORKDIR ${DIR}/build
 RUN cabal v2-build --only-dependencies crux-llvm
 RUN cabal v2-build crux-llvm
-ENV CLANG=clang-11
-ENV LLVM_LINK=llvm-link-11
+ENV CLANG=clang-12
+ENV LLVM_LINK=llvm-link-12
 RUN cabal v2-test crux-llvm
 RUN cp `cabal v2-exec which crux-llvm` /usr/local/bin
 RUN cp `cabal v2-exec which crux-llvm-svcomp` /usr/local/bin
 
-FROM debian:buster-slim
+FROM ubuntu:22.04
 
 USER root
-RUN echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
-RUN apt-get update
-RUN apt-get install -y libgmp10 zlibc zlib1g clang-11 llvm-11-tools unzip locales
+RUN apt-get update && \
+    apt-get install -y \
+      libgmp10 zlib1g clang-12 llvm-12-tools unzip locales
 
 COPY --from=build /usr/local/bin/* /usr/local/bin/
 
@@ -45,7 +67,7 @@ ARG DIR=/crux-llvm
 WORKDIR ${DIR}
 ADD crux-llvm/c-src c-src
 # Use LLVM 7 bitcode file for libcxx until LLVM version is available
-RUN cp c-src/libcxx-7.1.0.bc c-src/libcxx-11.0.1.bc
+RUN cp c-src/libcxx-7.1.0.bc c-src/libcxx-12.0.1.bc
 
 # (Temporary) fix for
 # https://github.com/galoisinc/crucible/issues/887: the libDir default
@@ -56,8 +78,8 @@ RUN cp -r c-src /usr/local/
 RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && \
     locale-gen
 ENV LD_LIBRARY_PATH=/usr/local/lib
-ENV CLANG=clang-11
-ENV LLVM_LINK=llvm-link-11
+ENV CLANG=clang-12
+ENV LLVM_LINK=llvm-link-12
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8

--- a/.github/Dockerfile-crux-mir
+++ b/.github/Dockerfile-crux-mir
@@ -7,14 +7,21 @@ RUN rustup component add --toolchain nightly-2020-03-22 rustc-dev
 RUN rustup default nightly-2020-03-22
 RUN cargo install --locked
 
-FROM haskell:8.8.4 AS build
+FROM ubuntu:22.04 AS build
 
-RUN apt-get update && apt-get install -y wget libncurses-dev unzip
+RUN apt-get update && \
+    apt-get install -y \
+      # ghcup requirements
+      build-essential curl libffi-dev libffi8 libgmp-dev libgmp10 libncurses-dev libncurses6 libtinfo6 \
+      # Crux dependencies \
+      zlib1g-dev \
+      # Miscellaneous
+      unzip wget
 
 COPY --from=mir_json /usr/local/cargo /usr/local/cargo
 COPY --from=mir_json /usr/local/rustup /usr/local/rustup
 WORKDIR /usr/local/bin
-RUN curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20210917/ubuntu-18.04-bin.zip"
+RUN curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20220812/ubuntu-22.04-bin.zip"
 RUN unzip solvers.zip && rm solvers.zip && chmod +x *
 
 ENV CARGO_HOME=/usr/local/cargo
@@ -23,6 +30,15 @@ ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/rustup/lib
 ENV LANG=C.UTF-8 \
     LC_ALL=C.UTF-8
 
+ENV PATH=/root/ghcup-download/bin:/root/.ghcup/bin:$PATH
+RUN mkdir -p /root/ghcup-download/bin && \
+    curl -L https://downloads.haskell.org/~ghcup/0.1.17.7/x86_64-linux-ghcup-0.1.17.7 -o /root/ghcup-download/bin/ghcup && \
+    chmod +x /root/ghcup-download/bin/ghcup
+RUN mkdir -p /root/.ghcup && \
+    ghcup --version && \
+    ghcup install cabal 3.6.2.0 && \
+    ghcup install ghc 8.8.4 && \
+    ghcup set ghc 8.8.4
 RUN cabal v2-update
 
 ARG DIR=/crux-mir
@@ -47,11 +63,12 @@ RUN ./translate_libs.sh
 WORKDIR ${DIR}/build
 RUN cabal v2-test crux-mir
 
-FROM debian:buster-slim
+FROM ubuntu:22.04
 
 USER root
-RUN apt-get update
-RUN apt-get install -y libgmp10 zlibc zlib1g libcurl4
+RUN apt-get update && \
+    apt-get install -y \
+      libgmp10 zlib1g libcurl4
 
 ARG DIR=/crux-mir
 COPY --from=mir_json /usr/local/cargo /usr/local/cargo

--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -64,7 +64,7 @@ test() {
 
 install_llvm() {
   if [[ "$RUNNER_OS" = "Linux" ]]; then
-    sudo apt-get update -q && sudo apt-get install -y clang-10 llvm-10-tools
+    sudo apt-get update -q && sudo apt-get install -y clang-12 llvm-12-tools
   elif [[ "$RUNNER_OS" = "macOS" ]]; then
     brew install llvm@11
   elif [[ "$RUNNER_OS" = "Windows" ]]; then

--- a/.github/workflows/crucible-go-build.yml
+++ b/.github/workflows/crucible-go-build.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
         ghc: ["8.10.7", "9.0.2", "9.2.4"]
         include:
           - os: macos-12
@@ -49,7 +49,7 @@ jobs:
         uses: cachix/install-nix-action@v16
         with:
           nix_path: nixpkgs=channel:21.11
-          install_url: https://releases.nixos.org/nix/nix-2.4/install
+          install_url: https://releases.nixos.org/nix/nix-2.10.3/install
 
       - uses: actions/cache@v2
         name: Cache cabal store
@@ -64,7 +64,7 @@ jobs:
       - shell: bash
         run: .github/ci.sh install_system_deps
         env:
-          SOLVER_PKG_VERSION: "snapshot-20220721"
+          SOLVER_PKG_VERSION: "snapshot-20220812"
           BUILD_TARGET_OS: ${{ matrix.os }}
 
       - name: Setup Environment Vars

--- a/.github/workflows/crucible-jvm-build.yml
+++ b/.github/workflows/crucible-jvm-build.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
         ghc: ["8.10.7", "9.0.2", "9.2.4"]
         include:
           - os: macos-12
@@ -49,7 +49,7 @@ jobs:
         uses: cachix/install-nix-action@v16
         with:
           nix_path: nixpkgs=channel:21.11
-          install_url: https://releases.nixos.org/nix/nix-2.4/install
+          install_url: https://releases.nixos.org/nix/nix-2.10.3/install
 
       - uses: actions/cache@v2
         name: Cache cabal store
@@ -64,7 +64,7 @@ jobs:
       - shell: bash
         run: .github/ci.sh install_system_deps
         env:
-          SOLVER_PKG_VERSION: "snapshot-20220721"
+          SOLVER_PKG_VERSION: "snapshot-20220812"
           BUILD_TARGET_OS: ${{ matrix.os }}
 
       - name: Setup Environment Vars

--- a/.github/workflows/crucible-wasm-build.yml
+++ b/.github/workflows/crucible-wasm-build.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
         ghc: ["8.10.7", "9.0.2", "9.2.4"]
         include:
           - os: macos-12
@@ -49,7 +49,7 @@ jobs:
         uses: cachix/install-nix-action@v16
         with:
           nix_path: nixpkgs=channel:21.11
-          install_url: https://releases.nixos.org/nix/nix-2.4/install
+          install_url: https://releases.nixos.org/nix/nix-2.10.3/install
 
       - uses: actions/cache@v2
         name: Cache cabal store
@@ -64,7 +64,7 @@ jobs:
       - shell: bash
         run: .github/ci.sh install_system_deps
         env:
-          SOLVER_PKG_VERSION: "snapshot-20220721"
+          SOLVER_PKG_VERSION: "snapshot-20220812"
           BUILD_TARGET_OS: ${{ matrix.os }}
 
       - name: Setup Environment Vars

--- a/.github/workflows/crux-llvm-build.yml
+++ b/.github/workflows/crux-llvm-build.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   outputs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       changed: ${{ steps.outputs.outputs.changed-files }}
       name: ${{ steps.outputs.outputs.name }}
@@ -43,12 +43,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
         ghc: ["8.10.7", "9.0.2", "9.2.4"]
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             ghc: 8.8.4
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             ghc: 9.2.4
           - os: macos-12
             ghc: 9.2.4
@@ -70,7 +70,7 @@ jobs:
         uses: cachix/install-nix-action@v16
         with:
           nix_path: nixpkgs=channel:21.11
-          install_url: https://releases.nixos.org/nix/nix-2.4/install
+          install_url: https://releases.nixos.org/nix/nix-2.10.3/install
 
       - uses: actions/cache@v2
         name: Cache cabal store
@@ -85,7 +85,7 @@ jobs:
       - shell: bash
         run: .github/ci.sh install_system_deps
         env:
-          SOLVER_PKG_VERSION: "snapshot-20220721"
+          SOLVER_PKG_VERSION: "snapshot-20220812"
           BUILD_TARGET_OS: ${{ matrix.os }}
 
       - name: Setup Environment Vars
@@ -149,25 +149,25 @@ jobs:
         run: .github/ci.sh test crucible-llvm
         if: runner.os == 'Linux'
         env:
-          LLVM_LINK: "llvm-link-10"
-          LLVM_AS: "llvm-as-10"
-          CLANG: "clang-10"
+          LLVM_LINK: "llvm-link-12"
+          LLVM_AS: "llvm-as-12"
+          CLANG: "clang-12"
 
       - shell: bash
         name: Test crux-llvm (Linux)
         run: .github/ci.sh test crux-llvm
         if: runner.os == 'Linux'
         env:
-          LLVM_LINK: "llvm-link-10"
-          CLANG: "clang-10"
+          LLVM_LINK: "llvm-link-12"
+          CLANG: "clang-12"
 
       - shell: bash
         name: Test uc-crux-llvm (Linux)
         run: .github/ci.sh test uc-crux-llvm
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-22.04'
         env:
-          LLVM_LINK: "llvm-link-10"
-          CLANG: "clang-10"
+          LLVM_LINK: "llvm-link-12"
+          CLANG: "clang-12"
 
       - shell: bash
         name: Install LLVM-11 for MacOS

--- a/.github/workflows/crux-mir-build.yml
+++ b/.github/workflows/crux-mir-build.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   outputs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       changed: ${{ steps.outputs.outputs.changed-files }}
       name: ${{ steps.outputs.outputs.name }}
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
         ghc: ["8.10.7", "9.0.2", "9.2.4"]
         include:
           - os: macos-12
@@ -64,7 +64,7 @@ jobs:
         uses: cachix/install-nix-action@v16
         with:
           nix_path: nixpkgs=channel:21.11
-          install_url: https://releases.nixos.org/nix/nix-2.4/install
+          install_url: https://releases.nixos.org/nix/nix-2.10.3/install
 
       - name: Install latest Rust nightly
         uses: actions-rs/toolchain@v1
@@ -86,7 +86,7 @@ jobs:
       - shell: bash
         run: .github/ci.sh install_system_deps
         env:
-          SOLVER_PKG_VERSION: "snapshot-20220721"
+          SOLVER_PKG_VERSION: "snapshot-20220812"
           BUILD_TARGET_OS: ${{ matrix.os }}
 
       - name: Setup Environment Vars


### PR DESCRIPTION
GitHub Actions has deprecated its Ubuntu 18.04 runners, and they will be
removed by December 1, 2022. Moreover, GitHub Actions now offers Ubuntu 22.04
runners.  It seems like a good time to upgrade our CI accordingly.

Somewhat annoyingly, the `haskell` Docker images that we use in our Dockerfiles
use such an old version of Debian that their version of `glibc` is incompatible
with any of the `what4-solvers` built for Ubuntu 20.04 or 22.04. As a result, I
switched them from the `haskell` Docker image to the `ubuntu` one. This
required some minor tweaks to how dependencies are installed, but nothing too
serious.

The minimum version of LLVM that GitHub Actions' Ubuntu 22.04 runners support
is LLVM 12, so I took the time to update the LLVM versions accordingly.