### PR TITLE
CI: Install `llvm@12` with `brew` on macOS

### DIFF
--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -66,7 +66,7 @@ install_llvm() {
   if [[ "$RUNNER_OS" = "Linux" ]]; then
     sudo apt-get update -q && sudo apt-get install -y clang-12 llvm-12-tools
   elif [[ "$RUNNER_OS" = "macOS" ]]; then
-    brew install llvm@11
+    brew install llvm@12
   elif [[ "$RUNNER_OS" = "Windows" ]]; then
     choco install llvm
   else


### PR DESCRIPTION
This is done for two reasons:

1. It provides a workaround for https://github.com/Homebrew/brew/issues/15859 (which causes `brew install llvm@11` to fail) until a fix becomes available. Practically speaking, this means that the nightly Crux builds will work once again.
2. It means that our CI consistently tests against LLVM 12 on both Linux and macOS.