### PR TITLE
crucible-llvm: Helpers for binding function handles

### DIFF
--- a/crucible-llvm/CHANGELOG.md
+++ b/crucible-llvm/CHANGELOG.md
@@ -1,3 +1,8 @@
+# next
+
+* `bindLLVMFunPtr` now accepts an `Text.LLVM.AST.Symbol` rather than a whole `Declare`.
+  Use `decName` to get a `Symbol` from a `Declare`.
+
 # 0.5
 * Add `?memOpts :: MemOptions` constraints to the following functions:
   * `Lang.Crucible.LLVM.MemModel`: `doStore`, `storeRaw`, `condStoreRaw`, and

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
@@ -725,19 +725,18 @@ doMallocSize sz bak allocType mut loc mem alignment = do
 bindLLVMFunPtr ::
   (IsSymBackend sym bak, HasPtrWidth wptr) =>
   bak ->
-  L.Declare ->
+  L.Symbol ->
   FnHandle args ret ->
   MemImpl sym ->
   IO (MemImpl sym)
-bindLLVMFunPtr bak dec h mem
-  | L.decVarArgs dec
-  , (_ Ctx.:> VectorRepr AnyRepr) <- handleArgTypes h
+bindLLVMFunPtr bak nm h mem
+  | (_ Ctx.:> VectorRepr AnyRepr) <- handleArgTypes h
 
-  = do ptr <- doResolveGlobal bak mem (L.decName dec)
+  = do ptr <- doResolveGlobal bak mem nm
        doInstallHandle bak ptr (VarargsFnHandle h) mem
 
   | otherwise
-  = do ptr <- doResolveGlobal bak mem (L.decName dec)
+  = do ptr <- doResolveGlobal bak mem nm
        doInstallHandle bak ptr (SomeFnHandle h) mem
 
 doInstallHandle


### PR DESCRIPTION
Introduce a few low-level helpers for binding function handles. These helpers abstract patterns seen in different parts of the codebase (override registration and lazy CFG translation).