### PR TITLE
`crux-mir` CI: Free up some extra disk space

### DIFF
--- a/.github/workflows/crux-mir-build.yml
+++ b/.github/workflows/crux-mir-build.yml
@@ -226,6 +226,18 @@ jobs:
         with:
           submodules: true
 
+      - name: Clear up some disk space
+        run: |
+          # The crux-mir Docker image is rather large (~1GB compressed), and
+          # the mere act of building the image requires just over 14 GB of disk
+          # space, which the maximum provided by a GitHub Action CI runner. To
+          # clear up some extra space, we delete ~10GB worth of pre-installed
+          # GitHub Actions tools, none of which we make use of.
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY" # Python installations
+
       - uses: rlespinasse/github-slug-action@v3.x
 
       - id: common-tag


### PR DESCRIPTION
These tools take up about 10GB of extra space. We are just barely exceeding GitHub Action's maximum disk size of 14GB when building the `crux-mir` Docker image, so having some extra disk space would be welcome indeed.

Fixes #1175.