### PR TITLE
Export `string` from `Lang.Crucible.Syntax.Concrete`

### DIFF
--- a/crucible-syntax/src/Lang/Crucible/Syntax/Concrete.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Concrete.hs
@@ -40,6 +40,7 @@ module Lang.Crucible.Syntax.Concrete
   , atomName
   , freshAtom
   , nat
+  , string
   , isType
   , operands
   -- * Rules for pretty-printing language syntax


### PR DESCRIPTION
This export allows `ParserHooks` instances to make use of the parser for strings.