### PR TITLE
Add upper version bounds to `simple-get-opt`

### DIFF
--- a/.github/workflows/crucible-go-build.yml
+++ b/.github/workflows/crucible-go-build.yml
@@ -65,7 +65,7 @@ jobs:
           path: |
             ${{ steps.setup-haskell.outputs.cabal-store }}
             dist-newstyle
-          key: ${{ env.CACHE_VERSION }}-cabal-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles(format('cabal.GHC-{0}.config', matrix.ghc)) }}-${{ github.sha }}
+          key: ${{ env.CACHE_VERSION }}-cabal-${{ matrix.os }}-${{ matrix.ghc }}-${{ hashFiles(format('cabal.GHC-{0}.config', matrix.ghc)) }}-${{ github.sha }}
           restore-keys: |
             ${{ env.CACHE_VERSION }}-cabal-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles(format('cabal.GHC-{0}.config', matrix.ghc)) }}-
 

--- a/.github/workflows/crucible-jvm-build.yml
+++ b/.github/workflows/crucible-jvm-build.yml
@@ -65,7 +65,7 @@ jobs:
           path: |
             ${{ steps.setup-haskell.outputs.cabal-store }}
             dist-newstyle
-          key: ${{ env.CACHE_VERSION }}-cabal-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles(format('cabal.GHC-{0}.config', matrix.ghc)) }}-${{ github.sha }}
+          key: ${{ env.CACHE_VERSION }}-cabal-${{ matrix.os }}-${{ matrix.ghc }}-${{ hashFiles(format('cabal.GHC-{0}.config', matrix.ghc)) }}-${{ github.sha }}
           restore-keys: |
             ${{ env.CACHE_VERSION }}-cabal-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles(format('cabal.GHC-{0}.config', matrix.ghc)) }}-
 

--- a/.github/workflows/crucible-wasm-build.yml
+++ b/.github/workflows/crucible-wasm-build.yml
@@ -65,7 +65,7 @@ jobs:
           path: |
             ${{ steps.setup-haskell.outputs.cabal-store }}
             dist-newstyle
-          key: ${{ env.CACHE_VERSION }}-cabal-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles(format('cabal.GHC-{0}.config', matrix.ghc)) }}-${{ github.sha }}
+          key: ${{ env.CACHE_VERSION }}-cabal-${{ matrix.os }}-${{ matrix.ghc }}-${{ hashFiles(format('cabal.GHC-{0}.config', matrix.ghc)) }}-${{ github.sha }}
           restore-keys: |
             ${{ env.CACHE_VERSION }}-cabal-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles(format('cabal.GHC-{0}.config', matrix.ghc)) }}-
 

--- a/.github/workflows/crux-mir-build.yml
+++ b/.github/workflows/crux-mir-build.yml
@@ -87,7 +87,7 @@ jobs:
           path: |
             ${{ steps.setup-haskell.outputs.cabal-store }}
             dist-newstyle
-          key: ${{ env.CACHE_VERSION }}-cabal-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles(format('cabal.GHC-{0}.config', matrix.ghc)) }}-${{ github.sha }}
+          key: ${{ env.CACHE_VERSION }}-cabal-${{ matrix.os }}-${{ matrix.ghc }}-${{ hashFiles(format('cabal.GHC-{0}.config', matrix.ghc)) }}-${{ github.sha }}
           restore-keys: |
             ${{ env.CACHE_VERSION }}-cabal-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles(format('cabal.GHC-{0}.config', matrix.ghc)) }}-
 

--- a/.github/workflows/crux-mir-build.yml
+++ b/.github/workflows/crux-mir-build.yml
@@ -44,9 +44,13 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         ghc: ["8.10.7", "9.0.2", "9.2.4"]
-        include:
-          - os: macos-12
-            ghc: 9.2.4
+        # include:
+          # Disable the macOS build for now due to
+          # https://github.com/GaloisInc/crucible/issues/1050
+          #
+          # - os: macos-12
+          #   ghc: 9.2.4
+
           # We want Windows soon, but it doesn't need to be now
     name: crux-mir - GHC v${{ matrix.ghc }} - ${{ matrix.os }}
     steps:

--- a/crucible-concurrency/crucible-concurrency.cabal
+++ b/crucible-concurrency/crucible-concurrency.cabal
@@ -43,7 +43,7 @@ library
                      , parameterized-utils
                      , prettyprinter
                      , random
-                     , simple-get-opt
+                     , simple-get-opt < 0.5
                      , text
                      , transformers
                      , vector

--- a/crux-mir/crux-mir.cabal
+++ b/crux-mir/crux-mir.cabal
@@ -51,7 +51,7 @@ library
                  aig,
                  crux,
                  scientific       >= 0.3,
-                 simple-get-opt,
+                 simple-get-opt < 0.5,
                  config-schema,
                  template-haskell
 

--- a/crux/crux.cabal
+++ b/crux/crux.cabal
@@ -53,7 +53,7 @@ library
     ansi-terminal,
     Glob >= 0.10 && < 0.11,
     raw-strings-qq,
-    simple-get-opt,
+    simple-get-opt < 0.5,
     config-value,
     config-schema >= 1.2.2.0,
     semigroupoids,

--- a/uc-crux-llvm/uc-crux-llvm.cabal
+++ b/uc-crux-llvm/uc-crux-llvm.cabal
@@ -25,7 +25,7 @@ common bldflags
   -- A list of warnings and the GHC version in which they were introduced is
   -- available here:
   -- https://ghc.gitlab.haskell.org/ghc/doc/users_guide/using-warnings.html
-  
+
   -- Since GHC 8.10 or earlier:
   ghc-options:
     -Wall
@@ -65,9 +65,9 @@ common bldflags
     -Werror=unused-imports
     -Werror=warnings-deprecations
     -Werror=wrong-do-bind
-    
+
   if impl(ghc >= 9.2)
-    ghc-options: 
+    ghc-options:
       -Werror=ambiguous-fields
       -Werror=operator-whitespace
       -Werror=operator-whitespace-ext-conflict
@@ -75,7 +75,7 @@ common bldflags
 
   -- TODO(lb): Test these with GHC 9.4
   -- if impl(ghc >= 9.4)
-  --   ghc-options: 
+  --   ghc-options:
   --     -Werror=forall-identifier
   --     -Werror=misplaced-pragmas
   --     -Werror=redundant-strictness-flags
@@ -210,7 +210,7 @@ library
     prettyprinter >= 1.7.0,
     scheduler,
     semigroupoids,
-    simple-get-opt,
+    simple-get-opt < 0.5,
     template-haskell,
     text,
     vector,


### PR DESCRIPTION
This avoids the build failures in #1048 until `crux` and friends can be adapted to work with `simple-get-opt-0.5`.