### PR TITLE
llvm: Export `CallStack` internals from an internal module

### DIFF
--- a/crucible-llvm/crucible-llvm.cabal
+++ b/crucible-llvm/crucible-llvm.cabal
@@ -72,6 +72,7 @@ library
     Lang.Crucible.LLVM.MalformedLLVMModule
     Lang.Crucible.LLVM.MemModel
     Lang.Crucible.LLVM.MemModel.CallStack
+    Lang.Crucible.LLVM.MemModel.CallStack.Internal
     Lang.Crucible.LLVM.MemModel.Generic
     Lang.Crucible.LLVM.MemModel.MemLog
     Lang.Crucible.LLVM.MemModel.Partial

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/CallStack.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/CallStack.hs
@@ -10,8 +10,10 @@
 
 module Lang.Crucible.LLVM.MemModel.CallStack
   ( CallStack
+  , null
   , getCallStack
   , ppCallStack
   ) where
 
+import Prelude hiding (null)
 import Lang.Crucible.LLVM.MemModel.CallStack.Internal

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/CallStack.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/CallStack.hs
@@ -2,15 +2,11 @@
 -- |
 -- Module           : Lang.Crucible.LLVM.MemModel.CallStack
 -- Description      : Call stacks from the LLVM memory model
--- Copyright        : (c) Galois, Inc 2021
+-- Copyright        : (c) Galois, Inc 2024
 -- License          : BSD3
--- Maintainer       : Rob Dockins <rdockins@galois.com>
+-- Maintainer       : Langston Barrett <langston@galois.com>
 -- Stability        : provisional
 ------------------------------------------------------------------------
-
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE OverloadedStrings #-}
 
 module Lang.Crucible.LLVM.MemModel.CallStack
   ( CallStack
@@ -18,32 +14,4 @@ module Lang.Crucible.LLVM.MemModel.CallStack
   , ppCallStack
   ) where
 
-import           Data.Foldable (toList)
-import           Data.Sequence (Seq)
-import qualified Data.Sequence as Seq
-import           Data.Text (Text)
-import qualified Prettyprinter as PP
-
-import           Lang.Crucible.LLVM.MemModel.MemLog (MemState(..))
-
-newtype FunctionName =
-  FunctionName { getFunctionName :: Text }
-  deriving (Eq, Monoid, Ord, Semigroup)
-
-newtype CallStack =
-  CallStack { runCallStack :: Seq FunctionName }
-  deriving (Eq, Monoid, Ord, Semigroup)
-
-cons :: FunctionName -> CallStack -> CallStack
-cons top (CallStack rest) = CallStack (top Seq.<| rest)
-
-getCallStack :: MemState sym -> CallStack
-getCallStack =
-  \case
-    EmptyMem{} -> CallStack mempty
-    StackFrame _ _ nm _ rest -> cons (FunctionName nm) (getCallStack rest)
-    BranchFrame _ _ _ rest -> getCallStack rest
-
-ppCallStack :: CallStack -> PP.Doc ann
-ppCallStack =
-  PP.vsep . toList . fmap (PP.pretty . getFunctionName) . runCallStack
+import Lang.Crucible.LLVM.MemModel.CallStack.Internal

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/CallStack/Internal.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/CallStack/Internal.hs
@@ -33,6 +33,9 @@ newtype CallStack =
 cons :: FunctionName -> CallStack -> CallStack
 cons top (CallStack rest) = CallStack (top Seq.<| rest)
 
+null :: CallStack -> Bool
+null = Seq.null . runCallStack
+
 getCallStack :: MemState sym -> CallStack
 getCallStack =
   \case

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/CallStack/Internal.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/CallStack/Internal.hs
@@ -26,16 +26,20 @@ newtype FunctionName =
   FunctionName { getFunctionName :: Text }
   deriving (Eq, Monoid, Ord, Semigroup)
 
+-- | Call stacks (lists of function names), mostly for diagnostics
 newtype CallStack =
   CallStack { runCallStack :: Seq FunctionName }
   deriving (Eq, Monoid, Ord, Semigroup)
 
+-- | Add a function name to the top of the call stack
 cons :: FunctionName -> CallStack -> CallStack
 cons top (CallStack rest) = CallStack (top Seq.<| rest)
 
+-- | Is this 'CallStack' empty?
 null :: CallStack -> Bool
 null = Seq.null . runCallStack
 
+-- | Summarize the 'StackFrame's of a 'MemState' into a 'CallStack'
 getCallStack :: MemState sym -> CallStack
 getCallStack =
   \case
@@ -43,6 +47,7 @@ getCallStack =
     StackFrame _ _ nm _ rest -> cons (FunctionName nm) (getCallStack rest)
     BranchFrame _ _ _ rest -> getCallStack rest
 
+-- | Pretty-print a call stack (one function per line)
 ppCallStack :: CallStack -> PP.Doc ann
 ppCallStack =
   PP.vsep . toList . fmap (PP.pretty . getFunctionName) . runCallStack

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/CallStack/Internal.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/CallStack/Internal.hs
@@ -1,0 +1,45 @@
+------------------------------------------------------------------------
+-- |
+-- Module           : Lang.Crucible.LLVM.MemModel.CallStack.Internal
+-- Description      : Call stacks from the LLVM memory model (implementation details)
+-- Copyright        : (c) Galois, Inc 2024
+-- License          : BSD3
+-- Maintainer       : Langston Barrett <langston@galois.com>
+-- Stability        : provisional
+------------------------------------------------------------------------
+
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Lang.Crucible.LLVM.MemModel.CallStack.Internal where
+
+import           Data.Foldable (toList)
+import           Data.Sequence (Seq)
+import qualified Data.Sequence as Seq
+import           Data.Text (Text)
+import qualified Prettyprinter as PP
+
+import           Lang.Crucible.LLVM.MemModel.MemLog (MemState(..))
+
+newtype FunctionName =
+  FunctionName { getFunctionName :: Text }
+  deriving (Eq, Monoid, Ord, Semigroup)
+
+newtype CallStack =
+  CallStack { runCallStack :: Seq FunctionName }
+  deriving (Eq, Monoid, Ord, Semigroup)
+
+cons :: FunctionName -> CallStack -> CallStack
+cons top (CallStack rest) = CallStack (top Seq.<| rest)
+
+getCallStack :: MemState sym -> CallStack
+getCallStack =
+  \case
+    EmptyMem{} -> CallStack mempty
+    StackFrame _ _ nm _ rest -> cons (FunctionName nm) (getCallStack rest)
+    BranchFrame _ _ _ rest -> getCallStack rest
+
+ppCallStack :: CallStack -> PP.Doc ann
+ppCallStack =
+  PP.vsep . toList . fmap (PP.pretty . getFunctionName) . runCallStack


### PR DESCRIPTION
Also fixes #1112.