### PR TITLE
crucible-llvm: Generalize override registration code

### DIFF
--- a/crucible-llvm/CHANGELOG.md
+++ b/crucible-llvm/CHANGELOG.md
@@ -1,5 +1,8 @@
 # next
 
+* Override registration code was generalized. `bind_llvm_{handle,func}`
+  now don't require a whole `LLVMContext`, just a `GlobalVar Mem`, and are
+  polymorphic over `ext`.
 * `build_llvm_override` is now generic over the `ext` type parameter. This
   should be a backwards-compatible change.
 * `LLVMOverride` now has an additional `ext` type parameter. See the Haddocks

--- a/crucible-llvm/src/Lang/Crucible/LLVM.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM.hs
@@ -88,7 +88,8 @@ registerModuleFn handleWarning mtrans sym =
           s = UseCFG cfg (postdomInfo cfg)
       binds <- use (stateContext . functionBindings)
       let llvmCtx = mtrans ^. transContext
-      bind_llvm_handle llvmCtx (L.decName decl) h s
+      let mvar = llvmMemVar llvmCtx
+      bind_llvm_handle mvar (L.decName decl) h s
 
       when (isJust $ lookupHandleMap h $ fnBindings binds) $
         do loc <- liftIO . getCurrentProgramLoc =<< getSymInterface
@@ -157,7 +158,8 @@ registerLazyModuleFn handleWarning mtrans sym =
    
         -- Bind the function handle to the appropriate global symbol.
         let llvmCtx = mtrans ^. transContext
-        bind_llvm_handle llvmCtx (L.decName decl) h s
+        let mvar = llvmMemVar llvmCtx
+        bind_llvm_handle mvar (L.decName decl) h s
 
 
 llvmGlobalsToCtx


### PR DESCRIPTION
`bind_llvm_{handle,func}` now:

- Don't require a whole `LLVMContext`, just a `GlobalVar Mem`
- Are polymorphic over `ext`