### PR TITLE
crucible-syntax: Remove `ACFG` in favor of `AnyCFG`

### DIFF
--- a/crucible-syntax/CHANGELOG.md
+++ b/crucible-syntax/CHANGELOG.md
@@ -1,3 +1,10 @@
+# next
+
+* The type `ACFG` has been removed in favor of `Lang.Crucible.CFG.Reg.AnyCFG`,
+  which serves a similar purpose (hiding the argument and return types). The
+  CFG argument and return types can be recovered via
+  `Lang.Crucible.CFG.Reg.{cfgArgTypes,cfgReturnType}`.
+
 # 0.3
 
 * The return type of `prog`:

--- a/crucible-syntax/src/Lang/Crucible/Syntax/Prog.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Prog.hs
@@ -95,7 +95,7 @@ doParseCheck fn theInput pprint outh =
                 assertNoExterns externs
                 assertNoForwardDecs fds
                 forM_ ok $
-                 \(ACFG _ _ theCfg) ->
+                 \(AnyCFG theCfg) ->
                    do C.SomeCFG ssa <- return $ toSSA theCfg
                       hPutStrLn outh $ show $ cfgHandle theCfg
                       hPutStrLn outh $ show $ C.ppCFG' True (postdomInfo ssa) ssa

--- a/crucible/src/Lang/Crucible/CFG/Core.hs
+++ b/crucible/src/Lang/Crucible/CFG/Core.hs
@@ -823,7 +823,7 @@ instance PrettyExt ext => Show (SomeCFG ext i r)
   where show cfg = case cfg of SomeCFG c -> show c
 
 -- | Control flow graph.  This data type closes existentially
---   over all the type parameters.
+--   over all the type parameters except @ext@.
 data AnyCFG ext where
   AnyCFG :: CFG ext blocks init ret
          -> AnyCFG ext

--- a/crucible/src/Lang/Crucible/CFG/Generator.hs
+++ b/crucible/src/Lang/Crucible/CFG/Generator.hs
@@ -134,7 +134,7 @@ import           What4.Symbol
 import           Lang.Crucible.CFG.Core (AnyCFG(..))
 import           Lang.Crucible.CFG.Expr(App(..))
 import           Lang.Crucible.CFG.Extension
-import           Lang.Crucible.CFG.Reg
+import           Lang.Crucible.CFG.Reg hiding (AnyCFG)
 import           Lang.Crucible.CFG.EarlyMergeLoops (earlyMergeLoops)
 import           Lang.Crucible.FunctionHandle
 import           Lang.Crucible.Types

--- a/crucible/src/Lang/Crucible/CFG/Reg.hs
+++ b/crucible/src/Lang/Crucible/CFG/Reg.hs
@@ -34,9 +34,11 @@ module Lang.Crucible.CFG.Reg
     CFG(..)
   , cfgEntryBlock
   , cfgInputTypes
+  , cfgArgTypes
   , cfgReturnType
   , substCFG
   , SomeCFG(..)
+  , AnyCFG(..)
   , Label(..)
   , substLabel
   , LambdaLabel(..)
@@ -924,7 +926,11 @@ cfgEntryBlock g =
     (Fold.find (\b -> blockID b == LabelID (cfgEntryLabel g)) (cfgBlocks g))
 
 cfgInputTypes :: CFG ext s init ret -> CtxRepr init
-cfgInputTypes g = handleArgTypes (cfgHandle g)
+cfgInputTypes = cfgArgTypes
+{-# DEPRECATED cfgInputTypes "Use cfgArgTypes instead" #-}
+
+cfgArgTypes :: CFG ext s init ret -> CtxRepr init
+cfgArgTypes g = handleArgTypes (cfgHandle g)
 
 cfgReturnType :: CFG ext s init ret -> TypeRepr ret
 cfgReturnType g = handleReturnType (cfgHandle g)
@@ -1007,7 +1013,16 @@ instance PrettyExt ext => Pretty (CFG ext s init ret) where
          , vcat (pretty <$> cfgBlocks g) ]
 
 ------------------------------------------------------------------------
--- SomeCFG
+-- SomeCFG, AnyCFG
 
 -- | 'SomeCFG' is a CFG with an arbitrary parameter 's'.
 data SomeCFG ext init ret = forall s . SomeCFG !(CFG ext s init ret)
+
+-- | Control flow graph.  This data type closes existentially
+--   over all the type parameters.
+data AnyCFG ext where
+  AnyCFG :: CFG ext blocks init ret
+         -> AnyCFG ext
+
+instance PrettyExt ext => Show (AnyCFG ext) where
+  show cfg = case cfg of AnyCFG c -> show c

--- a/crucible/src/Lang/Crucible/CFG/Reg.hs
+++ b/crucible/src/Lang/Crucible/CFG/Reg.hs
@@ -1019,7 +1019,7 @@ instance PrettyExt ext => Pretty (CFG ext s init ret) where
 data SomeCFG ext init ret = forall s . SomeCFG !(CFG ext s init ret)
 
 -- | Control flow graph.  This data type closes existentially
---   over all the type parameters.
+--   over all the type parameters except @ext@.
 data AnyCFG ext where
   AnyCFG :: CFG ext blocks init ret
          -> AnyCFG ext

--- a/crucible/src/Lang/Crucible/CFG/SSAConversion.hs
+++ b/crucible/src/Lang/Crucible/CFG/SSAConversion.hs
@@ -966,7 +966,7 @@ toSSA :: C.IsSyntaxExtension ext
       -> C.SomeCFG ext init ret
 toSSA g = do
   let h = cfgHandle g
-  let initTypes = cfgInputTypes g
+  let initTypes = cfgArgTypes g
   let entry = cfgEntryLabel g
   let blocks = cfgBlocks g
   case resolveBlockMap (handleName h) entry blocks of


### PR DESCRIPTION
Fixes #1149. Also adds `cfgArgTypes` for registerized CFGs, for consistency with the SSA API.