### PR TITLE
`crux`: Add `--offline-solver-output` flag

### DIFF
--- a/crux/src/Crux/Config/Common.hs
+++ b/crux/src/Crux/Config/Common.hs
@@ -174,6 +174,9 @@ data CruxOptions = CruxOptions
   , onlineSolverOutput       :: Maybe FilePath
     -- ^ The file to store the interaction with the online goal solver (if
     -- solving is being performed online)
+  , offlineSolverOutput      :: Maybe FilePath
+    -- ^ A template to use for files to store interactions with offline goal
+    -- solvers (if solving is being performed offline).
 
   , yicesMCSat               :: Bool
     -- ^ Should the MC-SAT Yices solver be enabled (disables unsat cores; default: no)
@@ -295,6 +298,10 @@ cruxOptions = Config
           onlineSolverOutput <-
             sectionMaybe "online-solver-output" stringSpec
             "The file to store the interaction with the online goal solver (if any) (default: none)"
+
+          offlineSolverOutput <-
+            sectionMaybe "offine-solver-output" stringSpec
+            (pack offlineSolverOutputHelp)
 
           simVerbose <-
             section "sim-verbose" numSpec 1
@@ -447,7 +454,7 @@ cruxOptions = Config
       , Option [] ["no-unsat-cores"]
         "Disable computing unsat cores for successful proofs"
         $ NoArg $ \opts -> Right opts { unsatCores = False }
-      
+
       , Option "n" ["get-abducts"]
         "Get these many abducts. Only works with cvc5, 0 otherwise."
         $ ReqArg "ABDUCTS"
@@ -476,6 +483,10 @@ cruxOptions = Config
       , Option [] ["online-solver-output"]
         "The file to store the interaction with the online goal solver (if any) (default: none)"
         $ ReqArg "FILE" $ \f opts -> Right opts { onlineSolverOutput = Just f }
+
+      , Option [] ["offline-solver-output"]
+        offlineSolverOutputHelp
+        $ ReqArg "FILE" $ \f opts -> Right opts { offlineSolverOutput = Just f }
 
       , Option [] ["mcsat"]
         "Enable the MC-SAT solver in Yices (disables unsat cores)"
@@ -516,6 +527,15 @@ cruxOptions = Config
         $ ReqArg "FPREP" $ \v opts -> Right opts { floatMode = map toLower v }
       ]
   }
+
+offlineSolverOutputHelp :: String
+offlineSolverOutputHelp = unlines
+  [ "A template to use for files to store interactions with offline goal solvers"
+  , "(if any) (default: none). For example, if the template is `offline-output.smt2`,"
+  , "then each file will be named `offline-output-<goal number>-<solver name>.smt2,"
+  , "where <goal number> is the number of the goal that was proven (starting at 0)"
+  , "and <solver name> is the name of the solver used to dispatch that goal."
+  ]
 
 dflt :: String -> (String -> OptSetter opts) -> (Maybe String -> OptSetter opts)
 dflt x p mb = p (fromMaybe x mb)

--- a/crux/src/Crux/Goal.hs
+++ b/crux/src/Crux/Goal.hs
@@ -24,6 +24,8 @@ import qualified Data.Text as Text
 import           Data.Void
 import           Prettyprinter
 import           System.Exit (ExitCode(ExitSuccess))
+import           System.FilePath ((<.>), splitExtension)
+import           System.IO (Handle, IOMode(..), withFile)
 import qualified System.Timeout as ST
 
 import What4.Interface (notPred, getConfiguration, IsExprBuilder)
@@ -220,7 +222,7 @@ proveGoalsOffline adapters opts ctx explainFailure (Just gs0) = do
           goal <- notPred sym (p ^. labeledPred)
 
           res <- dispatchSolversOnGoalAsync (goalTimeout opts) adapters
-                           (runOneSolver p assumptionsInScope assumptions goal)
+                           (runOneSolver p assumptionsInScope assumptions goal goalNumber)
           end goalNumber
           case res of
             Right Nothing -> do
