### PR TITLE
RFC: crucible-llvm: Parameterize over memory and pointer types

### DIFF
--- a/crucible-llvm/crucible-llvm.cabal
+++ b/crucible-llvm/crucible-llvm.cabal
@@ -77,6 +77,7 @@ library
     Lang.Crucible.LLVM.Intrinsics.Libc
     Lang.Crucible.LLVM.Intrinsics.LLVM
     Lang.Crucible.LLVM.MalformedLLVMModule
+    Lang.Crucible.LLVM.Mem
     Lang.Crucible.LLVM.MemModel
     Lang.Crucible.LLVM.MemModel.CallStack
     Lang.Crucible.LLVM.MemModel.CallStack.Internal

--- a/crucible-llvm/src/Lang/Crucible/LLVM.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM.hs
@@ -60,8 +60,7 @@ import           What4.ProgramLoc (plSourceLoc)
 --   This will immediately build Crucible CFGs for each function
 --   defined in the module.
 registerModule ::
-   (1 <= ArchWidth arch, HasPtrWidth (ArchWidth arch), IsSymInterface sym) =>
-   mem ~ Mem =>
+   (1 <= ArchWidth arch, HasPtrWidth (ArchWidth arch), IsSymInterface sym, mem ~ Mem) =>
    (LLVMTranslationWarning -> IO ()) {- ^ A callback for handling traslation warnings -} ->
    ModuleTranslation mem arch ->
    OverrideSim p sym (LLVM mem) rtp l a ()
@@ -72,8 +71,7 @@ registerModule handleWarning mtrans =
 --   module translation. This will immediately build a Crucible CFG for
 --   the named function.
 registerModuleFn ::
-   (1 <= ArchWidth arch, HasPtrWidth (ArchWidth arch), IsSymInterface sym) =>
-   mem ~ Mem =>
+   (1 <= ArchWidth arch, HasPtrWidth (ArchWidth arch), IsSymInterface sym, mem ~ Mem) =>
    (LLVMTranslationWarning -> IO ()) {- ^ A callback for handling traslation warnings -} ->
    ModuleTranslation mem arch ->
    L.Symbol ->
@@ -101,8 +99,7 @@ registerModuleFn handleWarning mtrans sym =
 -- | Lazily register all the functions defined in the LLVM module.  See
 --   'registerLazyModuleFn' for a description.
 registerLazyModule ::
-   (1 <= ArchWidth arch, HasPtrWidth (ArchWidth arch), IsSymInterface sym) =>
-   mem ~ Mem =>
+   (1 <= ArchWidth arch, HasPtrWidth (ArchWidth arch), IsSymInterface sym, mem ~ Mem) =>
    (LLVMTranslationWarning -> IO ()) {- ^ A callback for handling traslation warnings -} ->
    ModuleTranslation mem arch ->
    OverrideSim p sym (LLVM mem) rtp l a ()
@@ -118,8 +115,7 @@ registerLazyModule handleWarning mtrans =
 --   Note that the callback for printing translation warnings may be called at
 --   a much-later point, when the function in question is actually first invoked.
 registerLazyModuleFn ::
-   (1 <= ArchWidth arch, HasPtrWidth (ArchWidth arch), IsSymInterface sym) =>
-   mem ~ Mem =>
+   (1 <= ArchWidth arch, HasPtrWidth (ArchWidth arch), IsSymInterface sym, mem ~ Mem) =>
    (LLVMTranslationWarning -> IO ()) {- ^ A callback for handling translation warnings -} ->
    ModuleTranslation mem arch ->
    L.Symbol ->
@@ -179,8 +175,7 @@ llvmGlobals
 llvmGlobals memVar mem = emptyGlobals & insertGlobal memVar mem
 
 llvmExtensionImpl ::
-  (HasLLVMAnn sym) =>
-  mem ~ Mem =>
+  (HasLLVMAnn sym, mem ~ Mem) =>
   MemOptions ->
   ExtensionImpl p sym (LLVM mem)
 llvmExtensionImpl mo =

--- a/crucible-llvm/src/Lang/Crucible/LLVM.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM.hs
@@ -62,8 +62,8 @@ import           What4.ProgramLoc (plSourceLoc)
 registerModule ::
    (1 <= ArchWidth arch, HasPtrWidth (ArchWidth arch), IsSymInterface sym) =>
    (LLVMTranslationWarning -> IO ()) {- ^ A callback for handling traslation warnings -} ->
-   ModuleTranslation arch ->
-   OverrideSim p sym LLVM rtp l a ()
+   ModuleTranslation mem arch ->
+   OverrideSim p sym (LLVM mem) rtp l a ()
 registerModule handleWarning mtrans =
    mapM_ (registerModuleFn handleWarning mtrans) (map (L.decName.fst) (mtrans ^. modTransDefs))
 
@@ -73,9 +73,9 @@ registerModule handleWarning mtrans =
 registerModuleFn ::
    (1 <= ArchWidth arch, HasPtrWidth (ArchWidth arch), IsSymInterface sym) =>
    (LLVMTranslationWarning -> IO ()) {- ^ A callback for handling traslation warnings -} ->
-   ModuleTranslation arch ->
+   ModuleTranslation mem arch ->
    L.Symbol ->
-   OverrideSim p sym LLVM rtp l a ()
+   OverrideSim p sym (LLVM mem) rtp l a ()
 registerModuleFn handleWarning mtrans sym =
   liftIO (getTranslatedCFG mtrans sym) >>= \case
     Nothing ->
@@ -101,8 +101,8 @@ registerModuleFn handleWarning mtrans sym =
 registerLazyModule ::
    (1 <= ArchWidth arch, HasPtrWidth (ArchWidth arch), IsSymInterface sym) =>
    (LLVMTranslationWarning -> IO ()) {- ^ A callback for handling traslation warnings -} ->
-   ModuleTranslation arch ->
-   OverrideSim p sym LLVM rtp l a ()
+   ModuleTranslation mem arch ->
+   OverrideSim p sym (LLVM mem) rtp l a ()
 registerLazyModule handleWarning mtrans =
    mapM_ (registerLazyModuleFn handleWarning mtrans) (map (L.decName.fst) (mtrans ^. modTransDefs))
 
@@ -117,9 +117,9 @@ registerLazyModule handleWarning mtrans =
 registerLazyModuleFn ::
    (1 <= ArchWidth arch, HasPtrWidth (ArchWidth arch), IsSymInterface sym) =>
    (LLVMTranslationWarning -> IO ()) {- ^ A callback for handling translation warnings -} ->
-   ModuleTranslation arch ->
+   ModuleTranslation mem arch ->
    L.Symbol ->
-   OverrideSim p sym LLVM rtp l a ()
+   OverrideSim p sym (LLVM mem) rtp l a ()
 registerLazyModuleFn handleWarning mtrans sym =
   liftIO (getTranslatedFnHandle mtrans sym) >>= \case
     Nothing -> 
@@ -177,7 +177,7 @@ llvmGlobals memVar mem = emptyGlobals & insertGlobal memVar mem
 llvmExtensionImpl ::
   (HasLLVMAnn sym) =>
   MemOptions ->
-  ExtensionImpl p sym LLVM
+  ExtensionImpl p sym (LLVM mem)
 llvmExtensionImpl mo =
   let ?memOpts = mo in
   ExtensionImpl

--- a/crucible-llvm/src/Lang/Crucible/LLVM.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM.hs
@@ -61,6 +61,7 @@ import           What4.ProgramLoc (plSourceLoc)
 --   defined in the module.
 registerModule ::
    (1 <= ArchWidth arch, HasPtrWidth (ArchWidth arch), IsSymInterface sym) =>
+   mem ~ Mem =>
    (LLVMTranslationWarning -> IO ()) {- ^ A callback for handling traslation warnings -} ->
    ModuleTranslation mem arch ->
    OverrideSim p sym (LLVM mem) rtp l a ()
@@ -72,6 +73,7 @@ registerModule handleWarning mtrans =
 --   the named function.
 registerModuleFn ::
    (1 <= ArchWidth arch, HasPtrWidth (ArchWidth arch), IsSymInterface sym) =>
+   mem ~ Mem =>
    (LLVMTranslationWarning -> IO ()) {- ^ A callback for handling traslation warnings -} ->
    ModuleTranslation mem arch ->
    L.Symbol ->
@@ -100,6 +102,7 @@ registerModuleFn handleWarning mtrans sym =
 --   'registerLazyModuleFn' for a description.
 registerLazyModule ::
    (1 <= ArchWidth arch, HasPtrWidth (ArchWidth arch), IsSymInterface sym) =>
+   mem ~ Mem =>
    (LLVMTranslationWarning -> IO ()) {- ^ A callback for handling traslation warnings -} ->
    ModuleTranslation mem arch ->
    OverrideSim p sym (LLVM mem) rtp l a ()
@@ -116,6 +119,7 @@ registerLazyModule handleWarning mtrans =
 --   a much-later point, when the function in question is actually first invoked.
 registerLazyModuleFn ::
    (1 <= ArchWidth arch, HasPtrWidth (ArchWidth arch), IsSymInterface sym) =>
+   mem ~ Mem =>
    (LLVMTranslationWarning -> IO ()) {- ^ A callback for handling translation warnings -} ->
    ModuleTranslation mem arch ->
    L.Symbol ->
@@ -163,19 +167,20 @@ registerLazyModuleFn handleWarning mtrans sym =
 
 
 llvmGlobalsToCtx
-   :: LLVMContext arch
+   :: mem ~ Mem => LLVMContext mem arch
    -> MemImpl sym
    -> SymGlobalState sym
 llvmGlobalsToCtx = llvmGlobals . llvmMemVar
 
 llvmGlobals
-   :: GlobalVar Mem
+   :: mem ~ Mem => GlobalVar Mem
    -> MemImpl sym
    -> SymGlobalState sym
 llvmGlobals memVar mem = emptyGlobals & insertGlobal memVar mem
 
 llvmExtensionImpl ::
   (HasLLVMAnn sym) =>
+  mem ~ Mem =>
   MemOptions ->
   ExtensionImpl p sym (LLVM mem)
 llvmExtensionImpl mo =

--- a/crucible-llvm/src/Lang/Crucible/LLVM/ArraySizeProfile.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/ArraySizeProfile.hs
@@ -199,8 +199,7 @@ updateProfiles llvm cell state
 arraySizeProfile ::
   forall sym ext mem arch p rtp.
   ( C.IsSymInterface sym, C.HasLLVMAnn sym, C.HasPtrWidth (C.ArchWidth arch)
-  , ?memOpts :: C.MemOptions ) =>
-  mem ~ C.Mem =>
+  , ?memOpts :: C.MemOptions , mem ~ C.Mem) =>
   C.LLVMContext mem arch ->
   IORef (Map Text [FunctionProfile]) ->
   IO (C.ExecutionFeature p sym ext rtp)

--- a/crucible-llvm/src/Lang/Crucible/LLVM/ArraySizeProfile.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/ArraySizeProfile.hs
@@ -175,7 +175,8 @@ argProfiles sym mem as =
 updateProfiles ::
   ( C.IsSymInterface sym, C.HasLLVMAnn sym, C.HasPtrWidth (C.ArchWidth arch)
   , ?memOpts :: C.MemOptions ) =>
-  C.LLVMContext arch ->
+  mem ~ C.Mem =>
+  C.LLVMContext mem arch ->
   IORef (Map Text [FunctionProfile]) ->
   C.ExecState p sym ext rtp ->
   IO ()
@@ -196,10 +197,11 @@ updateProfiles llvm cell state
   | otherwise = pure ()
 
 arraySizeProfile ::
-  forall sym ext arch p rtp.
+  forall sym ext mem arch p rtp.
   ( C.IsSymInterface sym, C.HasLLVMAnn sym, C.HasPtrWidth (C.ArchWidth arch)
   , ?memOpts :: C.MemOptions ) =>
-  C.LLVMContext arch ->
+  mem ~ C.Mem =>
+  C.LLVMContext mem arch ->
   IORef (Map Text [FunctionProfile]) ->
   IO (C.ExecutionFeature p sym ext rtp)
 arraySizeProfile llvm profiles = do

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Ctors.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Ctors.hs
@@ -158,9 +158,8 @@ callAllCtors = callCtors (const True)
 
 -- | Make a 'LLVMGenerator' into a CFG by making it a function with no arguments
 -- that returns unit.
-generatorToCFG :: forall mem arch wptr ret. (HasPtrWidth wptr, wptr ~ ArchWidth arch, 16 <= wptr)
-  => Mem.Mem mem
-               => Text
+generatorToCFG :: forall mem arch wptr ret. (HasPtrWidth wptr, wptr ~ ArchWidth arch, 16 <= wptr, Mem.Mem mem)
+  => Text
                -> HandleAllocator
                -> LLVMContext mem arch
                -> (forall s. LLVMGenerator s mem arch ret (Expr (LLVM mem) s ret))
@@ -184,9 +183,8 @@ generatorToCFG name halloc llvmctx gen ret = do
   return $! toSSA g
 
 -- | Create a CFG that calls some of the functions in @llvm.global_ctors@.
-callCtorsCFG :: forall mem arch wptr. (HasPtrWidth wptr, wptr ~ ArchWidth arch, 16 <= wptr)
-  => Mem.Mem mem
-             => (Ctor -> Bool) -- ^ Filter function
+callCtorsCFG :: forall mem arch wptr. (HasPtrWidth wptr, wptr ~ ArchWidth arch, 16 <= wptr, Mem.Mem mem)
+  => (Ctor -> Bool) -- ^ Filter function
              -> L.Module
              -> HandleAllocator
              -> LLVMContext mem arch

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Ctors.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Ctors.hs
@@ -158,14 +158,14 @@ callAllCtors = callCtors (const True)
 generatorToCFG :: forall mem arch wptr ret. (HasPtrWidth wptr, wptr ~ ArchWidth arch, 16 <= wptr)
                => Text
                -> HandleAllocator
-               -> LLVMContext arch
+               -> LLVMContext mem arch
                -> (forall s. LLVMGenerator s mem arch ret (Expr (LLVM mem) s ret))
                -> TypeRepr ret
                -> IO (Core.SomeCFG (LLVM mem) Core.EmptyCtx ret)
 generatorToCFG name halloc llvmctx gen ret = do
   ref <- newIORef []
   let ?lc = _llvmTypeCtx llvmctx
