### PR TITLE
crucible-llvm-cli: Support for overrides; loading and calling functions

### DIFF
--- a/crucible-cli/src/Lang/Crucible/CLI.hs
+++ b/crucible-cli/src/Lang/Crucible/CLI.hs
@@ -64,8 +64,8 @@ import What4.Solver (defaultLogData, runZ3InOverride, z3Options)
 -- | Allows users to hook into the various stages of 'simulateProgram'.
 data SimulateProgramHooks ext = SimulateProgramHooks
   { setupHook ::
-      forall p sym rtp a r t st fs. (IsSymInterface sym, sym ~ ExprBuilder t st fs) =>
-        sym ->
+      forall p sym bak rtp a r t st fs. (IsSymBackend sym bak, sym ~ ExprBuilder t st fs) =>
+        bak ->
         HandleAllocator ->
         OverrideSim p sym ext rtp a r ()
     -- ^ Override action to execute before simulation. Used by the LLVM
@@ -159,7 +159,7 @@ simulateProgramWithExtension mkExt fn theInput outh profh opts hooks =
                        let simSt  = InitialState simCtx gst defaultAbortHandler retType $
                                       runOverrideSim retType $
                                         do mapM_ (registerFnBinding . fst) ovrs
-                                           setupHook hooks sym ha
+                                           setupHook hooks bak ha
                                            regValue <$> callFnVal (HandleFnVal mainHdl) emptyRegMap
 
                        hPutStrLn outh "==== Begin Simulation ===="

--- a/crucible-llvm-cli/test-data/ptr.cbl
+++ b/crucible-llvm-cli/test-data/ptr.cbl
@@ -21,4 +21,12 @@
     (assert! (equal? vblk0 vblk) "stored block numbers equal")
     (assert! (equal? voff0 voff) "stored offsets equal")
 
+    (let g (resolve-global "malloc"))
+    (let gblk (ptr-block 64 g))
+    (assert! (not (equal? gblk 0)) "malloc block number nonzero")
+    (let h (load-handle (Ptr 64) ((Ptr 64)) g))
+    (let m (funcall h p0))
+    (let mblk (ptr-block 64 m))
+    (assert! (not (equal? mblk 0)) "malloc'd block number nonzero")
+
     (return ())))

--- a/crucible-llvm-syntax/README.md
+++ b/crucible-llvm-syntax/README.md
@@ -32,7 +32,13 @@ If the numeral `w` is the width of a pointer and `n` is an arbitrary numeral,
 - `ptr-ite : Bool -> Ptr n -> Ptr n -> Ptr n`: if-then-else for pointers
 - `alloca : Alignment -> Bitvector w -> Ptr w`: allocate space on the stack
 - `load : Alignment -> LLVMType -> Ptr w -> T`: load a value from memory, where the type `T` is determined by the `LLVMType`
+- `load-handle : Type -> [Type] -> Ptr w -> T`: load a function handle from memory, where the type `T` is determined by the given return and argument types
 - `store : Alignment -> LLVMType -> Ptr w -> T -> Unit`: store a value to memory, where the type `T` is determined by the `LLVMType`
+- `resolve-global : String -> Ptr w`: get the address of a global variable
+
+`Type` signifies a Crucible type, rather than an LLVM type. This means there
+are no C- or LLVM-like `Type`s such as `i8*` or `size_t`, but rather the base
+Crucible types as defined by `crucible-syntax`, and `(Ptr n)`.
 
 ## Further extensions
 

--- a/crucible-llvm-syntax/crucible-llvm-syntax.cabal
+++ b/crucible-llvm-syntax/crucible-llvm-syntax.cabal
@@ -97,6 +97,7 @@ library
     crucible >= 0.1,
     crucible-llvm,
     crucible-syntax,
+    llvm-pretty,
     mtl,
     parameterized-utils >= 0.1.7,
     prettyprinter,

--- a/crucible-llvm-syntax/test-data/ptr.cbl
+++ b/crucible-llvm-syntax/test-data/ptr.cbl
@@ -21,4 +21,7 @@
     (assert! (equal? vblk0 vblk) "stored block numbers equal")
     (assert! (equal? voff0 voff) "stored offsets equal")
 
+    (let g (resolve-global "malloc"))
+    (let h (load-handle (Ptr 64) ((Ptr 64)) g))
+
     (return p)))

--- a/crucible-llvm-syntax/test-data/ptr.out.good
+++ b/crucible-llvm-syntax/test-data/ptr.out.good
@@ -19,6 +19,8 @@
       (let voff (ptr-offset 8 v))
       (assert! (equal? vblk0 vblk) "stored block numbers equal")
       (assert! (equal? voff0 voff) "stored offsets equal")
+      (let g (resolve-global "malloc"))
+      (let h (load-handle (Ptr 64) ((Ptr 64)) g))
       (return p)))
 
 test-ptr
@@ -77,6 +79,10 @@ test-ptr
   $22 = stringLit("stored offsets equal")
   % 22:5
   assert($21, $22)