@@ -246,12 +248,18 @@ proveGoalsOffline adapters opts ctx explainFailure (Just gs0) = do
                  -> Assumptions sym
                  -> BoolExpr t
                  -> BoolExpr t
+                 -> Integer
                  -> WS.SolverAdapter st
                  -> IO ([ProgramLoc], ProofResult sym)
-    runOneSolver p assumptionsInScope assumptions goal adapter = do
-      -- NOTE: We don't currently provide a method for capturing the output
-      -- sent to offline solvers.  We would probably want a file per goal per adapter.
-      let logData = WS.defaultLogData
+    runOneSolver p assumptionsInScope assumptions goal goalNumber adapter =
+      -- Create a file to a single offline solver interaction, assuming the user
+      -- has selected this option. A single Crux session might invoke an offline
+      -- solver multiple times, so each file has unique suffixes to indicate the
+      -- goal number and which solver in particular was used to solve the goal.
+      -- (Recall that a Crux user can choose multiple offline solvers, so it is
+      -- important to indicate which solver was picked for each goal.)
+      withMaybeOfflineSolverOutputHandle (offlineSolverOutput opts) $ \mbLogHandle ->
+      let logData = WS.defaultLogData { WS.logHandle = mbLogHandle } in
       WS.solver_adapter_check_sat adapter (ctx ^. ctxSymInterface) logData [assumptions, goal] $ \satRes ->
         case satRes of
           Unsat _ -> do
@@ -271,6 +279,25 @@ proveGoalsOffline adapters opts ctx explainFailure (Just gs0) = do
             explain <- explainFailure Nothing p
             let locs = assumptionsTopLevelLocs assumptionsInScope
             return (locs, NotProved explain Nothing [])
+      where
+        -- Create a handle for a file based on the template. For instance, if
+        -- the template is @solver-output.smt2@, then create a file named
+        -- @solver-output-<goal number>-<solver name>.smt2@.
+        withOfflineSolverOutputHandle :: FilePath -> (Handle -> IO r) -> IO r
+        withOfflineSolverOutputHandle template k =
+          let (templateName, templateExt) = splitExtension template
+              fileName = templateName ++ "-" ++ show goalNumber
+                                      ++ "-" ++ WS.solver_adapter_name adapter
+                                     <.> templateExt in
+          withFile fileName WriteMode k
+
+        -- Lift @withOfflineSolverOutputHandle@ to a @Maybe FilePath@ argument.
+        withMaybeOfflineSolverOutputHandle ::
+          Maybe FilePath -> (Maybe Handle -> IO r) -> IO r
+        withMaybeOfflineSolverOutputHandle mbTemplate k =
+          case mbTemplate of
+            Just template -> withOfflineSolverOutputHandle template (k . Just)
+            Nothing       -> k Nothing
 
 evalModelFromEvents :: [CrucibleEvent GroundValueWrapper] -> ModelView
 evalModelFromEvents evs = ModelView (foldl f (modelVals emptyModelView) evs)

--- a/uc-crux-llvm/test/Utils.hs
+++ b/uc-crux-llvm/test/Utils.hs
@@ -180,6 +180,7 @@ withOptions llvmModule file k =
         , Crux.forceOfflineGoalSolving = False
         , Crux.pathSatSolverOutput = Nothing
         , Crux.onlineSolverOutput = Nothing
+        , Crux.offlineSolverOutput = Nothing
         , Crux.yicesMCSat = False
         , Crux.floatMode = "default"
         , Crux.proofGoalsFailFast = False


### PR DESCRIPTION
The implementation details for `--offline-solver-output` differ a bit from those of `--online-solver-output` due to the fact that (1) offline solvers are invoked multiple times to handle multiple goals, and (2) users can specify multiple offline solvers. See `withOfflineSolverOutputHandle`.

Fixes #1051.