### PR TITLE
crucible-syntax: Bump version bound on megaparsec

### DIFF
--- a/crucible-syntax/crucible-syntax.cabal
+++ b/crucible-syntax/crucible-syntax.cabal
@@ -24,7 +24,7 @@ library
     mtl,
     parameterized-utils >= 0.1.7,
     prettyprinter >= 1.7.0,
-    megaparsec >= 7.0 && < 9.4,
+    megaparsec >= 7.0 && < 9.7,
     text,
     transformers,
     vector,


### PR DESCRIPTION
Version 9.6 is out now and appears to work just fine.