### PR TITLE
`crux-llvm`: Don't call `llvm-link` when given single input `.bc` file

### DIFF
--- a/crux-llvm/test-data/golden/golden/invoke-test.at-least-clang12.z3.good
+++ b/crux-llvm/test-data/golden/golden/invoke-test.at-least-clang12.z3.good
@@ -13,67 +13,68 @@
 [Crux]           StackAlloc 48 0x8:[64] Mutable 8-byte-aligned internal
 [Crux]         Writes:
 [Crux]           Indexed chunk:
-[Crux]             48 |->   *(48, 0x0:[64]) := (39, 0x0:[64])
+[Crux]             48 |->   *(48, 0x0:[64]) := (40, 0x0:[64])
 [Crux]       Stack frame main
 [Crux]         No writes or allocations
 [Crux]       Base memory
 [Crux]         Allocations:
 [Crux]           StackAlloc 47 0x0:[64] Mutable 8-byte-aligned crux-llvm main(argc, argv) simulation
-[Crux]           GlobalAlloc 46 0x1:[64] Immutable 1-byte-aligned [global variable  ] 
-[Crux]           GlobalAlloc 45 0x0:[64] Immutable 1-byte-aligned [global variable  ] 
-[Crux]           GlobalAlloc 44 0x40:[64] Immutable 8-byte-aligned [global variable  ] 
-[Crux]           GlobalAlloc 43 0x20:[64] Immutable 8-byte-aligned [global variable  ] 
+[Crux]           GlobalAlloc 46 0x40:[64] Immutable 8-byte-aligned [global variable  ] 
+[Crux]           GlobalAlloc 45 0x20:[64] Immutable 8-byte-aligned [global variable  ] 
+[Crux]           GlobalAlloc 44 0x1:[64] Immutable 1-byte-aligned [global variable  ] 
+[Crux]           GlobalAlloc 43 0x0:[64] Immutable 1-byte-aligned [global variable  ] 
 [Crux]           GlobalAlloc 42 0x30:[64] Immutable 8-byte-aligned [global variable  ] vtable.0
