### PR TITLE
`crucible-syntax`: Add support for `extern`s

### DIFF
--- a/crucible-concurrency/src/Cruces/CrucesMain.hs
+++ b/crucible-concurrency/src/Cruces/CrucesMain.hs
@@ -48,7 +48,6 @@ import What4.FunctionName
 import qualified Crux
 import           Crux.Types
 
-import Data.Parameterized.Pair
 import qualified SimpleGetOpt as GetOpt
 import Text.Read (readMaybe)
 
@@ -128,7 +127,7 @@ run (cruxOpts, opts) =
                   bak ->
                   IO ( FnVal s Ctx.EmptyCtx C.UnitType
                      , ExplorePrimitives (ThreadExec DPOR s () C.UnitType) s ()
-                     , [Pair C.TypeRepr GlobalVar]
+                     , [Some GlobalVar]
                      , FunctionBindings (ThreadExec DPOR s () C.UnitType) s ()
                      )
                 mkSym _bak =

--- a/crucible-concurrency/src/Cruces/CrucesMain.hs
+++ b/crucible-concurrency/src/Cruces/CrucesMain.hs
@@ -141,9 +141,12 @@ run (cruxOpts, opts) =
                        Left err -> error $ show err
                        Right (ParsedProgram
                                { parsedProgGlobals = gs
+                               , parsedProgExterns = externs
                                , parsedProgCFGs = cs
                                , parsedProgForwardDecs = fds
                                }) -> do
+                         unless (Map.null externs) $
+                           error "Externs not currently supported"
                          unless (Map.null fds) $
                            error "Forward declarations not currently supported"
                          return ( findMain (fromString "main") cs

--- a/crucible-concurrency/src/Cruces/ExploreCrux.hs
+++ b/crucible-concurrency/src/Cruces/ExploreCrux.hs
@@ -24,7 +24,6 @@ import           System.IO (Handle)
 import           What4.Interface
 import           What4.Config
 
-import           Data.Parameterized.Pair(Pair)
 import qualified Data.Parameterized.Context as Ctx
 import           Lang.Crucible.FunctionHandle (HandleAllocator)
 import qualified Lang.Crucible.CFG.Core as C
@@ -58,7 +57,7 @@ exploreCallback :: forall alg.
    bak ->
         IO ( FnVal s Ctx.EmptyCtx C.UnitType
            , ExplorePrimitives (ThreadExec alg s () C.UnitType) s ()
-           , [Pair C.TypeRepr C.GlobalVar]
+           , [Some C.GlobalVar]
            , FunctionBindings (ThreadExec alg s () C.UnitType) s ())
            ) ->
   Crux.SimulatorCallbacks Crux.CruxLogMessage Crux.Types.CruxSimulationResult
@@ -111,7 +110,7 @@ exploreOvr :: forall sym bak ext alg ret rtp msgs.
   Crux.Logs msgs =>
   Crux.SupportsCruxLogMessage msgs =>
   (?bound::Int, IsSymBackend sym bak, IsSyntaxExtension ext, SchedulingAlgorithm alg, RegValue sym ret ~ ()) =>
-  bak -> 
+  bak ->
   Maybe (Crux.SomeOnlineSolver sym bak) ->
   Crux.CruxOptions ->
   (forall rtp'. OverrideSim (Exploration alg ext ret sym) sym ext rtp' Ctx.EmptyCtx ret (RegValue sym ret)) ->

--- a/crucible-syntax/CHANGELOG.md
+++ b/crucible-syntax/CHANGELOG.md
@@ -12,9 +12,12 @@
   TopParser s (ParsedProgram ext)
   ```
 
-  Where the `parsedProgGlobals :: Map GlobalName (Pair TypeRepr GlobalVar)` and
+  Where the `parsedProgGlobals :: Map GlobalName (Some GlobalVar)` and
   `parsedProgCFGs :: [ACFG ext]` fields of `ParsedProgram` now serve the roles
-  previously filled by the first and second fields of the returned tuple.
+  previously filled by the first and second fields of the returned tuple. (Note
+  that `Pair TypeRepr GlobalVar` has been simplified to `Some GlobalVar`, as
+  the `TypeRepr` of a `GlobalVar` can be retrieved through its `globalType`
+  field.)
 * The type of `simulateProgram`'s last argument:
 
   ```hs