-  let def :: forall args. FunctionDef (LLVM mem) (LLVMState arch) args ret IO
+  let def :: forall args. FunctionDef (LLVM mem) (LLVMState mem arch) args ret IO
       def _inputs = (state, gen)
         where state = LLVMState { _identMap     = empty
                                 , _blockInfoMap = empty
@@ -184,7 +184,7 @@ callCtorsCFG :: forall mem arch wptr. (HasPtrWidth wptr, wptr ~ ArchWidth arch, 
              => (Ctor -> Bool) -- ^ Filter function
              -> L.Module
              -> HandleAllocator
-             -> LLVMContext arch
+             -> LLVMContext mem arch
              -> IO (Core.SomeCFG (LLVM mem) Core.EmptyCtx UnitType)
 callCtorsCFG select mod_ halloc llvmctx = do
   generatorToCFG "llvm_global_ctors" halloc llvmctx (callCtors select mod_) UnitRepr

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Errors.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Errors.hs
@@ -62,7 +62,7 @@ import qualified Lang.Crucible.LLVM.Errors.UndefinedBehavior as UB
 -- | Combine the three types of bad behaviors
 --
 data BadBehavior sym where
-  BBUndefinedBehavior :: UB.UndefinedBehavior (RegValue' sym) -> BadBehavior sym
+  BBUndefinedBehavior :: UB.UndefinedBehavior mem (RegValue' sym) -> BadBehavior sym
   BBMemoryError       :: ME.MemoryError sym -> BadBehavior sym
  deriving Typeable
 
@@ -93,14 +93,14 @@ data LLVMSafetyAssertion sym =
 -- We expose these rather than the constructors to retain the freedom to
 -- change the internal representation.
 
-undefinedBehavior' :: UB.UndefinedBehavior (RegValue' sym)
+undefinedBehavior' :: UB.UndefinedBehavior mem (RegValue' sym)
                    -> Pred sym
                    -> Text
                    -> LLVMSafetyAssertion sym
 undefinedBehavior' ub pred expl =
   LLVMSafetyAssertion (BBUndefinedBehavior ub) pred (Just expl)
 
-undefinedBehavior :: UB.UndefinedBehavior (RegValue' sym)
+undefinedBehavior :: UB.UndefinedBehavior mem (RegValue' sym)
                   -> Pred sym
                   -> LLVMSafetyAssertion sym
 undefinedBehavior ub pred =
@@ -110,14 +110,14 @@ memoryError :: (1 <= w) => ME.MemoryOp sym w -> ME.MemoryErrorReason -> Pred sym
 memoryError mop rsn pred =
   LLVMSafetyAssertion (BBMemoryError (ME.MemoryError mop rsn)) pred Nothing
 
-poison' :: Poison.Poison (RegValue' sym)
+poison' :: Poison.Poison mem (RegValue' sym)
         -> Pred sym
         -> Text
         -> LLVMSafetyAssertion sym
 poison' poison_ pred expl =
   LLVMSafetyAssertion (BBUndefinedBehavior (UB.PoisonValueCreated poison_)) pred (Just expl)
 
-poison :: Poison.Poison (RegValue' sym)
+poison :: Poison.Poison mem (RegValue' sym)
        -> Pred sym
        -> LLVMSafetyAssertion sym
 poison poison_ pred =

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Errors/UndefinedBehavior.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Errors/UndefinedBehavior.hs
@@ -101,24 +101,24 @@ ppPtrComparison Leq = "Ordering comparison (<=)"
 --
 -- The commented-out constructors correspond to behaviors that don't have
 -- explicit checks yet (but probably should!).
-data UndefinedBehavior (e :: CrucibleType -> Type) where
+data UndefinedBehavior mem (e :: CrucibleType -> Type) where
 
   -- -------------------------------- Memory management
 
   FreeBadOffset ::
     (1 <= w) =>
     e (LLVMPointerType w) ->
-    UndefinedBehavior e
+    UndefinedBehavior mem e
 
   FreeUnallocated ::
     (1 <= w) =>
     e (LLVMPointerType w) ->
-    UndefinedBehavior e
+    UndefinedBehavior mem e
 
   DoubleFree ::
     (1 <= w) =>
     e (LLVMPointerType w) ->
-    UndefinedBehavior e
+    UndefinedBehavior mem e
 
   -- | Arguments: Destination pointer, fill byte, length
   MemsetInvalidRegion ::
@@ -126,21 +126,21 @@ data UndefinedBehavior (e :: CrucibleType -> Type) where
     e (LLVMPointerType w) ->
     e (BVType 8) ->
     e (BVType v) ->
-    UndefinedBehavior e
+    UndefinedBehavior mem e
 
   -- | Arguments: Read destination, alignment
   ReadBadAlignment ::
     (1 <= w) =>
     e (LLVMPointerType w) ->
     Alignment ->
-    UndefinedBehavior e
+    UndefinedBehavior mem e
 
   -- | Arguments: Write destination, alignment
   WriteBadAlignment ::
     (1 <= w) =>
     e (LLVMPointerType w) ->
     Alignment ->
-    UndefinedBehavior e
+    UndefinedBehavior mem e
 
   -- -------------------------------- Pointer arithmetic
 
@@ -148,7 +148,7 @@ data UndefinedBehavior (e :: CrucibleType -> Type) where
     (1 <= w) =>
     e (LLVMPointerType w) ->
     e (BVType w) ->
-    UndefinedBehavior e
+    UndefinedBehavior mem e
 
   -- | Arguments: kind of comparison, the invalid pointer, the other pointer
   CompareInvalidPointer ::
@@ -156,7 +156,7 @@ data UndefinedBehavior (e :: CrucibleType -> Type) where
     PtrComparisonOperator ->
     e (LLVMPointerType w) ->
     e (LLVMPointerType w) ->
-    UndefinedBehavior e
+    UndefinedBehavior mem e
 
   -- | "In all other cases, the behavior is undefined"
   -- TODO: 'PtrComparisonOperator' argument?
@@ -164,7 +164,7 @@ data UndefinedBehavior (e :: CrucibleType -> Type) where
     (1 <= w) =>
     e (LLVMPointerType w) ->
     e (LLVMPointerType w) ->
-    UndefinedBehavior e
+    UndefinedBehavior mem e
 
   -- | "When two pointers are subtracted, both shall point to elements of the
   -- same array object"
@@ -172,7 +172,7 @@ data UndefinedBehavior (e :: CrucibleType -> Type) where
     (1 <= w) =>
     e (LLVMPointerType w) ->
     e (LLVMPointerType w) ->
-    UndefinedBehavior e
+    UndefinedBehavior mem e
 
   -- | Pointer cast to an integer type other than
   --   pointer width integers
@@ -180,21 +180,21 @@ data UndefinedBehavior (e :: CrucibleType -> Type) where
     (1 <= w) =>
     e (LLVMPointerType w) ->
     StorageType ->
-    UndefinedBehavior e
+    UndefinedBehavior mem e
 
   -- | Pointer used in an unsupported arithmetic or bitvector operation
   PointerUnsupportedOp ::
     (1 <= w) =>
     e (LLVMPointerType w) ->
     String ->
-    UndefinedBehavior e
+    UndefinedBehavior mem e
 
   -- | Pointer cast to a floating-point type
   PointerFloatCast ::
     (1 <= w) =>
     e (LLVMPointerType w) ->
     StorageType ->
-    UndefinedBehavior e
+    UndefinedBehavior mem e
 
   -- | "One of the following shall hold: [...] one operand is a pointer and the
   -- other is a null pointer constant."
@@ -202,35 +202,35 @@ data UndefinedBehavior (e :: CrucibleType -> Type) where
     (1 <= w) =>
     e (LLVMPointerType w) ->
     e (BVType w) ->
-    UndefinedBehavior e
+    UndefinedBehavior mem e
 
   -------------------------------- Division operators
 
   -- | @SymBV@ or @Expr _ _ (BVType w)@
-  UDivByZero   :: (1 <= w) => e (BVType w) -> e (BVType w) -> UndefinedBehavior e
-  SDivByZero   :: (1 <= w) => e (BVType w) -> e (BVType w) -> UndefinedBehavior e
-  URemByZero   :: (1 <= w) => e (BVType w) -> e (BVType w) -> UndefinedBehavior e
-  SRemByZero   :: (1 <= w) => e (BVType w) -> e (BVType w) -> UndefinedBehavior e
-  SDivOverflow :: (1 <= w) => e (BVType w) -> e (BVType w) -> UndefinedBehavior e
-  SRemOverflow :: (1 <= w) => e (BVType w) -> e (BVType w) -> UndefinedBehavior e
+  UDivByZero   :: (1 <= w) => e (BVType w) -> e (BVType w) -> UndefinedBehavior mem e
+  SDivByZero   :: (1 <= w) => e (BVType w) -> e (BVType w) -> UndefinedBehavior mem e
+  URemByZero   :: (1 <= w) => e (BVType w) -> e (BVType w) -> UndefinedBehavior mem e
+  SRemByZero   :: (1 <= w) => e (BVType w) -> e (BVType w) -> UndefinedBehavior mem e
+  SDivOverflow :: (1 <= w) => e (BVType w) -> e (BVType w) -> UndefinedBehavior mem e
+  SRemOverflow :: (1 <= w) => e (BVType w) -> e (BVType w) -> UndefinedBehavior mem e
 
   -------------------------------- Integer arithmetic
 
-  AbsIntMin    :: (1 <= w) => e (BVType w) -> UndefinedBehavior e
+  AbsIntMin    :: (1 <= w) => e (BVType w) -> UndefinedBehavior mem e
 
   PoisonValueCreated ::
-    Poison.Poison e ->
-    UndefinedBehavior e
+    Poison.Poison mem e ->
+    UndefinedBehavior mem e
 
   {-
-  MemcpyDisjoint          :: UndefinedBehavior e
-  DereferenceBadAlignment :: UndefinedBehavior e
-  ModifiedStringLiteral   :: UndefinedBehavior e
+  MemcpyDisjoint          :: UndefinedBehavior mem e
+  DereferenceBadAlignment :: UndefinedBehavior mem e
+  ModifiedStringLiteral   :: UndefinedBehavior mem e
   -}
   deriving (Typeable)
 
 -- | Which document prohibits this behavior?
-standard :: UndefinedBehavior e -> Standard
+standard :: UndefinedBehavior mem e -> Standard
 standard =
   \case
 
@@ -276,7 +276,7 @@ standard =
     -}
 
 -- | Which section(s) of the document prohibit this behavior?
-cite :: UndefinedBehavior e -> Doc ann
+cite :: UndefinedBehavior mem e -> Doc ann
 cite =
   \case
 
@@ -326,7 +326,7 @@ cite =
 -- | What happened, and why is it a problem?
 --
 -- This is a generic explanation that doesn't use the included data.
-explain :: UndefinedBehavior e -> Doc ann
+explain :: UndefinedBehavior mem e -> Doc ann
 explain =
   \case
 
@@ -393,7 +393,7 @@ explain =
 -- | Pretty-print the additional information held by the constructors
 -- (for symbolic expressions)
 details :: W4I.IsExpr (W4I.SymExpr sym)
-        => UndefinedBehavior (RegValue' sym)
+        => UndefinedBehavior mem (RegValue' sym)
         -> [Doc ann]
 details =
   \case
@@ -488,19 +488,19 @@ details =
         ppOffset :: W4I.IsExpr e => e (BaseBVType w) -> Doc ann
         ppOffset = ("Offset:" <+>) . W4I.printSymExpr
 
-pp :: (UndefinedBehavior e -> [Doc ann]) -- ^ Printer for constructor data
-   -> UndefinedBehavior e
+pp :: (UndefinedBehavior mem e -> [Doc ann]) -- ^ Printer for constructor data
+   -> UndefinedBehavior mem e
    -> Doc ann
 pp extra ub = vcat (explain ub : extra ub ++ ppCitation ub)
 
 -- | Pretty-printer for symbolic backends
 ppDetails ::
   W4I.IsExpr (W4I.SymExpr sym) =>
-  UndefinedBehavior (RegValue' sym) ->
+  UndefinedBehavior mem (RegValue' sym) ->
   Doc ann
 ppDetails ub = vcat (details ub ++ ppCitation ub)
 
-ppCitation :: UndefinedBehavior e -> [Doc ann]
+ppCitation :: UndefinedBehavior mem e -> [Doc ann]
 ppCitation ub =
    (cat [ "Reference: "
         , indent 2 (pretty (ppStd (standard ub)))
@@ -515,54 +515,54 @@ ppCitation ub =
 
 $(return [])
 
-instance TestEqualityC UndefinedBehavior where
+instance TestEqualityC (UndefinedBehavior mem) where
   testEqualityC subterms x y = isJust $
     $(U.structuralTypeEquality [t|UndefinedBehavior|]
-       [ ( U.DataArg 0 `U.TypeApp` U.AnyType
+       [ ( U.DataArg 1 `U.TypeApp` U.AnyType
          , [| subterms |]
          )
-       , ( U.ConType [t|Poison.Poison|] `U.TypeApp` U.AnyType
+       , ( U.ConType [t|Poison.Poison|] `U.TypeApp` U.AnyType `U.TypeApp` U.AnyType
          , [| \a b -> if testEqualityC subterms a b then Just Refl else Nothing |]
          )
        ]
      ) x y
 
-instance OrdC UndefinedBehavior where
+instance OrdC (UndefinedBehavior mem) where
   compareC subterms ub1 ub2 = toOrdering $
     $(U.structuralTypeOrd [t|UndefinedBehavior|]
-       [ ( U.DataArg 0 `U.TypeApp` U.AnyType
+       [ ( U.DataArg 1 `U.TypeApp` U.AnyType
          , [| subterms |]
          )
-       , ( U.ConType [t|Poison.Poison|] `U.TypeApp` U.AnyType
+       , ( U.ConType [t|Poison.Poison|] `U.TypeApp` U.AnyType `U.TypeApp` U.AnyType
          , [| \a b -> fromOrdering (compareC subterms a b) |]
          )
        ]
      ) ub1 ub2
 
-instance FunctorF UndefinedBehavior where
+instance FunctorF (UndefinedBehavior mem) where
   fmapF = TF.fmapFDefault
 
-instance FoldableF UndefinedBehavior where
+instance FoldableF (UndefinedBehavior mem) where
   foldMapF = TF.foldMapFDefault
 
-instance TraversableF UndefinedBehavior where
+instance TraversableF (UndefinedBehavior mem) where
   traverseF subterms =
     $(U.structuralTraversal [t|UndefinedBehavior|]
-       [ ( U.DataArg 0 `U.TypeApp` U.AnyType
+       [ ( U.DataArg 1 `U.TypeApp` U.AnyType
          , [| \_ x -> subterms x |]
          )
-       , ( U.ConType [t|Poison.Poison|] `U.TypeApp` U.AnyType
+       , ( U.ConType [t|Poison.Poison|] `U.TypeApp` U.AnyType `U.TypeApp` U.AnyType
          , [| \_ x -> traverseF subterms x |]
          )
        ]
      ) subterms
 
 
-concUB :: forall sym.
+concUB :: forall sym mem.
   W4I.IsExprBuilder sym =>
   sym ->
   (forall tp. W4I.SymExpr sym tp -> IO (GroundValue tp)) ->
-  UndefinedBehavior (RegValue' sym) -> IO (UndefinedBehavior (RegValue' sym))
+  UndefinedBehavior mem (RegValue' sym) -> IO (UndefinedBehavior mem (RegValue' sym))
 concUB sym conc ub =
   let bv :: forall w. (1 <= w) => RegValue' sym (BVType w) -> IO (RegValue' sym (BVType w))
       bv (RV x) = RV <$> concBV sym conc x in

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Eval.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Eval.hs
@@ -54,7 +54,7 @@ assertSideCondition ::
   (HasLLVMAnn sym, IsSymBackend sym bak) =>
   bak ->
   CallStack ->
-  LLVMSideCondition (RegValue' sym) ->
+  LLVMSideCondition mem (RegValue' sym) ->
   IO ()
 assertSideCondition bak callStack (LLVMSideCondition (RV p) ub) =
   do let sym = backendGetSym bak

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Eval.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Eval.hs
@@ -62,13 +62,13 @@ assertSideCondition bak callStack (LLVMSideCondition (RV p) ub) =
      assert bak p' err
 
 llvmExtensionEval ::
-  forall sym bak p ext rtp blocks r ctx.
+  forall sym bak p ext mem rtp blocks r ctx.
   (HasLLVMAnn sym, IsSymBackend sym bak) =>
   bak ->
   IntrinsicTypes sym ->
   (Int -> String -> IO ()) ->
   CrucibleState p sym ext rtp blocks r ctx ->
-  EvalAppFunc sym LLVMExtensionExpr
+  EvalAppFunc sym (LLVMExtensionExpr mem)
 
 llvmExtensionEval bak _iTypes _logFn state eval e =
   let sym = backendGetSym bak in

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Eval.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Eval.hs
@@ -64,8 +64,7 @@ assertSideCondition bak callStack (LLVMSideCondition (RV p) ub) =
 
 llvmExtensionEval ::
   forall sym bak p ext mem rtp blocks r ctx.
-  mem ~ Mem =>
-  (HasLLVMAnn sym, IsSymBackend sym bak) =>
+  (mem ~ Mem, HasLLVMAnn sym, IsSymBackend sym bak) =>
   bak ->
   IntrinsicTypes sym ->
   (Int -> String -> IO ()) ->

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Eval.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Eval.hs
@@ -36,8 +36,9 @@ import           Lang.Crucible.LLVM.MemModel.Pointer
 import           Lang.Crucible.LLVM.Types (Mem)
 
 callStackFromMemVar ::
+  mem ~ Mem =>
   SimState p sym ext rtp lang args ->
-  GlobalVar Mem ->
+  GlobalVar mem ->
   CallStack
 callStackFromMemVar state mvar =
   getCallStack . view memState . memImplHeap $
@@ -63,6 +64,7 @@ assertSideCondition bak callStack (LLVMSideCondition (RV p) ub) =
 
 llvmExtensionEval ::
   forall sym bak p ext mem rtp blocks r ctx.
+  mem ~ Mem =>
   (HasLLVMAnn sym, IsSymBackend sym bak) =>
   bak ->
   IntrinsicTypes sym ->

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Extension.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Extension.hs
@@ -30,6 +30,7 @@ import Lang.Crucible.Types (CrucibleType)
 
 import Lang.Crucible.LLVM.Extension.Arch
 import Lang.Crucible.LLVM.Extension.Syntax
+import Lang.Crucible.LLVM.Mem (Mem)
 
 -- | The Crucible extension type marker for LLVM.
 data LLVM (mem :: CrucibleType)
@@ -41,4 +42,4 @@ data LLVM (mem :: CrucibleType)
 type instance ExprExtension (LLVM mem) = LLVMExtensionExpr mem
 type instance StmtExtension (LLVM mem) = LLVMStmt mem
 
-instance IsSyntaxExtension (LLVM mem)
+instance Mem mem => IsSyntaxExtension (LLVM mem)

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Extension.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Extension.hs
@@ -31,13 +31,13 @@ import Lang.Crucible.LLVM.Extension.Arch
 import Lang.Crucible.LLVM.Extension.Syntax
 
 -- | The Crucible extension type marker for LLVM.
-data LLVM
+data LLVM mem
   deriving (Data, Eq, Generic , Ord, Typeable)
 
 -- -----------------------------------------------------------------------
 -- ** Syntax
 
-type instance ExprExtension LLVM = LLVMExtensionExpr
-type instance StmtExtension LLVM = LLVMStmt
+type instance ExprExtension (LLVM mem) = LLVMExtensionExpr mem
+type instance StmtExtension (LLVM mem) = LLVMStmt mem
 
-instance IsSyntaxExtension LLVM
+instance IsSyntaxExtension (LLVM mem)

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Extension.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Extension.hs
@@ -26,12 +26,13 @@ import Data.Typeable (Typeable)
 import GHC.Generics ( Generic )
 
 import Lang.Crucible.CFG.Extension
+import Lang.Crucible.Types (CrucibleType)
 
 import Lang.Crucible.LLVM.Extension.Arch
 import Lang.Crucible.LLVM.Extension.Syntax
 
 -- | The Crucible extension type marker for LLVM.
-data LLVM mem
+data LLVM (mem :: CrucibleType)
   deriving (Data, Eq, Generic , Ord, Typeable)
 
 -- -----------------------------------------------------------------------

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Globals.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Globals.hs
@@ -105,8 +105,8 @@ type GlobalInitializerMap = Map L.Symbol (L.Global, Either String (MemType, Mayb
 
 -- | @makeGlobalMap@ creates a map from names of LLVM global variables
 -- to the values of their initializers, if any are included in the module.
-makeGlobalMap :: forall arch wptr. (?lc :: TypeContext, HasPtrWidth wptr)
-              => LLVMContext arch
+makeGlobalMap :: forall mem arch wptr. (?lc :: TypeContext, HasPtrWidth wptr)
+              => LLVMContext mem arch
               -> L.Module
               -> GlobalInitializerMap
 makeGlobalMap ctx m = foldl' addAliases globalMap (Map.toList (llvmGlobalAliases ctx))
@@ -153,7 +153,7 @@ initializeAllMemory
    :: ( IsSymBackend sym bak, HasPtrWidth wptr, HasLLVMAnn sym
       , ?memOpts :: MemOptions )
    => bak
-   -> LLVMContext arch
+   -> LLVMContext mem arch
    -> L.Module
    -> IO (MemImpl sym)
 initializeAllMemory = initializeMemory (const True)
@@ -162,7 +162,7 @@ initializeMemoryConstGlobals
    :: ( IsSymBackend sym bak, HasPtrWidth wptr, HasLLVMAnn sym
       , ?memOpts :: MemOptions )
    => bak
-   -> LLVMContext arch
+   -> LLVMContext mem arch
    -> L.Module
    -> IO (MemImpl sym)
 initializeMemoryConstGlobals = initializeMemory (L.gaConstant . L.globalAttrs)
@@ -172,7 +172,7 @@ initializeMemory
       , ?memOpts :: MemOptions )
    => (L.Global -> Bool)
    -> bak
-   -> LLVMContext arch
+   -> LLVMContext mem arch
    -> L.Module
    -> IO (MemImpl sym)
 initializeMemory predicate bak llvm_ctx llvmModl = do
@@ -226,7 +226,7 @@ allocLLVMFunPtr ::
   ( IsSymBackend sym bak, HasPtrWidth wptr, HasLLVMAnn sym
   , ?memOpts :: MemOptions ) =>
   bak ->
-  LLVMContext arch ->
+  LLVMContext mem arch ->
   MemImpl sym ->
   Either L.Declare L.Define ->
   IO (MemImpl sym)

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics.hs
@@ -68,8 +68,7 @@ llvmIntrinsicTypes =
 -- | Register all declare and define overrides
 register_llvm_overrides ::
   ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch
-  , ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions ) =>
-  mem ~ Mem =>
+  , ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions , mem ~ Mem) =>
   L.Module ->
   [OverrideTemplate p sym mem arch rtp l a] {- ^ Additional "define" overrides -} ->
   [OverrideTemplate p sym mem arch rtp l a] {- ^ Additional "declare" overrides -} ->
@@ -126,8 +125,7 @@ register_llvm_overrides_ llvmctx acts decls =
          runMaybeT (flip runReaderT (decl,declnm,llvmctx) $ asum (map overrideTemplateAction acts'))
 
 register_llvm_define_overrides ::
-  (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch) =>
-  mem ~ Mem =>
+  (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch, mem ~ Mem) =>
   L.Module ->
   [OverrideTemplate p sym mem arch rtp l a] ->
   LLVMContext mem arch ->
@@ -139,8 +137,7 @@ register_llvm_define_overrides llvmModule addlOvrs llvmctx =
 
 register_llvm_declare_overrides ::
   ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch
-  , ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions ) =>
-  mem ~ Mem =>
+  , ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions , mem ~ Mem) =>
   L.Module ->
   [OverrideTemplate p sym mem arch rtp l a] ->
   LLVMContext mem arch ->
@@ -153,8 +150,7 @@ register_llvm_declare_overrides llvmModule addlOvrs llvmctx =
 -- | Register overrides for declared-but-not-defined functions
 declare_overrides ::
   ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch
-  , ?lc :: TypeContext, ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions ) =>
-  mem ~ Mem =>
+  , ?lc :: TypeContext, ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions , mem ~ Mem) =>
   [OverrideTemplate p sym mem arch rtp l a]
 declare_overrides =
   concat
@@ -170,8 +166,7 @@ declare_overrides =
 -- | Register those overrides that should apply even when the corresponding
 -- function has a definition
 define_overrides ::
-  (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch, ?lc :: TypeContext) =>
-  mem ~ Mem =>
+  (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch, ?lc :: TypeContext, mem ~ Mem) =>
   [OverrideTemplate p sym mem arch rtp l a]
 define_overrides =
   [ Libcxx.register_cpp_override Libcxx.putToOverride12

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics.hs
@@ -69,10 +69,11 @@ llvmIntrinsicTypes =
 register_llvm_overrides ::
   ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch
   , ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions ) =>
+  mem ~ Mem =>
   L.Module ->
   [OverrideTemplate p sym mem arch rtp l a] {- ^ Additional "define" overrides -} ->
   [OverrideTemplate p sym mem arch rtp l a] {- ^ Additional "declare" overrides -} ->
-  LLVMContext arch ->
+  LLVMContext mem arch ->
   OverrideSim p sym (LLVM mem) rtp l a ()
 register_llvm_overrides llvmModule defineOvrs declareOvrs llvmctx =
   do register_llvm_define_overrides llvmModule defineOvrs llvmctx
@@ -86,6 +87,7 @@ register_llvm_overrides llvmModule defineOvrs declareOvrs llvmctx =
 -- more detail, including examining function arguments
 -- and the structure of C++ demangled names to extract more information.
 filterTemplates ::
+  mem ~ Mem =>
   [OverrideTemplate p sym mem arch rtp l a] ->
   L.Declare ->
   [OverrideTemplate p sym mem arch rtp l a]
@@ -111,7 +113,8 @@ filterTemplates ts decl = filter (f . overrideTemplateMatcher) ts
 
 -- | Helper function for registering overrides
 register_llvm_overrides_ ::
-  LLVMContext arch ->
+  mem ~ Mem =>
+  LLVMContext mem arch ->
   [OverrideTemplate p sym mem arch rtp l a] ->
   [L.Declare] ->
   OverrideSim p sym (LLVM mem) rtp l a ()
@@ -124,9 +127,10 @@ register_llvm_overrides_ llvmctx acts decls =
 
 register_llvm_define_overrides ::
   (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch) =>
+  mem ~ Mem =>
   L.Module ->
   [OverrideTemplate p sym mem arch rtp l a] ->
-  LLVMContext arch ->
+  LLVMContext mem arch ->
   OverrideSim p sym (LLVM mem) rtp l a ()
 register_llvm_define_overrides llvmModule addlOvrs llvmctx =
   let ?lc = llvmctx^.llvmTypeCtx in
@@ -136,9 +140,10 @@ register_llvm_define_overrides llvmModule addlOvrs llvmctx =
 register_llvm_declare_overrides ::
   ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch
   , ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions ) =>
+  mem ~ Mem =>
   L.Module ->
   [OverrideTemplate p sym mem arch rtp l a] ->
-  LLVMContext arch ->
+  LLVMContext mem arch ->
   OverrideSim p sym (LLVM mem) rtp l a ()
 register_llvm_declare_overrides llvmModule addlOvrs llvmctx =
   let ?lc = llvmctx^.llvmTypeCtx
@@ -149,6 +154,7 @@ register_llvm_declare_overrides llvmModule addlOvrs llvmctx =
 declare_overrides ::
   ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch
   , ?lc :: TypeContext, ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions ) =>
+  mem ~ Mem =>
   [OverrideTemplate p sym mem arch rtp l a]
 declare_overrides =
   concat
@@ -165,6 +171,7 @@ declare_overrides =
 -- function has a definition
 define_overrides ::
   (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch, ?lc :: TypeContext) =>
+  mem ~ Mem =>
   [OverrideTemplate p sym mem arch rtp l a]
 define_overrides =
   [ Libcxx.register_cpp_override Libcxx.putToOverride12

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics.hs
@@ -70,10 +70,10 @@ register_llvm_overrides ::
   ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch
   , ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions ) =>
   L.Module ->
-  [OverrideTemplate p sym arch rtp l a] {- ^ Additional "define" overrides -} ->
-  [OverrideTemplate p sym arch rtp l a] {- ^ Additional "declare" overrides -} ->
+  [OverrideTemplate p sym mem arch rtp l a] {- ^ Additional "define" overrides -} ->
+  [OverrideTemplate p sym mem arch rtp l a] {- ^ Additional "declare" overrides -} ->
   LLVMContext arch ->
-  OverrideSim p sym LLVM rtp l a ()
+  OverrideSim p sym (LLVM mem) rtp l a ()
 register_llvm_overrides llvmModule defineOvrs declareOvrs llvmctx =
   do register_llvm_define_overrides llvmModule defineOvrs llvmctx
      register_llvm_declare_overrides llvmModule declareOvrs llvmctx
@@ -86,9 +86,9 @@ register_llvm_overrides llvmModule defineOvrs declareOvrs llvmctx =
 -- more detail, including examining function arguments
 -- and the structure of C++ demangled names to extract more information.
 filterTemplates ::
-  [OverrideTemplate p sym arch rtp l a] ->
+  [OverrideTemplate p sym mem arch rtp l a] ->
   L.Declare ->
-  [OverrideTemplate p sym arch rtp l a]
+  [OverrideTemplate p sym mem arch rtp l a]
 filterTemplates ts decl = filter (f . overrideTemplateMatcher) ts
  where
  L.Symbol nm = L.decName decl
@@ -112,9 +112,9 @@ filterTemplates ts decl = filter (f . overrideTemplateMatcher) ts
 -- | Helper function for registering overrides
 register_llvm_overrides_ ::
   LLVMContext arch ->
-  [OverrideTemplate p sym arch rtp l a] ->
+  [OverrideTemplate p sym mem arch rtp l a] ->
   [L.Declare] ->
-  OverrideSim p sym LLVM rtp l a ()
+  OverrideSim p sym (LLVM mem) rtp l a ()
 register_llvm_overrides_ llvmctx acts decls =
     forM_ decls $ \decl ->
       do let acts' = filterTemplates acts decl
@@ -125,9 +125,9 @@ register_llvm_overrides_ llvmctx acts decls =
 register_llvm_define_overrides ::
   (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch) =>
   L.Module ->
-  [OverrideTemplate p sym arch rtp l a] ->
+  [OverrideTemplate p sym mem arch rtp l a] ->
   LLVMContext arch ->
-  OverrideSim p sym LLVM rtp l a ()
+  OverrideSim p sym (LLVM mem) rtp l a ()
 register_llvm_define_overrides llvmModule addlOvrs llvmctx =
   let ?lc = llvmctx^.llvmTypeCtx in
   register_llvm_overrides_ llvmctx (addlOvrs ++ define_overrides) $
@@ -137,9 +137,9 @@ register_llvm_declare_overrides ::
   ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch
   , ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions ) =>
   L.Module ->
-  [OverrideTemplate p sym arch rtp l a] ->
+  [OverrideTemplate p sym mem arch rtp l a] ->
   LLVMContext arch ->
-  OverrideSim p sym LLVM rtp l a ()
+  OverrideSim p sym (LLVM mem) rtp l a ()
 register_llvm_declare_overrides llvmModule addlOvrs llvmctx =
   let ?lc = llvmctx^.llvmTypeCtx
   in register_llvm_overrides_ llvmctx (addlOvrs ++ declare_overrides) $
@@ -149,7 +149,7 @@ register_llvm_declare_overrides llvmModule addlOvrs llvmctx =
 declare_overrides ::
   ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch
   , ?lc :: TypeContext, ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions ) =>
-  [OverrideTemplate p sym arch rtp l a]
+  [OverrideTemplate p sym mem arch rtp l a]
 declare_overrides =
   concat
   [ map (\(SomeLLVMOverride ov) -> basic_llvm_override ov) Libc.libc_overrides
@@ -165,7 +165,7 @@ declare_overrides =
 -- function has a definition
 define_overrides ::
   (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch, ?lc :: TypeContext) =>
-  [OverrideTemplate p sym arch rtp l a]
+  [OverrideTemplate p sym mem arch rtp l a]
 define_overrides =
   [ Libcxx.register_cpp_override Libcxx.putToOverride12
   , Libcxx.register_cpp_override Libcxx.putToOverride9

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Common.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Common.hs
@@ -258,8 +258,7 @@ register_1arg_polymorphic_override prefix overrideFn =
        _ -> empty
 
 basic_llvm_override :: forall p args ret sym mem arch wptr l a rtp.
-  mem ~ Mem =>
-  (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr) =>
+  (mem ~ Mem, IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr) =>
   LLVMOverride p sym (LLVM mem) mem args ret ->
   OverrideTemplate p sym mem arch rtp l a
 basic_llvm_override ovr = OverrideTemplate matcher regOvr
@@ -313,8 +312,7 @@ isMatchingDeclaration requested provided = and
  matchingArgList (x:xs) (y:ys) = x `L.eqTypeModuloOpaquePtrs` y && matchingArgList xs ys
 
 register_llvm_override :: forall p args ret sym mem arch wptr l a rtp.
-  (IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym) =>
-  mem ~ Mem =>
+  (IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym, mem ~ Mem) =>
   LLVMOverride p sym (LLVM mem) mem args ret ->
   RegOverrideM p sym mem arch rtp l a ()
 register_llvm_override llvmOverride = do
@@ -335,8 +333,7 @@ register_llvm_override llvmOverride = do
 -- | Bind a function handle, and also bind the function to the global function
 -- allocation in the LLVM memory.
 bind_llvm_handle ::
-  (IsSymInterface sym, HasPtrWidth wptr) =>
-  mem ~ Mem =>
+  (IsSymInterface sym, HasPtrWidth wptr, mem ~ Mem) =>
   GlobalVar mem ->
   L.Symbol ->
   FnHandle args ret ->
@@ -353,8 +350,7 @@ bind_llvm_handle mvar nm hdl impl = do
 -- Creates and binds a function handle, and also binds the function to the
 -- global function allocation in the LLVM memory.
 bind_llvm_func ::
-  (IsSymInterface sym, HasPtrWidth wptr) =>
-  mem ~ Mem =>
+  (IsSymInterface sym, HasPtrWidth wptr, mem ~ Mem) =>
   GlobalVar mem ->
   L.Symbol ->
   Ctx.Assignment TypeRepr args ->
@@ -380,8 +376,7 @@ bind_llvm_func mvar nm args ret impl = do
 -- Crucible CFGs written in crucible-syntax. For more usual cases, use
 -- 'Lang.Crucible.LLVM.Intrinsics.register_llvm_overrides'.
 do_register_llvm_override :: forall p args ret sym ext mem arch wptr l a rtp.
-  (IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym) =>
-  mem ~ Mem =>
+  (IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym, mem ~ Mem) =>
   LLVMContext mem arch ->
   LLVMOverride p sym ext mem args ret ->
   OverrideSim p sym ext rtp l a ()
@@ -410,8 +405,7 @@ do_register_llvm_override llvmctx llvmOverride = do
 --
 -- c.f. 'Lang.Crucible.LLVM.Globals.allocLLVMFunPtr'
 alloc_and_register_override ::
-  (IsSymBackend sym bak, HasPtrWidth wptr, HasLLVMAnn sym, ?memOpts :: MemOptions) =>
-  mem ~ Mem =>
+  (IsSymBackend sym bak, HasPtrWidth wptr, HasLLVMAnn sym, ?memOpts :: MemOptions, mem ~ Mem) =>
   bak ->
   LLVMContext mem arch ->
   LLVMOverride p sym (LLVM mem) mem args ret ->

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/LLVM.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/LLVM.hs
@@ -62,8 +62,7 @@ import           Lang.Crucible.LLVM.TypeContext (TypeContext)
 
 -- | Local helper to make a null pointer in 'OverrideSim'
 mkNull
-  :: (IsSymInterface sym, HasPtrWidth wptr)
-  => mem ~ Mem
+  :: (IsSymInterface sym, HasPtrWidth wptr, mem ~ Mem)
   => OverrideSim p sym ext rtp args ret (LLVMPtr sym wptr)
 mkNull = do
   sym <- getSymInterface
@@ -78,8 +77,7 @@ mkNull = do
 -- via 'Lang.Crucible.LLVM.Intrinsics.Common.basic_llvm_override'.
 basic_llvm_overrides ::
   ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
-  , ?lc :: TypeContext, ?memOpts :: MemOptions ) =>
-  mem ~ Mem =>
+  , ?lc :: TypeContext, ?memOpts :: MemOptions , mem ~ Mem) =>
   [SomeLLVMOverride p sym ext mem]
 basic_llvm_overrides =
   [ SomeLLVMOverride llvmLifetimeStartOverride
@@ -264,8 +262,7 @@ poly1_llvm_overrides =
 --
 -- <https://llvm.org/docs/LangRef.html#llvm-lifetime-start-intrinsic LLVM docs>
 llvmLifetimeStartOverride
-  :: (IsSymInterface sym, HasPtrWidth wptr)
-  => mem ~ Mem
+  :: (IsSymInterface sym, HasPtrWidth wptr, mem ~ Mem)
   => LLVMOverride p sym ext mem (EmptyCtx ::> BVType 64 ::> LLVMPointerType wptr) UnitType
 llvmLifetimeStartOverride =
   [llvmOvr| void @llvm.lifetime.start( i64, i8* ) |]
@@ -275,8 +272,7 @@ llvmLifetimeStartOverride =
 --
 -- <https://llvm.org/docs/LangRef.html#llvm-lifetime-end-intrinsic LLVM docs>
 llvmLifetimeEndOverride
-  :: (IsSymInterface sym, HasPtrWidth wptr)
-  => mem ~ Mem
+  :: (IsSymInterface sym, HasPtrWidth wptr, mem ~ Mem)
   => LLVMOverride p sym ext mem (EmptyCtx ::> BVType 64 ::> LLVMPointerType wptr) UnitType
 llvmLifetimeEndOverride =
   [llvmOvr| void @llvm.lifetime.end( i64, i8* ) |]
@@ -319,8 +315,7 @@ llvmLifetimeOverrideOverload_opaque startOrEnd =
 --
 -- <https://llvm.org/docs/LangRef.html#llvm-invariant-start-intrinsic LLVM docs>
 llvmInvariantStartOverride
-  :: (IsSymInterface sym, HasPtrWidth wptr)
-  => mem ~ Mem
+  :: (IsSymInterface sym, HasPtrWidth wptr, mem ~ Mem)
   => NatRepr width
   -> LLVMOverride p sym ext mem
        (EmptyCtx ::> BVType 64 ::> LLVMPointerType wptr)
@@ -332,8 +327,7 @@ llvmInvariantStartOverride w =
 
 -- | Like 'llvmInvariantStartOverride', but with an opaque pointer type.
 llvmInvariantStartOverride_opaque
-  :: (IsSymInterface sym, HasPtrWidth wptr)
-  => mem ~ Mem
+  :: (IsSymInterface sym, HasPtrWidth wptr, mem ~ Mem)
   => LLVMOverride p sym ext mem
        (EmptyCtx ::> BVType 64 ::> LLVMPointerType wptr)
        (LLVMPointerType wptr)
@@ -344,8 +338,7 @@ llvmInvariantStartOverride_opaque =
 
 -- | See comment on 'llvmInvariantStartOverride'.
 llvmInvariantEndOverride
-  :: (IsSymInterface sym, HasPtrWidth wptr)
-  => mem ~ Mem
+  :: (IsSymInterface sym, HasPtrWidth wptr, mem ~ Mem)
   => NatRepr width
   -> LLVMOverride p sym ext mem
        (EmptyCtx ::> LLVMPointerType wptr ::> BVType 64 ::> LLVMPointerType wptr)
@@ -357,8 +350,7 @@ llvmInvariantEndOverride w =
 
 -- | See comment on 'llvmInvariantStartOverride_opaque'.
 llvmInvariantEndOverride_opaque
-  :: (IsSymInterface sym, HasPtrWidth wptr)
-  => mem ~ Mem
+  :: (IsSymInterface sym, HasPtrWidth wptr, mem ~ Mem)
   => LLVMOverride p sym ext mem
        (EmptyCtx ::> LLVMPointerType wptr ::> BVType 64 ::> LLVMPointerType wptr)
        UnitType
@@ -419,16 +411,14 @@ llvmUBSanTrapOverride =
       liftIO $ addFailedAssertion bak $ AssertFailureSimError "llvm.ubsantrap() called" "")
 
 llvmStacksave
-  :: (IsSymInterface sym, HasPtrWidth wptr)
-  => mem ~ Mem
+  :: (IsSymInterface sym, HasPtrWidth wptr, mem ~ Mem)
   => LLVMOverride p sym ext mem EmptyCtx (LLVMPointerType wptr)
 llvmStacksave =
   [llvmOvr| i8* @llvm.stacksave() |]
   (\_memOps _args -> mkNull)
 
 llvmStackrestore
-  :: (IsSymInterface sym, HasPtrWidth wptr)
-  => mem ~ Mem
+  :: (IsSymInterface sym, HasPtrWidth wptr, mem ~ Mem)
   => LLVMOverride p sym ext mem (EmptyCtx ::> LLVMPointerType wptr) UnitType
 llvmStackrestore =
   [llvmOvr| void @llvm.stackrestore( i8* ) |]
@@ -672,8 +662,7 @@ llvmMemcpyOverride_8_8_64_noalign_opaque =
 
 
 llvmObjectsizeOverride_32
-  :: (IsSymInterface sym, HasPtrWidth wptr)
-  => mem ~ Mem
+  :: (IsSymInterface sym, HasPtrWidth wptr, mem ~ Mem)
   => LLVMOverride p sym ext mem (EmptyCtx ::> LLVMPointerType wptr ::> BVType 1) (BVType 32)
 llvmObjectsizeOverride_32 =
   [llvmOvr| i32 @llvm.objectsize.i32.p0i8( i8*, i1 ) |]
@@ -704,8 +693,7 @@ llvmObjectsizeOverride_32_null_dynamic_opaque =
   (\memOps args -> Ctx.uncurryAssignment (callObjectsize_null_dynamic memOps knownNat) args)
 
 llvmObjectsizeOverride_64
-  :: (IsSymInterface sym, HasPtrWidth wptr)
-  => mem ~ Mem
+  :: (IsSymInterface sym, HasPtrWidth wptr, mem ~ Mem)
   => LLVMOverride p sym ext mem (EmptyCtx ::> LLVMPointerType wptr ::> BVType 1) (BVType 64)
 llvmObjectsizeOverride_64 =
   [llvmOvr| i64 @llvm.objectsize.i64.p0i8( i8*, i1 ) |]
@@ -776,8 +764,7 @@ llvmPrefetchOverride_preLLVM10 =
   (\_memOps _args -> pure ())
 
 llvmFshl ::
-  (1 <= w, IsSymInterface sym) =>
-  mem ~ Mem =>
+  (1 <= w, IsSymInterface sym, mem ~ Mem) =>
   NatRepr w ->
   LLVMOverride p sym ext mem
     (EmptyCtx ::> BVType w ::> BVType w ::> BVType w)
@@ -788,8 +775,7 @@ llvmFshl w =
  (\_memOps args -> Ctx.uncurryAssignment (callFshl w) args)
 
 llvmFshr ::
-  (1 <= w, IsSymInterface sym) =>
-  mem ~ Mem =>
+  (1 <= w, IsSymInterface sym, mem ~ Mem) =>
   NatRepr w ->
   LLVMOverride p sym ext mem
     (EmptyCtx ::> BVType w ::> BVType w ::> BVType w)
@@ -800,8 +786,7 @@ llvmFshr w =
  (\_memOps args -> Ctx.uncurryAssignment (callFshr w) args)
 
 llvmSaddWithOverflow
-  :: (1 <= w, IsSymInterface sym)
-  => mem ~ Mem
+  :: (1 <= w, IsSymInterface sym, mem ~ Mem)
   => NatRepr w ->
      LLVMOverride p sym ext mem
          (EmptyCtx ::> BVType w ::> BVType w)
@@ -812,8 +797,7 @@ llvmSaddWithOverflow w =
   (\memOps args -> Ctx.uncurryAssignment (callSaddWithOverflow memOps) args)
 
 llvmUaddWithOverflow
-  :: (1 <= w, IsSymInterface sym)
-  => mem ~ Mem
+  :: (1 <= w, IsSymInterface sym, mem ~ Mem)
   => NatRepr w ->
      LLVMOverride p sym ext mem
          (EmptyCtx ::> BVType w ::> BVType w)
@@ -825,8 +809,7 @@ llvmUaddWithOverflow w =
 
 
 llvmSsubWithOverflow
-  :: (1 <= w, IsSymInterface sym)
-  => mem ~ Mem
+  :: (1 <= w, IsSymInterface sym, mem ~ Mem)
   => NatRepr w ->
      LLVMOverride p sym ext mem
          (EmptyCtx ::> BVType w ::> BVType w)
@@ -838,8 +821,7 @@ llvmSsubWithOverflow w =
 
 
 llvmUsubWithOverflow
-  :: (1 <= w, IsSymInterface sym)
-  => mem ~ Mem
+  :: (1 <= w, IsSymInterface sym, mem ~ Mem)
   => NatRepr w ->
      LLVMOverride p sym ext mem
          (EmptyCtx ::> BVType w ::> BVType w)
@@ -850,8 +832,7 @@ llvmUsubWithOverflow w =
     (\memOps args -> Ctx.uncurryAssignment (callUsubWithOverflow memOps) args)
 
 llvmSmulWithOverflow
-  :: (1 <= w, IsSymInterface sym)
-  => mem ~ Mem
+  :: (1 <= w, IsSymInterface sym, mem ~ Mem)
   => NatRepr w ->
      LLVMOverride p sym ext mem
          (EmptyCtx ::> BVType w ::> BVType w)
@@ -862,8 +843,7 @@ llvmSmulWithOverflow w =
     (\memOps args -> Ctx.uncurryAssignment (callSmulWithOverflow memOps) args)
 
 llvmUmulWithOverflow
-  :: (1 <= w, IsSymInterface sym)
-  => mem ~ Mem
+  :: (1 <= w, IsSymInterface sym, mem ~ Mem)
   => NatRepr w ->
      LLVMOverride p sym ext mem
          (EmptyCtx ::> BVType w ::> BVType w)
@@ -874,8 +854,7 @@ llvmUmulWithOverflow w =
   (\memOps args -> Ctx.uncurryAssignment (callUmulWithOverflow memOps) args)
 
 llvmUmax ::
-  (1 <= w, IsSymInterface sym) =>
-  mem ~ Mem =>
+  (1 <= w, IsSymInterface sym, mem ~ Mem) =>
   NatRepr w ->
   LLVMOverride p sym ext mem
      (EmptyCtx ::> BVType w ::> BVType w)
@@ -886,8 +865,7 @@ llvmUmax w =
     (\memOps args -> Ctx.uncurryAssignment (callUmax memOps) args)
 
 llvmUmin ::
-  (1 <= w, IsSymInterface sym) =>
-  mem ~ Mem =>
+  (1 <= w, IsSymInterface sym, mem ~ Mem) =>
   NatRepr w ->
   LLVMOverride p sym ext mem
      (EmptyCtx ::> BVType w ::> BVType w)
@@ -898,8 +876,7 @@ llvmUmin w =
     (\memOps args -> Ctx.uncurryAssignment (callUmin memOps) args)
 
 llvmSmax ::
-  (1 <= w, IsSymInterface sym) =>
-  mem ~ Mem =>
+  (1 <= w, IsSymInterface sym, mem ~ Mem) =>
   NatRepr w ->
   LLVMOverride p sym ext mem
      (EmptyCtx ::> BVType w ::> BVType w)
@@ -910,8 +887,7 @@ llvmSmax w =
     (\memOps args -> Ctx.uncurryAssignment (callSmax memOps) args)
 
 llvmSmin ::
-  (1 <= w, IsSymInterface sym) =>
-  mem ~ Mem =>
+  (1 <= w, IsSymInterface sym, mem ~ Mem) =>
   NatRepr w ->
   LLVMOverride p sym ext mem
      (EmptyCtx ::> BVType w ::> BVType w)
@@ -922,8 +898,7 @@ llvmSmin w =
     (\memOps args -> Ctx.uncurryAssignment (callSmin memOps) args)
 
 llvmCtlz
-  :: (1 <= w, IsSymInterface sym)
-  => mem ~ Mem
+  :: (1 <= w, IsSymInterface sym, mem ~ Mem)
   => NatRepr w ->
      LLVMOverride p sym ext mem
          (EmptyCtx ::> BVType w ::> BVType 1)
@@ -934,8 +909,7 @@ llvmCtlz w =
     (\memOps args -> Ctx.uncurryAssignment (callCtlz memOps) args)
 
 llvmCttz
-  :: (1 <= w, IsSymInterface sym)
-  => mem ~ Mem
+  :: (1 <= w, IsSymInterface sym, mem ~ Mem)
   => NatRepr w
   -> LLVMOverride p sym ext mem
          (EmptyCtx ::> BVType w ::> BVType 1)
@@ -946,8 +920,7 @@ llvmCttz w =
     (\memOps args -> Ctx.uncurryAssignment (callCttz memOps) args)
 
 llvmCtpop
-  :: (1 <= w, IsSymInterface sym)
-  => mem ~ Mem
+  :: (1 <= w, IsSymInterface sym, mem ~ Mem)
   => NatRepr w
   -> LLVMOverride p sym ext mem
          (EmptyCtx ::> BVType w)
@@ -958,8 +931,7 @@ llvmCtpop w =
     (\memOps args -> Ctx.uncurryAssignment (callCtpop memOps) args)
 
 llvmBitreverse
-  :: (1 <= w, IsSymInterface sym)
-  => mem ~ Mem
+  :: (1 <= w, IsSymInterface sym, mem ~ Mem)
   => NatRepr w
   -> LLVMOverride p sym ext mem
          (EmptyCtx ::> BVType w)
@@ -992,8 +964,7 @@ llvmBSwapOverride widthRepr =
     }}}
 
 llvmAbsOverride ::
-  (1 <= w, IsSymInterface sym, HasLLVMAnn sym) =>
-  mem ~ Mem =>
+  (1 <= w, IsSymInterface sym, HasLLVMAnn sym, mem ~ Mem) =>
   NatRepr w ->
   LLVMOverride p sym ext mem
      (EmptyCtx ::> BVType w ::> BVType 1)
@@ -1459,8 +1430,7 @@ callObjectsize _mvar w
       bvIte sym t z n
 
 callObjectsize_null
-  :: (1 <= w, IsSymInterface sym)
-  => mem ~ Mem
+  :: (1 <= w, IsSymInterface sym, mem ~ Mem)
   => GlobalVar mem
   -> NatRepr w
   -> RegEntry sym (LLVMPointerType wptr)
@@ -1470,8 +1440,7 @@ callObjectsize_null
 callObjectsize_null mvar w ptr flag _nullUnknown = callObjectsize mvar w ptr flag
 
 callObjectsize_null_dynamic
-  :: (1 <= w, IsSymInterface sym)
-  => mem ~ Mem
+  :: (1 <= w, IsSymInterface sym, mem ~ Mem)
   => GlobalVar mem
   -> NatRepr w
   -> RegEntry sym (LLVMPointerType wptr)
@@ -1507,8 +1476,7 @@ callCtlz _mvar
         bvCountLeadingZeros sym val
 
 callFshl
-  :: (1 <= w, IsSymInterface sym)
-  => mem ~ Mem
+  :: (1 <= w, IsSymInterface sym, mem ~ Mem)
   => NatRepr w
   -> RegEntry sym (BVType w)
   -> RegEntry sym (BVType w)
@@ -1533,8 +1501,7 @@ callFshl w x y amt =
      bvSelect sym w w z
 
 callFshr
-  :: (1 <= w, IsSymInterface sym)
-  => mem ~ Mem
+  :: (1 <= w, IsSymInterface sym, mem ~ Mem)
   => NatRepr w
   -> RegEntry sym (BVType w)
   -> RegEntry sym (BVType w)
@@ -1656,8 +1623,7 @@ callUmulWithOverflow _mvar
       return (Empty :> RV z :> RV ov')
 
 callUmax
-  :: (1 <= w, IsSymInterface sym)
-  => mem ~ Mem
+  :: (1 <= w, IsSymInterface sym, mem ~ Mem)
   => GlobalVar mem
   -> RegEntry sym (BVType w)
   -> RegEntry sym (BVType w)
@@ -1669,8 +1635,7 @@ callUmax _mvar (regValue -> x) (regValue -> y) = do
     bvIte sym xGtY x y
 
 callUmin
-  :: (1 <= w, IsSymInterface sym)
-  => mem ~ Mem
+  :: (1 <= w, IsSymInterface sym, mem ~ Mem)
   => GlobalVar mem
   -> RegEntry sym (BVType w)
   -> RegEntry sym (BVType w)
@@ -1682,8 +1647,7 @@ callUmin _mvar (regValue -> x) (regValue -> y) = do
     bvIte sym xLtY x y
 
 callSmax
-  :: (1 <= w, IsSymInterface sym)
-  => mem ~ Mem
+  :: (1 <= w, IsSymInterface sym, mem ~ Mem)
   => GlobalVar mem
   -> RegEntry sym (BVType w)
   -> RegEntry sym (BVType w)
@@ -1695,8 +1659,7 @@ callSmax _mvar (regValue -> x) (regValue -> y) = do
     bvIte sym xGtY x y
 
 callSmin
-  :: (1 <= w, IsSymInterface sym)
-  => mem ~ Mem
+  :: (1 <= w, IsSymInterface sym, mem ~ Mem)
   => GlobalVar mem
   -> RegEntry sym (BVType w)
   -> RegEntry sym (BVType w)

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libc.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libc.hs
@@ -77,8 +77,7 @@ import           Lang.Crucible.LLVM.Intrinsics.Options
 -- model (e.g., Macaw).
 libc_overrides ::
   ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
-  , ?lc :: TypeContext, ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions ) =>
-  mem ~ Mem =>
+  , ?lc :: TypeContext, ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions , mem ~ Mem) =>
   [SomeLLVMOverride p sym ext mem]
 libc_overrides =
   [ SomeLLVMOverride llvmAbortOverride
@@ -183,8 +182,7 @@ libc_overrides =
 
 llvmMemcpyOverride
   :: ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
-     , ?memOpts :: MemOptions )
-  => mem ~ Mem
+     , ?memOpts :: MemOptions , mem ~ Mem)
   => LLVMOverride p sym ext mem
            (EmptyCtx ::> LLVMPointerType wptr
                      ::> LLVMPointerType wptr
@@ -203,8 +201,7 @@ llvmMemcpyOverride =
 
 llvmMemcpyChkOverride
   :: ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
-     , ?memOpts :: MemOptions )
-  => mem ~ Mem
+     , ?memOpts :: MemOptions , mem ~ Mem)
   => LLVMOverride p sym ext mem
          (EmptyCtx ::> LLVMPointerType wptr
                    ::> LLVMPointerType wptr
@@ -224,8 +221,7 @@ llvmMemcpyChkOverride =
 
 llvmMemmoveOverride
   :: ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
-     , ?memOpts :: MemOptions )
-  => mem ~ Mem
+     , ?memOpts :: MemOptions , mem ~ Mem)
   => LLVMOverride p sym ext mem
          (EmptyCtx ::> (LLVMPointerType wptr)
                    ::> (LLVMPointerType wptr)
@@ -242,8 +238,7 @@ llvmMemmoveOverride =
     )
 
 llvmMemsetOverride :: forall p sym ext mem wptr.
-     (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
-  => mem ~ Mem
+     (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, mem ~ Mem)
   => LLVMOverride p sym ext mem
          (EmptyCtx ::> LLVMPointerType wptr
                    ::> BVType 32
@@ -264,8 +259,7 @@ llvmMemsetOverride =
     )
 
 llvmMemsetChkOverride
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
-  => mem ~ Mem
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, mem ~ Mem)
   => LLVMOverride p sym ext mem
          (EmptyCtx ::> LLVMPointerType wptr
                  ::> BVType 32
@@ -291,8 +285,7 @@ llvmMemsetChkOverride =
 
 llvmCallocOverride
   :: ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
-     , ?lc :: TypeContext, ?memOpts :: MemOptions )
-  => mem ~ Mem
+     , ?lc :: TypeContext, ?memOpts :: MemOptions , mem ~ Mem)
   => LLVMOverride p sym ext mem
          (EmptyCtx ::> BVType wptr ::> BVType wptr)
          (LLVMPointerType wptr)
@@ -304,8 +297,7 @@ llvmCallocOverride =
 
 llvmReallocOverride
   :: ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
-     , ?lc :: TypeContext, ?memOpts :: MemOptions )
-  => mem ~ Mem
+     , ?lc :: TypeContext, ?memOpts :: MemOptions , mem ~ Mem)
   => LLVMOverride p sym ext mem
          (EmptyCtx ::> LLVMPointerType wptr ::> BVType wptr)
          (LLVMPointerType wptr)
