### PR TITLE
`crux-llvm-test`: Sanitize SMT formulas in `--get-abducts` output

### DIFF
--- a/crux-llvm/crux-llvm.cabal
+++ b/crux-llvm/crux-llvm.cabal
@@ -174,4 +174,6 @@ test-suite crux-llvm-test
   build-depends:
                 crux-llvm,
                 extra,
+                regex-base,
+                regex-posix,
                 versions

--- a/crux-llvm/test-data/golden/abd-test-file-32.cvc5.good
+++ b/crux-llvm/test-data/golden/abd-test-file-32.cvc5.good
@@ -2,7 +2,7 @@
 [Crux]   test-data/golden/abd-test-file-32.c:11:0: error: in main
 [Crux]   crucible_assert
 [Crux] 
-[Crux]   One of the following 3 fact(s) would entail the goal
+[Crux]   One of the following 3 facts would entail the goal
 [Crux]   * <unstable SMT formula output removed>
 [Crux]   * <unstable SMT formula output removed>
 [Crux]   * <unstable SMT formula output removed>

--- a/crux-llvm/test-data/golden/abd-test-file-32.cvc5.good
+++ b/crux-llvm/test-data/golden/abd-test-file-32.cvc5.good
@@ -3,7 +3,7 @@
 [Crux]   crucible_assert
 [Crux] 
 [Crux]   One of the following 3 fact(s) would entail the goal
