### PR TITLE
crucible-llvm: Show function name in override panic messages

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Common.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Common.hs
@@ -139,6 +139,7 @@ newtype ValTransformer p sym tp tp' =
 
 transformLLVMArgs :: forall m p sym bak args args'.
   (IsSymBackend sym bak, Monad m, HasLLVMAnn sym) =>
+  -- | This function name is only used in panic messages.
   FunctionName ->
   bak ->
   CtxRepr args' ->
@@ -162,6 +163,7 @@ transformLLVMArgs fnName _ _ _ =
 
 transformLLVMRet ::
   (IsSymBackend sym bak, Monad m, HasLLVMAnn sym) =>
+  -- | This function name is only used in panic messages.
   FunctionName ->
   bak ->
   TypeRepr ret  ->


### PR DESCRIPTION
I'm hitting this panic and I'd like to know why!