@@ -316,8 +308,7 @@ llvmReallocOverride =
 
 llvmMallocOverride
   :: ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
-     , ?lc :: TypeContext, ?memOpts :: MemOptions )
-  => mem ~ Mem
+     , ?lc :: TypeContext, ?memOpts :: MemOptions , mem ~ Mem)
   => LLVMOverride p sym ext mem
          (EmptyCtx ::> BVType wptr)
          (LLVMPointerType wptr)
@@ -328,8 +319,7 @@ llvmMallocOverride =
 
 posixMemalignOverride ::
   ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
-  , ?lc :: TypeContext, ?memOpts :: MemOptions ) =>
-  mem ~ Mem =>
+  , ?lc :: TypeContext, ?memOpts :: MemOptions , mem ~ Mem) =>
   LLVMOverride p sym ext mem
       (EmptyCtx ::> LLVMPointerType wptr
                 ::> BVType wptr
@@ -341,8 +331,7 @@ posixMemalignOverride =
 
 
 llvmFreeOverride
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
-  => mem ~ Mem
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, mem ~ Mem)
   => LLVMOverride p sym ext mem
          (EmptyCtx ::> LLVMPointerType wptr)
          UnitType
@@ -355,8 +344,7 @@ llvmFreeOverride =
 
 llvmPrintfOverride
   :: ( IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym
-     , ?memOpts :: MemOptions )
-  => mem ~ Mem
+     , ?memOpts :: MemOptions , mem ~ Mem)
   => LLVMOverride p sym ext mem
          (EmptyCtx ::> LLVMPointerType wptr
                    ::> VectorType AnyType)
