### PR TITLE
uc-crux-llvm: Track more sources of unsoundness

### DIFF
--- a/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Check.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Check.hs
@@ -146,6 +146,8 @@ createCheckOverride ::
   -- predictes/constraints it checks (see 'CheckedCall') in this 'IORef'. The
   -- order of the calls will be the reverse of the order they were encountered
   -- during symbolic execution.
+  --
+  -- See Note [IORefs].
   IORef [CheckedCall m sym arch argTypes] ->
   -- | Function argument types
   Ctx.Assignment (FullTypeRepr m) argTypes ->
@@ -229,6 +231,8 @@ checkOverrideFromResult ::
   AppContext ->
   ModuleContext m arch ->
   -- | Predicates checked during simulation
+  --
+  -- See Note [IORefs].
   IORef [CheckedCall m sym arch argTypes] ->
   -- | Function argument types
   Ctx.Assignment (FullTypeRepr m) argTypes ->

--- a/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Skip.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Skip.hs
@@ -102,9 +102,9 @@ unsoundSkipOverrides ::
   ModuleContext m arch ->
   bak ->
   ModuleTranslation arch ->
-  -- | Set of skip overrides encountered during execution
+  -- | Set of skip overrides encountered during execution, see Note [IORefs].
   IORef (Set SkipOverrideName) ->
-  -- | Origins of created values
+  -- | Origins of created values. See Note [IORefs].
   IORef (ExprTracker m sym argTypes) ->
   -- | Postconditions of each override (constraints on return values,
   -- information about clobbered pointer values such as arguments or global
@@ -197,8 +197,9 @@ createSkipOverride ::
   ) =>
   ModuleContext m arch ->
   bak ->
+  -- | Set of skip overrides encountered during execution, see Note [IORefs].
   IORef (Set SkipOverrideName) ->
-  -- | Origins of created values
+  -- | Origins of created values. See Note [IORefs].
   IORef (ExprTracker m sym argTypes) ->
   -- | Constraints on the return value, clobbered pointer values such as
   -- arguments or global variables

--- a/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Spec.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Spec.hs
@@ -95,9 +95,9 @@ specOverrides ::
   (?memOpts :: MemOptions) =>
   ModuleContext m arch ->
   bak ->
-  -- | Track any unsound specs used
+  -- | Track any unsound specs used. See Note [IORefs].
   IORef (Set SpecUse) ->
-  -- | Origins of created values
+  -- | Origins of created values. See Note [IORefs].
   IORef (ExprTracker m sym argTypes) ->
   -- | Specs of each override, see 'Specs'.
   Map (FuncSymbol m) (SomeSpecs m) ->
