### PR TITLE
{uc-,}crux-llvm: Recommend cloning with --recurse-submodules

### DIFF
--- a/crux-llvm/README.md
+++ b/crux-llvm/README.md
@@ -56,7 +56,7 @@ The `crux-llvm` tool can be built by doing the following:
 
 * Clone (incl. the submodules) the `crucible` repository:
 
-        git clone --recursive https://github.com/GaloisInc/crucible.git
+        git clone --recurse-submodules https://github.com/GaloisInc/crucible.git
 
 * Build the `crux-llvm` package:
 

--- a/uc-crux-llvm/README.md
+++ b/uc-crux-llvm/README.md
@@ -139,7 +139,7 @@ The `uc-crux-llvm` tool can be built by doing the following:
 
 * Clone the enclosing `crucible` repository:
 
-        git clone https://github.com/GaloisInc/crucible.git
+        git clone --recurse-submodules https://github.com/GaloisInc/crucible.git
 
 * Change to the `uc-crux-llvm` directory and run the build script:
 


### PR DESCRIPTION
See commentary on #888. Also, --recursive is no longer part of the git clone manpage, so replace with --recurse-submodules.