-  % 24:5
+  % 24:12
+  $23 = resolveGlobal crucible-llvm-syntax-test-memory "malloc"
+  % 25:12
+  $24 = loadFunctionHandle crucible-llvm-syntax-test-memory $23 as Nothing
+  % 27:5
   return $4
   % no postdom

--- a/crucible-llvm/crucible-llvm.cabal
+++ b/crucible-llvm/crucible-llvm.cabal
@@ -67,6 +67,8 @@ library
     Lang.Crucible.LLVM.Extension
     Lang.Crucible.LLVM.Globals
     Lang.Crucible.LLVM.Intrinsics
+    Lang.Crucible.LLVM.Intrinsics.Libc
+    Lang.Crucible.LLVM.Intrinsics.LLVM
     Lang.Crucible.LLVM.MalformedLLVMModule
     Lang.Crucible.LLVM.MemModel
     Lang.Crucible.LLVM.MemModel.CallStack
@@ -90,9 +92,7 @@ library
     Lang.Crucible.LLVM.Extension.Arch
     Lang.Crucible.LLVM.Extension.Syntax
     Lang.Crucible.LLVM.Intrinsics.Common
-    Lang.Crucible.LLVM.Intrinsics.Libc
     Lang.Crucible.LLVM.Intrinsics.Libcxx
-    Lang.Crucible.LLVM.Intrinsics.LLVM
     Lang.Crucible.LLVM.Intrinsics.Options
     Lang.Crucible.LLVM.MemModel.Common
     Lang.Crucible.LLVM.MemModel.Options

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Errors/MemoryError.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Errors/MemoryError.hs
@@ -58,7 +58,7 @@ data MemoryOp sym w
        (Maybe String, LLVMPtr sym w) -- src
        (SymBV sym wlen) -- length
        (Mem sym)
-  | MemLoadHandleOp L.Type (Maybe String) (LLVMPtr sym w) (Mem sym)
+  | MemLoadHandleOp (Maybe L.Type) (Maybe String) (LLVMPtr sym w) (Mem sym)
   | forall wlen. (1 <= wlen) => MemInvalidateOp
        Text (Maybe String) (LLVMPtr sym w) (SymBV sym wlen) (Mem sym)
 
@@ -157,7 +157,11 @@ ppMemoryOp (MemCopyOp (gsym_dest, dest) (gsym_src, src) len mem) =
        ]
 
 ppMemoryOp (MemLoadHandleOp sig gsym ptr mem) =
-  vsep [ "Attempting to load callable function with type:" <+> viaShow (L.ppType sig)
+  vsep [ case sig of
+           Just s ->
+             hsep ["Attempting to load callable function with type:", viaShow (L.ppType s)]
+           Nothing ->
+             hsep ["Attempting to load callable function:"]
        , indent 2 (hsep ([ "Via pointer:" ] ++ ppGSym gsym ++ [ ppPtr ptr ]))
        , "In memory state:"
        , indent 2 (ppMem mem)

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Extension/Syntax.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Extension/Syntax.hs
@@ -171,7 +171,7 @@ data LLVMStmt (f :: CrucibleType -> Type) :: CrucibleType -> Type where
   LLVM_LoadHandle ::
      HasPtrWidth wptr =>
      !(GlobalVar Mem)            {- Memory global variable -} ->
-     !L.Type                     {- expected LLVM type of the function -} ->
+     !(Maybe L.Type)             {- expected LLVM type of the function (used only for pretty-printing) -} ->
      !(f (LLVMPointerType wptr)) {- Pointer to load from -} ->
      !(CtxRepr args)             {- Expected argument types of the function -} ->
      !(TypeRepr ret)             {- Expected return type of the function -} ->

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Instruction.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Instruction.hs
@@ -1877,7 +1877,7 @@ callOrdinaryFunction instr _tailCall fnTy@(L.FunTy lretTy _largTys _varargs) fn 
       case asScalar fn' of
         Scalar _ PtrRepr ptr -> do
           memVar <- getMemVar
-          v   <- extensionStmt (LLVM_LoadHandle memVar fnTy ptr argTypes retTy)
+          v   <- extensionStmt (LLVM_LoadHandle memVar (Just fnTy) ptr argTypes retTy)
           ret <- call v args''
           assign_f (BaseExpr retTy ret)
         _ -> fail $ unwords ["unsupported function value", show fn]


### PR DESCRIPTION
- [x] Exports low-level overrides from crucible-llvm that can be registered without having to construct an `L.Declare`
- [x] Uses the above to register an override for `malloc` inside `crucible-llvm-syntax`
- [x] Removes the `L.Type` from the LLVM operation for loading a function handle from a pointer
- [x] Adds concrete syntax for the LLVM syntax extension operation of loading a function handle from a pointer (#1118)
- [x] Adds concrete syntax for resolving LLVM global names to pointers (#1118)
- [x] Adds a simulation test to crucible-llvm-cli that calls the `malloc` override