@@ -155,9 +155,9 @@ createSpecOverride ::
   (fs ~ 'FS.FuncSig va mft args) =>
   ModuleContext m arch ->
   bak ->
-  -- | Track any unsound specs used
+  -- | Track any unsound specs used. See Note [IORefs].
   IORef (Set SpecUse) ->
-  -- | Origins of created values
+  -- | Origins of created values. See Note [IORefs].
   IORef (ExprTracker m sym argTypes) ->
   -- | Function to be overridden
   FuncSymbol m ->

--- a/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Spec.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Spec.hs
@@ -9,9 +9,6 @@ Stability    : provisional
 These overrides are useful for describing the behavior of external/library
 functions, or for soundly skipping complex functions even when they happen to be
 defined.
-
-TODO(lb, #932): Track which specs actually execute and whether they are over- or
-under-approximate.
 -}
 
 {-# LANGUAGE DataKinds #-}

--- a/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Spec.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Spec.hs
@@ -9,6 +9,8 @@ Stability    : provisional
 These overrides are useful for describing the behavior of external/library
 functions, or for soundly skipping complex functions even when they happen to be
 defined.
+
+See @doc/specs.md@.
 -}
 
 {-# LANGUAGE DataKinds #-}

--- a/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Spec.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Spec.hs
@@ -80,7 +80,8 @@ import           UCCrux.LLVM.Specs.Type (SomeSpecs)
 import qualified UCCrux.LLVM.Specs.Type as Spec
 {- ORMOLU_ENABLE -}
 
--- | A spec with this soundness was used in place of this function
+-- | A user-supplied spec with the soundness specified here was used in place of
+-- analyzing the function directly.
 data SpecUse
   = SpecUse
     { specUseFn :: FunctionName

--- a/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Unsound.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Unsound.hs
@@ -75,6 +75,7 @@ newtype UnsoundOverrideName = UnsoundOverrideName {getUnsoundOverrideName :: Tex
 -- /indefinite/.
 unsoundOverrides ::
   (?lc :: TypeContext, ?memOpts :: LLVMMem.MemOptions) =>
+  -- | See Note [IORefs].
   IORef (Set UnsoundOverrideName) ->
   [ForAllSymArch PolymorphicLLVMOverride]
 unsoundOverrides usedRef =

--- a/uc-crux-llvm/src/UCCrux/LLVM/Run/Check.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Run/Check.hs
@@ -176,18 +176,23 @@ checkInferredContracts appCtx modCtx funCtx halloc cruxOpts llOpts constraints c
      cfg
      cruxOpts
      llOpts
-     (Sim.SimulatorCallbacks $
-       do ovs <- overrides
-          return $
-            Sim.SimulatorHooks
-              { Sim.createOverrideHooks = map fst ovs
-              , Sim.resultHook =
-                \bak mem args cruxResult ucResult ->
-                  return $
-                    CheckResult $
-                      \k -> k bak mem args cruxResult ucResult (map snd ovs)
-              })
+     callbacks
+     Map.empty
   where
+
+    callbacks =
+      Sim.SimulatorCallbacks $
+        do ovs <- overrides
+           return $
+             Sim.SimulatorHooks
+               { Sim.createOverrideHooks = map fst ovs
+               , Sim.resultHook =
+                 \bak mem args cruxResult ucResult ->
+                   return $
+                     CheckResult $
+                       \k -> k bak mem args cruxResult ucResult (map snd ovs)
+               }
+
     -- Create one override for each function with preconditions we want to
     -- check, as well as a way to get the results ('SomeCheckedCalls').
     overrides ::

--- a/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE TupleSections #-}
 {-
 Module       : UCCrux.LLVM.Run.Simulate
 Description  : Run the simulator once.
@@ -19,6 +18,7 @@ Stability    : provisional
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
 
 module UCCrux.LLVM.Run.Simulate
   ( UCCruxSimulationResult (..),

--- a/uc-crux-llvm/src/UCCrux/LLVM/Run/Unsoundness.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Run/Unsoundness.hs
@@ -75,7 +75,10 @@ ppUnsoundness s u =
               bullets specs
         ]
   where
-    bullets = map ((PP.pretty "-" PP.<+>) . PP.pretty)
+    bullets l =
+      if null l
+      then [PP.pretty "[None]"]
+      else map ((PP.pretty "-" PP.<+>) . PP.pretty) l
     specs =
       mapMaybe
         (\(OvSpec.SpecUse nm s') ->

--- a/uc-crux-llvm/src/UCCrux/LLVM/Soundness.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Soundness.hs
@@ -45,6 +45,7 @@ data Soundness
   | Indefinite
   deriving (Eq, Ord, Show)
 
+-- | @'stringToSoundness' ('soundnessToString' s) == 'Just' s@
 stringToSoundness :: String -> Maybe Soundness
 stringToSoundness =
   \case
@@ -54,6 +55,8 @@ stringToSoundness =
     "indefinite" -> Just Indefinite
     _ -> Nothing
 
+-- | If @'stringToSoundness' s == 'Just' s0@, then
+-- @'soundnessToString' <$> 'stringToSoundness' s == 'Just' s@
 soundnessToString :: Soundness -> String
 soundnessToString =
   \case

--- a/uc-crux-llvm/src/UCCrux/LLVM/Soundness.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Soundness.hs
@@ -12,9 +12,12 @@ Stability        : provisional
 module UCCrux.LLVM.Soundness
   ( Soundness(..),
     stringToSoundness,
+    soundnessToString,
     atLeastAsSound
   )
 where
+
+import           Prelude hiding (min)
 
 -- | Description of the soundness of a feature of the analysis.
 --
@@ -50,6 +53,14 @@ stringToSoundness =
     "underapprox" -> Just Underapprox
     "indefinite" -> Just Indefinite
     _ -> Nothing
+
+soundnessToString :: Soundness -> String
+soundnessToString =
+  \case
+    Precise -> "precise"
+    Overapprox -> "overapprox"
+    Underapprox -> "underapprox"
+    Indefinite -> "indefinite"
 
 -- | The partial order on 'Soundness', asks whether the first 'Soundness' is at
 -- least as sound as the second.

--- a/uc-crux-llvm/src/UCCrux/LLVM/Specs/Type.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Specs/Type.hs
@@ -24,7 +24,8 @@ module UCCrux.LLVM.Specs.Type
     Specs(..),
     SomeSpecs(..),
     minimalSpec,
-    minimalSpecs
+    minimalSpecs,
+    specMaxSoundness
   )
 where
 
@@ -106,3 +107,9 @@ minimalSpecs = Specs . neSingleton . minimalSpec
   where
     -- | Added as NE.singleton in base-4.15/GHC 9.
     neSingleton x = x NE.:| []
+
+-- | The upper bound of the soundness of the pre- and post-condition of this
+-- spec. This can be considered as the "overall" soundness of the spec, i.e.,
+-- it reflects the unsoundness of both the pre- and post-condition.
+specMaxSoundness :: Spec m fs -> Soundness
+specMaxSoundness s = max (specPreSound s) (specPostSound s)

--- a/uc-crux-llvm/src/UCCrux/LLVM/Stats.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Stats.hs
@@ -60,7 +60,7 @@ getStats result =
           timeouts = toEnum $ length timeouts',
           truePositiveFreq =
             case Result.summary result of
-              Result.FoundBugs bugs -> Freq.count (toList bugs)
+              Result.FoundBugs _unsoundness bugs -> Freq.count (toList bugs)
               _ -> Freq.empty,
           unclassifiedFreq = Freq.count (map (bugBehavior . locatedValue) unclass),
           diagnosisFreq =

--- a/uc-crux-llvm/test/Check.hs
+++ b/uc-crux-llvm/test/Check.hs
@@ -96,11 +96,11 @@ checkOverrideTests =
                             appCtx
                             modCtx
                             funCtxF
+                            Map.empty
                             fcgf
                             cruxOpts
                             llOpts
                             halloc
-                            Map.empty
 
                         -- Construct override that checks that y is nonnull
 
@@ -162,6 +162,7 @@ checkOverrideTests =
                             cruxOpts
                             llOpts
                             callbacks
+                            Map.empty
 
                         return ()
                     )

--- a/uc-crux-llvm/test/Test.hs
+++ b/uc-crux-llvm/test/Test.hs
@@ -217,7 +217,7 @@ hasBugs fn (Result.SomeBugfindingResult' (Result.SomeBugfindingResult _ result _
   do
     [] TH.@=? map show (Result.uncertainResults result)
     case Result.summary result of
-      Result.FoundBugs _bugs -> pure ()
+      Result.FoundBugs _unsoundness _bugs -> pure ()
       _ -> TH.assertFailure (unwords ["Expected", fn, "to have bugs"])
 
 isSafe :: Unsoundness -> String -> SomeBugfindingResult' -> IO ()
@@ -392,14 +392,24 @@ isUnimplemented file fn =
 
 skipOverrides :: [String] -> Unsoundness
 skipOverrides names =
-  Unsoundness Set.empty (Set.fromList (map (SkipOverrideName . Text.pack) names))
+  Unsoundness
+    { unsoundOverridesUsed = Set.empty
+    , unsoundSkipOverridesUsed =
+        Set.fromList (map (SkipOverrideName . Text.pack) names)
+    , unsoundSpecsUsed = Set.empty
+    }
 
 skipOverride :: String -> Unsoundness
 skipOverride = skipOverrides . (: [])
 
 unsoundOverride :: String -> Unsoundness
 unsoundOverride name =
-  Unsoundness (Set.singleton (UnsoundOverrideName (Text.pack name))) Set.empty
+  Unsoundness
+    { unsoundOverridesUsed =
+        Set.singleton (UnsoundOverrideName (Text.pack name))
+    , unsoundSkipOverridesUsed = Set.empty
+    , unsoundSpecsUsed = Set.empty
+    }
 
 inFileTests :: TT.TestTree
 inFileTests =

--- a/uc-crux-llvm/test/Utils.hs
+++ b/uc-crux-llvm/test/Utils.hs
@@ -20,6 +20,7 @@ module Utils
 {- ORMOLU_DISABLE -}
 import           Control.Lens ((^.))
 import           Control.Exception (try)
+import qualified Data.Map as Map
 import           Data.Maybe (fromMaybe, isNothing)
 import           System.Environment (lookupEnv)
 import           System.FilePath ((</>))
@@ -241,4 +242,5 @@ simulateFunc file func makeCallbacks =
                   cruxOpts
                   llOpts
                   cbs
+                  Map.empty
     )


### PR DESCRIPTION
Fixes #932, #907. The upshot is that in situations like #907, UC-Crux will faithfully report conditions that may lead it to claim that there is a bug when, in fact, there isn't. Here's the new output for the test case in that ticket:
```
[Crux] Attempting to prove verification conditions.
[UC-Crux-LLVM] Results for do_getline
[UC-Crux-LLVM] Found likely bugs
[UC-Crux-LLVM] In addition to any assumptions listed above, the following sources of unsoundness may invalidate this claim that there is a bug:
[UC-Crux-LLVM] The following unsound overrides (built-in functions) were used:
[UC-Crux-LLVM]   Execution of the following functions was skipped:
[UC-Crux-LLVM]   - getline
[UC-Crux-LLVM]   The following unsound specifications were applied:
[UC-Crux-LLVM] Read from data that concretely wasn't a pointer at getline.c:8:5
```