### PR TITLE
crucible-llvm: Refactor and export override pipe-fitting code

### DIFF
--- a/crucible-llvm/crucible-llvm.cabal
+++ b/crucible-llvm/crucible-llvm.cabal
@@ -73,6 +73,7 @@ library
     Lang.Crucible.LLVM.Extension
     Lang.Crucible.LLVM.Globals
     Lang.Crucible.LLVM.Intrinsics
+    Lang.Crucible.LLVM.Intrinsics.Cast
     Lang.Crucible.LLVM.Intrinsics.Libc
     Lang.Crucible.LLVM.Intrinsics.LLVM
     Lang.Crucible.LLVM.MalformedLLVMModule
@@ -98,7 +99,6 @@ library
     Lang.Crucible.LLVM.Errors.Standards
     Lang.Crucible.LLVM.Extension.Arch
     Lang.Crucible.LLVM.Extension.Syntax
-    Lang.Crucible.LLVM.Intrinsics.Cast
     Lang.Crucible.LLVM.Intrinsics.Common
     Lang.Crucible.LLVM.Intrinsics.Libcxx
     Lang.Crucible.LLVM.Intrinsics.Options

--- a/crucible-llvm/crucible-llvm.cabal
+++ b/crucible-llvm/crucible-llvm.cabal
@@ -98,6 +98,7 @@ library
     Lang.Crucible.LLVM.Errors.Standards
     Lang.Crucible.LLVM.Extension.Arch
     Lang.Crucible.LLVM.Extension.Syntax
+    Lang.Crucible.LLVM.Intrinsics.Cast
     Lang.Crucible.LLVM.Intrinsics.Common
     Lang.Crucible.LLVM.Intrinsics.Libcxx
     Lang.Crucible.LLVM.Intrinsics.Options

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Cast.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Cast.hs
@@ -1,6 +1,6 @@
 -- |
 -- Module           : Lang.Crucible.LLVM.Intrinsics.Cast
--- Description      : Cast between bitvectors and pointers in signatuers
+-- Description      : Cast between bitvectors and pointers in signatures
 -- Copyright        : (c) Galois, Inc 2024
 -- License          : BSD3
 -- Maintainer       : Langston Barrett <langston@galois.com>

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Cast.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Cast.hs
@@ -74,7 +74,7 @@ newtype ValCast p sym ext tp tp' =
 -- | Attempt to construct a function to cast between 'Ctx.Assignment's of
 -- 'RegEntry's.
 castLLVMArgs :: forall p sym ext bak args args'.
-  (IsSymBackend sym bak, HasLLVMAnn sym) =>
+  IsSymBackend sym bak =>
   bak ->
   CtxRepr args' ->
   CtxRepr args ->
@@ -94,7 +94,7 @@ castLLVMArgs _ _ _ = Left MismatchedShape
 -- | Attempt to construct a function to cast values of type @ret@ to type
 -- @ret'@.
 castLLVMRet ::
-  (IsSymBackend sym bak, HasLLVMAnn sym) =>
+  IsSymBackend sym bak =>
   bak ->
   TypeRepr ret  ->
   TypeRepr ret' ->

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Cast.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Cast.hs
@@ -15,29 +15,23 @@
 module Lang.Crucible.LLVM.Intrinsics.Cast
   ( ValCastError
   , printValCastError
-  , ArgTransformer(applyArgTransformer)
-  , ValTransformer(applyValTransformer)
-  , transformLLVMArgs
-  , transformLLVMRet
+  , ArgCast(applyArgCast)
+  , ValCast(applyValCast)
+  , castLLVMArgs
+  , castLLVMRet
   ) where
 
 import           Control.Monad.IO.Class (liftIO)
 import           Control.Lens
-import           Data.Either.Extra (mapLeft)
-import qualified Data.Text as Text
-import           Data.Vector (Vector)
 
 import qualified Data.Parameterized.Context as Ctx
 import           Data.Parameterized.Some (Some(Some))
 import           Data.Parameterized.TraversableFC (fmapFC)
 
 import           Lang.Crucible.Backend
