### PR TITLE
`crux-mir`: Avoid pointer arithmetic in `vec::IntoIter`

### DIFF
--- a/crux-mir/lib/Patches.md
+++ b/crux-mir/lib/Patches.md
@@ -57,6 +57,11 @@ identify all of the code that was changed in each patch.
   in sync with `ptr` and `end`, and avoids the need for pointer
   arithmetic.
 
+* Avoid pointer arithmetic in `vec` `IntoIter` (last applied: December 11, 2023)
+
+  The same problem as above exists for `vec::into_iter::IntoIter::size_hint`,
+  and we fix it in the same way by adding a `len` field to `IntoIter`.
+
 * Implement `str::as_bytes` via `crucible_identity_transmute` (last applied: May 16, 2023)
 
   This is necessary to avoid a gnarly use of `transmute`.

--- a/crux-mir/lib/alloc/src/vec/mod.rs
+++ b/crux-mir/lib/alloc/src/vec/mod.rs
@@ -2794,6 +2794,7 @@ impl<T, A: Allocator> IntoIterator for Vec<T, A> {
                 alloc,
                 ptr: begin,
                 end,
+                len: me.len(),
             }
         }
     }

--- a/crux-mir/test/conc_eval/vec/into_iter.rs
+++ b/crux-mir/test/conc_eval/vec/into_iter.rs
@@ -1,0 +1,20 @@
+#![cfg_attr(not(with_main), no_std)]
+// Test iterator for 0-length vec
+
+#[cfg(not(with_main))] extern crate std;
+#[cfg(not(with_main))] use std::vec;
+
+pub fn f(count: u32) -> u32 {
+    let mut v1 = vec![];
+    (0..count).for_each(|i| v1.push(i));
+    let mut sum = 0;
+    for i in v1 {
+        sum += i;
+    }
+    sum
+}
+
+pub static ARG: u32 = 0;
+
+#[cfg(with_main)] pub fn main() { println!("{:?}", f(ARG)); }
+#[cfg(not(with_main))] #[cfg_attr(crux, crux::test)] fn crux_test() -> u32 { f(ARG) }


### PR DESCRIPTION
We do the same thing as 69e92cb for `vec::IntoIter`.

Fixes #1144.