### PR TITLE
CI: Work around GHC installation issues on Windows

### DIFF
--- a/.github/workflows/crucible-go-build.yml
+++ b/.github/workflows/crucible-go-build.yml
@@ -44,6 +44,14 @@ jobs:
         with:
           ghc-version: ${{ matrix.ghc }}
 
+      - name: Post-GHC installation fixups on Windows
+        shell: bash
+        if: runner.os == 'Windows'
+        run: |
+          # A workaround for https://github.com/Mistuke/CabalChoco/issues/5
+          cabal user-config update -a "extra-include-dirs: \"\""
+          cabal user-config update -a "extra-lib-dirs: \"\""
+
       - name: Install Nix
         if: runner.os == 'Linux'
         uses: cachix/install-nix-action@v16

--- a/.github/workflows/crucible-jvm-build.yml
+++ b/.github/workflows/crucible-jvm-build.yml
@@ -44,6 +44,14 @@ jobs:
         with:
           ghc-version: ${{ matrix.ghc }}
 
+      - name: Post-GHC installation fixups on Windows
+        shell: bash
+        if: runner.os == 'Windows'
+        run: |
+          # A workaround for https://github.com/Mistuke/CabalChoco/issues/5
+          cabal user-config update -a "extra-include-dirs: \"\""
+          cabal user-config update -a "extra-lib-dirs: \"\""
+
       - name: Install Nix
         if: runner.os == 'Linux'
         uses: cachix/install-nix-action@v16

--- a/.github/workflows/crucible-wasm-build.yml
+++ b/.github/workflows/crucible-wasm-build.yml
@@ -44,6 +44,14 @@ jobs:
         with:
           ghc-version: ${{ matrix.ghc }}
 
+      - name: Post-GHC installation fixups on Windows
+        shell: bash
+        if: runner.os == 'Windows'
+        run: |
+          # A workaround for https://github.com/Mistuke/CabalChoco/issues/5
+          cabal user-config update -a "extra-include-dirs: \"\""
+          cabal user-config update -a "extra-lib-dirs: \"\""
+
       - name: Install Nix
         if: runner.os == 'Linux'
         uses: cachix/install-nix-action@v16

--- a/.github/workflows/crux-llvm-build.yml
+++ b/.github/workflows/crux-llvm-build.yml
@@ -65,6 +65,14 @@ jobs:
         with:
           ghc-version: ${{ matrix.ghc }}
 
+      - name: Post-GHC installation fixups on Windows
+        shell: bash
+        if: runner.os == 'Windows'
+        run: |
+          # A workaround for https://github.com/Mistuke/CabalChoco/issues/5
+          cabal user-config update -a "extra-include-dirs: \"\""
+          cabal user-config update -a "extra-lib-dirs: \"\""
+
       - name: Install Nix
         if: runner.os == 'Linux'
         uses: cachix/install-nix-action@v16

--- a/.github/workflows/crux-mir-build.yml
+++ b/.github/workflows/crux-mir-build.yml
@@ -59,6 +59,14 @@ jobs:
         with:
           ghc-version: ${{ matrix.ghc }}
 
+      - name: Post-GHC installation fixups on Windows
+        shell: bash
+        if: runner.os == 'Windows'
+        run: |
+          # A workaround for https://github.com/Mistuke/CabalChoco/issues/5
+          cabal user-config update -a "extra-include-dirs: \"\""
+          cabal user-config update -a "extra-lib-dirs: \"\""
+
       - name: Install Nix
         if: runner.os == 'Linux'
         uses: cachix/install-nix-action@v16


### PR DESCRIPTION
This should avoid nasty linker errors as observed in https://gitlab.haskell.org/ghc/ghc/-/issues/21111 until the upstream tools can be fixed.