@@ -367,8 +355,7 @@ llvmPrintfOverride =
 
 llvmPrintfChkOverride
   :: ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
-     , ?memOpts :: MemOptions )
-  => mem ~ Mem
+     , ?memOpts :: MemOptions , mem ~ Mem)
   => LLVMOverride p sym ext mem
          (EmptyCtx ::> BVType 32
                    ::> LLVMPointerType wptr
@@ -389,8 +376,7 @@ llvmPutCharOverride =
 
 llvmPutsOverride
   :: ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
-     , ?memOpts :: MemOptions )
-  => mem ~ Mem
+     , ?memOpts :: MemOptions , mem ~ Mem)
   => LLVMOverride p sym ext mem (EmptyCtx ::> LLVMPointerType wptr) (BVType 32)
 llvmPutsOverride =
   [llvmOvr| i32 @puts( i8* ) |]
@@ -398,8 +384,7 @@ llvmPutsOverride =
 
 llvmStrlenOverride
   :: ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
-     , ?memOpts :: MemOptions )
-  => mem ~ Mem
+     , ?memOpts :: MemOptions , mem ~ Mem)
   => LLVMOverride p sym ext mem (EmptyCtx ::> LLVMPointerType wptr) (BVType wptr)
 llvmStrlenOverride =
   [llvmOvr| size_t @strlen( i8* ) |]
@@ -413,8 +398,7 @@ llvmStrlenOverride =
 
 callRealloc
   :: ( IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym
-     , ?memOpts :: MemOptions )
-  => mem ~ Mem
+     , ?memOpts :: MemOptions , mem ~ Mem)
   => GlobalVar mem
   -> Alignment
   -> RegEntry sym (LLVMPointerType wptr)
@@ -457,8 +441,7 @@ callRealloc mvar alignment (regValue -> ptr) (regValue -> sz) =
 
 callPosixMemalign
   :: ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
