### PR TITLE
Consistently use same Rust nightly across CI and Docker images

### DIFF
--- a/.github/Dockerfile-crux-mir
+++ b/.github/Dockerfile-crux-mir
@@ -1,13 +1,19 @@
+# If you update this, make sure to also update RUST_TOOLCHAIN in
+# .github/workflows/crux-mir-build.yml
+ARG RUST_TOOLCHAIN="nightly-2023-01-23"
+
 FROM rust:1.46.0 AS mir_json
+ARG RUST_TOOLCHAIN
 
 ADD dependencies/mir-json /mir-json
 WORKDIR /mir-json
-RUN rustup toolchain install nightly-2020-03-22 --force
-RUN rustup component add --toolchain nightly-2020-03-22 rustc-dev
-RUN rustup default nightly-2020-03-22
+RUN rustup toolchain install ${RUST_TOOLCHAIN} --force
+RUN rustup component add --toolchain ${RUST_TOOLCHAIN} rustc-dev
+RUN rustup default ${RUST_TOOLCHAIN}
 RUN cargo install --locked
 
 FROM ubuntu:22.04 AS build
+ARG RUST_TOOLCHAIN
 
 RUN apt-get update && \
     apt-get install -y \
@@ -58,7 +64,7 @@ RUN cabal v2-build --only-dependencies crux-mir
 RUN cabal v2-build crux-mir
 RUN cp `cabal v2-exec which crux-mir` /usr/local/bin
 RUN cp /usr/local/cargo/bin/* /usr/local/bin/
-RUN rustup default nightly-2020-03-22
+RUN rustup default ${RUST_TOOLCHAIN}
 WORKDIR ${DIR}/build/crux-mir
 RUN ./translate_libs.sh
 WORKDIR ${DIR}/build

--- a/.github/workflows/crux-mir-build.yml
+++ b/.github/workflows/crux-mir-build.yml
@@ -20,6 +20,9 @@ env:
   # (symptom: "No suitable image found ... unknown file type, first
   # eight bytes: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00")
   CACHE_VERSION: 4
+  # If you update this, make sure to also update RUST_TOOLCHAIN in
+  # .github/Dockerfile-crux-mir
+  RUST_TOOLCHAIN: "nightly-2023-01-23"
 
 jobs:
   config:
@@ -101,7 +104,7 @@ jobs:
       - name: Install latest Rust nightly
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2023-01-23
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
           override: true
           components: rustc-dev
 


### PR DESCRIPTION
This should fix the nightly `crux-mir` Docker job. While I was in town, I made sure to leave breadcrumbs to the reader such that if they ever update the Rust nightly in one spot, they will remember to update it in the other spot.