### PR TITLE
Fix Docker issues uncovered during Crux 0.7 release

### DIFF
--- a/.github/Dockerfile-crux-llvm
+++ b/.github/Dockerfile-crux-llvm
@@ -17,7 +17,7 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 WORKDIR /usr/local/bin
-RUN curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20220812/ubuntu-22.04-bin.zip"
+RUN curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20220902/ubuntu-22.04-bin.zip"
 RUN unzip solvers.zip && rm solvers.zip && chmod +x *
 
 ENV PATH=/root/ghcup-download/bin:/root/.ghcup/bin:$PATH

--- a/.github/Dockerfile-crux-mir
+++ b/.github/Dockerfile-crux-mir
@@ -21,7 +21,7 @@ RUN apt-get update && \
 COPY --from=mir_json /usr/local/cargo /usr/local/cargo
 COPY --from=mir_json /usr/local/rustup /usr/local/rustup
 WORKDIR /usr/local/bin
-RUN curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20220812/ubuntu-22.04-bin.zip"
+RUN curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20220902/ubuntu-22.04-bin.zip"
 RUN unzip solvers.zip && rm solvers.zip && chmod +x *
 
 ENV CARGO_HOME=/usr/local/cargo

--- a/.github/Dockerfile-crux-mir
+++ b/.github/Dockerfile-crux-mir
@@ -2,6 +2,8 @@ FROM rust:1.46.0 AS mir_json
 
 ADD dependencies/mir-json /mir-json
 WORKDIR /mir-json
+# Work around https://github.com/rust-lang/cargo/issues/10303
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 RUN rustup toolchain install nightly-2020-03-22 --force
 RUN rustup component add --toolchain nightly-2020-03-22 rustc-dev
 RUN rustup default nightly-2020-03-22

--- a/.github/Dockerfile-crux-mir
+++ b/.github/Dockerfile-crux-mir
@@ -47,6 +47,7 @@ ARG DIR=/crux-mir
 RUN mkdir -p ${DIR}/build
 ADD crucible ${DIR}/build/crucible
 ADD crucible-concurrency ${DIR}/build/crucible-concurrency
+ADD crucible-mir ${DIR}/build/crucible-mir
 ADD crucible-syntax ${DIR}/build/crucible-syntax
 ADD crux ${DIR}/build/crux
 ADD crux-mir ${DIR}/build/crux-mir

--- a/.github/cabal.project.crux-mir
+++ b/.github/cabal.project.crux-mir
@@ -1,6 +1,7 @@
 packages:
   crucible/
   crucible-concurrency/
+  crucible-mir/
   crucible-syntax/
   crux/
   crux-mir/


### PR DESCRIPTION
The `Dockerfile`s used for the `crux-llvm` and `crux-mir` were slightly broken, but unfortunately, we do not currently test these on CI, so I was not aware of this until I was preparing the Crux 0.7. Once this lands, I will push these to the `release-crux-0.7` branch as well.