### PR TITLE
CI: Run crux-llvm test suite in macOS

### DIFF
--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -70,6 +70,7 @@ install_llvm() {
     echo "CLANG=clang-12" >> "$GITHUB_ENV"
   elif [[ "$RUNNER_OS" = "macOS" ]]; then
     brew install llvm@12
+    echo "$(brew --prefix)/opt/llvm@12/bin" >> "$GITHUB_PATH"
   elif [[ "$RUNNER_OS" = "Windows" ]]; then
     choco install llvm
   else

--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -65,6 +65,9 @@ test() {
 install_llvm() {
   if [[ "$RUNNER_OS" = "Linux" ]]; then
     sudo apt-get update -q && sudo apt-get install -y clang-12 llvm-12-tools
+    echo "LLVM_LINK=llvm-link-12" >> "$GITHUB_ENV"
+    echo "LLVM_AS=llvm-as-12" >> "$GITHUB_ENV"
+    echo "CLANG=clang-12" >> "$GITHUB_ENV"
   elif [[ "$RUNNER_OS" = "macOS" ]]; then
     brew install llvm@12
   elif [[ "$RUNNER_OS" = "Windows" ]]; then

--- a/.github/workflows/crux-llvm-build.yml
+++ b/.github/workflows/crux-llvm-build.yml
@@ -186,7 +186,7 @@ jobs:
         run: .github/ci.sh test crucible-cli
 
       - shell: bash
-        name: Test crucible-symio (Linux)
+        name: Test crucible-symio
         run: cabal test pkg:crucible-symio
         if: runner.os == 'Linux'
 
@@ -200,12 +200,12 @@ jobs:
           CLANG: "clang-12"
 
       - shell: bash
-        name: Test crucible-llvm-syntax (Linux)
+        name: Test crucible-llvm-syntax
         run: .github/ci.sh test crucible-llvm-syntax
         if: runner.os == 'Linux'
 
       - shell: bash
-        name: Test crucible-llvm-cli (Linux)
+        name: Test crucible-llvm-cli
         run: .github/ci.sh test crucible-llvm-cli
         if: runner.os == 'Linux'
 

--- a/.github/workflows/crux-llvm-build.yml
+++ b/.github/workflows/crux-llvm-build.yml
@@ -194,10 +194,6 @@ jobs:
         name: Test crucible-llvm (Linux)
         run: .github/ci.sh test crucible-llvm
         if: runner.os == 'Linux'
-        env:
-          LLVM_LINK: "llvm-link-12"
-          LLVM_AS: "llvm-as-12"
-          CLANG: "clang-12"
 
       - shell: bash
         name: Test crucible-llvm-syntax
@@ -213,17 +209,11 @@ jobs:
         name: Test crux-llvm (Linux)
         run: .github/ci.sh test crux-llvm
         if: runner.os == 'Linux'
-        env:
-          LLVM_LINK: "llvm-link-12"
-          CLANG: "clang-12"
 
       - shell: bash
         name: Test uc-crux-llvm (Linux)
         run: .github/ci.sh test uc-crux-llvm
         if: matrix.os == 'ubuntu-22.04'
-        env:
-          LLVM_LINK: "llvm-link-12"
-          CLANG: "clang-12"
 
       - shell: bash
         name: Install LLVM-11 for MacOS

--- a/.github/workflows/crux-llvm-build.yml
+++ b/.github/workflows/crux-llvm-build.yml
@@ -191,9 +191,9 @@ jobs:
         if: runner.os == 'Linux'
 
       - shell: bash
-        name: Test crucible-llvm (Linux)
+        name: Test crucible-llvm
         run: .github/ci.sh test crucible-llvm
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' || runner.os == 'macOS'
 
       - shell: bash
         name: Test crucible-llvm-syntax
@@ -206,53 +206,14 @@ jobs:
         if: runner.os == 'Linux'
 
       - shell: bash
-        name: Test crux-llvm (Linux)
+        name: Test crux-llvm
         run: .github/ci.sh test crux-llvm
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' || runner.os == 'macOS'
 
       - shell: bash
         name: Test uc-crux-llvm (Linux)
         run: .github/ci.sh test uc-crux-llvm
         if: matrix.os == 'ubuntu-22.04'
-
-      - shell: bash
-        name: Install LLVM-11 for MacOS
-        if: runner.os == 'macOS'
-        run: |
-          LLVM_TAR=https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/clang+llvm-11.0.0-x86_64-apple-darwin.tar.xz
-          curl -sSL $LLVM_TAR -o llvm.tar.xz && tar xzf llvm.tar.xz && mv clang+llvm-* llvm
-          echo "#!/usr/bin/env bash" > llvm/bin/clang-withIncl
-          echo "clang -I${{ github.workspace }}/llvm/include -I${{ github.workspace }}/llvm/include/c++/v1" >> llvm/bin/clang-withIncl
-          chmod +x llvm/bin/clang-withIncl
-          echo "$PWD/llvm/bin" >> $GITHUB_PATH
-
-      - uses: actions/cache@v2
-        name: Cache LLVM-11
-        if: runner.os == 'macOS'
-        with:
-          path: ${{ github.workspace }}/llvm
-          key: llvm-11.0.0
-          restore-keys: llvm-11.0.0
-
-      - shell: bash
-        name: Test crucible-llvm (macOS)
-        run: .github/ci.sh test crucible-llvm
-        if: runner.os == 'macOS'
-        env:
-          LLVM_LINK: "${{ github.workspace }}/llvm/bin/llvm-link"
-          LLVM_AS: "${{ github.workspace }}/llvm/bin/llvm-as"
-          CLANG: "${{ github.workspace }}/llvm/bin/clang"
-
-        # We disable the crux-llvm test suite on macOS due to
-        # https://github.com/GaloisInc/crucible/issues/885 and
-        # https://github.com/GaloisInc/crucible/issues/999
-      - shell: bash
-        name: Test crux-llvm (macOS)
-        run: .github/ci.sh test crux-llvm
-        if: runner.os == 'macOS' && false
-        env:
-          LLVM_LINK: "${{ github.workspace }}/llvm/bin/llvm-link"
-          CLANG: "${{ github.workspace }}/llvm/bin/clang-withIncl"
 
       - name: Create binary artifact
         shell: bash

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics.hs
@@ -333,6 +333,7 @@ declare_overrides =
   , basic_llvm_override Libc.llvmIsnanOverride
   , basic_llvm_override Libc.llvm__isnanOverride
   , basic_llvm_override Libc.llvm__isnanfOverride
+  , basic_llvm_override Libc.llvm__isnandOverride
   , basic_llvm_override Libc.llvmSqrtOverride
   , basic_llvm_override Libc.llvmSqrtfOverride
   , basic_llvm_override Libc.llvmSinOverride
@@ -379,6 +380,8 @@ declare_overrides =
   , basic_llvm_override Libc.llvmLog2fOverride
   , basic_llvm_override Libc.llvmExp10Override
   , basic_llvm_override Libc.llvmExp10fOverride
+  , basic_llvm_override Libc.llvm__exp10Override
+  , basic_llvm_override Libc.llvm__exp10fOverride
   , basic_llvm_override Libc.llvmLog10Override
   , basic_llvm_override Libc.llvmLog10fOverride
 

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics.hs
@@ -98,6 +98,8 @@ filterTemplates ts decl = filter (f . overrideTemplateMatcher) ts
  f (ExactMatch x)       = x == nm
  f (PrefixMatch pfx)    = pfx `isPrefixOf` nm
  f (SubstringsMatch as) = filterSubstrings as nm
+ -- See Note [Darwin aliases] in Lang.Crucible.LLVM.Intrinsics.Common
+ f (DarwinAliasMatch x) = x == stripDarwinAliases nm
 
  filterSubstrings [] _ = True
  filterSubstrings (a:as) xs =

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libc.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libc.hs
@@ -508,8 +508,7 @@ callStrlen bak mvar (regValue -> strPtr) = do
 callAssert
   :: ( IsSymBackend sym bak, HasPtrWidth wptr, HasLLVMAnn sym
      , ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions )
-  => Bool -- ^ 'True' if this is @__assert_fail()@, 'False' otherwise.
-  -> GlobalVar Mem
+  => GlobalVar Mem
   -> bak
   -> Ctx.Assignment (RegEntry sym)
         (EmptyCtx ::> LLVMPointerType wptr
@@ -518,7 +517,7 @@ callAssert
                   ::> LLVMPointerType wptr)
   -> forall r args reg.
      OverrideSim p sym ext r args reg (RegValue sym UnitType)
-callAssert assert_fail mvar bak (Empty :> _pfn :> _pfile :> _pline :> ptxt ) =
+callAssert mvar bak (Empty :> _pfn :> _pfile :> _pline :> ptxt ) =
   do let sym = backendGetSym bak
      when failUponExit $
        do mem <- readGlobal mvar
@@ -531,10 +530,7 @@ callAssert assert_fail mvar bak (Empty :> _pfn :> _pfile :> _pline :> ptxt ) =
   where
     failUponExit :: Bool
     failUponExit
-      | assert_fail
       = abnormalExitBehavior ?intrinsicsOpts `elem` [AlwaysFail, OnlyAssertFail]
-      | otherwise
-      = abnormalExitBehavior ?intrinsicsOpts == AlwaysFail
 
 callExit :: ( IsSymBackend sym bak
             , ?intrinsicsOpts :: IntrinsicsOptions )
@@ -837,6 +833,15 @@ llvm__isnanfOverride =
   [llvmOvr| i32 @__isnanf( float ) |]
   (\_memOps sym args -> Ctx.uncurryAssignment (callIsnan sym (knownNat @32)) args)
 
+-- macOS compiles isnan() to __isnand() when the argument is a double.
+llvm__isnandOverride ::
+  IsSymInterface sym =>
+  LLVMOverride p sym
+     (EmptyCtx ::> FloatType DoubleFloat)
+     (BVType 32)
+llvm__isnandOverride =
+  [llvmOvr| i32 @__isnand( double ) |]
+  (\_memOps sym args -> Ctx.uncurryAssignment (callIsnan sym (knownNat @32)) args)
 
 llvmSqrtOverride ::
   IsSymInterface sym =>
@@ -1410,6 +1415,26 @@ llvmExp10fOverride =
   [llvmOvr| float @exp10f( float ) |]
   (\_memOps bak args -> Ctx.uncurryAssignment (callSpecialFunction1 bak W4.Exp10) args)
 
+-- macOS uses __exp10(f) instead of exp10(f).
+
+llvm__exp10Override ::
+  IsSymInterface sym =>
+  LLVMOverride p sym
+     (EmptyCtx ::> FloatType DoubleFloat)
+     (FloatType DoubleFloat)
+llvm__exp10Override =
+  [llvmOvr| double @__exp10( double ) |]
+  (\_memOps bak args -> Ctx.uncurryAssignment (callSpecialFunction1 bak W4.Exp10) args)
+
+llvm__exp10fOverride ::
+  IsSymInterface sym =>
+  LLVMOverride p sym
+     (EmptyCtx ::> FloatType SingleFloat)
+     (FloatType SingleFloat)
+llvm__exp10fOverride =
+  [llvmOvr| float @__exp10f( float ) |]
+  (\_memOps bak args -> Ctx.uncurryAssignment (callSpecialFunction1 bak W4.Exp10) args)
+
 -- log10(f)
 
 llvmLog10Override ::
@@ -1445,7 +1470,7 @@ llvmAssertRtnOverride
         UnitType
 llvmAssertRtnOverride =
   [llvmOvr| void @__assert_rtn( i8*, i8*, i32, i8* ) |]
-  (callAssert False)
+  callAssert
 
 -- From glibc
 llvmAssertFailOverride
@@ -1459,7 +1484,7 @@ llvmAssertFailOverride
         UnitType
 llvmAssertFailOverride =
   [llvmOvr| void @__assert_fail( i8*, i8*, i32, i8* ) |]
-  (callAssert True)
+  callAssert
 
 
 llvmAbortOverride

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Options.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Options.hs
@@ -20,9 +20,9 @@ data AbnormalExitBehavior
     -- ^ Functions which trigger an abnormal exit will always cause Crucible
     --   to fail.
   | OnlyAssertFail
-    -- ^ The @__assert_fail()@ function will cause Crucible to fail, while
-    --   other functions which triggern an abnormal exit will not cause
-    --   failures. This option is primarily useful for SV-COMP.
+    -- ^ The @__assert_fail()@ or @__assert_rtn()@ functions will cause Crucible
+    --   to fail, while other functions which trigger an abnormal exit will not
+    --   cause failures. This option is primarily useful for SV-COMP.
   | NeverFail
     -- ^ Functions which trigger an abnormal exit will never cause Crucible
     --   to fail. This option is primarily useful for SV-COMP.

--- a/crux-llvm/test-data/golden/T785a.c
+++ b/crux-llvm/test-data/golden/T785a.c
@@ -10,10 +10,13 @@ int main() {
     abort();
   } else if (crucible_int8_t("test_exit")) {
     exit(1);
-  } else if (crucible_int8_t("test_assert_fail")) {
-    __assert_fail("0", "T785a.c", 16, "__assert_fail");
+#if defined(__APPLE__)
+    __assert_rtn("0", "T785b.c", 15, "__assert_rtn");
+#else
+    __assert_fail("0", "T785b.c", 17, "__assert_fail");
+#endif
   } else if (crucible_int8_t("test_crucible_assert")) {
-    crucible_assert(0, "T785a.c", 18);
+    crucible_assert(0, "T785b.c", 20);
   } else if (crucible_int8_t("test_CPROVER_assert")) {
     __CPROVER_assert(0, "__CPROVER_assert");
   }

--- a/crux-llvm/test-data/golden/T785b.c
+++ b/crux-llvm/test-data/golden/T785b.c
@@ -5,15 +5,22 @@
 
 extern void __CPROVER_assert(int32_t, const char *);
 
+#if defined(__APPLE__)
+// The expected output for this test case specifically mentions __assert_fail,
+// so we need to call that in particular. __assert_fail isn't defined on macOS,
+// so define a shim for it so that we can simulate it.
+extern void __assert_fail(const char *, const char *, unsigned int, const char *);
+#endif
+
 int main() {
   if (crucible_int8_t("test_abort")) {
     abort();
   } else if (crucible_int8_t("test_exit")) {
     exit(1);
   } else if (crucible_int8_t("test_assert_fail")) {
-    __assert_fail("0", "T785b.c", 16, "__assert_fail");
+    __assert_fail("0", "T785b.c", 21, "__assert_fail");
   } else if (crucible_int8_t("test_crucible_assert")) {
-    crucible_assert(0, "T785b.c", 18);
+    crucible_assert(0, "T785b.c", 23);
   } else if (crucible_int8_t("test_CPROVER_assert")) {
     __CPROVER_assert(0, "__CPROVER_assert");
   }

--- a/crux-llvm/test-data/golden/T785b.z3.good
+++ b/crux-llvm/test-data/golden/T785b.z3.good
@@ -1,5 +1,5 @@
 [Crux] Found counterexample for verification goal
-[Crux]   test-data/golden/T785b.c:14:5: error: in main
+[Crux]   test-data/golden/T785b.c:21:5: error: in main
 [Crux]   Call to assert()
 [Crux]   Details:
 [Crux]     __assert_fail

--- a/crux-llvm/test-data/golden/golden/double_free.c
+++ b/crux-llvm/test-data/golden/golden/double_free.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include <crucible.h>
 
-void do_free(int *p) __attribute__((noinline)) {
+void __attribute__((noinline)) do_free(int *p) {
   free(p);
 }
 

--- a/crux-llvm/test-data/golden/isinf.c
+++ b/crux-llvm/test-data/golden/isinf.c
@@ -16,8 +16,11 @@ int main(void) {
   check(isinf(d3) == -1);
   check(isinf(d4) ==  0);
 
+#if !defined(__APPLE__)
   // The parentheses around (isinf) are important here, as this instructs Clang
-  // to compile isinf as a direct function call rather than as a macro.
+  // to compile isinf as a direct function call rather than as a macro. This is
+  // not portable, however, For instance, macOS only provides isinf as a macro,
+  // not as a function.
   check((isinf)(d1) ==  0);
   check((isinf)(d2) ==  1);
   check((isinf)(d3) == -1);
@@ -27,6 +30,7 @@ int main(void) {
   check(__isinf(d2) ==  1);
   check(__isinf(d3) == -1);
   check(__isinf(d4) ==  0);
+#endif
 
   check(__builtin_isinf_sign(d1) ==  0);
   check(__builtin_isinf_sign(d2) ==  1);
@@ -46,6 +50,7 @@ int main(void) {
   check(isinf(f3) == -1);
   check(isinf(f4) ==  0);
 
+#if !defined(__APPLE__)
   check((isinf)(f1) ==  0);
   check((isinf)(f2) ==  1);
   check((isinf)(f3) == -1);
@@ -55,6 +60,7 @@ int main(void) {
   check(__isinff(f2) ==  1);
   check(__isinff(f3) == -1);
   check(__isinff(f4) ==  0);
+#endif
 
   check(__builtin_isinf_sign(f1) ==  0);
   check(__builtin_isinf_sign(f2) ==  1);

--- a/crux-llvm/test-data/golden/isinf.c
+++ b/crux-llvm/test-data/golden/isinf.c
@@ -11,25 +11,29 @@ int main(void) {
   double d3 = -INFINITY; // Infinite
   double d4 = NAN;       // Not infinite (and also not finite)
 
-  check(isinf(d1) ==  0);
-  check(isinf(d2) ==  1);
-  check(isinf(d3) == -1);
-  check(isinf(d4) ==  0);
+  // The C standard only requires that isinf(x) return a non-zero value when x
+  // is infinite. Unlike __builtin_isinf_sign(x), we cannot guarantee that this
+  // return value will be a specific number, so we make the tests below as
+  // generic as possible.
+  check(!(isinf(d1)));
+  check(isinf(d2));
+  check(isinf(d3));
+  check(!(isinf(d4)));
 
 #if !defined(__APPLE__)
   // The parentheses around (isinf) are important here, as this instructs Clang
   // to compile isinf as a direct function call rather than as a macro. This is
   // not portable, however, For instance, macOS only provides isinf as a macro,
   // not as a function.
-  check((isinf)(d1) ==  0);
-  check((isinf)(d2) ==  1);
-  check((isinf)(d3) == -1);
-  check((isinf)(d4) ==  0);
+  check(!((isinf)(d1)));
+  check((isinf)(d2));
+  check((isinf)(d3));
+  check(!((isinf)(d4)));
 
-  check(__isinf(d1) ==  0);
-  check(__isinf(d2) ==  1);
-  check(__isinf(d3) == -1);
-  check(__isinf(d4) ==  0);
+  check(!(__isinf(d1)));
+  check(__isinf(d2));
+  check(__isinf(d3));
+  check(!(__isinf(d4)));
 #endif
 
   check(__builtin_isinf_sign(d1) ==  0);
@@ -45,21 +49,21 @@ int main(void) {
   float f3 = -INFINITY; // Infinite
   float f4 = NAN;       // Not infinite (and also not finite)
 
-  check(isinf(f1) ==  0);
-  check(isinf(f2) ==  1);
-  check(isinf(f3) == -1);
-  check(isinf(f4) ==  0);
+  check(!(isinf(f1)));
+  check(isinf(f2));
+  check(isinf(f3));
+  check(!(isinf(f4)));
 
 #if !defined(__APPLE__)
-  check((isinf)(f1) ==  0);
-  check((isinf)(f2) ==  1);
-  check((isinf)(f3) == -1);
-  check((isinf)(f4) ==  0);
+  check(!((isinf)(f1)));
+  check((isinf)(f2));
+  check((isinf)(f3));
+  check(!((isinf)(f4)));
 
-  check(__isinff(f1) ==  0);
-  check(__isinff(f2) ==  1);
-  check(__isinff(f3) == -1);
-  check(__isinff(f4) ==  0);
+  check(!(__isinff(f1)));
+  check(__isinff(f2));
+  check(__isinff(f3));
+  check(!(__isinff(f4)));
 #endif
 
   check(__builtin_isinf_sign(f1) ==  0);

--- a/crux-llvm/test-data/golden/isnan.c
+++ b/crux-llvm/test-data/golden/isnan.c
@@ -5,17 +5,23 @@ int main() {
   // double
   double d = NAN;
   check(isnan(d));
-  check((isnan)(d)); // The parentheses around (isnan) are important here,
-                          // as this instructs Clang to compile isnan as a
-                          // direct function call rather than as a macro.
+#if !defined(__APPLE__)
+  // The parentheses around (isnan) are important here, as this instructs Clang
+  // to compile isnan as a direct function call rather than as a macro. This is
+  // not portable, however, For instance, macOS only provides isnan as a macro,
+  // not as a function.
+  check((isnan)(d));
   check(__isnan(d));
+#endif
   check(__builtin_isnan(d));
 
   // float
   float f = NAN;
   check(isnan(f));
+#if !defined(__APPLE__)
   check((isnan)(f));
   check(__isnanf(f));
+#endif
   check(__builtin_isnan(f));
 
   return 0;

--- a/crux-llvm/test-data/golden/special-functions.c
+++ b/crux-llvm/test-data/golden/special-functions.c
@@ -2,6 +2,11 @@
 #include <crucible.h>
 #include <math.h>
 
+#if defined(__APPLE__)
+# define exp10f __exp10f
+# define exp10  __exp10
+#endif
+
 int main() {
   ///////////////
   // constants //

--- a/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Run/Simulate.hs
@@ -337,6 +337,8 @@ registerOverrides appCtx modCtx kind overrides =
           "functions with prefix " <> Text.pack nm
         LLVMIntrinsics.SubstringsMatch nms ->
           "functions with names containing " <> Text.pack (show nms)
+        LLVMIntrinsics.DarwinAliasMatch nm ->
+          Text.pack (LLVMIntrinsics.stripDarwinAliases nm)
 
 registerDefinedFns ::
   (?intrinsicsOpts :: LLVMIntrinsics.IntrinsicsOptions) =>


### PR DESCRIPTION
Previously, we concocted a `clang-withIncl` script for running Clang on macOS CI runners, but this neglected to pass any arguments to Clang (among other issues). This patch replaces the `clang-withIncl` machinery with a much simpler, Homebrew-based setup for install Clang/LLVM. With this in place, we can finally run the `crux-llvm` test suite on macOS.

Fixes https://github.com/GaloisInc/crucible/issues/999.

-----

Running the test suite on macOS reveals several additional issues, among them #885 and #1013. This PR also applies a series of fixes for these issues.