-     , ?lc :: TypeContext, ?memOpts :: MemOptions )
-  => mem ~ Mem
+     , ?lc :: TypeContext, ?memOpts :: MemOptions , mem ~ Mem)
   => GlobalVar mem
   -> RegEntry sym (LLVMPointerType wptr)
   -> RegEntry sym (BVType wptr)
@@ -484,8 +467,7 @@ callPosixMemalign mvar (regValue -> outPtr) (regValue -> align) (regValue -> sz)
 
 callMalloc
   :: ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
-     , ?memOpts :: MemOptions )
-  => mem ~ Mem
+     , ?memOpts :: MemOptions , mem ~ Mem)
   => GlobalVar mem
   -> Alignment
   -> RegEntry sym (BVType wptr)
@@ -627,8 +609,7 @@ callPuts mvar
 
 callStrlen
   :: ( IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym
-     , ?memOpts :: MemOptions )
-  => mem ~ Mem
+     , ?memOpts :: MemOptions , mem ~ Mem)
   => GlobalVar mem
   -> RegEntry sym (LLVMPointerType wptr)
   -> OverrideSim p sym ext r args ret (RegValue sym (BVType wptr))
@@ -639,8 +620,7 @@ callStrlen mvar (regValue -> strPtr) =
 
 callAssert
   :: ( IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym
-     , ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions )
-  => mem ~ Mem
+     , ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions , mem ~ Mem)
   => GlobalVar mem
   -> Ctx.Assignment (RegEntry sym)
         (EmptyCtx ::> LLVMPointerType wptr
@@ -1598,8 +1578,7 @@ llvmLog10fOverride =
 -- from OSX libc
 llvmAssertRtnOverride
   :: ( IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym
-     , ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions )
-  => mem ~ Mem
+     , ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions , mem ~ Mem)
   => LLVMOverride p sym ext mem
         (EmptyCtx ::> LLVMPointerType wptr
                   ::> LLVMPointerType wptr
@@ -1613,8 +1592,7 @@ llvmAssertRtnOverride =
 -- From glibc
 llvmAssertFailOverride
   :: ( IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym
-     , ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions )
-  => mem ~ Mem
+     , ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions , mem ~ Mem)
   => LLVMOverride p sym ext mem
         (EmptyCtx ::> LLVMPointerType wptr
                   ::> LLVMPointerType wptr
@@ -1701,8 +1679,7 @@ llvmNtohsOverride =
   (\_memOps args -> Ctx.uncurryAssignment (callBSwapIfLittleEndian (knownNat @2)) args)
 
 llvmAbsOverride ::
-  (IsSymInterface sym, HasLLVMAnn sym) =>
-  mem ~ Mem =>
+  (IsSymInterface sym, HasLLVMAnn sym, mem ~ Mem) =>
   LLVMOverride p sym ext mem
       (EmptyCtx ::> BVType 32)
       (BVType 32)
@@ -1716,8 +1693,7 @@ llvmAbsOverride =
 -- for @labs@. See Note [Overrides involving (unsigned) long] in
 -- Lang.Crucible.LLVM.Intrinsics.
 llvmLAbsOverride_32 ::
-  (IsSymInterface sym, HasLLVMAnn sym) =>
-  mem ~ Mem =>
+  (IsSymInterface sym, HasLLVMAnn sym, mem ~ Mem) =>
   LLVMOverride p sym ext mem
       (EmptyCtx ::> BVType 32)
       (BVType 32)
@@ -1728,8 +1704,7 @@ llvmLAbsOverride_32 =
         Ctx.uncurryAssignment (callLibcAbs callStack (knownNat @32)) args)
 
 llvmLAbsOverride_64 ::
-  (IsSymInterface sym, HasLLVMAnn sym) =>
-  mem ~ Mem =>
+  (IsSymInterface sym, HasLLVMAnn sym, mem ~ Mem) =>
   LLVMOverride p sym ext mem
       (EmptyCtx ::> BVType 64)
       (BVType 64)
@@ -1740,8 +1715,7 @@ llvmLAbsOverride_64 =
         Ctx.uncurryAssignment (callLibcAbs callStack (knownNat @64)) args)
 
 llvmLLAbsOverride ::
-  (IsSymInterface sym, HasLLVMAnn sym) =>
-  mem ~ Mem =>
+  (IsSymInterface sym, HasLLVMAnn sym, mem ~ Mem) =>
   LLVMOverride p sym ext mem
       (EmptyCtx ::> BVType 64)
       (BVType 64)

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libc.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libc.hs
@@ -78,7 +78,8 @@ import           Lang.Crucible.LLVM.Intrinsics.Options
 libc_overrides ::
   ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
   , ?lc :: TypeContext, ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions ) =>
-  [SomeLLVMOverride p sym ext]
+  mem ~ Mem =>
+  [SomeLLVMOverride p sym ext mem]
 libc_overrides =
   [ SomeLLVMOverride llvmAbortOverride
   , SomeLLVMOverride llvmAssertRtnOverride
@@ -183,7 +184,8 @@ libc_overrides =
 llvmMemcpyOverride
   :: ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
      , ?memOpts :: MemOptions )
-  => LLVMOverride p sym ext
+  => mem ~ Mem
+  => LLVMOverride p sym ext mem
            (EmptyCtx ::> LLVMPointerType wptr
                      ::> LLVMPointerType wptr
                      ::> BVType wptr)
@@ -202,7 +204,8 @@ llvmMemcpyOverride =
 llvmMemcpyChkOverride
   :: ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
      , ?memOpts :: MemOptions )
-  => LLVMOverride p sym ext
+  => mem ~ Mem
+  => LLVMOverride p sym ext mem
          (EmptyCtx ::> LLVMPointerType wptr
                    ::> LLVMPointerType wptr
                    ::> BVType wptr
@@ -222,7 +225,8 @@ llvmMemcpyChkOverride =
 llvmMemmoveOverride
   :: ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
      , ?memOpts :: MemOptions )
-  => LLVMOverride p sym ext
+  => mem ~ Mem
+  => LLVMOverride p sym ext mem
          (EmptyCtx ::> (LLVMPointerType wptr)
                    ::> (LLVMPointerType wptr)
                    ::> BVType wptr)
@@ -237,9 +241,10 @@ llvmMemmoveOverride =
          return $ regValue $ args^._1 -- return first argument
     )
 
-llvmMemsetOverride :: forall p sym ext wptr.
+llvmMemsetOverride :: forall p sym ext mem wptr.
      (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
-  => LLVMOverride p sym ext
+  => mem ~ Mem
+  => LLVMOverride p sym ext mem
          (EmptyCtx ::> LLVMPointerType wptr
                    ::> BVType 32
                    ::> BVType wptr)
@@ -260,7 +265,8 @@ llvmMemsetOverride =
 
 llvmMemsetChkOverride
   :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
-  => LLVMOverride p sym ext
+  => mem ~ Mem
+  => LLVMOverride p sym ext mem
          (EmptyCtx ::> LLVMPointerType wptr
                  ::> BVType 32
                  ::> BVType wptr
@@ -286,7 +292,8 @@ llvmMemsetChkOverride =
 llvmCallocOverride
   :: ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
      , ?lc :: TypeContext, ?memOpts :: MemOptions )
-  => LLVMOverride p sym ext
+  => mem ~ Mem
+  => LLVMOverride p sym ext mem
          (EmptyCtx ::> BVType wptr ::> BVType wptr)
          (LLVMPointerType wptr)
 llvmCallocOverride =
@@ -298,7 +305,8 @@ llvmCallocOverride =
 llvmReallocOverride
   :: ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
      , ?lc :: TypeContext, ?memOpts :: MemOptions )
-  => LLVMOverride p sym ext
+  => mem ~ Mem
+  => LLVMOverride p sym ext mem
          (EmptyCtx ::> LLVMPointerType wptr ::> BVType wptr)
          (LLVMPointerType wptr)
 llvmReallocOverride =
@@ -309,7 +317,8 @@ llvmReallocOverride =
 llvmMallocOverride
   :: ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
      , ?lc :: TypeContext, ?memOpts :: MemOptions )
-  => LLVMOverride p sym ext
+  => mem ~ Mem
+  => LLVMOverride p sym ext mem
          (EmptyCtx ::> BVType wptr)
          (LLVMPointerType wptr)
 llvmMallocOverride =
@@ -320,7 +329,8 @@ llvmMallocOverride =
 posixMemalignOverride ::
   ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
   , ?lc :: TypeContext, ?memOpts :: MemOptions ) =>
-  LLVMOverride p sym ext
+  mem ~ Mem =>
+  LLVMOverride p sym ext mem
       (EmptyCtx ::> LLVMPointerType wptr
                 ::> BVType wptr
                 ::> BVType wptr)
@@ -332,7 +342,8 @@ posixMemalignOverride =
 
 llvmFreeOverride
   :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
-  => LLVMOverride p sym ext
+  => mem ~ Mem
+  => LLVMOverride p sym ext mem
          (EmptyCtx ::> LLVMPointerType wptr)
          UnitType
 llvmFreeOverride =
@@ -345,7 +356,8 @@ llvmFreeOverride =
 llvmPrintfOverride
   :: ( IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym
      , ?memOpts :: MemOptions )
-  => LLVMOverride p sym ext
+  => mem ~ Mem
+  => LLVMOverride p sym ext mem
          (EmptyCtx ::> LLVMPointerType wptr
                    ::> VectorType AnyType)
          (BVType 32)
@@ -356,7 +368,8 @@ llvmPrintfOverride =
 llvmPrintfChkOverride
   :: ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
      , ?memOpts :: MemOptions )
-  => LLVMOverride p sym ext
+  => mem ~ Mem
+  => LLVMOverride p sym ext mem
          (EmptyCtx ::> BVType 32
                    ::> LLVMPointerType wptr
                    ::> VectorType AnyType)
@@ -368,7 +381,7 @@ llvmPrintfChkOverride =
 
 llvmPutCharOverride
   :: (IsSymInterface sym, HasPtrWidth wptr)
-  => LLVMOverride p sym ext (EmptyCtx ::> BVType 32) (BVType 32)
+  => LLVMOverride p sym ext mem (EmptyCtx ::> BVType 32) (BVType 32)
 llvmPutCharOverride =
   [llvmOvr| i32 @putchar( i32 ) |]
   (\memOps args -> Ctx.uncurryAssignment (callPutChar memOps) args)
@@ -377,7 +390,8 @@ llvmPutCharOverride =
 llvmPutsOverride
   :: ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
      , ?memOpts :: MemOptions )
-  => LLVMOverride p sym ext (EmptyCtx ::> LLVMPointerType wptr) (BVType 32)
+  => mem ~ Mem
+  => LLVMOverride p sym ext mem (EmptyCtx ::> LLVMPointerType wptr) (BVType 32)
 llvmPutsOverride =
   [llvmOvr| i32 @puts( i8* ) |]
   (\memOps args -> Ctx.uncurryAssignment (callPuts memOps) args)
@@ -385,7 +399,8 @@ llvmPutsOverride =
 llvmStrlenOverride
   :: ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
      , ?memOpts :: MemOptions )
-  => LLVMOverride p sym ext (EmptyCtx ::> LLVMPointerType wptr) (BVType wptr)
+  => mem ~ Mem
+  => LLVMOverride p sym ext mem (EmptyCtx ::> LLVMPointerType wptr) (BVType wptr)
 llvmStrlenOverride =
   [llvmOvr| size_t @strlen( i8* ) |]
   (\memOps args -> Ctx.uncurryAssignment (callStrlen memOps) args)
@@ -399,7 +414,8 @@ llvmStrlenOverride =
 callRealloc
   :: ( IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym
      , ?memOpts :: MemOptions )
-  => GlobalVar Mem
+  => mem ~ Mem
+  => GlobalVar mem
   -> Alignment
   -> RegEntry sym (LLVMPointerType wptr)
   -> RegEntry sym (BVType wptr)
@@ -442,7 +458,8 @@ callRealloc mvar alignment (regValue -> ptr) (regValue -> sz) =
 callPosixMemalign
   :: ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
      , ?lc :: TypeContext, ?memOpts :: MemOptions )
-  => GlobalVar Mem
+  => mem ~ Mem
+  => GlobalVar mem
   -> RegEntry sym (LLVMPointerType wptr)
   -> RegEntry sym (BVType wptr)
   -> RegEntry sym (BVType wptr)
@@ -468,7 +485,8 @@ callPosixMemalign mvar (regValue -> outPtr) (regValue -> align) (regValue -> sz)
 callMalloc
   :: ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
      , ?memOpts :: MemOptions )
-  => GlobalVar Mem
+  => mem ~ Mem
+  => GlobalVar mem
   -> Alignment
   -> RegEntry sym (BVType wptr)
   -> OverrideSim p sym ext r args ret (RegValue sym (LLVMPointerType wptr))
@@ -482,7 +500,8 @@ callMalloc mvar alignment (regValue -> sz) =
 callCalloc
   :: ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
      , ?memOpts :: MemOptions )
-  => GlobalVar Mem
+  => mem ~ Mem
+  => GlobalVar mem
   -> Alignment
   -> RegEntry sym (BVType wptr)
   -> RegEntry sym (BVType wptr)
@@ -496,7 +515,8 @@ callCalloc mvar alignment
 
 callFree
   :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
-  => GlobalVar Mem
+  => mem ~ Mem
+  => GlobalVar mem
   -> RegEntry sym (LLVMPointerType wptr)
   -> OverrideSim p sym ext r args ret ()
 callFree mvar
@@ -512,7 +532,8 @@ callFree mvar
 callMemcpy
   :: ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
      , ?memOpts :: MemOptions )
-  => GlobalVar Mem
+  => mem ~ Mem
+  => GlobalVar mem
   -> RegEntry sym (LLVMPointerType wptr)
   -> RegEntry sym (LLVMPointerType wptr)
   -> RegEntry sym (BVType w)
@@ -535,7 +556,8 @@ callMemcpy mvar
 callMemmove
   :: ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr
      , ?memOpts :: MemOptions )
-  => GlobalVar Mem
+  => mem ~ Mem
+  => GlobalVar mem
   -> RegEntry sym (LLVMPointerType wptr)
   -> RegEntry sym (LLVMPointerType wptr)
   -> RegEntry sym (BVType w)
@@ -554,7 +576,8 @@ callMemmove mvar
 
 callMemset
   :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
-  => GlobalVar Mem
+  => mem ~ Mem
+  => GlobalVar mem
   -> RegEntry sym (LLVMPointerType wptr)
   -> RegEntry sym (BVType 8)
   -> RegEntry sym (BVType w)
@@ -575,7 +598,7 @@ callMemset mvar
 
 callPutChar
   :: IsSymInterface sym
-  => GlobalVar Mem
+  => GlobalVar mem
   -> RegEntry sym (BVType 32)
   -> OverrideSim p sym ext r args ret (RegValue sym (BVType 32))
 callPutChar _mvar
@@ -588,7 +611,8 @@ callPutChar _mvar
 callPuts
   :: ( IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym
      , ?memOpts :: MemOptions )
-  => GlobalVar Mem
+  => mem ~ Mem
+  => GlobalVar mem
   -> RegEntry sym (LLVMPointerType wptr)
   -> OverrideSim p sym ext r args ret (RegValue sym (BVType 32))
 callPuts mvar
@@ -604,7 +628,8 @@ callPuts mvar
 callStrlen
   :: ( IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym
      , ?memOpts :: MemOptions )
-  => GlobalVar Mem
+  => mem ~ Mem
+  => GlobalVar mem
   -> RegEntry sym (LLVMPointerType wptr)
   -> OverrideSim p sym ext r args ret (RegValue sym (BVType wptr))
 callStrlen mvar (regValue -> strPtr) =
@@ -615,7 +640,8 @@ callStrlen mvar (regValue -> strPtr) =
 callAssert
   :: ( IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym
      , ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions )
-  => GlobalVar Mem
+  => mem ~ Mem
+  => GlobalVar mem
   -> Ctx.Assignment (RegEntry sym)
         (EmptyCtx ::> LLVMPointerType wptr
                   ::> LLVMPointerType wptr
@@ -657,7 +683,8 @@ callExit ec =
 callPrintf
   :: ( IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym
      , ?memOpts :: MemOptions )
-  => GlobalVar Mem
+  => mem ~ Mem
+  => GlobalVar mem
   -> RegEntry sym (LLVMPointerType wptr)
   -> RegEntry sym (VectorType AnyType)
   -> OverrideSim p sym ext r args ret (RegValue sym (BVType 32))
@@ -805,7 +832,7 @@ printfOps bak valist =
 
 llvmCeilOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType DoubleFloat)
      (FloatType DoubleFloat)
 llvmCeilOverride =
@@ -814,7 +841,7 @@ llvmCeilOverride =
 
 llvmCeilfOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType SingleFloat)
      (FloatType SingleFloat)
 llvmCeilfOverride =
@@ -824,7 +851,7 @@ llvmCeilfOverride =
 
 llvmFloorOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType DoubleFloat)
      (FloatType DoubleFloat)
 llvmFloorOverride =
@@ -833,7 +860,7 @@ llvmFloorOverride =
 
 llvmFloorfOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType SingleFloat)
      (FloatType SingleFloat)
 llvmFloorfOverride =
@@ -841,9 +868,9 @@ llvmFloorfOverride =
   (\_memOps args -> Ctx.uncurryAssignment callFloor args)
 
 llvmFmafOverride ::
-     forall sym p ext
+     forall sym p ext mem
    . IsSymInterface sym
-  => LLVMOverride p sym ext
+  => LLVMOverride p sym ext mem
         (EmptyCtx ::> FloatType SingleFloat
                   ::> FloatType SingleFloat
                   ::> FloatType SingleFloat)
@@ -853,9 +880,9 @@ llvmFmafOverride =
   (\_memOps args -> Ctx.uncurryAssignment callFMA args)
 
 llvmFmaOverride ::
-     forall sym p ext
+     forall sym p ext mem
    . IsSymInterface sym
-  => LLVMOverride p sym ext
+  => LLVMOverride p sym ext mem
         (EmptyCtx ::> FloatType DoubleFloat
                   ::> FloatType DoubleFloat
                   ::> FloatType DoubleFloat)
@@ -878,7 +905,7 @@ llvmFmaOverride =
 
 llvmIsinfOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType DoubleFloat)
      (BVType 32)
 llvmIsinfOverride =
@@ -892,7 +919,7 @@ llvmIsinfOverride =
 -- http://refspecs.linux-foundation.org/LSB_4.0.0/LSB-Core-generic/LSB-Core-generic/baselib---isinff.html.
 llvm__isinfOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType DoubleFloat)
      (BVType 32)
 llvm__isinfOverride =
@@ -901,7 +928,7 @@ llvm__isinfOverride =
 
 llvm__isinffOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType SingleFloat)
      (BVType 32)
 llvm__isinffOverride =
