### PR TITLE
uc-crux-llvm: Use Natural instead of Integer where appropriate

### DIFF
--- a/uc-crux-llvm/src/UCCrux/LLVM/Classify.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Classify.hs
@@ -128,7 +128,7 @@ elemsFromOffset ::
 elemsFromOffset mts offset partType =
   let pointedTo = asFullType mts partType
       typeSize = sizeInBytes mts pointedTo
-   in 1 + fromIntegral (BV.asUnsigned (What4.fromConcreteBV offset) `div` typeSize)
+   in 1 + fromIntegral (BV.asNatural (What4.fromConcreteBV offset) `div` typeSize)
 
 unclass ::
   (MonadIO f, What4.IsExpr (What4.SymExpr sym)) =>

--- a/uc-crux-llvm/src/UCCrux/LLVM/Cursor.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Cursor.hs
@@ -75,6 +75,10 @@ data Cursor m (inTy :: FullType m) (atTy :: FullType m) where
   Here :: FullTypeRepr m atTy -> Cursor m atTy atTy
   Dereference ::
     -- | Which array index?
+    --
+    -- This is an 'Int' and not a 'Numeric.Natural.Natural' because it is used
+    -- to index into a 'Data.Sequence.Seq', so it would have to be downcasted if
+    -- it were a 'Numeric.Natural.Natural'.
     Int ->
     Cursor m inTy atTy ->
     Cursor m ('FTPtr inTy) atTy

--- a/uc-crux-llvm/src/UCCrux/LLVM/Setup/Monad.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Setup/Monad.hs
@@ -49,6 +49,7 @@ import           Control.Monad.RWS (RWST, runRWST)
 import           Data.Proxy (Proxy(Proxy))
 import           Data.Text (Text)
 import qualified Data.Text.IO as TextIO
+import           Numeric.Natural (Natural)
 
 import qualified Text.LLVM.AST as L
 
@@ -276,7 +277,7 @@ malloc ::
   -- | Path to this pointer
   Selector m argTypes inTy ('FTPtr atTy) ->
   -- | Size, as in number of elements. Should be strictly positive.
-  Integer ->
+  Natural ->
   Setup m arch sym argTypes (LLVMMem.LLVMPtr sym (ArchWidth arch))
 malloc bak fullTypeRepr selector size =
   do


### PR DESCRIPTION
Fixes #692. Other uses of types like Int were audited, but I determined that
they are necessary, because they are used to interact with APIs like
Data.Sequence, and so promoting them would just result in unsafe downcasts
elsewhere.