-[Crux]   * (= x #b00000000000000000000000000000001)
-[Crux]   * (= x #b00000000000000000000000000000000)
-[Crux]   * (bvult x #b00000000000000000000000001100011)
+[Crux]   * <unstable SMT formula output removed>
+[Crux]   * <unstable SMT formula output removed>
+[Crux]   * <unstable SMT formula output removed>
 [Crux] Overall status: Invalid.

--- a/crux-llvm/test-data/golden/abd-test-file-32.pre-clang13.cvc5.good
+++ b/crux-llvm/test-data/golden/abd-test-file-32.pre-clang13.cvc5.good
@@ -1,9 +1,0 @@
-[Crux] Found counterexample for verification goal
-[Crux]   test-data/golden/abd-test-file-32.c:11:0: error: in main
-[Crux]   crucible_assert
-[Crux] 
-[Crux]   One of the following 3 fact(s) would entail the goal
-[Crux]   * (bvult x #b00000000000000000000000000000001)
-[Crux]   * (bvult #b00000000000000000000000001100100 x)
-[Crux]   * (= #b00000000000000000000000000000001 x)
-[Crux] Overall status: Invalid.

--- a/crux-llvm/test-data/golden/abd-test-file-8.cvc5.good
+++ b/crux-llvm/test-data/golden/abd-test-file-8.cvc5.good
@@ -2,7 +2,7 @@
 [Crux]   test-data/golden/abd-test-file-8.c:11:0: error: in main
 [Crux]   crucible_assert
 [Crux] 
-[Crux]   One of the following 3 fact(s) would entail the goal
+[Crux]   One of the following 3 facts would entail the goal
 [Crux]   * <unstable SMT formula output removed>
 [Crux]   * <unstable SMT formula output removed>
 [Crux]   * <unstable SMT formula output removed>

--- a/crux-llvm/test-data/golden/abd-test-file-8.cvc5.good
+++ b/crux-llvm/test-data/golden/abd-test-file-8.cvc5.good
@@ -3,7 +3,7 @@
 [Crux]   crucible_assert
 [Crux] 
 [Crux]   One of the following 3 fact(s) would entail the goal
-[Crux]   * (bvult x #b00000001)
-[Crux]   * (bvult #b01100100 x)
-[Crux]   * (= #b00000001 x)
+[Crux]   * <unstable SMT formula output removed>
+[Crux]   * <unstable SMT formula output removed>
+[Crux]   * <unstable SMT formula output removed>
 [Crux] Overall status: Invalid.

--- a/crux-llvm/test-data/golden/abd-test-maxint-32.cvc5.good
+++ b/crux-llvm/test-data/golden/abd-test-maxint-32.cvc5.good
@@ -2,7 +2,7 @@
 [Crux]   test-data/golden/abd-test-maxint-32.c:6:0: error: in main
 [Crux]   crucible_assert
 [Crux] 
-[Crux]   One of the following 2 fact(s) would entail the goal
+[Crux]   One of the following 2 facts would entail the goal
 [Crux]   * <unstable SMT formula output removed>
 [Crux]   * <unstable SMT formula output removed>
 [Crux] Overall status: Invalid.

--- a/crux-llvm/test-data/golden/abd-test-maxint-32.cvc5.good
+++ b/crux-llvm/test-data/golden/abd-test-maxint-32.cvc5.good
@@ -3,6 +3,6 @@
 [Crux]   crucible_assert
 [Crux] 
 [Crux]   One of the following 2 fact(s) would entail the goal
-[Crux]   * (bvult x #b00000000000000000000000000000001)
-[Crux]   * (bvult x #b11111111111111111111111111111111)
+[Crux]   * <unstable SMT formula output removed>
+[Crux]   * <unstable SMT formula output removed>
 [Crux] Overall status: Invalid.

--- a/crux-llvm/test-data/golden/abd-test-trans-8.cvc5.good
+++ b/crux-llvm/test-data/golden/abd-test-trans-8.cvc5.good
@@ -2,7 +2,7 @@
 [Crux]   test-data/golden/abd-test-trans-8.c:9:0: error: in main
 [Crux]   crucible_assert
 [Crux] 
-[Crux]   One of the following 3 fact(s) would entail the goal
+[Crux]   One of the following 3 facts would entail the goal
 [Crux]   * <unstable SMT formula output removed>
 [Crux]   * <unstable SMT formula output removed>
 [Crux]   * <unstable SMT formula output removed>

--- a/crux-llvm/test-data/golden/abd-test-trans-8.cvc5.good
+++ b/crux-llvm/test-data/golden/abd-test-trans-8.cvc5.good
@@ -3,7 +3,7 @@
 [Crux]   crucible_assert
 [Crux] 
 [Crux]   One of the following 3 fact(s) would entail the goal
-[Crux]   * (= z y)
-[Crux]   * (= (bvashr x z) #b00000001)
-[Crux]   * (bvult z (bvlshr x y))
+[Crux]   * <unstable SMT formula output removed>
+[Crux]   * <unstable SMT formula output removed>
+[Crux]   * <unstable SMT formula output removed>
 [Crux] Overall status: Invalid.

--- a/crux/src/Crux/FormatOut.hs
+++ b/crux/src/Crux/FormatOut.hs
@@ -84,6 +84,9 @@ sayWhatFailedGoals skipIncompl showVars allGls =
                     else [] 
                  -- print abducts, if any
                  ++ if s /= [] then
+                      -- NB: If you update the contents of this error message,
+                      -- make sure to update the corresponding regex that
+                      -- checks for this in crux-llvm/test/Test.hs.
                       PP.pretty ("One of the following " ++ show (length s) ++ " fact(s) would entail the goal")
                       : (map (\x -> PP.pretty ('*' : ' ' : x)) s)
                     else [])]

--- a/crux/src/Crux/FormatOut.hs
+++ b/crux/src/Crux/FormatOut.hs
@@ -81,7 +81,7 @@ sayWhatFailedGoals skipIncompl showVars allGls =
                  -- variable events that led to this failure
                  ++ if showVars then
                       ["Symbolic variables:", PP.indent 2 (PP.vcat (ppVars evs))]
-                    else [] 
+                    else []
                  -- print abducts, if any
                  ++ if s /= [] then
                       -- NB: If you update the contents of this error message,

--- a/crux/src/Crux/FormatOut.hs
+++ b/crux/src/Crux/FormatOut.hs
@@ -84,11 +84,18 @@ sayWhatFailedGoals skipIncompl showVars allGls =
                     else []
                  -- print abducts, if any
                  ++ if s /= [] then
-                      -- NB: If you update the contents of this error message,
-                      -- make sure to update the corresponding regex that
-                      -- checks for this in crux-llvm/test/Test.hs.
-                      PP.pretty ("One of the following " ++ show (length s) ++ " fact(s) would entail the goal")
-                      : (map (\x -> PP.pretty ('*' : ' ' : x)) s)
+                      let numFacts = length s
+                          -- NB: If you update the contents of this error
+                          -- message, make sure to update the corresponding
+                          -- regexes that check for this in
+                          -- crux-llvm/test/Test.hs.
+                          herald = PP.plural
+                                     "The following fact"
+                                     ("One of the following"
+                                        PP.<+> PP.viaShow numFacts
+                                        PP.<+> "facts")
+                                     numFacts PP.<+> "would entail the goal" in
+                      herald : (map (\x -> PP.pretty ('*' : ' ' : x)) s)
                     else [])]
          | otherwise ->
            [ PP.nest 2 $ PP.vcat [ "Failed to prove verification goal", ex ] ]


### PR DESCRIPTION
Unfortunately, the abducts (i.e., SMT formulas) that CVC5 suggests are wildly sensitive to the particular CVC5 and LLVM versions being used, which makes the abducts poorly suited to golden test output. This patch scrubs the SMT formulas from `crux`'s `--get-abducts` output to avoid this issue.

Fixes #1086.