-[Crux]           GlobalAlloc 41 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core3fmt9Arguments16new_v1_formatted17hd5e9ced080c81dfaE
-[Crux]           GlobalAlloc 40 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core3fmt10ArgumentV13new17h0af350dc6d28844eE
-[Crux]           GlobalAlloc 39 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4test4main17h21e0b94bad749a9eE
-[Crux]           GlobalAlloc 38 0x0:[64] Immutable 1-byte-aligned [defined function ] main
-[Crux]           GlobalAlloc 37 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core3ptr31_$LT$impl$u20$$BP$mut$u20$T$GT$3add17h8c3ba94a5f9e63b3E
-[Crux]           GlobalAlloc 36 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core5slice29_$LT$impl$u20$$u5b$T$u5d$$GT$3len17hd158f8061ea13277E
-[Crux]           GlobalAlloc 35 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core5slice29_$LT$impl$u20$$u5b$T$u5d$$GT$10as_mut_ptr17h0cc7f77ba7a559f2E
-[Crux]           GlobalAlloc 34 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core3ptr31_$LT$impl$u20$$BP$mut$u20$T$GT$6offset17hdf0bba33c31d7941E
-[Crux]           GlobalAlloc 33 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core3mem7size_of17h24506033ef7ef062E
-[Crux]           GlobalAlloc 32 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core3ptr31_$LT$impl$u20$$BP$mut$u20$T$GT$7is_null17heb54d174dd3ad0e3E
-[Crux]           GlobalAlloc 31 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core3ptr31_$LT$impl$u20$$BP$mut$u20$T$GT$3add17he8137b02ed5a1862E
-[Crux]           GlobalAlloc 30 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core3ptr31_$LT$impl$u20$$BP$mut$u20$T$GT$12wrapping_add17h3f944d3e55c804bdE
-[Crux]           GlobalAlloc 29 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core5slice29_$LT$impl$u20$$u5b$T$u5d$$GT$3len17hfcd8fb803edc91ecE
+[Crux]           GlobalAlloc 41 0x0:[64] Immutable 1-byte-aligned [defined function ] main
+[Crux]           GlobalAlloc 40 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4test4main17h21e0b94bad749a9eE
+[Crux]           GlobalAlloc 39 0x0:[64] Immutable 1-byte-aligned [defined function ] f
+[Crux]           GlobalAlloc 38 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN94_$LT$core..slice..IterMut$LT$$u27$a$C$$u20$T$GT$$u20$as$u20$core..iter..iterator..Iterator$GT$4next17hb33d39b685e46f5aE
+[Crux]           GlobalAlloc 37 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN94_$LT$core..slice..IterMut$LT$$u27$a$C$$u20$T$GT$$u20$as$u20$core..iter..iterator..Iterator$GT$4next17h54ce825ac39c65a6E
+[Crux]           GlobalAlloc 36 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN68_$LT$std..process..ExitCode$u20$as$u20$std..process..Termination$GT$6report17h269423f2b50d143fE
+[Crux]           GlobalAlloc 35 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN54_$LT$I$u20$as$u20$core..iter..traits..IntoIterator$GT$9into_iter17h8263e821b42cf117E
+[Crux]           GlobalAlloc 34 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN54_$LT$I$u20$as$u20$core..iter..traits..IntoIterator$GT$9into_iter17h664642be175905efE
+[Crux]           GlobalAlloc 33 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17ha97fdaad4e15facaE
+[Crux]           GlobalAlloc 32 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core5slice29_$LT$impl$u20$$u5b$T$u5d$$GT$8iter_mut17h9ec72aa0f1adbb13E
+[Crux]           GlobalAlloc 31 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core5slice29_$LT$impl$u20$$u5b$T$u5d$$GT$8iter_mut17h705dbea5bcc6571dE
+[Crux]           GlobalAlloc 30 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core5slice29_$LT$impl$u20$$u5b$T$u5d$$GT$3len17hfcd8fb803edc91ecE
+[Crux]           GlobalAlloc 29 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core5slice29_$LT$impl$u20$$u5b$T$u5d$$GT$3len17hd158f8061ea13277E
 [Crux]           GlobalAlloc 28 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core5slice29_$LT$impl$u20$$u5b$T$u5d$$GT$10as_mut_ptr17hf0bc8639b7d66054E