--- a/crucible-syntax/README.txt
+++ b/crucible-syntax/README.txt
@@ -87,6 +87,22 @@ of a function ahead of time, but you will know it at some point after parsing
 the program. It is the responsibility of the client to ensure that forward
 declarations are resolved to Crucible definitions before being invoked.
 
+Global variables
+
+A global variable is a form that begins with the keyword "defglobal", followed
+by an identifier prefixed with two dollar signs (e.g., $$global-name) as well
+as a type. A global variable is a mutable reference that scopes over all of the
+functions defined in the program. The value of a global variable can be set
+with the "set-global!" form.
+
+A program can reference a global variable defined externally by using an extern
+declaration. An extern declaration is exactly like a "defglobal" declaration,
+but using the "extern" keyword instead of "defglobal". The difference between
+an extern and a normal global variable is that the value of an extern may
+already have been set by the time that the .cbl file which declares the extern
+uses it. It is the responsibility of the client to ensure that externs are
+inserted into the Crucible symbolic global state before being accessed.
+
 Types
 
 si ::= 'Unicode' | 'Char16' | 'Char8'

--- a/crucible-syntax/src/Lang/Crucible/Syntax/Atoms.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Atoms.hs
@@ -40,7 +40,7 @@ newtype FunName = FunName Text deriving (Eq, Ord, Show)
 newtype GlobalName = GlobalName Text deriving (Eq, Ord, Show)
 
 -- | Individual language keywords (reserved identifiers)
-data Keyword = Defun | DefBlock | DefGlobal | Declare
+data Keyword = Defun | DefBlock | DefGlobal | Declare | Extern
              | Registers
              | Start
              | SetGlobal
@@ -93,6 +93,7 @@ keywords =
   , ("defblock", DefBlock)
   , ("defglobal", DefGlobal)
   , ("declare", Declare)
+  , ("extern", Extern)
   , ("registers", Registers)
 
     -- statements

--- a/crucible-syntax/src/Lang/Crucible/Syntax/Concrete.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Concrete.hs
@@ -177,9 +177,8 @@ data ParserHooks ext = ParserHooks {
        , ?parserHooks :: ParserHooks ext
        -- ParserHooks instance to use recursively when parsing.
        )
-    => m (Pair TypeRepr (Atom s))
-    -- ^ A pair containing a type and an atom of that type from evaluation of
-    -- syntax extension.
+    => m (Some (Atom s))
+    -- ^ The atom computed from evaluating the syntax extension.
 }
 
 -- | A ParserHooks instance that adds no extensions to the crucible-syntax
@@ -189,12 +188,12 @@ defaultParserHooks = ParserHooks empty empty
 
 -- | The results of parsing a program.
 data ParsedProgram ext = ParsedProgram
