### PR TITLE
uc-crux-llvm: Additional abstract newtypes for reporting stats

### DIFF
--- a/uc-crux-llvm/src/UCCrux/LLVM/Run/Explore.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Run/Explore.hs
@@ -24,7 +24,6 @@ import           Control.Scheduler (Comp(Par), traverseConcurrently)
 import           Control.Exception (displayException)
 import           Data.Function ((&))
 import           Data.Map (Map)
-import qualified Data.Map.Strict as Map
 import           Data.Text.IO (writeFile)
 import qualified Data.Text as Text
 import           Data.Traversable (for)
@@ -62,6 +61,7 @@ import qualified UCCrux.LLVM.Run.Result as Result
 import           UCCrux.LLVM.Run.Loop (loopOnFunction)
 import           UCCrux.LLVM.Specs.Type (SomeSpecs)
 import           UCCrux.LLVM.Stats (Stats(unimplementedFreq), getStats, ppStats)
+import qualified UCCrux.LLVM.Stats.Freq as Freq
 {- ORMOLU_ENABLE -}
 
 withTimeout :: Int -> IO a -> IO (Either () a)
@@ -109,7 +109,7 @@ exploreOne appCtx modCtx cruxOpts llOpts exOpts halloc specs dir defnSym =
               writeFile logFilePath (Text.pack (displayException unin))
               pure
                 ( mempty
-                    { unimplementedFreq = Map.singleton (panicComponent unin) 1
+                    { unimplementedFreq = Freq.singleton (panicComponent unin)
                     }
                 )
           Left () ->

--- a/uc-crux-llvm/src/UCCrux/LLVM/Stats/Count.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Stats/Count.hs
@@ -1,0 +1,78 @@
+{-
+Module       : UCCrux.LLVM.Stats.Count
+Description  : Unbounded unsigned integers with limited arithmetic operations.
+Copyright    : (c) Galois, Inc 2022
+License      : BSD3
+Maintainer   : Langston Barrett <langston@galois.com>
+Stability    : provisional
+
+Intended to be imported qualified as @Count@.
+-}
+
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module UCCrux.LLVM.Stats.Count
+  ( Count
+  , fromNat
+  , toNat
+  , zero
+  , one
+  , inc
+  , plus
+  , absDiff
+  , div
+  , divNat
+  )
+where
+
+import           Prelude hiding (div, log)
+import qualified Prelude as Pre
+import           Numeric.Natural (Natural)
+
+-- | Type of unbounded unsigned integers with limited arithmetic operations.
+--
+-- Semantically intended to count stuff.
+--
+-- Comparison to other types:
+--
+-- * 'Word' has different semantic connotations - the name implies it is just a
+--   bitvector of machine-word size. It is bounded, which may lead to over- and
+--   under-flow.
+-- * 'Natural' supports operations that can throw exceptions such as @-@.
+-- * 'Int' is signed.
+newtype Count = Count { getCount :: Natural }
+  deriving (Eq, Enum, Ord, Show)
+
+fromNat :: Natural -> Count
+fromNat = Count
+
+toNat :: Count -> Natural
+toNat = getCount
+
+-- | @zero == 'fromNat' 0@.
+zero :: Count
+zero = Count 0
+
+-- | @one == 'fromNat' 1@.
+one :: Count
+one = Count 1
+
+-- | @inc == 'plus' 'one'@.
+inc :: Count -> Count
+inc = Count . (+1) . getCount
+
+-- | @'plus' c d == 'fromNat' ('toNat' c + 'toNat' d)@.
+plus :: Count -> Count -> Count
+plus c d = Count (getCount c + getCount d)
+
+-- | Absolute value of the difference between two 'Count'.
+absDiff :: Count -> Count -> Natural
+absDiff (Count c1) (Count c2) = max c1 c2 - min c1 c2
+
+-- | Integer (truncating) division
+div :: Count -> Count -> Count
+div c1 c2 = Count (getCount c1 `Pre.div` getCount c2)
+
+-- | Integer (truncating) division by a 'Natural'
+divNat :: Count -> Natural -> Count
+divNat c w = c `div` Count w

--- a/uc-crux-llvm/src/UCCrux/LLVM/Stats/Freq.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Stats/Freq.hs
@@ -1,0 +1,90 @@
+{-
+Module       : UCCrux.LLVM.Stats.Freq
+Description  : Count frequencies, i.e., occurrences of something.
+Copyright    : (c) Galois, Inc 2022
+License      : BSD3
+Maintainer   : Langston Barrett <langston@galois.com>
+Stability    : provisional
+
+Intended to be imported qualified as @Freq@.
+-}
+
+module UCCrux.LLVM.Stats.Freq
+  ( Freq
+  , empty
+  , toList
+  , inc
+  , singleton
+  , incBy
+  , map
+  , count
+  , sorted
+  )
+where
+
+import           Prelude hiding (map)
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Sequence (Seq)
+import qualified Data.Sequence as Seq
+
+import           UCCrux.LLVM.Stats.Count (Count)
+import qualified UCCrux.LLVM.Stats.Count as Count
+
+-- | Count frequencies, i.e., occurrences of @k@s.
+--
+-- Internal note: A key not being present is semantically the same as it having
+-- a value of 'Count.zero'.
+newtype Freq k = Freq { getFreq :: Map k Count }
+  deriving (Eq, Ord, Show)
+
+empty :: Ord k => Freq k
+empty = Freq Map.empty
+
+-- | Convert to list.
+--
+-- It is undefined whether or not the list will include pairs with 'Count.zero'
+-- as their second component; they may be omitted.
+--
+-- Equations:
+--
+-- @toList 'empty' == []@
+toList :: Ord k => Freq k -> [(k, Count)]
+toList = Map.toList . getFreq
+
+-- | Increment the occurrences of a key @k@ by 'Count.one'.
+--
+-- Equations:
+--
+-- @forall k. 'inc' k == 'incBy' k 'Count.one'@
+--
+-- @forall k. 'toList' (inc k 'empty') == [(k, 'Count.one')]@
+inc :: Ord k => k -> Freq k -> Freq k
+inc k = incBy k Count.one
+
+-- | @forall k. singleton k == 'inc' k 'empty'@
+singleton :: Ord k => k -> Freq k
+singleton k = inc k empty
+
+-- | Increment the occurrences of a key @k@ by some amount.
+incBy :: Ord k => k -> Count -> Freq k -> Freq k
+incBy k c = Freq . Map.insertWith Count.plus k c . getFreq
+
+-- | Map over the counts of all of the occurrences.
+map :: Ord k => (Count -> Count) -> Freq k -> Freq k
+map f = Freq . Map.map f . getFreq
+
+-- | Count the occurrences of each item in the list.
+count :: Ord k => [k] -> Freq k
+count = foldr inc empty
+
+sorted :: Ord k => Freq k -> Seq (k, Count)
+sorted = Seq.sortOn snd . Seq.fromList . Map.toList . getFreq
+
+-- | Merges the counts with 'Count.plus'.
+instance Ord k => Semigroup (Freq k) where
+  x <> y = Freq (Map.unionWith Count.plus (getFreq x) (getFreq y))
+
+-- | @'mempty' == 'empty'@
+instance Ord k => Monoid (Freq k) where
+  mempty = empty

--- a/uc-crux-llvm/uc-crux-llvm.cabal
+++ b/uc-crux-llvm/uc-crux-llvm.cabal
@@ -98,6 +98,8 @@ library
     UCCrux.LLVM.Specs.Apply
     UCCrux.LLVM.Specs.Type
     UCCrux.LLVM.Stats
+    UCCrux.LLVM.Stats.Count
+    UCCrux.LLVM.Stats.Freq
     UCCrux.LLVM.View
     UCCrux.LLVM.View.Constraint
     UCCrux.LLVM.View.Cursor


### PR DESCRIPTION
Just refactoring for clarity and removal of some unnecessarily bounded numeric types.