-[Crux]           GlobalAlloc 27 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core3ptr8null_mut17h236caeaa39cf68eeE
-[Crux]           GlobalAlloc 26 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core3ptr31_$LT$impl$u20$$BP$mut$u20$T$GT$6offset17h1a0a27c95852d960E
-[Crux]           GlobalAlloc 25 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core3ptr31_$LT$impl$u20$$BP$mut$u20$T$GT$15wrapping_offset17h835906e17eda2d9eE
-[Crux]           GlobalAlloc 24 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core3mem7size_of17h901aeab6d69720f2E
-[Crux]           GlobalAlloc 23 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core3ptr31_$LT$impl$u20$$BP$mut$u20$T$GT$7is_null17hefda0dbc6462cbcdE
-[Crux]           GlobalAlloc 22 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN94_$LT$core..slice..IterMut$LT$$u27$a$C$$u20$T$GT$$u20$as$u20$core..iter..iterator..Iterator$GT$4next17hb33d39b685e46f5aE
-[Crux]           GlobalAlloc 21 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN54_$LT$I$u20$as$u20$core..iter..traits..IntoIterator$GT$9into_iter17h8263e821b42cf117E
-[Crux]           GlobalAlloc 20 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core5slice29_$LT$impl$u20$$u5b$T$u5d$$GT$8iter_mut17h705dbea5bcc6571dE
-[Crux]           GlobalAlloc 19 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN94_$LT$core..slice..IterMut$LT$$u27$a$C$$u20$T$GT$$u20$as$u20$core..iter..iterator..Iterator$GT$4next17h54ce825ac39c65a6E
-[Crux]           GlobalAlloc 18 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN54_$LT$I$u20$as$u20$core..iter..traits..IntoIterator$GT$9into_iter17h664642be175905efE
-[Crux]           GlobalAlloc 17 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core5slice29_$LT$impl$u20$$u5b$T$u5d$$GT$8iter_mut17h9ec72aa0f1adbb13E
-[Crux]           GlobalAlloc 16 0x0:[64] Immutable 1-byte-aligned [defined function ] f
-[Crux]           GlobalAlloc 15 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN3std3sys4unix7process14process_common8ExitCode6as_i3217h131bd83b3a6fff4bE
-[Crux]           GlobalAlloc 14 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN68_$LT$std..process..ExitCode$u20$as$u20$std..process..Termination$GT$6report17h269423f2b50d143fE
-[Crux]           GlobalAlloc 13 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17ha97fdaad4e15facaE
-[Crux]           GlobalAlloc 12 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core3ops8function6FnOnce9call_once17h27d755cee67a2edbE
-[Crux]           GlobalAlloc 11 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core3ops8function6FnOnce9call_once32_$u7b$$u7b$vtable.shim$u7d$$u7d$17hbfe54a791614f945E
-[Crux]           GlobalAlloc 10 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h6e1c450892b1f754E
-[Crux]           GlobalAlloc 9 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core3ptr18real_drop_in_place17h96afe4d514bb3c38E
+[Crux]           GlobalAlloc 27 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core5slice29_$LT$impl$u20$$u5b$T$u5d$$GT$10as_mut_ptr17h0cc7f77ba7a559f2E
+[Crux]           GlobalAlloc 26 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core3ptr8null_mut17h236caeaa39cf68eeE
+[Crux]           GlobalAlloc 25 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core3ptr31_$LT$impl$u20$$BP$mut$u20$T$GT$7is_null17hefda0dbc6462cbcdE
+[Crux]           GlobalAlloc 24 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core3ptr31_$LT$impl$u20$$BP$mut$u20$T$GT$7is_null17heb54d174dd3ad0e3E
+[Crux]           GlobalAlloc 23 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core3ptr31_$LT$impl$u20$$BP$mut$u20$T$GT$6offset17hdf0bba33c31d7941E
+[Crux]           GlobalAlloc 22 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core3ptr31_$LT$impl$u20$$BP$mut$u20$T$GT$6offset17h1a0a27c95852d960E
+[Crux]           GlobalAlloc 21 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core3ptr31_$LT$impl$u20$$BP$mut$u20$T$GT$3add17he8137b02ed5a1862E
+[Crux]           GlobalAlloc 20 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core3ptr31_$LT$impl$u20$$BP$mut$u20$T$GT$3add17h8c3ba94a5f9e63b3E
+[Crux]           GlobalAlloc 19 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core3ptr31_$LT$impl$u20$$BP$mut$u20$T$GT$15wrapping_offset17h835906e17eda2d9eE
+[Crux]           GlobalAlloc 18 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core3ptr31_$LT$impl$u20$$BP$mut$u20$T$GT$12wrapping_add17h3f944d3e55c804bdE
+[Crux]           GlobalAlloc 17 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core3ptr18real_drop_in_place17h96afe4d514bb3c38E
+[Crux]           GlobalAlloc 16 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core3ops8function6FnOnce9call_once32_$u7b$$u7b$vtable.shim$u7d$$u7d$17hbfe54a791614f945E
+[Crux]           GlobalAlloc 15 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core3ops8function6FnOnce9call_once17h27d755cee67a2edbE
+[Crux]           GlobalAlloc 14 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core3mem7size_of17h901aeab6d69720f2E
+[Crux]           GlobalAlloc 13 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core3mem7size_of17h24506033ef7ef062E
+[Crux]           GlobalAlloc 12 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core3fmt9Arguments16new_v1_formatted17hd5e9ced080c81dfaE
+[Crux]           GlobalAlloc 11 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN4core3fmt10ArgumentV13new17h0af350dc6d28844eE
+[Crux]           GlobalAlloc 10 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN3std3sys4unix7process14process_common8ExitCode6as_i3217h131bd83b3a6fff4bE
+[Crux]           GlobalAlloc 9 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h6e1c450892b1f754E
 [Crux]           GlobalAlloc 8 0x0:[64] Immutable 1-byte-aligned [defined function ] _ZN3std2rt10lang_start17h4f32aa1279b9079fE