-  { parsedProgGlobals :: Map GlobalName (Pair TypeRepr GlobalVar)
+  { parsedProgGlobals :: Map GlobalName (Some GlobalVar)
     -- ^ The parsed @defglobal@s.
-  , parsedProgExterns :: Map GlobalName (Pair TypeRepr GlobalVar)
-    -- ^ For each parsed @extern@, map its name to its type and global variable.
-    --   It is the responsibility of the caller to insert each global variable
-    --   into the 'SymGlobalState' alongside an appropriate 'RegValue'.
+  , parsedProgExterns :: Map GlobalName (Some GlobalVar)
+    -- ^ For each parsed @extern@, map its name to its global variable. It is
+    --   the responsibility of the caller to insert each global variable into
+    --   the 'SymGlobalState' alongside an appropriate 'RegValue'.
   , parsedProgCFGs :: [ACFG ext]
     -- ^ The CFGs for each parsed @defun@.
   , parsedProgForwardDecs :: Map FunctionName SomeHandle
@@ -552,13 +551,13 @@ synthExpr typeHint =
     okAtom theAtoms x =
       case Map.lookup x theAtoms of
         Nothing -> Nothing
-        Just (Pair t anAtom) -> Just $ SomeE t (EAtom anAtom)
+        Just (Some anAtom) -> Just $ SomeE (typeOfAtom anAtom) (EAtom anAtom)
 
     regRef :: m (SomeExpr ext s)
     regRef =
-      do Pair t r <- regRef'
+      do Some r <- regRef'
          loc <- position
-         return (SomeE t (EReg loc r))
+         return (SomeE (typeOfReg r) (EReg loc r))
 
     deref :: m (SomeExpr ext s)
     deref =
@@ -573,9 +572,9 @@ synthExpr typeHint =
 
     globRef :: m (SomeExpr ext s)
     globRef =
-      do Pair t g <- globRef'
+      do Some g <- globRef'
          loc <- position
-         return (SomeE t (EGlob loc g))
+         return (SomeE (globalType g) (EGlob loc g))
 
     crucibleAtom :: m (SomeExpr ext s)
     crucibleAtom =
@@ -1282,13 +1281,13 @@ check t =
 
 data LabelInfo :: Type -> Type where
   NoArgLbl :: Label s -> LabelInfo s
-  ArgLbl :: forall s ty . TypeRepr ty -> LambdaLabel s ty -> LabelInfo s
+  ArgLbl :: forall s ty . LambdaLabel s ty -> LabelInfo s
 
 data ProgramState s =
   ProgramState { _progFunctions :: Map FunctionName FunctionHeader
                , _progForwardDecs :: Map FunctionName FunctionHeader
-               , _progGlobals :: Map GlobalName (Pair TypeRepr GlobalVar)
-               , _progExterns :: Map GlobalName (Pair TypeRepr GlobalVar)
+               , _progGlobals :: Map GlobalName (Some GlobalVar)
+               , _progExterns :: Map GlobalName (Some GlobalVar)
                , _progHandleAlloc :: HandleAllocator
                }
 
@@ -1298,10 +1297,10 @@ progFunctions = lens _progFunctions (\s v -> s { _progFunctions = v })
 progForwardDecs :: Simple Lens (ProgramState s) (Map FunctionName FunctionHeader)
 progForwardDecs = lens _progForwardDecs (\s v -> s { _progForwardDecs = v })
 
-progGlobals :: Simple Lens (ProgramState s) (Map GlobalName (Pair TypeRepr GlobalVar))
+progGlobals :: Simple Lens (ProgramState s) (Map GlobalName (Some GlobalVar))
 progGlobals = lens _progGlobals (\s v -> s { _progGlobals = v })
 
-progExterns :: Simple Lens (ProgramState s) (Map GlobalName (Pair TypeRepr GlobalVar))
+progExterns :: Simple Lens (ProgramState s) (Map GlobalName (Some GlobalVar))
 progExterns = lens _progExterns (\s v -> s { _progExterns = v })
 
 progHandleAlloc :: Simple Lens (ProgramState s) HandleAllocator
@@ -1310,8 +1309,8 @@ progHandleAlloc = lens _progHandleAlloc (\s v -> s { _progHandleAlloc = v })
 
 data SyntaxState s =
   SyntaxState { _stxLabels :: Map LabelName (LabelInfo s)
-              , _stxAtoms :: Map AtomName (Pair TypeRepr (Atom s))
-              , _stxRegisters :: Map RegName (Pair TypeRepr (Reg s))
+              , _stxAtoms :: Map AtomName (Some (Atom s))
+              , _stxRegisters :: Map RegName (Some (Reg s))
               , _stxNonceGen :: NonceGenerator IO s
               , _stxProgState :: ProgramState s
               }
@@ -1341,10 +1340,10 @@ initSyntaxState =
 stxLabels :: Simple Lens (SyntaxState s) (Map LabelName (LabelInfo s))
 stxLabels = lens _stxLabels (\s v -> s { _stxLabels = v })
 
-stxAtoms :: Simple Lens (SyntaxState s) (Map AtomName (Pair TypeRepr (Atom s)))
+stxAtoms :: Simple Lens (SyntaxState s) (Map AtomName (Some (Atom s)))
 stxAtoms = lens _stxAtoms (\s v -> s { _stxAtoms = v })
 
-stxRegisters :: Simple Lens (SyntaxState s) (Map RegName (Pair TypeRepr (Reg s)))
+stxRegisters :: Simple Lens (SyntaxState s) (Map RegName (Some (Reg s)))
 stxRegisters = lens _stxRegisters (\s v -> s { _stxRegisters = v })
 
 stxNonceGen :: Getter (SyntaxState s) (NonceGenerator IO s)
@@ -1359,10 +1358,10 @@ stxFunctions = stxProgState . progFunctions
 stxForwardDecs :: Simple Lens (SyntaxState s) (Map FunctionName FunctionHeader)
 stxForwardDecs = stxProgState . progForwardDecs
 
-stxGlobals :: Simple Lens (SyntaxState s) (Map GlobalName (Pair TypeRepr GlobalVar))
+stxGlobals :: Simple Lens (SyntaxState s) (Map GlobalName (Some GlobalVar))
 stxGlobals = stxProgState . progGlobals
 
-stxExterns :: Simple Lens (SyntaxState s) (Map GlobalName (Pair TypeRepr GlobalVar))
+stxExterns :: Simple Lens (SyntaxState s) (Map GlobalName (Some GlobalVar))
 stxExterns = stxProgState . progExterns
 
 newtype CFGParser s ret a =
@@ -1454,7 +1453,7 @@ lambdaLabelBinding :: ( MonadSyntax Atomic m
                       , MonadState (SyntaxState s) m
                       , MonadIO m
                       , ?parserHooks :: ParserHooks ext )
-                   => m (LabelName, (Pair TypeRepr (LambdaLabel s)))
+                   => m (LabelName, Some (LambdaLabel s))
 lambdaLabelBinding =
   call $
   depCons uniqueLabel $
@@ -1464,9 +1463,9 @@ lambdaLabelBinding =
       depCons isType $
       \(Some t) ->
         do (lbl, anAtom) <- freshLambdaLabel t
-           stxLabels %= Map.insert l (ArgLbl t lbl)
-           stxAtoms %= Map.insert x (Pair t anAtom)
-           return (l, (Pair t lbl))
+           stxLabels %= Map.insert l (ArgLbl lbl)
+           stxAtoms %= Map.insert x (Some anAtom)
+           return (l, Some lbl)
 
   where uniqueLabel =
           do labels <- use stxLabels
@@ -1495,7 +1494,7 @@ newUnassignedReg t =
                    , typeOfReg = t
                    }
 
-regRef' :: (MonadSyntax Atomic m, MonadReader (SyntaxState s) m) => m (Pair TypeRepr (Reg s))
+regRef' :: (MonadSyntax Atomic m, MonadReader (SyntaxState s) m) => m (Some (Reg s))
 regRef' =
   describe "known register name" $
   do rn <- regName
@@ -1504,7 +1503,7 @@ regRef' =
        Just reg -> return reg
        Nothing -> empty
 
-globRef' :: (MonadSyntax Atomic m, MonadReader (SyntaxState s) m) => m (Pair TypeRepr GlobalVar)
+globRef' :: (MonadSyntax Atomic m, MonadReader (SyntaxState s) m) => m (Some GlobalVar)
 globRef' =
   describe "known global variable name" $
   do x <- globalName
@@ -1529,7 +1528,7 @@ atomSetter :: forall m ext s
               , IsSyntaxExtension ext
               , ?parserHooks :: ParserHooks ext )
            => AtomName -- ^ The name of the atom being set, used for fresh name internals