@@ -910,7 +937,7 @@ llvm__isinffOverride =
 
 llvmIsnanOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType DoubleFloat)
      (BVType 32)
 llvmIsnanOverride =
@@ -924,7 +951,7 @@ llvmIsnanOverride =
 -- http://refspecs.linux-foundation.org/LSB_4.0.0/LSB-Core-generic/LSB-Core-generic/baselib---isnanf.html.
 llvm__isnanOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType DoubleFloat)
      (BVType 32)
 llvm__isnanOverride =
@@ -933,7 +960,7 @@ llvm__isnanOverride =
 
 llvm__isnanfOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType SingleFloat)
      (BVType 32)
 llvm__isnanfOverride =
@@ -943,7 +970,7 @@ llvm__isnanfOverride =
 -- macOS compiles isnan() to __isnand() when the argument is a double.
 llvm__isnandOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType DoubleFloat)
      (BVType 32)
 llvm__isnandOverride =
@@ -952,7 +979,7 @@ llvm__isnandOverride =
 
 llvmSqrtOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType DoubleFloat)
      (FloatType DoubleFloat)
 llvmSqrtOverride =
@@ -961,7 +988,7 @@ llvmSqrtOverride =
 
 llvmSqrtfOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType SingleFloat)
      (FloatType SingleFloat)
 llvmSqrtfOverride =
@@ -1074,7 +1101,7 @@ callSqrt (regValue -> x) = do
 
 llvmSinOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType DoubleFloat)
      (FloatType DoubleFloat)
 llvmSinOverride =
@@ -1083,7 +1110,7 @@ llvmSinOverride =
 
 llvmSinfOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType SingleFloat)
      (FloatType SingleFloat)
 llvmSinfOverride =
@@ -1094,7 +1121,7 @@ llvmSinfOverride =
 
 llvmCosOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType DoubleFloat)
      (FloatType DoubleFloat)
 llvmCosOverride =
@@ -1103,7 +1130,7 @@ llvmCosOverride =
 
 llvmCosfOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType SingleFloat)
      (FloatType SingleFloat)
 llvmCosfOverride =
@@ -1114,7 +1141,7 @@ llvmCosfOverride =
 
 llvmTanOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType DoubleFloat)
      (FloatType DoubleFloat)
 llvmTanOverride =
@@ -1123,7 +1150,7 @@ llvmTanOverride =
 
 llvmTanfOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType SingleFloat)
      (FloatType SingleFloat)
 llvmTanfOverride =
@@ -1134,7 +1161,7 @@ llvmTanfOverride =
 
 llvmAsinOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType DoubleFloat)
      (FloatType DoubleFloat)
 llvmAsinOverride =
@@ -1143,7 +1170,7 @@ llvmAsinOverride =
 
 llvmAsinfOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType SingleFloat)
      (FloatType SingleFloat)
 llvmAsinfOverride =
@@ -1154,7 +1181,7 @@ llvmAsinfOverride =
 
 llvmAcosOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType DoubleFloat)
      (FloatType DoubleFloat)
 llvmAcosOverride =
@@ -1163,7 +1190,7 @@ llvmAcosOverride =
 
 llvmAcosfOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType SingleFloat)
      (FloatType SingleFloat)
 llvmAcosfOverride =
@@ -1174,7 +1201,7 @@ llvmAcosfOverride =
 
 llvmAtanOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType DoubleFloat)
      (FloatType DoubleFloat)
 llvmAtanOverride =
@@ -1183,7 +1210,7 @@ llvmAtanOverride =
 
 llvmAtanfOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType SingleFloat)
      (FloatType SingleFloat)
 llvmAtanfOverride =
@@ -1197,7 +1224,7 @@ llvmAtanfOverride =
 
 llvmSinhOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType DoubleFloat)
      (FloatType DoubleFloat)
 llvmSinhOverride =
@@ -1206,7 +1233,7 @@ llvmSinhOverride =
 
 llvmSinhfOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType SingleFloat)
      (FloatType SingleFloat)
 llvmSinhfOverride =
@@ -1217,7 +1244,7 @@ llvmSinhfOverride =
 
 llvmCoshOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType DoubleFloat)
      (FloatType DoubleFloat)
 llvmCoshOverride =
@@ -1226,7 +1253,7 @@ llvmCoshOverride =
 
 llvmCoshfOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType SingleFloat)
      (FloatType SingleFloat)
 llvmCoshfOverride =
@@ -1237,7 +1264,7 @@ llvmCoshfOverride =
 
 llvmTanhOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType DoubleFloat)
      (FloatType DoubleFloat)
 llvmTanhOverride =
@@ -1246,7 +1273,7 @@ llvmTanhOverride =
 
 llvmTanhfOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType SingleFloat)
      (FloatType SingleFloat)
 llvmTanhfOverride =
@@ -1257,7 +1284,7 @@ llvmTanhfOverride =
 
 llvmAsinhOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType DoubleFloat)
      (FloatType DoubleFloat)
 llvmAsinhOverride =
@@ -1266,7 +1293,7 @@ llvmAsinhOverride =
 
 llvmAsinhfOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType SingleFloat)
      (FloatType SingleFloat)
 llvmAsinhfOverride =
@@ -1277,7 +1304,7 @@ llvmAsinhfOverride =
 
 llvmAcoshOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType DoubleFloat)
      (FloatType DoubleFloat)
 llvmAcoshOverride =
@@ -1286,7 +1313,7 @@ llvmAcoshOverride =
 
 llvmAcoshfOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType SingleFloat)
      (FloatType SingleFloat)
 llvmAcoshfOverride =
@@ -1297,7 +1324,7 @@ llvmAcoshfOverride =
 
 llvmAtanhOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType DoubleFloat)
      (FloatType DoubleFloat)
 llvmAtanhOverride =
@@ -1306,7 +1333,7 @@ llvmAtanhOverride =
 
 llvmAtanhfOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType SingleFloat)
      (FloatType SingleFloat)
 llvmAtanhfOverride =
@@ -1320,7 +1347,7 @@ llvmAtanhfOverride =
 
 llvmHypotOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType DoubleFloat ::> FloatType DoubleFloat)
      (FloatType DoubleFloat)
 llvmHypotOverride =
@@ -1329,7 +1356,7 @@ llvmHypotOverride =
 
 llvmHypotfOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType SingleFloat ::> FloatType SingleFloat)
      (FloatType SingleFloat)
 llvmHypotfOverride =
@@ -1340,7 +1367,7 @@ llvmHypotfOverride =
 
 llvmAtan2Override ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType DoubleFloat ::> FloatType DoubleFloat)
      (FloatType DoubleFloat)
 llvmAtan2Override =
@@ -1349,7 +1376,7 @@ llvmAtan2Override =
 
 llvmAtan2fOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType SingleFloat ::> FloatType SingleFloat)
      (FloatType SingleFloat)
 llvmAtan2fOverride =
@@ -1363,7 +1390,7 @@ llvmAtan2fOverride =
 
 llvmPowfOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType SingleFloat ::> FloatType SingleFloat)
      (FloatType SingleFloat)
 llvmPowfOverride =
@@ -1372,7 +1399,7 @@ llvmPowfOverride =
 
 llvmPowOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType DoubleFloat ::> FloatType DoubleFloat)
      (FloatType DoubleFloat)
 llvmPowOverride =
@@ -1383,7 +1410,7 @@ llvmPowOverride =
 
 llvmExpOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType DoubleFloat)
      (FloatType DoubleFloat)
 llvmExpOverride =
@@ -1392,7 +1419,7 @@ llvmExpOverride =
 
 llvmExpfOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType SingleFloat)
      (FloatType SingleFloat)
 llvmExpfOverride =
@@ -1403,7 +1430,7 @@ llvmExpfOverride =
 
 llvmLogOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType DoubleFloat)
      (FloatType DoubleFloat)
 llvmLogOverride =
@@ -1412,7 +1439,7 @@ llvmLogOverride =
 
 llvmLogfOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType SingleFloat)
      (FloatType SingleFloat)
 llvmLogfOverride =
@@ -1423,7 +1450,7 @@ llvmLogfOverride =
 
 llvmExpm1Override ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType DoubleFloat)
      (FloatType DoubleFloat)
 llvmExpm1Override =
@@ -1432,7 +1459,7 @@ llvmExpm1Override =
 
 llvmExpm1fOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType SingleFloat)
      (FloatType SingleFloat)
 llvmExpm1fOverride =
@@ -1443,7 +1470,7 @@ llvmExpm1fOverride =
 
 llvmLog1pOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType DoubleFloat)
      (FloatType DoubleFloat)
 llvmLog1pOverride =
@@ -1452,7 +1479,7 @@ llvmLog1pOverride =
 
 llvmLog1pfOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType SingleFloat)
      (FloatType SingleFloat)
 llvmLog1pfOverride =
@@ -1466,7 +1493,7 @@ llvmLog1pfOverride =
 
 llvmExp2Override ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType DoubleFloat)
      (FloatType DoubleFloat)
 llvmExp2Override =
@@ -1475,7 +1502,7 @@ llvmExp2Override =
 
 llvmExp2fOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType SingleFloat)
      (FloatType SingleFloat)
 llvmExp2fOverride =
@@ -1486,7 +1513,7 @@ llvmExp2fOverride =
 
 llvmLog2Override ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType DoubleFloat)
      (FloatType DoubleFloat)
 llvmLog2Override =
@@ -1495,7 +1522,7 @@ llvmLog2Override =
 
 llvmLog2fOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType SingleFloat)
      (FloatType SingleFloat)
 llvmLog2fOverride =
@@ -1509,7 +1536,7 @@ llvmLog2fOverride =
 
 llvmExp10Override ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType DoubleFloat)
      (FloatType DoubleFloat)
 llvmExp10Override =
@@ -1518,7 +1545,7 @@ llvmExp10Override =
 
 llvmExp10fOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType SingleFloat)
      (FloatType SingleFloat)
 llvmExp10fOverride =
@@ -1529,7 +1556,7 @@ llvmExp10fOverride =
 
 llvm__exp10Override ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType DoubleFloat)
      (FloatType DoubleFloat)
 llvm__exp10Override =
@@ -1538,7 +1565,7 @@ llvm__exp10Override =
 
 llvm__exp10fOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType SingleFloat)
      (FloatType SingleFloat)
 llvm__exp10fOverride =
@@ -1549,7 +1576,7 @@ llvm__exp10fOverride =
 
 llvmLog10Override ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType DoubleFloat)
      (FloatType DoubleFloat)
 llvmLog10Override =
@@ -1558,7 +1585,7 @@ llvmLog10Override =
 
 llvmLog10fOverride ::
   IsSymInterface sym =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
      (EmptyCtx ::> FloatType SingleFloat)
      (FloatType SingleFloat)
 llvmLog10fOverride =
@@ -1572,7 +1599,8 @@ llvmLog10fOverride =
 llvmAssertRtnOverride
   :: ( IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym
      , ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions )
