### PR TITLE
`crucible-llvm`: Do not assume UTF-8 encoding in `printf` override

### DIFF
--- a/crucible-llvm/CHANGELOG.md
+++ b/crucible-llvm/CHANGELOG.md
@@ -14,6 +14,9 @@
 * `Lang.Crucible.LLVM` : new functions `registerLazyModuleFn` and
   `registerLazyModule`, which delay the building of Crucible CFGs until
   the functions in question are actually called.
+* `executeDirectives` in `Lang.Crucible.LLVM.Printf` now returns a `ByteString`
+  instead of a `String` so that we can better preserve the exact bytes used in
+  string arguments, without applying a particular text encoding.
 
 
 

--- a/crucible-llvm/doc/limitations.md
+++ b/crucible-llvm/doc/limitations.md
@@ -22,11 +22,15 @@ Printf accuracy
 The `printf` implementation provided with `crucible-llvm` makes a
 reasonable effort to implement the various conversion codes, but there
 are some places where the formatting does not strictly conform to
-the specification (most notably, regarding displayed precision for
-floating-point values). We also do not implement the "%a" conversion
-code for binary formatted floating-point values.
-We also will simply print a collection of '?' characters for symbolic
-values.
+the specification. Most notably:
+
+* We do not correctly display precision for floating-point values.
+* We do not implement the `%a` conversion code for binary formatted
+  floating-point values.
+* We assume that all characters in C strings are exactly 1 byte in size, which
+  means that format strings using `%ls` will likely not work as expected.
+* We will simply print a collection of `?` characters for symbolic
+  values.
 
 Thus the exact printed output, number of characters printed, etc,
 may not exactly match that of a conforming implementation.

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libc.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libc.hs
@@ -31,6 +31,7 @@ import           Control.Lens ((^.), _1, _2, _3)
 import qualified Codec.Binary.UTF8.Generic as UTF8
 import           Control.Monad.Reader
 import           Control.Monad.State
+import qualified Data.ByteString as BS
 import qualified Data.Vector as V
 import           System.IO
 import qualified GHC.Stack as GHC
@@ -568,7 +569,7 @@ callPrintf bak mvar
         ((str, n), mem') <- liftIO $ runStateT (executeDirectives (printfOps bak valist) ds) mem
         writeGlobal mvar mem'
         h <- printHandle <$> getContext
-        liftIO $ hPutStr h str
+        liftIO $ BS.hPutStr h str
         liftIO $ bvLit (backendGetSym bak) knownNat (BV.mkBV knownNat (toInteger n))
 
 printfOps :: ( IsSymBackend sym bak, HasLLVMAnn sym, HasPtrWidth wptr


### PR DESCRIPTION
Previously, the implementation of the `printf` override would UTF-8–encode all string arguments that it displays. This patch changes it so that it instead converts the characters from each string argument directly to `ByteString`s using `Data.ByteString.pack`, without picking a particular text encoding. This relies on the assumption that C strings are arrays of 1-byte characters, which is an assumption that the implementation was already relying on implicitly. I have explicitly documented this assumption in
`crucible-llvm/doc/limitations.md`.

It is difficult to write a `crux-llvm` test case that properly covers this new code, as the `printf` override's output is somewhat insensitive to the exact text encoding used. This is primarily useful for downstream code that implements a `sprintf` override, and in that context, the text encoding very much matters, as it can affect the length of the string that it stores.

Fixes #1010.