-           -> m (Pair TypeRepr (Atom s))
+           -> m (Some (Atom s))
 atomSetter (AtomName anText) =
   call ( newref
      <|> emptyref
@@ -1545,20 +1544,20 @@ atomSetter (AtomName anText) =
          , MonadIO m
          , IsSyntaxExtension ext
          )
-      => m (Pair TypeRepr (Atom s))
+      => m (Some (Atom s))
 
     newref =
-      do Pair t e <- reading $ unary Ref synth
+      do Pair _ e <- reading $ unary Ref synth
          loc <- position
          anAtom <- eval loc e
          anotherAtom <- freshAtom loc (NewRef anAtom)
-         return $ Pair (ReferenceRepr t) anotherAtom
+         return $ Some anotherAtom
 
     emptyref =
       do Some t' <- reading $ unary EmptyRef isType
          loc <- position
          anAtom <- freshAtom loc (NewEmptyRef t')
-         return $ Pair (ReferenceRepr t') anAtom
+         return $ Some anAtom
 
     fresh =
       do t <- reading (unary Fresh isType)
@@ -1569,20 +1568,20 @@ atomSetter (AtomName anText) =
                do loc <- position
                   case t of
                     Some (FloatRepr fi) ->
-                      Pair (FloatRepr fi) <$>
+                      Some <$>
                         freshAtom loc (FreshFloat fi (Just nm))
                     Some NatRepr ->
-                      Pair NatRepr <$> freshAtom loc (FreshNat (Just nm))
+                      Some <$> freshAtom loc (FreshNat (Just nm))
                     Some tp
                       | AsBaseType bt <- asBaseType tp ->
-                          Pair tp <$> freshAtom loc (FreshConstant bt (Just nm))
+                          Some <$> freshAtom loc (FreshConstant bt (Just nm))
                       | otherwise -> describe "atomic type" $ empty
 
     evaluated =
-       do Pair tp e' <- reading synth
+       do Pair _ e' <- reading synth
           loc <- position
           anAtom <- eval loc e'
-          return $ Pair tp anAtom
+          return $ Some anAtom
 
 -- | Parse a list of operands (for example, the arguments to a function)
 operands :: forall s ext m tps
@@ -1620,7 +1619,7 @@ funcall
      , IsSyntaxExtension ext
      , ?parserHooks :: ParserHooks ext
      )
-  => m (Pair TypeRepr (Atom s))
+  => m (Some (Atom s))
 funcall =
   followedBy (kw Funcall) $
   depConsCond (reading synth) $
@@ -1631,7 +1630,7 @@ funcall =
              funAtom <- eval loc fun
              operandAtoms <- operands funArgs
              endAtom <- freshAtom loc $ Call funAtom operandAtoms ret
-             return $ Right $ Pair ret endAtom
+             return $ Right $ Some endAtom
         _ -> return $ Left "a function"
 
 
@@ -1678,8 +1677,8 @@ normStmt' =
           use (stxGlobals . at g) >>=
             \case
               Nothing -> return $ Left "known global variable name"
-              Just (Pair t var) ->
-                do (Posd loc e) <- fst <$> cons (located $ reading $ check t) emptyList
+              Just (Some var) ->
+                do (Posd loc e) <- fst <$> cons (located $ reading $ check $ globalType var) emptyList
                    a <- eval loc e
                    tell [Posd loc $ WriteGlobal var a]
                    return (Right ())
@@ -1687,8 +1686,8 @@ normStmt' =
     setReg =
       followedBy (kw SetRegister) $
       depCons (reading regRef') $
-      \(Pair ty r) ->
-        depCons (reading $ located $ check ty) $
+      \(Some r) ->
+        depCons (reading $ located $ check $ typeOfReg r) $
         \(Posd loc e) ->
           do emptyList
              v <- eval loc e
@@ -1792,17 +1791,17 @@ termStmt' retTy =
          later $ describe "known label with no arguments" $
            case l of
              Nothing -> empty
-             Just (ArgLbl _ _) -> empty
+             Just (ArgLbl _) -> empty
              Just (NoArgLbl lbl) -> pure lbl
 
-    lambdaLabel :: m (Pair TypeRepr (LambdaLabel s))
+    lambdaLabel :: m (Some (LambdaLabel s))
     lambdaLabel =
       do x <- labelName
          l <- use (stxLabels . at x)
          later $ describe "known label with an argument" $
            case l of
              Nothing -> empty
-             Just (ArgLbl t lbl) -> pure $ Pair t lbl
+             Just (ArgLbl lbl) -> pure $ Some lbl
              Just (NoArgLbl _) -> empty
 
     typedLambdaLabel :: TypeRepr t -> m (LambdaLabel s t)
@@ -1812,8 +1811,8 @@ termStmt' retTy =
          later $ describe ("known label with an " <> T.pack (show t) <> " argument") $
            case l of
              Nothing -> empty
-             Just (ArgLbl t' lbl) ->
-               case testEquality t' t of
+             Just (ArgLbl lbl) ->
+               case testEquality (typeOfAtom (lambdaAtom lbl)) t of
                  Nothing -> empty
                  Just Refl -> pure lbl
              Just (NoArgLbl _) -> empty
@@ -1905,8 +1904,8 @@ termStmt' retTy =
     out = followedBy (kw Output_) $
           do -- commit
              depCons lambdaLabel $
-               \(Pair argTy lbl) ->
-                 depCons (located (reading (check argTy))) $
+               \(Some lbl) ->
+                 depCons (located (reading (check (typeOfAtom (lambdaAtom lbl))))) $
                    \(Posd loc arg) ->
                      emptyList *>
                        (Output lbl <$> eval loc arg)
@@ -1960,16 +1959,16 @@ saveArgs :: (MonadState (SyntaxState s) m, MonadError (ExprErr s) m)
          -> m ()
 saveArgs ctx1 ctx2 =
   let combined = Ctx.zipWith
-                   (\(Arg x p t) argAtom ->
-                      (Const (Pair t (Functor.Pair (Const x) (Functor.Pair (Const p) argAtom)))))
+                   (\(Arg x p _) argAtom ->
+                      (Const (Some (Functor.Pair (Const x) (Functor.Pair (Const p) argAtom)))))
                    ctx1 ctx2
   in forFC_ combined $
-       \(Const (Pair t (Functor.Pair (Const x) (Functor.Pair (Const argPos) y)))) ->
+       \(Const (Some (Functor.Pair (Const x) (Functor.Pair (Const argPos) y)))) ->
          with (stxAtoms . at x) $
            \case
              Just _ -> throwError $ DuplicateAtom argPos x
              Nothing ->
-               do stxAtoms %= Map.insert x (Pair t y)
+               do stxAtoms %= Map.insert x (Some y)
 
 data FunctionHeader =
   forall args ret .
@@ -2021,13 +2020,14 @@ functionHeader defun =
 
 global :: (?parserHooks :: ParserHooks ext)
        => AST s
-       -> TopParser s (Pair TypeRepr GlobalVar)
+       -> TopParser s (Some GlobalVar)
 global stx =
   do (var@(GlobalName varName), Some t) <- liftSyntaxParse (call (binary DefGlobal globalName isType)) stx
      ha <- use $ stxProgState  . progHandleAlloc
      v <- liftIO $ freshGlobalVar ha varName t
-     stxGlobals %= Map.insert var (Pair t v)
-     return $ Pair t v
+     let sv = Some v
+     stxGlobals %= Map.insert var sv
+     return sv
 
 -- | Parse a forward declaration.
 declare :: (?parserHooks :: ParserHooks ext)
@@ -2052,13 +2052,14 @@ declare stx =
 -- | Parse an extern.
 extern :: (?parserHooks :: ParserHooks ext)
        => AST s
-       -> TopParser s (Pair TypeRepr GlobalVar)
+       -> TopParser s (Some GlobalVar)
 extern stx =
   do (var@(GlobalName varName), Some t) <- liftSyntaxParse (call (binary Extern globalName isType)) stx
      ha <- use $ stxProgState  . progHandleAlloc
      v <- liftIO $ freshGlobalVar ha varName t
-     stxExterns %= Map.insert var (Pair t v)
-     return $ Pair t v
+     let sv = Some v
+     stxExterns %= Map.insert var sv
+     return sv
 
 topLevel :: (?parserHooks :: ParserHooks ext)
          => AST s
@@ -2130,7 +2131,7 @@ blocks ret =
         argBlock =
           call $
           depConsCond lambdaLabelBinding $
-          \ (l, (Pair _ lbl)) ->
+          \ (l, (Some lbl)) ->
             do pr <- progress
                body <- anything
                return $ Right (l, LambdaID lbl, pr, body)
@@ -2209,7 +2210,7 @@ initParser (FunctionHeader _ (funArgs :: Ctx.Assignment Arg init) _ _ _) (Functi
     saveRegister (L [A (Rg x), t]) =
       do Some ty <- liftSyntaxParse isType t
          r <- newUnassignedReg ty
-         stxRegisters %= Map.insert x (Pair ty r)
+         stxRegisters %= Map.insert x (Some r)
     saveRegister other = throwError $ InvalidRegister (syntaxPos other) other
 
 cfgs :: ( IsSyntaxExtension ext
@@ -2234,7 +2235,7 @@ prog defuns =
             st <- get
             (theBlocks, st') <- liftSyntaxParse (runStateT (blocks ret) st) body
             put st'
-            let vs = Set.fromList [ Some (AtomValue a) | Pair _ a <- args ]
+            let vs = Set.fromList [ Some (AtomValue a) | Some a <- args ]
             case theBlocks of
               []       -> error "found no blocks"
               (e:rest) ->

--- a/crucible-syntax/src/Lang/Crucible/Syntax/Prog.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Prog.hs
@@ -26,7 +26,6 @@ import Text.Megaparsec as MP
 
 import Data.Parameterized.Nonce
 import qualified Data.Parameterized.Context as Ctx
-import Data.Parameterized.Pair (Pair(..))
 import Data.Parameterized.Some (Some(Some))
 
 import qualified Lang.Crucible.CFG.Core as C
@@ -44,7 +43,6 @@ import Lang.Crucible.Backend.Simple
 import Lang.Crucible.FunctionHandle
 import Lang.Crucible.Simulator
 import Lang.Crucible.Simulator.Profiling
-import Lang.Crucible.Types (TypeRepr)
 
 import What4.Config
 import What4.Interface (getConfiguration,notPred)
@@ -98,7 +96,7 @@ data SimulateProgramHooks = SimulateProgramHooks
     -- ^ Action to set up overrides before parsing a program.
   , resolveExternsHook ::
       forall sym t st fs. (IsSymInterface sym, sym ~ (ExprBuilder t st fs)) =>
-        sym -> Map GlobalName (Pair TypeRepr GlobalVar) -> SymGlobalState sym -> IO (SymGlobalState sym)
+        sym -> Map GlobalName (Some GlobalVar) -> SymGlobalState sym -> IO (SymGlobalState sym)
     -- ^ Action to resolve externs before simulating a program. If you do not
     --   intend to support externs, this is an appropriate place to error if a
     --   program contains one or more externs.
@@ -127,7 +125,7 @@ defaultSimulateProgramHooks = SimulateProgramHooks
        pure $ FnBindings emptyHandleMap
   }
 
-assertNoExterns :: Map GlobalName (Pair TypeRepr GlobalVar) -> IO ()
+assertNoExterns :: Map GlobalName (Some GlobalVar) -> IO ()
 assertNoExterns externs =
   unless (Map.null externs) $
   do putStrLn "Externs not currently supported"

--- a/crucible-syntax/test-data/extern-tests/main.cbl
+++ b/crucible-syntax/test-data/extern-tests/main.cbl
@@ -1,0 +1,7 @@
+(extern $$foo Integer)
+
+(defun @main () Unit
+  (start start:
+    (assert! (equal? $$foo 42) "$$foo equals 42")
+    (return ()))
+)

--- a/crucible-syntax/test-data/extern-tests/main.out.good
+++ b/crucible-syntax/test-data/extern-tests/main.out.good
@@ -1,0 +1,4 @@
+==== Begin Simulation ====
+
+==== Finish Simulation ====
+==== No proof obligations ====

--- a/crucible-syntax/test/Tests.hs
+++ b/crucible-syntax/test/Tests.hs
@@ -15,7 +15,7 @@ import qualified Data.Map as Map
 import Data.Map (Map)
 import Data.Monoid
 import qualified Data.Parameterized.Context as Ctx
-import Data.Parameterized.Pair (Pair(..))
+import Data.Parameterized.Some (Some(..))
 import Data.Text (Text)
 import Data.Type.Equality (TestEquality(..), (:~:)(..))
 import qualified Data.Text as T
@@ -36,7 +36,7 @@ import Lang.Crucible.Syntax.SExpr
 import Lang.Crucible.Syntax.ExprParse
 import Lang.Crucible.Syntax.Overrides as SyntaxOvrs
 import Lang.Crucible.Types
-import Lang.Crucible.CFG.Common (GlobalVar)
+import Lang.Crucible.CFG.Common (GlobalVar(..))
 import Lang.Crucible.CFG.SSAConversion
 
 import Test.Tasty (defaultMain, TestTree, testGroup)
@@ -300,12 +300,12 @@ resolvedExternTest =
     resolveExterns ::
       IsSymInterface sym =>
       sym ->
-      Map GlobalName (Pair TypeRepr GlobalVar) ->
+      Map GlobalName (Some GlobalVar) ->
       SymGlobalState sym ->
       IO (SymGlobalState sym)
     resolveExterns sym externs gst
-      | Just (Pair tp gv) <- Map.lookup (GlobalName "foo") externs
-      , Just Refl <- testEquality tp IntegerRepr
+      | Just (Some gv) <- Map.lookup (GlobalName "foo") externs
+      , Just Refl <- testEquality (globalType gv) IntegerRepr
       = do fooVal <- intLit sym 42
            pure $ insertGlobal gv fooVal gst
 


### PR DESCRIPTION
`extern` is to `defglobal` what `declare` is to `defun`. This patch adds the necessary parts to `crucible-syntax` to parse `extern`s, create fresh `GlobalVar`s for each `extern`, and put them into the `ParsedProgram` API so that callers can insert externs into the `SymGlobalState` with appropriate `RegValue`s. I've included a test case that demonstrates this in action.

Fixes #1054.