-[Crux]           GlobalAlloc 7 0x0:[64] Immutable 1-byte-aligned [external function] llvm.memcpy.p0i8.p0i8.i64
+[Crux]           GlobalAlloc 7 0x0:[64] Immutable 1-byte-aligned [external function] llvm.memset.p0i8.i64
 [Crux]           GlobalAlloc 6 0x0:[64] Immutable 1-byte-aligned [external function] _ZN3std2io5stdio6_print17hdec9324a4622df1eE
 [Crux]           GlobalAlloc 5 0x0:[64] Immutable 1-byte-aligned [external function] _ZN4core3fmt3num52_$LT$impl$u20$core..fmt..Display$u20$for$u20$i32$GT$3fmt17h7a9374c1576dce31E
-[Crux]           GlobalAlloc 4 0x0:[64] Immutable 1-byte-aligned [external function] llvm.memset.p0i8.i64
+[Crux]           GlobalAlloc 4 0x0:[64] Immutable 1-byte-aligned [external function] llvm.memcpy.p0i8.p0i8.i64
 [Crux]           GlobalAlloc 3 0x0:[64] Immutable 1-byte-aligned [external function] llvm.assume
 [Crux]           GlobalAlloc 2 0x0:[64] Immutable 1-byte-aligned [external function] rust_eh_personality
 [Crux]           GlobalAlloc 1 0x0:[64] Immutable 1-byte-aligned [external function] _ZN3std2rt19lang_start_internal17h3dc68cf5532522d7E
 [Crux]         Writes:
 [Crux]           Indexed chunk:
-[Crux]             42 |->   *(42, 0x0:[64]) := {base+0 = (9, 0x0:[64])
+[Crux]             42 |->   *(42, 0x0:[64]) := {base+0 = (17, 0x0:[64])
 [Crux]                      ,base+8 = 0x8:[64]
 [Crux]                      ,base+16 = 0x8:[64]
-[Crux]                      ,base+24 = (10, 0x0:[64])
-[Crux]                      ,base+32 = (10, 0x0:[64])
-[Crux]                      ,base+40 = (11, 0x0:[64])}
-[Crux]             46 |->   *(46, 0x0:[64]) := {base+0 = "\n"}
+[Crux]                      ,base+24 = (9, 0x0:[64])
+[Crux]                      ,base+32 = (9, 0x0:[64])
+[Crux]                      ,base+40 = (16, 0x0:[64])}
+[Crux]             46 |->
+[Crux]               *(46, 0x0:[64]) := {base+0 = "\SOH\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\ETX\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\ETX\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL \NUL\NUL\NUL\NUL\NUL\NUL\NUL\ETX\NUL\NUL\NUL\NUL\NUL\NUL\NUL"}
 [Crux]     in context:
 [Crux]       _ZN3std2rt10lang_start17h4f32aa1279b9079fE
 [Crux]       main


### PR DESCRIPTION
This has two benefits:

* `crux-llvm`'s compilation step becomes slightly faster, as using `llvm-link` is slower than a simple file copy.

* Moreover, calling `llvm-link file.bc -o file.bc` can sometimes rearrange the order of declarations in `file.bc`, which makes the output of certain test cases less stable across LLVM versions (see #1011). While it is difficult to avoid this issue in the general case where a user supplies multiple `.bc` files as input, we can at least avoid the issue for the common case of a single `.bc` file input.

Fixes #1011.