-  => LLVMOverride p sym ext
+  => mem ~ Mem
+  => LLVMOverride p sym ext mem
         (EmptyCtx ::> LLVMPointerType wptr
                   ::> LLVMPointerType wptr
                   ::> BVType 32
@@ -1586,7 +1614,8 @@ llvmAssertRtnOverride =
 llvmAssertFailOverride
   :: ( IsSymInterface sym, HasPtrWidth wptr, HasLLVMAnn sym
      , ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions )
-  => LLVMOverride p sym ext
+  => mem ~ Mem
+  => LLVMOverride p sym ext mem
         (EmptyCtx ::> LLVMPointerType wptr
                   ::> LLVMPointerType wptr
                   ::> BVType 32
@@ -1600,7 +1629,7 @@ llvmAssertFailOverride =
 llvmAbortOverride
   :: ( IsSymInterface sym
      , ?intrinsicsOpts :: IntrinsicsOptions )
-  => LLVMOverride p sym ext EmptyCtx UnitType
+  => LLVMOverride p sym ext mem EmptyCtx UnitType
 llvmAbortOverride =
   [llvmOvr| void @abort() |]
   (\_ _args ->
@@ -1614,10 +1643,10 @@ llvmAbortOverride =
   )
 
 llvmExitOverride
-  :: forall sym p ext
+  :: forall sym p ext mem
    . ( IsSymInterface sym
      , ?intrinsicsOpts :: IntrinsicsOptions )
-  => LLVMOverride p sym ext
+  => LLVMOverride p sym ext mem
          (EmptyCtx ::> BVType 32)
          UnitType
 llvmExitOverride =
@@ -1626,7 +1655,7 @@ llvmExitOverride =
 
 llvmGetenvOverride
   :: (IsSymInterface sym, HasPtrWidth wptr)
-  => LLVMOverride p sym ext
+  => LLVMOverride p sym ext mem
         (EmptyCtx ::> LLVMPointerType wptr)
         (LLVMPointerType wptr)
 llvmGetenvOverride =
@@ -1637,7 +1666,7 @@ llvmGetenvOverride =
 
 llvmHtonlOverride ::
   (IsSymInterface sym, ?lc :: TypeContext) =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
       (EmptyCtx ::> BVType 32)
       (BVType 32)
 llvmHtonlOverride =
@@ -1646,7 +1675,7 @@ llvmHtonlOverride =
 
 llvmHtonsOverride ::
   (IsSymInterface sym, ?lc :: TypeContext) =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
       (EmptyCtx ::> BVType 16)
       (BVType 16)
 llvmHtonsOverride =
@@ -1655,7 +1684,7 @@ llvmHtonsOverride =
 
 llvmNtohlOverride ::
   (IsSymInterface sym, ?lc :: TypeContext) =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
       (EmptyCtx ::> BVType 32)
       (BVType 32)
 llvmNtohlOverride =
@@ -1664,7 +1693,7 @@ llvmNtohlOverride =
 
 llvmNtohsOverride ::
   (IsSymInterface sym, ?lc :: TypeContext) =>
-  LLVMOverride p sym ext
+  LLVMOverride p sym ext mem
       (EmptyCtx ::> BVType 16)
       (BVType 16)
 llvmNtohsOverride =
@@ -1673,7 +1702,8 @@ llvmNtohsOverride =
 
 llvmAbsOverride ::
   (IsSymInterface sym, HasLLVMAnn sym) =>
-  LLVMOverride p sym ext
+  mem ~ Mem =>
+  LLVMOverride p sym ext mem
       (EmptyCtx ::> BVType 32)
       (BVType 32)
 llvmAbsOverride =
@@ -1687,7 +1717,8 @@ llvmAbsOverride =
 -- Lang.Crucible.LLVM.Intrinsics.
 llvmLAbsOverride_32 ::
   (IsSymInterface sym, HasLLVMAnn sym) =>
-  LLVMOverride p sym ext
+  mem ~ Mem =>
+  LLVMOverride p sym ext mem
       (EmptyCtx ::> BVType 32)
       (BVType 32)
 llvmLAbsOverride_32 =
@@ -1698,7 +1729,8 @@ llvmLAbsOverride_32 =
 
 llvmLAbsOverride_64 ::
   (IsSymInterface sym, HasLLVMAnn sym) =>
-  LLVMOverride p sym ext
+  mem ~ Mem =>
+  LLVMOverride p sym ext mem
       (EmptyCtx ::> BVType 64)
       (BVType 64)
 llvmLAbsOverride_64 =
@@ -1709,7 +1741,8 @@ llvmLAbsOverride_64 =
 
 llvmLLAbsOverride ::
   (IsSymInterface sym, HasLLVMAnn sym) =>
-  LLVMOverride p sym ext
+  mem ~ Mem =>
+  LLVMOverride p sym ext mem
       (EmptyCtx ::> BVType 64)
       (BVType 64)
 llvmLLAbsOverride =
@@ -1824,7 +1857,7 @@ callBSwapIfLittleEndian widthRepr vec =
 
 cxa_atexitOverride
   :: (IsSymInterface sym, HasPtrWidth wptr)
-  => LLVMOverride p sym ext
+  => LLVMOverride p sym ext mem
         (EmptyCtx ::> LLVMPointerType wptr ::> LLVMPointerType wptr ::> LLVMPointerType wptr)
         (BVType 32)
 cxa_atexitOverride =

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libc.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libc.hs
@@ -1806,7 +1806,7 @@ callAbs callStack checkIntMin widthRepr (regValue -> src) = do
           LibcAbsIntMinUB                 -> True
           LLVMAbsIntMinPoison shouldCheck -> shouldCheck
 
-      ub :: UB.UndefinedBehavior (RegValue' sym)
+      ub :: UB.UndefinedBehavior mem (RegValue' sym)
       ub = case checkIntMin of
              LibcAbsIntMinUB ->
                UB.AbsIntMin $ RV src

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libcxx.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libcxx.hs
@@ -67,8 +67,7 @@ import           Lang.Crucible.LLVM.Translation.Types
 -- | C++ overrides generally have a bit more work to do: their types are more
 -- complex, their names are mangled in the LLVM module, it's a big mess.
 register_cpp_override ::
-  (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr) =>
-  mem ~ Mem =>
+  (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, mem ~ Mem) =>
   SomeCPPOverride p sym mem arch ->
   OverrideTemplate p sym mem arch rtp l a
 register_cpp_override someCPPOverride =
@@ -188,9 +187,8 @@ constOverride substrings =
       _ -> panic_ "constOverride" decl argTys retTy
 
 -- | Make an override that always returns the same value.
-fixedOverride :: (IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => mem ~ Mem
-              => TypeRepr ty
+fixedOverride :: (IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch, mem ~ Mem)
+  => TypeRepr ty
               -> (GlobalVar Mem -> sym -> IO (RegValue sym ty))
               -> [String]
               -> (L.Symbol -> ABI.DecodedName -> Bool)
@@ -206,9 +204,8 @@ fixedOverride ty regval substrings =
       _ -> panic_ "fixedOverride" decl argTys retTy
 
 -- | Return @true@.
-trueOverride :: (IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => mem ~ Mem
-             => [String]
+trueOverride :: (IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch, mem ~ Mem)
+  => [String]
              -> (L.Symbol -> ABI.DecodedName -> Bool)
              -> SomeCPPOverride p sym mem arch
 trueOverride =
@@ -287,9 +284,8 @@ sentryOverride =
 -- | An override of the @bool@ operator (cast) on the @sentry@ class,
 --
 -- @sentry::operator bool()@
-sentryBoolOverride :: (IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch)
-  => mem ~ Mem
-                   => SomeCPPOverride p sym mem arch
+sentryBoolOverride :: (IsSymInterface sym, HasPtrWidth wptr, wptr ~ ArchWidth arch, mem ~ Mem)
+  => SomeCPPOverride p sym mem arch
 sentryBoolOverride =
   trueOverride ["basic_ostream", "sentry"] $ \_nm decodedName ->
     case decodedName of

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Mem.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Mem.hs
@@ -1,0 +1,37 @@
+-----------------------------------------------------------------------
+-- |
+-- Module           : Lang.Crucible.LLVM.Mem
+-- Description      : TODO
+-- Copyright        : (c) Galois, Inc 2024
+-- License          : BSD3
+-- Maintainer       : langston@galois.com
+-- Stability        : provisional
+------------------------------------------------------------------------
+
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+
+module Lang.Crucible.LLVM.Mem
+  ( Mem
+  , MemData
+  ) where
+
+import Data.Kind (Type)
+
+import Lang.Crucible.Types (CrucibleType)
+
+import qualified Lang.Crucible.LLVM.MemModel.Generic as G
+import qualified Lang.Crucible.LLVM.Types as T
+
+-- TODO: Move me!
+class Mem (mem :: CrucibleType) where
+  type MemData (mem :: CrucibleType) sym = (r :: Type) | r -> mem
+
+instance Mem T.Mem where
+  type MemData T.Mem sym = G.Mem sym

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Mem.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Mem.hs
@@ -8,30 +8,158 @@
 -- Stability        : provisional
 ------------------------------------------------------------------------
 
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilyDependencies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Lang.Crucible.LLVM.Mem
-  ( Mem
-  , MemData
+  ( PosNat(..)
+  , SomePointerRepr(..)
+  , Mem(..)
+  , IsPtrRepr(IsPtrRepr)
+  , isPtrRepr
+  , isPtrRepr'
+  , pattern IsPointerRepr
+  , pattern PointerRepr
+  , pattern KnownPointerRepr
+  , pattern PtrRepr
   ) where
 
 import Data.Kind (Type)
+import GHC.TypeLits (KnownNat, Nat, type (<=))
 
-import Lang.Crucible.Types (CrucibleType)
+import Data.Parameterized.NatRepr (NatRepr, knownNat)
+
+import Lang.Crucible.Types (BVType, CrucibleType, IntrinsicType, TypeRepr(..))
 
 import qualified Lang.Crucible.LLVM.MemModel.Generic as G
 import qualified Lang.Crucible.LLVM.Types as T
+import Data.Type.Equality ((:~:) (Refl), testEquality)
+import Data.Parameterized.Context (EmptyCtx)
+import Data.Parameterized (KnownRepr(knownRepr))
 
--- TODO: Move me!
+type PosNat :: Nat -> Type
+data PosNat w = 1 <= w => PosNat (NatRepr w)
+
+_withPosNat :: PosNat w -> (1 <= w => NatRepr w -> k) -> k
+_withPosNat (PosNat w) k = k w
+
+type SomePointerRepr :: CrucibleType -> CrucibleType -> Type
+data SomePointerRepr mem tp
+  = forall w. (1 <= w, tp ~ PointerType mem w) => SomePointerRepr (NatRepr w)
+
 class Mem (mem :: CrucibleType) where
   type MemData (mem :: CrucibleType) sym = (r :: Type) | r -> mem
+  type PointerType (mem :: CrucibleType) (w :: Nat) = (r :: CrucibleType) | r -> mem w
+
+  memRepr :: TypeRepr mem
+
+  ptrRepr :: 1 <= w => NatRepr w -> TypeRepr (PointerType mem w)
+  testPtrRepr :: TypeRepr tp -> Maybe (SomePointerRepr mem tp)
+  ptrEqAxiom :: (PointerType mem w0 ~ PointerType mem w) => w0 :~: w
+  -- | Intended for use in 'PointerRepr'
+  ptrReprWidth :: TypeRepr (PointerType mem w) -> PosNat w
+
+type IsPtrRepr :: CrucibleType -> CrucibleType -> Nat -> Type
+data IsPtrRepr mem tp w
+  = (1 <= w, tp ~ PointerType mem w) => IsPtrRepr
+
+isPtrRepr ::
+  forall w tp mem.
+  Mem mem =>
+  NatRepr w ->
+  TypeRepr tp ->
+  Maybe (IsPtrRepr mem tp w)
+isPtrRepr w r =
+  case testPtrRepr @mem r of
+    Just (SomePointerRepr (testEquality w -> Just Refl)) ->
+      Just IsPtrRepr
+    _ -> Nothing
+
+isPtrRepr' ::
+  forall mem tp wptr.
+  T.HasPtrWidth wptr =>
+  Mem mem =>
+  TypeRepr tp ->
+  Maybe (IsPtrRepr mem tp wptr)
+isPtrRepr' = isPtrRepr ?ptrWidth
+
+-- pattern PointerRepr' :: forall mem tp. Mem mem => forall w. (1 <= w, tp ~ PointerType mem w) => NatRepr w -> Proxy mem -> TypeRepr tp
+-- pattern PointerRepr' w <- (testPtrRepr @mem -> Just (SomePointerRepr w))
+--   where PointerRepr' w = ptrRepr w
+
+pattern IsPointerRepr :: forall mem tp. Mem mem => SomePointerRepr mem tp -> TypeRepr tp
+pattern IsPointerRepr t <- (testPtrRepr @mem -> Just t)
+
+-- pattern SomePointer :: Mem mem => TypeRepr tp -> SomePointerRepr mem tp
+-- pattern SomePointer r <- SomePointerRepr (ptrRepr -> PosNat r)
+
+pattern PointerRepr :: Mem mem => (1 <= w) => NatRepr w -> TypeRepr (PointerType mem w)
+pattern PointerRepr w <- (ptrReprWidth -> PosNat w)
+  where PointerRepr w = ptrRepr w
+
+pattern KnownPointerRepr :: forall w mem. (KnownNat w, Mem mem) => (1 <= w) => TypeRepr (PointerType mem w)
+pattern KnownPointerRepr <- (ptrReprWidth -> PosNat _)
+  where KnownPointerRepr = ptrRepr (knownNat @w)
+
+pattern PtrRepr :: forall mem wptr. (T.HasPtrWidth wptr, Mem mem) => TypeRepr (PointerType mem wptr)
+pattern PtrRepr = PointerRepr T.PtrWidth
+
+-------------------------------------------
+
+type Fresh = IntrinsicType "fresh_llvm_memory" EmptyCtx
+
+instance Mem Fresh where
+  type MemData Fresh sym = ()
+  type PointerType Fresh w = BVType w
+
+  memRepr = knownRepr
+  {-# INLINE memRepr #-}
+
+  ptrRepr = BVRepr
+
+  testPtrRepr =
+    \case
+      BVRepr w -> Just (SomePointerRepr w)
+      _ -> Nothing
+
+  ptrEqAxiom = Refl
+  {-# INLINE ptrEqAxiom #-}
+
+  ptrReprWidth (BVRepr w) = PosNat w
+
+-------------------------------------------
 
 instance Mem T.Mem where
   type MemData T.Mem sym = G.Mem sym
+  type PointerType T.Mem w = T.LLVMPointerType w
+
+  memRepr = T.memRepr
+  {-# INLINE memRepr #-}
+
+  ptrRepr w = T.LLVMPointerRepr w
+
+  testPtrRepr =
+    \case
+      T.LLVMPointerRepr w -> Just (SomePointerRepr w)
+      _ -> Nothing
+
+  ptrEqAxiom = Refl
+  {-# INLINE ptrEqAxiom #-}
+
+  ptrReprWidth = 
+    \case
+      T.LLVMPointerRepr w -> PosNat w
+      _ -> error "Bad LLVM pointer repr"

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
@@ -316,6 +316,7 @@ assertUndefined bak callStack p ub =
 
 assertStoreError ::
   (IsSymBackend sym bak, Partial.HasLLVMAnn sym, 1 <= wptr) =>
+  mem ~ Mem =>
   bak ->
   MemErrContext sym wptr ->
   MemoryErrorReason ->
@@ -355,6 +356,7 @@ instance IsSymInterface sym => IntrinsicClass sym "LLVM_memory" where
 --   LLVM extension statements are used to implement the memory model operations.
 llvmStatementExec ::
   (Partial.HasLLVMAnn sym, ?memOpts :: MemOptions) =>
+  mem ~ Mem =>
   EvalStmtFunc p sym (LLVM mem)
 llvmStatementExec stmt cst =
   let simCtx = cst^.stateContext
@@ -370,6 +372,7 @@ type EvalM p sym ext rtp blocks ret args a =
 --   memory accessing effects of these statements.
 evalStmt :: forall p sym bak ext mem rtp blocks ret args tp.
   (IsSymBackend sym bak, Partial.HasLLVMAnn sym, GHC.HasCallStack, ?memOpts :: MemOptions) =>
+  mem ~ Mem =>
   bak ->
   LLVMStmt mem (RegEntry sym) tp ->
   EvalM p sym ext rtp blocks ret args (RegValue sym tp)

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
@@ -355,7 +355,7 @@ instance IsSymInterface sym => IntrinsicClass sym "LLVM_memory" where
 --   LLVM extension statements are used to implement the memory model operations.
 llvmStatementExec ::
   (Partial.HasLLVMAnn sym, ?memOpts :: MemOptions) =>
-  EvalStmtFunc p sym LLVM
+  EvalStmtFunc p sym (LLVM mem)
 llvmStatementExec stmt cst =
   let simCtx = cst^.stateContext
    in withBackend simCtx $ \bak ->
@@ -368,10 +368,10 @@ type EvalM p sym ext rtp blocks ret args a =
 --   The semantics are explicitly organized as a state transformer monad
 --   that modifies the global state of the simulator; this captures the
 --   memory accessing effects of these statements.
-evalStmt :: forall p sym bak ext rtp blocks ret args tp.
+evalStmt :: forall p sym bak ext mem rtp blocks ret args tp.
   (IsSymBackend sym bak, Partial.HasLLVMAnn sym, GHC.HasCallStack, ?memOpts :: MemOptions) =>
   bak ->
-  LLVMStmt (RegEntry sym) tp ->
+  LLVMStmt mem (RegEntry sym) tp ->
   EvalM p sym ext rtp blocks ret args (RegValue sym tp)
 evalStmt bak = eval
  where
@@ -398,7 +398,7 @@ evalStmt bak = eval
   failedAssert msg details =
     lift $ addFailedAssertion bak $ AssertFailureSimError msg details
 
-  eval :: LLVMStmt (RegEntry sym) tp ->
+  eval :: LLVMStmt mem (RegEntry sym) tp ->
           EvalM p sym ext rtp blocks ret args (RegValue sym tp)
   eval (LLVM_PushFrame nm mvar) =
      do mem <- getMem mvar

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
@@ -315,8 +315,7 @@ assertUndefined bak callStack p ub =
 
 
 assertStoreError ::
-  (IsSymBackend sym bak, Partial.HasLLVMAnn sym, 1 <= wptr) =>
-  mem ~ Mem =>
+  (IsSymBackend sym bak, Partial.HasLLVMAnn sym, 1 <= wptr, mem ~ Mem) =>
   bak ->
   MemErrContext sym wptr ->
   MemoryErrorReason ->
@@ -355,8 +354,7 @@ instance IsSymInterface sym => IntrinsicClass sym "LLVM_memory" where
 -- | Top-level evaluation function for LLVM extension statements.
 --   LLVM extension statements are used to implement the memory model operations.
 llvmStatementExec ::
-  (Partial.HasLLVMAnn sym, ?memOpts :: MemOptions) =>
-  mem ~ Mem =>
+  (Partial.HasLLVMAnn sym, ?memOpts :: MemOptions, mem ~ Mem) =>
   EvalStmtFunc p sym (LLVM mem)
 llvmStatementExec stmt cst =
   let simCtx = cst^.stateContext
@@ -371,8 +369,7 @@ type EvalM p sym ext rtp blocks ret args a =
 --   that modifies the global state of the simulator; this captures the
 --   memory accessing effects of these statements.
 evalStmt :: forall p sym bak ext mem rtp blocks ret args tp.
-  (IsSymBackend sym bak, Partial.HasLLVMAnn sym, GHC.HasCallStack, ?memOpts :: MemOptions) =>
-  mem ~ Mem =>
+  (IsSymBackend sym bak, Partial.HasLLVMAnn sym, GHC.HasCallStack, ?memOpts :: MemOptions, mem ~ Mem) =>
   bak ->
   LLVMStmt mem (RegEntry sym) tp ->
   EvalM p sym ext rtp blocks ret args (RegValue sym tp)

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
@@ -306,7 +306,7 @@ assertUndefined ::
   bak ->
   CallStack ->
   Pred sym ->
-  (UB.UndefinedBehavior (RegValue' sym)) {- ^ The undesirable behavior -} ->
+  (UB.UndefinedBehavior mem (RegValue' sym)) {- ^ The undesirable behavior -} ->
   IO ()
 assertUndefined bak callStack p ub =
   do let sym = backendGetSym bak

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Partial.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Partial.hs
@@ -237,7 +237,7 @@ explainCex sym bbMap evalFn =
 annotateUB :: (IsSymInterface sym, HasLLVMAnn sym) =>
   sym ->
   CallStack ->
-  UB.UndefinedBehavior (RegValue' sym) ->
+  UB.UndefinedBehavior mem (RegValue' sym) ->
   Pred sym ->
   IO (Pred sym)
 annotateUB sym callStack ub p =
@@ -296,7 +296,7 @@ attachSideCondition ::
   sym ->
   CallStack ->
   Pred sym ->
-  UB.UndefinedBehavior (RegValue' sym) ->
+  UB.UndefinedBehavior mem (RegValue' sym) ->
   PartLLVMVal sym ->
   IO (PartLLVMVal sym)
 attachSideCondition sym callStack pnew ub pv =

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Partial.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Partial.hs
@@ -520,8 +520,7 @@ bvToX86_FP80 sym errCtx (NoErr _ v) =
 -- (low) bytes are given first. The allocation block number of each
 -- argument is asserted to equal 0, indicating non-pointers.
 bvConcat :: forall sym w.
-  (IsSymInterface sym, HasLLVMAnn sym, 1 <= w) =>
-  sym ->
+  (IsSymInterface sym, HasLLVMAnn sym, 1 <= w, sym ->
   MemoryOp sym w ->
   PartLLVMVal sym ->
   PartLLVMVal sym ->

--- a/crucible-llvm/src/Lang/Crucible/LLVM/SymIO.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/SymIO.hs
@@ -374,7 +374,8 @@ allocateFileDescriptor fsVars fh = do
 
 loadFileIdent
   :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, ?memOpts :: MemOptions)
-  => GlobalVar Mem
+  => mem ~ Mem
+  => GlobalVar mem
   -> LLVMPtr sym wptr
   -> OverrideSim p sym ext r args ret (SymIO.FileIdent sym)
 loadFileIdent memOps filename_ptr =
@@ -400,8 +401,9 @@ returnIOError = do
 
 openFile
   :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, ?memOpts :: MemOptions)
+  => mem ~ Mem
   => LLVMFileSystem wptr
-  -> LLVMOverride p sym ext
+  -> LLVMOverride p sym ext mem
            (EmptyCtx ::> LLVMPointerType wptr
                      ::> BVType 32)
            (BVType 32)
@@ -412,7 +414,8 @@ openFile fsVars =
 
 callOpenFile ::
   (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, ?memOpts :: MemOptions) =>
-  GlobalVar Mem ->
+  mem ~ Mem =>
+  GlobalVar mem ->
   LLVMFileSystem wptr ->
   RegEntry sym (LLVMPointerType wptr) ->
   RegEntry sym (BVType 32) ->
@@ -425,8 +428,9 @@ callOpenFile memOps fsVars filename_ptr _flags =
 
 closeFile
   :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
+  => mem ~ Mem
   => LLVMFileSystem wptr
-  -> LLVMOverride p sym ext
+  -> LLVMOverride p sym ext mem
            (EmptyCtx ::> BVType 32)
            (BVType 32)
 closeFile fsVars =
@@ -435,7 +439,8 @@ closeFile fsVars =
 
 callCloseFile ::
   (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr) =>
-  GlobalVar Mem ->
+  mem ~ Mem =>
+  GlobalVar mem ->
   LLVMFileSystem wptr ->
   RegEntry sym (BVType 32) ->
   OverrideSim p sym ext rtp args ret (RegValue sym (BVType 32))
@@ -450,8 +455,9 @@ callCloseFile _memOps fsVars filedesc =
 
 readFileHandle
   :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
+  => mem ~ Mem
   => LLVMFileSystem wptr
-  -> LLVMOverride p sym ext
+  -> LLVMOverride p sym ext mem
            (EmptyCtx ::> BVType 32
                      ::> LLVMPointerType wptr
                      ::> BVType wptr)
@@ -462,7 +468,8 @@ readFileHandle fsVars =
 
 callReadFileHandle ::
   (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr) =>
-  GlobalVar Mem ->
+  mem ~ Mem =>
+  GlobalVar mem ->
   LLVMFileSystem wptr ->
   RegEntry sym (BVType 32) ->
   RegEntry sym (LLVMPointerType wptr) ->
@@ -520,8 +527,9 @@ doConcreteWrite ptrw handles symFD chunk size =
 
 writeFileHandle
   :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, ?memOpts :: MemOptions)
+  => mem ~ Mem
   => LLVMFileSystem wptr
-  -> LLVMOverride p sym ext
+  -> LLVMOverride p sym ext mem
            (EmptyCtx ::> BVType 32
                      ::> LLVMPointerType wptr
                      ::> BVType wptr)
@@ -532,7 +540,8 @@ writeFileHandle fsVars =
 
 callWriteFileHandle ::
   (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, ?memOpts :: MemOptions) =>
-  GlobalVar Mem ->
+  mem ~ Mem =>
+  GlobalVar mem ->
   LLVMFileSystem wptr ->
   RegEntry sym (BVType 32) ->
   RegEntry sym (LLVMPointerType wptr) ->
@@ -556,6 +565,7 @@ callWriteFileHandle memOps fsVars filedesc buf count =
 -- See the 'initialLLVMFileSystem' function for creating the initial filesystem state
 symio_overrides
   :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch, ?memOpts :: MemOptions)
+  => mem ~ Mem
   => LLVMFileSystem wptr
   -> [OverrideTemplate p sym mem arch rtp l a]
 symio_overrides fs =

--- a/crucible-llvm/src/Lang/Crucible/LLVM/SymIO.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/SymIO.hs
@@ -557,7 +557,7 @@ callWriteFileHandle memOps fsVars filedesc buf count =
 symio_overrides
   :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch, ?memOpts :: MemOptions)
   => LLVMFileSystem wptr
-  -> [OverrideTemplate p sym arch rtp l a]
+  -> [OverrideTemplate p sym mem arch rtp l a]
 symio_overrides fs =
   [ basic_llvm_override $ openFile fs
   , basic_llvm_override $ closeFile fs

--- a/crucible-llvm/src/Lang/Crucible/LLVM/SymIO.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/SymIO.hs
@@ -373,8 +373,7 @@ allocateFileDescriptor fsVars fh = do
     return (fdesc, FDescMap (next + 1) ptrMap')
 
 loadFileIdent
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, ?memOpts :: MemOptions)
-  => mem ~ Mem
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, ?memOpts :: MemOptions, mem ~ Mem)
   => GlobalVar mem
   -> LLVMPtr sym wptr
   -> OverrideSim p sym ext r args ret (SymIO.FileIdent sym)
@@ -400,8 +399,7 @@ returnIOError = do
   liftIO $ W4.bvLit sym PtrWidth (BVS.mkBV PtrWidth (-1))
 
 openFile
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, ?memOpts :: MemOptions)
-  => mem ~ Mem
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, ?memOpts :: MemOptions, mem ~ Mem)
   => LLVMFileSystem wptr
   -> LLVMOverride p sym ext mem
            (EmptyCtx ::> LLVMPointerType wptr
@@ -413,8 +411,7 @@ openFile fsVars =
   (\memOps args -> uncurryAssignment (callOpenFile memOps fsVars) args)
 
 callOpenFile ::
-  (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, ?memOpts :: MemOptions) =>
-  mem ~ Mem =>
+  (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, ?memOpts :: MemOptions, mem ~ Mem) =>
   GlobalVar mem ->
   LLVMFileSystem wptr ->
   RegEntry sym (LLVMPointerType wptr) ->
@@ -427,8 +424,7 @@ callOpenFile memOps fsVars filename_ptr _flags =
        Right fileHandle -> allocateFileDescriptor fsVars fileHandle
 
 closeFile
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
-  => mem ~ Mem
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, mem ~ Mem)
   => LLVMFileSystem wptr
   -> LLVMOverride p sym ext mem
            (EmptyCtx ::> BVType 32)
@@ -438,8 +434,7 @@ closeFile fsVars =
   (\memOps args -> uncurryAssignment (callCloseFile memOps fsVars) args)
 
 callCloseFile ::
-  (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr) =>
-  mem ~ Mem =>
+  (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, mem ~ Mem) =>
   GlobalVar mem ->
   LLVMFileSystem wptr ->
   RegEntry sym (BVType 32) ->
@@ -454,8 +449,7 @@ callCloseFile _memOps fsVars filedesc =
        Nothing -> \_ -> returnIOError32
 
 readFileHandle
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr)
-  => mem ~ Mem
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, mem ~ Mem)
   => LLVMFileSystem wptr
   -> LLVMOverride p sym ext mem
            (EmptyCtx ::> BVType 32
@@ -467,8 +461,7 @@ readFileHandle fsVars =
   (\memOps args -> uncurryAssignment (callReadFileHandle memOps fsVars) args)
 
 callReadFileHandle ::
-  (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr) =>
-  mem ~ Mem =>
+  (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, mem ~ Mem) =>
   GlobalVar mem ->
   LLVMFileSystem wptr ->
   RegEntry sym (BVType 32) ->
@@ -526,8 +519,7 @@ doConcreteWrite ptrw handles symFD chunk size =
     _ -> return ()
 
 writeFileHandle
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, ?memOpts :: MemOptions)
-  => mem ~ Mem
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, ?memOpts :: MemOptions, mem ~ Mem)
   => LLVMFileSystem wptr
   -> LLVMOverride p sym ext mem
            (EmptyCtx ::> BVType 32
@@ -539,8 +531,7 @@ writeFileHandle fsVars =
   (\memOps args -> uncurryAssignment (callWriteFileHandle memOps fsVars) args)
 
 callWriteFileHandle ::
-  (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, ?memOpts :: MemOptions) =>
-  mem ~ Mem =>
+  (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, ?memOpts :: MemOptions, mem ~ Mem) =>
   GlobalVar mem ->
   LLVMFileSystem wptr ->
   RegEntry sym (BVType 32) ->
@@ -564,8 +555,7 @@ callWriteFileHandle memOps fsVars filedesc buf count =
 --
 -- See the 'initialLLVMFileSystem' function for creating the initial filesystem state
 symio_overrides
-  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch, ?memOpts :: MemOptions)
-  => mem ~ Mem
+  :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch, ?memOpts :: MemOptions, mem ~ Mem)
   => LLVMFileSystem wptr
   -> [OverrideTemplate p sym mem arch rtp l a]
 symio_overrides fs =

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation.hs
@@ -121,6 +121,7 @@ import           Lang.Crucible.FunctionHandle
 import           Lang.Crucible.LLVM.Extension
 import           Lang.Crucible.LLVM.MemType
 import           Lang.Crucible.LLVM.Globals
+import qualified Lang.Crucible.LLVM.Mem as Mem
 import           Lang.Crucible.LLVM.MemModel
 import qualified Lang.Crucible.LLVM.PrettyPrint as LPP
 import           Lang.Crucible.LLVM.Translation.Aliases
@@ -221,6 +222,7 @@ buildRegTypeMap m0 bb = foldM stmt m0 (L.bbStmts bb)
 
 -- | Generate crucible code for each LLVM statement in turn.
 generateStmts :: (?transOpts :: TranslationOptions)
+  => Mem.Mem mem
         => TypeRepr ret
         -> L.BlockLabel
         -> Set L.Ident {- ^ Set of usable identifiers -}
@@ -347,6 +349,7 @@ findFile _ = Nothing
 --   by translating the given LLVM statements.
 defineLLVMBlock
         :: (?transOpts :: TranslationOptions)
+        => Mem.Mem mem
         => TypeRepr ret
         -> LLVMBlockInfoMap s
         -> L.BasicBlock
@@ -365,6 +368,7 @@ defineLLVMBlock _ _ _ = fail "LLVM basic block has no label!"
 --   This step introduces a new dummy entry point that simply jumps to the LLVM entry
 --   point.  It is inconvenient to avoid doing this when using the Generator interface.
 genDefn :: (?transOpts :: TranslationOptions)
+        => Mem.Mem mem
         => L.Define
         -> TypeRepr ret
         -> LLVMGenerator s mem arch ret (Expr ext s ret)
@@ -419,6 +423,7 @@ checkEntryPointUseSet nm bi args
 --
 transDefine :: forall mem arch wptr args ret.
   (HasPtrWidth wptr, wptr ~ ArchWidth arch, ?transOpts :: TranslationOptions) =>
+  Mem.Mem mem =>
   FnHandle args ret ->
   LLVMContext mem arch ->
   IORef [LLVMTranslationWarning] ->
@@ -508,6 +513,7 @@ prepareCFGMapEntry halloc def =
 --   Will return 'Nothing' if the symbol does not refer to a function defined in this
 --   module.
 getTranslatedCFG ::
+  Mem.Mem mem =>
   ModuleTranslation mem arch ->
   L.Symbol ->
   IO (Maybe (L.Declare, C.AnyCFG (LLVM mem), [LLVMTranslationWarning]))

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation.hs
@@ -221,9 +221,8 @@ buildRegTypeMap m0 bb = foldM stmt m0 (L.bbStmts bb)
 
 
 -- | Generate crucible code for each LLVM statement in turn.
-generateStmts :: (?transOpts :: TranslationOptions)
-  => Mem.Mem mem
-        => TypeRepr ret
+generateStmts :: (?transOpts :: TranslationOptions, Mem.Mem mem)
+  => TypeRepr ret
         -> L.BlockLabel
         -> Set L.Ident {- ^ Set of usable identifiers -}
         -> [L.Stmt]
@@ -348,8 +347,7 @@ findFile _ = Nothing
 -- | Lookup the block info for the given LLVM block and then define a new crucible block
 --   by translating the given LLVM statements.
 defineLLVMBlock
-        :: (?transOpts :: TranslationOptions)
-        => Mem.Mem mem
+        :: (?transOpts :: TranslationOptions, Mem.Mem mem)
         => TypeRepr ret
         -> LLVMBlockInfoMap s
         -> L.BasicBlock
@@ -367,8 +365,7 @@ defineLLVMBlock _ _ _ = fail "LLVM basic block has no label!"
 --
 --   This step introduces a new dummy entry point that simply jumps to the LLVM entry
 --   point.  It is inconvenient to avoid doing this when using the Generator interface.
-genDefn :: (?transOpts :: TranslationOptions)
-        => Mem.Mem mem
+genDefn :: (?transOpts :: TranslationOptions, Mem.Mem mem)
         => L.Define
         -> TypeRepr ret
         -> LLVMGenerator s mem arch ret (Expr ext s ret)
@@ -422,8 +419,7 @@ checkEntryPointUseSet nm bi args
 -- | Translate a single LLVM function definition into a crucible CFG.
 --
 transDefine :: forall mem arch wptr args ret.
-  (HasPtrWidth wptr, wptr ~ ArchWidth arch, ?transOpts :: TranslationOptions) =>
-  Mem.Mem mem =>
+  (HasPtrWidth wptr, wptr ~ ArchWidth arch, ?transOpts :: TranslationOptions, Mem.Mem mem) =>
   FnHandle args ret ->
   LLVMContext mem arch ->
   IORef [LLVMTranslationWarning] ->

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Expr.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Expr.hs
@@ -334,8 +334,7 @@ explodeVector _ _ = Nothing
 -- Translations
 
 liftConstant ::
-  Mem.Mem mem =>
-  HasPtrWidth (ArchWidth arch) =>
+  (Mem.Mem mem, HasPtrWidth (ArchWidth arch)) =>
   LLVMConst ->
   LLVMGenerator s mem arch ret (LLVMExpr s mem arch)
 liftConstant c = case c of
@@ -488,16 +487,14 @@ transValue ty v =
 
 
 callIsNull
-   :: (1 <= w)
-  => Mem.Mem mem
-   => NatRepr w
+   :: (1 <= w, Mem.Mem mem)
+  => NatRepr w
    -> Expr (LLVM mem) s (PointerType mem w)
    -> LLVMGenerator s mem arch ret (Expr (LLVM mem) s BoolType)
 callIsNull w ex = App . Not <$> callIntToBool w ex
 
 callIntToBool
-  :: (1 <= w)
-  => Mem.Mem mem
+  :: (1 <= w, Mem.Mem mem)
   => NatRepr w
   -> Expr (LLVM mem) s (PointerType mem w)
   -> LLVMGenerator s mem arch ret (Expr (LLVM mem) s BoolType)
@@ -512,8 +509,7 @@ callIntToBool w ex =
      return (blk ./= litExpr 0 .|| (App (BVNonzero w off)))
 
 callAlloca
-   :: wptr ~ ArchWidth arch
-   => Mem.Mem mem
+   :: (wptr ~ ArchWidth arch, Mem.Mem mem)
    => Expr (LLVM mem) s (BVType wptr)
    -> Alignment
    -> LLVMGenerator s mem arch ret (Expr (LLVM mem) s (PointerType mem wptr))
@@ -533,8 +529,7 @@ callPopFrame = do
    void $ extensionStmt (LLVM_PopFrame memVar)
 
 callPtrAddOffset ::
-       wptr ~ ArchWidth arch
-    => Mem.Mem mem
+       (wptr ~ ArchWidth arch, Mem.Mem mem)
     => Expr (LLVM mem) s (PointerType mem wptr)
     -> Expr (LLVM mem) s (BVType wptr)
     -> LLVMGenerator s mem arch ret (Expr (LLVM mem) s (PointerType mem wptr))
@@ -543,8 +538,7 @@ callPtrAddOffset base off = do
     extensionStmt (LLVM_PtrAddOffset ?ptrWidth memVar base off)
 
 callPtrSubtract ::
-       wptr ~ ArchWidth arch
-    => Mem.Mem mem
+       (wptr ~ ArchWidth arch, Mem.Mem mem)
     => Expr (LLVM mem) s (PointerType mem wptr)
     -> Expr (LLVM mem) s (PointerType mem wptr)
     -> LLVMGenerator s mem arch ret (Expr (LLVM mem) s (BVType wptr))

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Instruction.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Instruction.hs
@@ -98,7 +98,7 @@ import           Lang.Crucible.Types
 --
 -- Allows for effectful computation of the predicates and expressions.
 sideConditionsA :: forall f ty s mem. Applicative f
-                => GlobalVar Mem
+                => GlobalVar mem
                 -> TypeRepr ty
                 -> Expr (LLVM mem) s ty
                     -- ^ Expression with side-condition
@@ -125,7 +125,7 @@ sideConditionsA mvar tyRepr expr conds =
         (x:xs) -> App $ ExtensionApp $ LLVM_SideConditions mvar tyRepr (x :| xs) expr
 
 -- | Assert that evaluation doesn't result in a poison value
-poisonSideCondition :: GlobalVar Mem
+poisonSideCondition :: GlobalVar mem
                     -> TypeRepr ty
                     -> Poison.Poison (Expr (LLVM mem) s)
                     -> Expr (LLVM mem) s ty

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Monad.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Monad.hs
@@ -131,18 +131,18 @@ mkLLVMContext mvar m = do
 
 -- | A monad providing state and continuations for translating LLVM expressions
 -- to CFGs.
-type LLVMGenerator s arch ret a =
+type LLVMGenerator s mem arch ret a =
   (?lc :: TypeContext, HasPtrWidth (ArchWidth arch)) =>
-    Generator LLVM s (LLVMState arch) ret IO a
+    Generator (LLVM mem) s (LLVMState arch) ret IO a
 
 -- | @LLVMGenerator@ without the constraint, can be nested further inside monads.
-type LLVMGenerator' s arch ret =
-  Generator LLVM s (LLVMState arch) ret IO
+type LLVMGenerator' s mem arch ret =
+  Generator (LLVM mem) s (LLVMState arch) ret IO
 
 
 -- LLVMState
 
-getMemVar :: LLVMGenerator s arch reg (GlobalVar Mem)
+getMemVar :: LLVMGenerator s mem arch reg (GlobalVar Mem)
 getMemVar = llvmMemVar . llvmContext <$> get
 
 -- | Maps identifiers to an associated register or defined expression.
@@ -177,7 +177,7 @@ translationWarnings = lens _translationWarnings (\s v -> s { _translationWarning
 functionSymbol :: Lens' (LLVMState arch s) L.Symbol
 functionSymbol = lens _functionSymbol (\s v -> s{ _functionSymbol = v })
 
-addWarning :: Text -> LLVMGenerator s arch ret ()
+addWarning :: Text -> LLVMGenerator s mem arch ret ()
 addWarning warn =
   do r <- use translationWarnings
      s <- use functionSymbol

--- a/crucible-llvm/test/MemSetup.hs
+++ b/crucible-llvm/test/MemSetup.hs
@@ -45,20 +45,20 @@ withInitializedMemory :: forall a. L.Module
                           -> IO a)
                       -> IO a
 withInitializedMemory mod' action =
-  withLLVMCtx mod' $ \(ctx :: LLVMTr.LLVMContext arch) sym ->
+  withLLVMCtx mod' $ \(ctx :: LLVMTr.LLVMContext mem arch) sym ->
     action @(LLVME.ArchWidth arch) =<< LLVMG.initializeAllMemory sym ctx mod'
 
 
 -- | Create an LLVM context from a module and make some assertions about it.
 withLLVMCtx :: forall a. L.Module
-            -> (forall arch sym bak.
+            -> (forall mem arch sym bak.
                    ( ?lc :: TypeContext
                    , LLVMM.HasPtrWidth (LLVME.ArchWidth arch)
                    , CB.IsSymBackend sym bak
                    , LLVMMem.HasLLVMAnn sym
                    , ?memOpts :: LLVMMem.MemOptions
                    )
-                => LLVMTr.LLVMContext arch
+                => LLVMTr.LLVMContext mem arch
                 -> bak
                 -> IO a)
             -> IO a

--- a/crucible-llvm/test/Tests.hs
+++ b/crucible-llvm/test/Tests.hs
@@ -46,7 +46,7 @@ import           System.FilePath ( (-<.>), splitExtension, splitFileName )
 import qualified System.Process as Proc
 
 -- Modules being tested
-import           Lang.Crucible.LLVM.MemModel ( mkMemVar )
+import           Lang.Crucible.LLVM.MemModel ( Mem, mkMemVar )
 import           Lang.Crucible.LLVM.MemType
 import           Lang.Crucible.LLVM.Translation
 
@@ -162,7 +162,7 @@ main = do
 
 
 
-testBuildTranslation :: FilePath -> (IO (Some ModuleTranslation) -> TestTree) -> [TestTree]
+testBuildTranslation :: FilePath -> (IO (Some (ModuleTranslation Mem)) -> TestTree) -> [TestTree]
 testBuildTranslation srcPath llvmTransTests =
   -- n.b. srcPath may be a relative path
   let (dName, srcName) = splitFileName srcPath
@@ -242,7 +242,7 @@ testBuildTranslation srcPath llvmTransTests =
     ]
 
 
-transCheck :: IO (Some ModuleTranslation) -> String -> TestTree
+transCheck :: IO (Some (ModuleTranslation Mem)) -> String -> TestTree
 transCheck getTrans = \case
 
   "extern_int" ->


### PR DESCRIPTION
**Note** that the code changes are *very WIP*. Further notes below.

The idea is that we have a lot of big changes we'd potentially like to
make to the memory model:

- #917: Decouple memory from control flow
- #404: Improve underlying symbolic type for pointer representation
- #399: Refactoring the memory model
- #366: Bit-level undef/poison

The problem is that these are all very hard to get started on, because
they would involve sweeping changes across Crucible-LLVM and all
downstream packages.

We could also consider alternative memory models for different
use-cases:

- A "flat" model based on a single SMT array with a bump allocator, to
  let the SMT solver handle more of the hairy details
- A "lazy" model in the style of UC-KLEE for under-constrained symbolic
  execution
- A "fresh" model that always returns fresh symbolic constants when read

All of these would have interesting trade-offs, but can't effectively be
explored at the moment.

This PR is the first step in making it easier to run such
experiments. The goal is to parameterize Crucible-LLVM over a typeclass
that provides (Crucible and Haskell) types and operations on memory and
pointers.

To that end, it introduces a new `mem` type variable. At the moment, a
lot of places in the code add the abstraction-breaking `mem ~ Mem`
constraint. The goal would be to gradually add operations to the `Mem`
class and remove such equality constraints.

Some notable downsides:

- Increased complexity. See e.g., the pattern matches in
  `Translation.Instruction`, which I couldn't figure out how to
  adequately replace. Counterpoint: programming against an well-defined
  interface (i.e., a typeclass) can reduce mental complexity by
  abstracting superfluous detail.
- Code churn within Crucible
- API churn for consumers

Notes on progress:

- This PR introduces the `mem` type variable and `Mem` typeclass.
- This PR far enough to compile, I haven't run the tests but there should be no behvioral changes (modulo one explicit TODO item).
- Translation is actually parametric over `Mem`, but evaluation just forces `mem` to be explicitly equal to the current memory model. More operations would be needed inside the `Mem` typeclass to make evaluation more parametric.
- Obviously, lots of formatting is seriously messed up. If we like this direction, I can clean that up.