-import           Lang.Crucible.Panic (panic)
 import           Lang.Crucible.Simulator.OverrideSim
 import           Lang.Crucible.Simulator.RegMap
 import           Lang.Crucible.Types
-
-import           What4.FunctionName
 
 import           Lang.Crucible.LLVM.MemModel
 
@@ -50,61 +44,61 @@ printValCastError =
   \case
     MismatchedShape -> ["argument shape mismatch"]
     ValCastError (Some ret) (Some ret') ->
-      [ "Cannot transform types"
+      [ "Cannot cast types"
       , "*** Source type: " ++ show ret
       , "*** Target type: " ++ show ret'
       ]
 
-newtype ArgTransformer p sym ext args args' =
-  ArgTransformer { applyArgTransformer :: (forall rtp l a.
+newtype ArgCast p sym ext args args' =
+  ArgCast { applyArgCast :: (forall rtp l a.
     Ctx.Assignment (RegEntry sym) args ->
     OverrideSim p sym ext rtp l a (Ctx.Assignment (RegEntry sym) args')) }
 
-newtype ValTransformer p sym ext tp tp' =
-  ValTransformer { applyValTransformer :: (forall rtp l a.
+newtype ValCast p sym ext tp tp' =
+  ValCast { applyValCast :: (forall rtp l a.
     RegValue sym tp ->
     OverrideSim p sym ext rtp l a (RegValue sym tp')) }
 
-transformLLVMArgs :: forall p sym ext bak args args'.
+castLLVMArgs :: forall p sym ext bak args args'.
   (IsSymBackend sym bak, HasLLVMAnn sym) =>
   bak ->
   CtxRepr args' ->
   CtxRepr args ->
-  Either ValCastError (ArgTransformer p sym ext args args')
-transformLLVMArgs _ Ctx.Empty Ctx.Empty =
-  Right (ArgTransformer (\_ -> return Ctx.Empty))
-transformLLVMArgs bak (rest' Ctx.:> tp') (rest Ctx.:> tp) =
-  do (ValTransformer f)  <- transformLLVMRet bak tp tp'
-     (ArgTransformer fs) <- transformLLVMArgs bak rest' rest
-     Right (ArgTransformer
+  Either ValCastError (ArgCast p sym ext args args')
+castLLVMArgs _ Ctx.Empty Ctx.Empty =
+  Right (ArgCast (\_ -> return Ctx.Empty))
+castLLVMArgs bak (rest' Ctx.:> tp') (rest Ctx.:> tp) =
+  do (ValCast f)  <- castLLVMRet bak tp tp'
+     (ArgCast fs) <- castLLVMArgs bak rest' rest
+     Right (ArgCast
               (\(xs Ctx.:> x) -> do
                     xs' <- fs xs
                     x'  <- f (regValue x)
                     pure (xs' Ctx.:> RegEntry tp' x')))
-transformLLVMArgs _ _ _ = Left MismatchedShape
+castLLVMArgs _ _ _ = Left MismatchedShape
 
-transformLLVMRet ::
+castLLVMRet ::
   (IsSymBackend sym bak, HasLLVMAnn sym) =>
   bak ->
   TypeRepr ret  ->
   TypeRepr ret' ->
-  Either ValCastError (ValTransformer p sym ext ret ret')
-transformLLVMRet bak (BVRepr w) (LLVMPointerRepr w')
+  Either ValCastError (ValCast p sym ext ret ret')
+castLLVMRet bak (BVRepr w) (LLVMPointerRepr w')
   | Just Refl <- testEquality w w'
-  = Right (ValTransformer (liftIO . llvmPointer_bv (backendGetSym bak)))
-transformLLVMRet bak (LLVMPointerRepr w) (BVRepr w')
+  = Right (ValCast (liftIO . llvmPointer_bv (backendGetSym bak)))
+castLLVMRet bak (LLVMPointerRepr w) (BVRepr w')
   | Just Refl <- testEquality w w'
-  = Right (ValTransformer (liftIO . projectLLVM_bv bak))
-transformLLVMRet bak (VectorRepr tp) (VectorRepr tp')
-  = do ValTransformer f <- transformLLVMRet bak tp tp'
-       Right (ValTransformer (traverse f))
-transformLLVMRet bak (StructRepr ctx) (StructRepr ctx')
-  = do ArgTransformer tf <- transformLLVMArgs bak ctx' ctx
-       Right (ValTransformer (\vals ->
+  = Right (ValCast (liftIO . projectLLVM_bv bak))
+castLLVMRet bak (VectorRepr tp) (VectorRepr tp')
+  = do ValCast f <- castLLVMRet bak tp tp'
+       Right (ValCast (traverse f))
+castLLVMRet bak (StructRepr ctx) (StructRepr ctx')
+  = do ArgCast tf <- castLLVMArgs bak ctx' ctx
+       Right (ValCast (\vals ->
           let vals' = Ctx.zipWith (\tp (RV v) -> RegEntry tp v) ctx vals in
           fmapFC (\x -> RV (regValue x)) <$> tf vals'))
 
-transformLLVMRet _bak ret ret'
+castLLVMRet _bak ret ret'
   | Just Refl <- testEquality ret ret'
-  = Right (ValTransformer return)
-transformLLVMRet _bak ret ret' = Left (ValCastError (Some ret) (Some ret'))
+  = Right (ValCast return)
+castLLVMRet _bak ret ret' = Left (ValCastError (Some ret) (Some ret'))

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Cast.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Cast.hs
@@ -1,0 +1,104 @@
+-- |
+-- Module           : Lang.Crucible.LLVM.Intrinsics.Cast
+-- Description      : Cast between bitvectors and pointers in signatuers
+-- Copyright        : (c) Galois, Inc 2024
+-- License          : BSD3
+-- Maintainer       : Langston Barrett <langston@galois.com>
+-- Stability        : provisional
+------------------------------------------------------------------------
+
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Lang.Crucible.LLVM.Intrinsics.Cast
+  ( ArgTransformer(applyArgTransformer)
+  , ValTransformer(applyValTransformer)
+  , transformLLVMArgs
+  , transformLLVMRet
+  ) where
+
+import           Control.Monad.IO.Class (liftIO)
+import           Control.Lens
+import qualified Data.Text as Text
+
+import qualified Data.Parameterized.Context as Ctx
+import           Data.Parameterized.TraversableFC (fmapFC)
+
+import           Lang.Crucible.Backend
+import           Lang.Crucible.Panic (panic)
+import           Lang.Crucible.Simulator.OverrideSim
+import           Lang.Crucible.Simulator.RegMap
+import           Lang.Crucible.Types
+
+import           What4.FunctionName
+
+import           Lang.Crucible.LLVM.MemModel
+
+newtype ArgTransformer p sym ext args args' =
+  ArgTransformer { applyArgTransformer :: (forall rtp l a.
+    Ctx.Assignment (RegEntry sym) args ->
+    OverrideSim p sym ext rtp l a (Ctx.Assignment (RegEntry sym) args')) }
+
+newtype ValTransformer p sym ext tp tp' =
+  ValTransformer { applyValTransformer :: (forall rtp l a.
+    RegValue sym tp ->
+    OverrideSim p sym ext rtp l a (RegValue sym tp')) }
+
+transformLLVMArgs :: forall m p sym ext bak args args'.
+  (IsSymBackend sym bak, Monad m, HasLLVMAnn sym) =>
+  -- | This function name is only used in panic messages.
+  FunctionName ->
+  bak ->
+  CtxRepr args' ->
+  CtxRepr args ->
+  m (ArgTransformer p sym ext args args')
+transformLLVMArgs _fnName _ Ctx.Empty Ctx.Empty =
+  return (ArgTransformer (\_ -> return Ctx.Empty))
+transformLLVMArgs fnName bak (rest' Ctx.:> tp') (rest Ctx.:> tp) = do
+  return (ArgTransformer
+           (\(xs Ctx.:> x) ->
+              do (ValTransformer f)  <- transformLLVMRet fnName bak tp tp'
+                 (ArgTransformer fs) <- transformLLVMArgs fnName bak rest' rest
+                 xs' <- fs xs
+                 x'  <- RegEntry tp' <$> f (regValue x)
+                 pure (xs' Ctx.:> x')))
+transformLLVMArgs fnName _ _ _ =
+  panic "Intrinsics.transformLLVMArgs"
+    [ "transformLLVMArgs: argument shape mismatch!"
+    , "in function: " ++ Text.unpack (functionName fnName)
+    ]
+
+transformLLVMRet ::
+  (IsSymBackend sym bak, Monad m, HasLLVMAnn sym) =>
+  -- | This function name is only used in panic messages.
+  FunctionName ->
+  bak ->
+  TypeRepr ret  ->
+  TypeRepr ret' ->
+  m (ValTransformer p sym ext ret ret')
+transformLLVMRet _fnName bak (BVRepr w) (LLVMPointerRepr w')
+  | Just Refl <- testEquality w w'
+  = return (ValTransformer (liftIO . llvmPointer_bv (backendGetSym bak)))
+transformLLVMRet _fnName bak (LLVMPointerRepr w) (BVRepr w')
+  | Just Refl <- testEquality w w'
+  = return (ValTransformer (liftIO . projectLLVM_bv bak))
+transformLLVMRet fnName bak (VectorRepr tp) (VectorRepr tp')
+  = do ValTransformer f <- transformLLVMRet fnName bak tp tp'
+       return (ValTransformer (traverse f))
+transformLLVMRet fnName bak (StructRepr ctx) (StructRepr ctx')
+  = do ArgTransformer tf <- transformLLVMArgs fnName bak ctx' ctx
+       return (ValTransformer (\vals ->
+          let vals' = Ctx.zipWith (\tp (RV v) -> RegEntry tp v) ctx vals in
+          fmapFC (\x -> RV (regValue x)) <$> tf vals'))
+
+transformLLVMRet _fnName _bak ret ret'
+  | Just Refl <- testEquality ret ret'
+  = return (ValTransformer return)
+transformLLVMRet fnName _bak ret ret'
+  = panic "Intrinsics.transformLLVMRet"
+      [ "Cannot transform types"
+      , "*** Source type: " ++ show ret
+      , "*** Target type: " ++ show ret'
+      , "in function: " ++ Text.unpack (functionName fnName)
+      ]
+

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Cast.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Cast.hs
@@ -82,8 +82,8 @@ castLLVMArgs :: forall p sym ext bak args args'.
 castLLVMArgs _ Ctx.Empty Ctx.Empty =
   Right (ArgCast (\_ -> return Ctx.Empty))
 castLLVMArgs bak (rest' Ctx.:> tp') (rest Ctx.:> tp) =
-  do (ValCast f)  <- castLLVMRet bak tp tp'
-     (ArgCast fs) <- castLLVMArgs bak rest' rest
+  do ValCast f  <- castLLVMRet bak tp tp'
+     ArgCast fs <- castLLVMArgs bak rest' rest
      Right (ArgCast
               (\(xs Ctx.:> x) -> do
                     xs' <- fs xs

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Common.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Common.hs
@@ -58,13 +58,11 @@ import qualified System.Info as Info
 import qualified ABI.Itanium as ABI
 import qualified Data.Parameterized.Context as Ctx
 import           Data.Parameterized.Some (Some(..))
-import           Data.Parameterized.TraversableFC (fmapFC)
 
 import           Lang.Crucible.Backend
 import           Lang.Crucible.CFG.Common (GlobalVar)
 import           Lang.Crucible.Simulator.ExecutionTree (FnState(UseOverride))
 import           Lang.Crucible.FunctionHandle (FnHandle, mkHandle')
-import           Lang.Crucible.Panic (panic)
 import           Lang.Crucible.Simulator (stateContext, simHandleAllocator)
 import           Lang.Crucible.Simulator.OverrideSim
 import           Lang.Crucible.Utils.MonadVerbosity (getLogFunction)
@@ -78,6 +76,7 @@ import           Lang.Crucible.LLVM.Eval (callStackFromMemVar)
 import           Lang.Crucible.LLVM.Globals (registerFunPtr)
 import           Lang.Crucible.LLVM.MemModel
 import           Lang.Crucible.LLVM.MemModel.CallStack (CallStack)
+import qualified Lang.Crucible.LLVM.Intrinsics.Cast as Cast
 import           Lang.Crucible.LLVM.Translation.Monad
 import           Lang.Crucible.LLVM.Translation.Types
 
@@ -199,74 +198,6 @@ apply this special case to other override functions (e.g.,
 ------------------------------------------------------------------------
 -- ** register_llvm_override
 
-newtype ArgTransformer p sym ext args args' =
-  ArgTransformer { applyArgTransformer :: (forall rtp l a.
-    Ctx.Assignment (RegEntry sym) args ->
-    OverrideSim p sym ext rtp l a (Ctx.Assignment (RegEntry sym) args')) }
-
-newtype ValTransformer p sym ext tp tp' =
-  ValTransformer { applyValTransformer :: (forall rtp l a.
-    RegValue sym tp ->
-    OverrideSim p sym ext rtp l a (RegValue sym tp')) }
-
-transformLLVMArgs :: forall m p sym ext bak args args'.
-  (IsSymBackend sym bak, Monad m, HasLLVMAnn sym) =>
-  -- | This function name is only used in panic messages.
-  FunctionName ->
-  bak ->
-  CtxRepr args' ->
-  CtxRepr args ->
-  m (ArgTransformer p sym ext args args')
-transformLLVMArgs _fnName _ Ctx.Empty Ctx.Empty =
-  return (ArgTransformer (\_ -> return Ctx.Empty))
-transformLLVMArgs fnName bak (rest' Ctx.:> tp') (rest Ctx.:> tp) = do
-  return (ArgTransformer
-           (\(xs Ctx.:> x) ->
-              do (ValTransformer f)  <- transformLLVMRet fnName bak tp tp'
-                 (ArgTransformer fs) <- transformLLVMArgs fnName bak rest' rest
-                 xs' <- fs xs
-                 x'  <- RegEntry tp' <$> f (regValue x)
-                 pure (xs' Ctx.:> x')))
-transformLLVMArgs fnName _ _ _ =
-  panic "Intrinsics.transformLLVMArgs"
-    [ "transformLLVMArgs: argument shape mismatch!"
-    , "in function: " ++ Text.unpack (functionName fnName)
-    ]
-
-transformLLVMRet ::
-  (IsSymBackend sym bak, Monad m, HasLLVMAnn sym) =>
-  -- | This function name is only used in panic messages.
-  FunctionName ->
-  bak ->
-  TypeRepr ret  ->
-  TypeRepr ret' ->
-  m (ValTransformer p sym ext ret ret')
-transformLLVMRet _fnName bak (BVRepr w) (LLVMPointerRepr w')
-  | Just Refl <- testEquality w w'
-  = return (ValTransformer (liftIO . llvmPointer_bv (backendGetSym bak)))
-transformLLVMRet _fnName bak (LLVMPointerRepr w) (BVRepr w')
-  | Just Refl <- testEquality w w'
-  = return (ValTransformer (liftIO . projectLLVM_bv bak))
-transformLLVMRet fnName bak (VectorRepr tp) (VectorRepr tp')
-  = do ValTransformer f <- transformLLVMRet fnName bak tp tp'
-       return (ValTransformer (traverse f))
-transformLLVMRet fnName bak (StructRepr ctx) (StructRepr ctx')
-  = do ArgTransformer tf <- transformLLVMArgs fnName bak ctx' ctx
-       return (ValTransformer (\vals ->
-          let vals' = Ctx.zipWith (\tp (RV v) -> RegEntry tp v) ctx vals in
-          fmapFC (\x -> RV (regValue x)) <$> tf vals'))
-
-transformLLVMRet _fnName _bak ret ret'
-  | Just Refl <- testEquality ret ret'
-  = return (ValTransformer return)
-transformLLVMRet fnName _bak ret ret'
-  = panic "Intrinsics.transformLLVMRet"
-      [ "Cannot transform types"
-      , "*** Source type: " ++ show ret
-      , "*** Target type: " ++ show ret'
-      , "in function: " ++ Text.unpack (functionName fnName)
-      ]
-
 -- | Do some pipe-fitting to match a Crucible override function into the shape
 --   expected by the LLVM calling convention.  This basically just coerces
 --   between values of @BVType w@ and values of @LLVMPointerType w@.
@@ -283,11 +214,11 @@ build_llvm_override ::
   OverrideSim p sym ext rtp l a (Override p sym ext args' ret')
 build_llvm_override fnm args ret args' ret' llvmOverride =
   ovrWithBackend $ \bak ->
-  do fargs <- transformLLVMArgs fnm bak args args'
-     fret  <- transformLLVMRet fnm bak ret  ret'
+  do fargs <- Cast.transformLLVMArgs fnm bak args args'
+     fret  <- Cast.transformLLVMRet fnm bak ret  ret'
      return $ mkOverride' fnm ret' $
             do RegMap xs <- getOverrideArgs
-               applyValTransformer fret =<< llvmOverride =<< applyArgTransformer fargs xs
+               Cast.applyValTransformer fret =<< llvmOverride =<< Cast.applyArgTransformer fargs xs
 
 polymorphic1_llvm_override :: forall p sym arch wptr l a rtp.
   (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr) =>

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Common.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Common.hs
@@ -216,14 +216,14 @@ build_llvm_override ::
 build_llvm_override fnm args ret args' ret' llvmOverride =
   ovrWithBackend $ \bak ->
   do fargs <-
-       case Cast.transformLLVMArgs bak args args' of
+       case Cast.castLLVMArgs bak args args' of
          Left err ->
            panic "Intrinsics.build_llvm_override"
              (Cast.printValCastError err ++
                [ "in function: " ++ Text.unpack (functionName fnm) ])
          Right f -> pure f
      fret <-
-       case Cast.transformLLVMRet bak ret ret' of
+       case Cast.castLLVMRet bak ret ret' of
          Left err ->
            panic "Intrinsics.build_llvm_override"
              (Cast.printValCastError err ++
@@ -231,7 +231,7 @@ build_llvm_override fnm args ret args' ret' llvmOverride =
          Right f -> pure f
      return $ mkOverride' fnm ret' $
             do RegMap xs <- getOverrideArgs
-               Cast.applyValTransformer fret =<< llvmOverride =<< Cast.applyArgTransformer fargs xs
+               Cast.applyValCast fret =<< llvmOverride =<< Cast.applyArgCast fargs xs
 
 polymorphic1_llvm_override :: forall p sym arch wptr l a rtp.
   (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr) =>


### PR DESCRIPTION
The code in question converts between bitvectors and pointers so that it is easy and natural to specify overrides using bitvectors, while at runtime only LLVM pointers are used. The built-in overrides (e.g., for libc) all expect to be wrapped in this casting code. They're all exported, so to make them usable by downstream clients, we also need to export the code that does the pipe-fitting.

- [x] Factor it into its own module
- [x] Make it return errors instead of panicing
- [x] Possibly rename it
- [x] Add haddocks