### PR TITLE
llvm: Refactor override matching

### DIFF
--- a/crucible-llvm/CHANGELOG.md
+++ b/crucible-llvm/CHANGELOG.md
@@ -1,5 +1,9 @@
 # next
 
+* The `RegOverrideM` monad was replaced by the `MakeOverride` function newtype.
+* Several type parameters were removed from `OverrideTemplate`, and the `ext`
+  parameter was added. This had downstream effects in `basic_llvm_override`,
+  `polymorphic1_llvm_override`, and other functions for registering overrides.
 * Override registration code was generalized. `bind_llvm_{handle,func}`
   now don't require a whole `LLVMContext`, just a `GlobalVar Mem`, and are
   polymorphic over `ext`.

--- a/crucible-llvm/crucible-llvm.cabal
+++ b/crucible-llvm/crucible-llvm.cabal
@@ -101,6 +101,7 @@ library
     Lang.Crucible.LLVM.Extension.Syntax
     Lang.Crucible.LLVM.Intrinsics.Common
     Lang.Crucible.LLVM.Intrinsics.Libcxx
+    Lang.Crucible.LLVM.Intrinsics.Match
     Lang.Crucible.LLVM.Intrinsics.Options
     Lang.Crucible.LLVM.MemModel.Common
     Lang.Crucible.LLVM.MemModel.Options

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics.hs
@@ -29,6 +29,7 @@ module Lang.Crucible.LLVM.Intrinsics
 
 , module Lang.Crucible.LLVM.Intrinsics.Common
 , module Lang.Crucible.LLVM.Intrinsics.Options
+, module Lang.Crucible.LLVM.Intrinsics.Match
 ) where
 
 import           Control.Lens hiding (op, (:>), Empty)
@@ -53,7 +54,7 @@ import           Lang.Crucible.LLVM.Intrinsics.Common
 import qualified Lang.Crucible.LLVM.Intrinsics.LLVM as LLVM
 import qualified Lang.Crucible.LLVM.Intrinsics.Libc as Libc
 import qualified Lang.Crucible.LLVM.Intrinsics.Libcxx as Libcxx
-import qualified Lang.Crucible.LLVM.Intrinsics.Match as Match
+import           Lang.Crucible.LLVM.Intrinsics.Match
 import           Lang.Crucible.LLVM.Intrinsics.Options
 
 llvmIntrinsicTypes :: IsSymInterface sym => IntrinsicTypes sym
@@ -86,7 +87,7 @@ filterTemplates ::
   [OverrideTemplate p sym ext arch] ->
   L.Declare ->
   [OverrideTemplate p sym ext arch]
-filterTemplates ts decl = filter (Match.matches nm . overrideTemplateMatcher) ts
+filterTemplates ts decl = filter (matches nm . overrideTemplateMatcher) ts
  where L.Symbol nm = L.decName decl
 
 -- | Helper function for registering overrides

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics.hs
@@ -68,8 +68,8 @@ register_llvm_overrides ::
   ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch
   , ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions ) =>
   L.Module ->
-  [OverrideTemplate p sym LLVM arch] {- ^ Additional "define" overrides -} ->
-  [OverrideTemplate p sym LLVM arch] {- ^ Additional "declare" overrides -} ->
+  [OverrideTemplate p sym LLVM arch] {- ^ Additional \"define\" overrides -} ->
+  [OverrideTemplate p sym LLVM arch] {- ^ Additional \"declare\" overrides -} ->
   LLVMContext arch ->
   OverrideSim p sym LLVM rtp l a ()
 register_llvm_overrides llvmModule defineOvrs declareOvrs llvmctx =

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Common.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Common.hs
@@ -107,15 +107,25 @@ llvmSizeT = L.PrimType $ L.Integer $ fromIntegral $ natValue $ PtrWidth
 llvmSSizeT :: HasPtrWidth wptr => L.Type
 llvmSSizeT = L.PrimType $ L.Integer $ fromIntegral $ natValue $ PtrWidth
 
+-- | A funcion that inspects an LLVM declaration (along with some other data),
+-- and constructs an override for the declaration if it can.
 newtype MakeOverride p sym ext arch =
   MakeOverride
     { _runMakeOverride ::
         L.Declare ->
+        -- Decoded version of the name in the declaration
         Maybe ABI.DecodedName ->
         LLVMContext arch ->
         Maybe (SomeLLVMOverride p sym ext)
     }
 
+-- | Checking if an override applies to a given declaration happens in two
+-- \"phases\".
+--
+-- * An initial, quick, string-based 'Match.TemplateMatcher' checks if an
+--   override might apply to a given declaration, based on its name
+-- * If the 'Match.TemplateMatcher' does indeed match, the slower 'MakeOverride'
+--   performs additional checks and potentially constructs a 'SomeLLVMOverride'.
 data OverrideTemplate p sym ext arch =
   OverrideTemplate
   { overrideTemplateMatcher :: Match.TemplateMatcher

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libcxx.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libcxx.hs
@@ -35,7 +35,6 @@ module Lang.Crucible.LLVM.Intrinsics.Libcxx
   ) where
 
 import qualified ABI.Itanium as ABI
-import           Control.Applicative (empty)
 import           Control.Lens ((^.))
 import           Control.Monad.Reader
 import           Data.List (isInfixOf)
@@ -70,16 +69,12 @@ import           Lang.Crucible.LLVM.Translation.Types
 register_cpp_override ::
   (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr) =>
   SomeCPPOverride p sym arch ->
-  OverrideTemplate p sym arch rtp l a
+  OverrideTemplate p sym LLVM arch
 register_cpp_override someCPPOverride =
   OverrideTemplate (Match.SubstringsMatch ("_Z" : cppOverrideSubstrings someCPPOverride)) $
-  do (requestedDecl, decName, llvmctx) <- ask
-     case decName of
-       Nothing -> empty
-       Just nm ->
-         case cppOverrideAction someCPPOverride requestedDecl nm llvmctx of
-           Nothing -> empty
-           Just (SomeLLVMOverride override) -> register_llvm_override override
+    MakeOverride $ \requestedDecl decName llvmctx -> do
+      nm <- decName
+      cppOverrideAction someCPPOverride requestedDecl nm llvmctx
 
 
 -- type CPPOverride p sym arch args ret =

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libcxx.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libcxx.hs
@@ -57,6 +57,7 @@ import           Lang.Crucible.Types (TypeRepr(UnitRepr), CtxRepr)
 
 import           Lang.Crucible.LLVM.Extension
 import           Lang.Crucible.LLVM.Intrinsics.Common
+import qualified Lang.Crucible.LLVM.Intrinsics.Match as Match
 import           Lang.Crucible.LLVM.MemModel
 import           Lang.Crucible.LLVM.Translation.Monad
 import           Lang.Crucible.LLVM.Translation.Types
@@ -71,7 +72,7 @@ register_cpp_override ::
   SomeCPPOverride p sym arch ->
   OverrideTemplate p sym arch rtp l a
 register_cpp_override someCPPOverride =
-  OverrideTemplate (SubstringsMatch ("_Z" : cppOverrideSubstrings someCPPOverride)) $
+  OverrideTemplate (Match.SubstringsMatch ("_Z" : cppOverrideSubstrings someCPPOverride)) $
   do (requestedDecl, decName, llvmctx) <- ask
      case decName of
        Nothing -> empty

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Match.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Match.hs
@@ -1,0 +1,109 @@
+-- |
+-- Module           : Lang.Crucible.LLVM.Intrinsics.Match
+-- Description      : Matching overrides to function names
+-- Copyright        : (c) Galois, Inc 2024
+-- License          : BSD3
+-- Maintainer       : Langston Barrett <langston@galois.com>
+-- Stability        : provisional
+------------------------------------------------------------------------
+
+module Lang.Crucible.LLVM.Intrinsics.Match
+  ( TemplateMatcher(..)
+  , matches
+  , stripDarwinAliases
+  ) where
+
+import           Control.Applicative (asum)
+import qualified Data.List as List
+import qualified Data.List.Extra as List (stripInfix)
+import           Data.Maybe (fromMaybe)
+
+-- | This type controls whether an override is installed for a given name found in a module.
+--  See 'Lang.Crucible.LLVM.Intrinsics.filterTemplates'.
+data TemplateMatcher
+  = ExactMatch String
+  | PrefixMatch String
+  | SubstringsMatch [String]
+  | DarwinAliasMatch String
+    -- ^ Match a name up to some number of Darwin aliases.
+    -- See @Note [Darwin aliases]@.
+
+-- | Check whether a 'TemplateMatcher' matches a given function name.
+matches ::
+  -- | Function name
+  String ->
+  TemplateMatcher ->
+  Bool
+matches nm (ExactMatch x)       = x == nm
+matches nm (PrefixMatch pfx)    = pfx `List.isPrefixOf` nm
+matches nm (DarwinAliasMatch x) = x == stripDarwinAliases nm
+matches nm (SubstringsMatch as) = filterSubstrings as nm
+  where
+    filterSubstrings [] _ = True
+    filterSubstrings (a:as) xs =
+      case restAfterSubstring a xs of
+        Nothing   -> False
+        Just rest -> filterSubstrings as rest
+
+    restAfterSubstring :: String -> String -> Maybe String
+    restAfterSubstring sub xs = asum [ List.stripPrefix sub tl | tl <- List.tails xs ]
+
+
+-- | Remove all prefixes and suffixes that might occur in a Darwin alias for
+-- a function name. See @Note [Darwin aliases]@.
+stripDarwinAliases :: String -> String
+stripDarwinAliases str =
+  -- Remove the \01_ prefix, if it exists...
+  let strNoPrefix = fromMaybe str (List.stripPrefix "\01_" str) in
+  -- ...and remove any suffixes as well. Because there can be multiple suffixes
+  -- in an alias, we use `stripInfix` in case one of the prefixes does not
+  -- appear at the very end of the name.
+  foldr (\suf s ->
+          case List.stripInfix suf s of
+            Just (before, after) -> before ++ after
+            Nothing              -> s)
+        strNoPrefix
+        suffixes
+  where
+    suffixes :: [String]
+    suffixes = [ "$UNIX2003"
+               , "$INODE64"
+               , "$1050"
+               , "$NOCANCEL"
+               , "$DARWIN_EXTSN"
+               ]
+
+{-
+Note [Darwin aliases]
+~~~~~~~~~~~~~~~~~~~~~
+Operating systems derived from Darwin, such as macOS, define several aliases
+for common libc functions for versioning purposes. These aliases are defined
+using __asm, so when Clang compiles these aliases, the name that appears in the
+resulting bitcode will look slightly different from what appears in the source
+C file. For example, compiling the write() function with Clang on macOS will
+produce LLVM bitcode with the name \01_write(), where \01 represents a leading
+ASCII character with code 0x01.
+
+Aside from the \01_ prefix, there also a number of suffixes that can be used
+in alias names (see `stripDarwinAliases` for the complete list). There are
+enough possible combinations that it is not wise to try and write them all out
+by hand. Instead, we take the approach that when using crucible-llvm on Darwin,
+we treat any C function as possibly containing Darwin aliases. That is:
+
+* In `basic_llvm_override`, we use a special DarwinAliasMatch template matcher
+  on Darwin. When matching against possible overrides, DarwinAliasMatch
+  indicates that function should be match the underlying name after removing
+  any possible Darwin-related prefixes or suffixes (see the
+  `stripDarwinAliases` function, which implements this).
+* If a function name in a program matches an override name after stripping
+  Darwin aliases, then we proceed to use the override, but with the override's
+  name switched out for the name of the function from the program. This way,
+  we write overrides for the "normalized" name (e.g., write) but have them work
+  seamlessly for aliases names (e.g., \01_write) as well.
+
+Currently, we only apply this special treatment in `basic_llvm_override`, as
+we have only observed the aliases being used on libc functions. We may need to
+apply this special case to other override functions (e.g.,
+`register_cpp_override`) if that proves insufficient.
+-}
+

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Match.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Match.hs
@@ -37,7 +37,7 @@ matches ::
 matches nm (ExactMatch x)       = x == nm
 matches nm (PrefixMatch pfx)    = pfx `List.isPrefixOf` nm
 matches nm (DarwinAliasMatch x) = x == stripDarwinAliases nm
-matches nm (SubstringsMatch as) = filterSubstrings as nm
+matches nm (SubstringsMatch subs) = filterSubstrings subs nm
   where
     filterSubstrings [] _ = True
     filterSubstrings (a:as) xs =

--- a/crucible-llvm/src/Lang/Crucible/LLVM/SymIO.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/SymIO.hs
@@ -557,7 +557,7 @@ callWriteFileHandle memOps fsVars filedesc buf count =
 symio_overrides
   :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch, ?memOpts :: MemOptions)
   => LLVMFileSystem wptr
-  -> [OverrideTemplate p sym LLVM arch]
+  -> [OverrideTemplate p sym ext arch]
 symio_overrides fs =
   [ basic_llvm_override $ openFile fs
   , basic_llvm_override $ closeFile fs

--- a/crucible-llvm/src/Lang/Crucible/LLVM/SymIO.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/SymIO.hs
@@ -557,7 +557,7 @@ callWriteFileHandle memOps fsVars filedesc buf count =
 symio_overrides
   :: (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch, ?memOpts :: MemOptions)
   => LLVMFileSystem wptr
-  -> [OverrideTemplate p sym arch rtp l a]
+  -> [OverrideTemplate p sym LLVM arch]
 symio_overrides fs =
   [ basic_llvm_override $ openFile fs
   , basic_llvm_override $ closeFile fs

--- a/crux-llvm/src/Crux/LLVM/Overrides.hs
+++ b/crux-llvm/src/Crux/LLVM/Overrides.hs
@@ -83,7 +83,7 @@ cruxLLVMOverrides ::
   ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch
   , ?lc :: TypeContext, ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions ) =>
   Proxy# arch ->
-  [OverrideTemplate (personality sym) sym arch rtp l a]
+  [OverrideTemplate (personality sym) sym ext arch]
 cruxLLVMOverrides arch =
   [ basic_llvm_override $
         [llvmOvr| i8 @crucible_int8_t( i8* ) |]
@@ -158,7 +158,7 @@ cbmcOverrides ::
   ( IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr, wptr ~ ArchWidth arch
   , ?lc :: TypeContext, ?intrinsicsOpts :: IntrinsicsOptions, ?memOpts :: MemOptions ) =>
   Proxy# arch ->
-  [OverrideTemplate (personality sym) sym arch rtp l a]
+  [OverrideTemplate (personality sym) sym ext arch]
 cbmcOverrides arch =
   [ basic_llvm_override $
       [llvmOvr| void @__CPROVER_assume( i32 ) |]
@@ -260,7 +260,7 @@ cbmcOverrides arch =
 
 svCompOverrides ::
   (IsSymInterface sym, HasLLVMAnn sym, HasPtrWidth wptr) =>
-  [OverrideTemplate (personality sym) sym arch rtp l a]
+  [OverrideTemplate (personality sym) sym ext arch]
 svCompOverrides =
   [ basic_llvm_override $
         [llvmOvr| i64 @__VERIFIER_nondet_longlong() |]

--- a/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Polymorphic.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Polymorphic.hs
@@ -11,10 +11,7 @@ Stability    : provisional
 {-# LANGUAGE RankNTypes #-}
 
 module UCCrux.LLVM.Overrides.Polymorphic
-  ( PolymorphicLLVMOverride,
-    makePolymorphicLLVMOverride,
-    getPolymorphicLLVMOverride,
-    ForAllSym,
+  ( ForAllSym,
     makeForAllSym,
     getForAllSym,
     withForAllSym,
@@ -28,24 +25,11 @@ where
 {- ORMOLU_DISABLE -}
 import           Lang.Crucible.Backend (IsSymInterface)
 
-import           Lang.Crucible.LLVM.Intrinsics (OverrideTemplate)
+import           Lang.Crucible.LLVM (LLVM)
 import           Lang.Crucible.LLVM.MemModel (HasLLVMAnn)
 
 import           Crux.LLVM.Overrides (ArchOk)
 {- ORMOLU_ENABLE -}
-
--- | An LLVM override that can be registered in a Crucible override of any type.
-newtype PolymorphicLLVMOverride arch p sym =
-  PolymorphicLLVMOverride
-    { getPolymorphicLLVMOverride ::
-        forall rtp l a.
-        OverrideTemplate p sym arch rtp l a
-    }
-
-makePolymorphicLLVMOverride ::
-  (forall rtp l a. OverrideTemplate p sym arch rtp l a) ->
-  PolymorphicLLVMOverride arch p sym
-makePolymorphicLLVMOverride = PolymorphicLLVMOverride
 
 newtype ForAllSym f =
   ForAllSym
@@ -53,14 +37,14 @@ newtype ForAllSym f =
         forall p sym.
         IsSymInterface sym =>
         HasLLVMAnn sym =>
-        f p sym
+        f p sym LLVM
     }
 
 makeForAllSym ::
   (forall p sym.
    IsSymInterface sym =>
    HasLLVMAnn sym =>
-   f p sym) ->
+   f p sym LLVM) ->
   ForAllSym f
 makeForAllSym = ForAllSym
 
@@ -68,7 +52,7 @@ withForAllSym ::
   IsSymInterface sym =>
   HasLLVMAnn sym =>
   ForAllSym f ->
-  (f p sym -> r) ->
+  (f p sym LLVM -> r) ->
   r
 withForAllSym (ForAllSym f) g = g f
 
@@ -80,7 +64,7 @@ newtype ForAllSymArch f =
         HasLLVMAnn sym =>
         ArchOk arch =>
         proxy arch ->
-        f arch p sym
+        f p sym LLVM arch
     }
 
 makeForAllSymArch ::
@@ -89,7 +73,7 @@ makeForAllSymArch ::
    HasLLVMAnn sym =>
    ArchOk arch =>
    proxy arch ->
-   f arch p sym) ->
+   f p sym LLVM arch) ->
   ForAllSymArch f
 makeForAllSymArch = ForAllSymArch
 
@@ -99,6 +83,6 @@ withForAllSymArch ::
   ArchOk arch =>
   ForAllSymArch f ->
   proxy arch ->
-  (f arch p sym -> r) ->
+  (f p sym LLVM arch -> r) ->
   r
 withForAllSymArch (ForAllSymArch f) proxy g = g (f proxy)

--- a/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Skip.hs
+++ b/uc-crux-llvm/src/UCCrux/LLVM/Overrides/Skip.hs
@@ -57,7 +57,7 @@ import           Lang.Crucible.LLVM.Extension (LLVM)
 import           Lang.Crucible.LLVM.MemModel (HasLLVMAnn, MemImpl, MemOptions)
 import           Lang.Crucible.LLVM.Translation (ModuleTranslation, transContext, llvmTypeCtx)
 import           Lang.Crucible.LLVM.TypeContext (TypeContext)
-import           Lang.Crucible.LLVM.Intrinsics (LLVMOverride(..), basic_llvm_override)
+import           Lang.Crucible.LLVM.Intrinsics (LLVMOverride(..), OverrideTemplate, basic_llvm_override)
 
 import           Crux.Types (OverM)
 
@@ -74,7 +74,6 @@ import qualified UCCrux.LLVM.FullType.FuncSig as FS
 import           UCCrux.LLVM.FullType.Type (MapToCrucibleType)
 import qualified UCCrux.LLVM.FullType.VarArgs as VA
 import           UCCrux.LLVM.Module (FuncSymbol, funcSymbol, makeFuncSymbol, isDebug, funcSymbolToString)
-import           UCCrux.LLVM.Overrides.Polymorphic (PolymorphicLLVMOverride, makePolymorphicLLVMOverride)
 import           UCCrux.LLVM.Postcondition.Apply (applyPostcond)
 import qualified UCCrux.LLVM.Postcondition.Type as Post
 import           UCCrux.LLVM.Postcondition.Type (UPostcond)
@@ -114,7 +113,7 @@ unsoundSkipOverrides ::
   -- variables)
   Map (FuncSymbol m) (UPostcond m) ->
   [L.Declare] ->
-  OverM personality sym LLVM [PolymorphicLLVMOverride arch (personality sym) sym]
+  OverM personality sym LLVM [OverrideTemplate (personality sym) sym LLVM arch]
 unsoundSkipOverrides modCtx bak mtrans usedRef annotationRef postconds decls =
   do
     let llvmCtx = mtrans ^. transContext
@@ -165,7 +164,7 @@ mkOverride ::
     MemImpl sym ->
     Ctx.Assignment (Crucible.RegEntry sym) (MapToCrucibleType arch args) ->
     IO (Crucible.RegValue sym (FS.ReturnTypeToCrucibleType arch mft), MemImpl sym)) ->
-  PolymorphicLLVMOverride arch (personality sym) sym
+  OverrideTemplate (personality sym) sym LLVM arch
 mkOverride modCtx _proxy funcSymb impl =
   -- There's a lot of duplication here because the case over whether or not the
   -- function is varargs can't be pushed further down; doing so causes "type is
@@ -174,29 +173,27 @@ mkOverride modCtx _proxy funcSymb impl =
     Some fs@(FuncSigRepr VA.IsVarArgsRepr argFTys retTy) ->
       case assignmentToCrucibleType modCtx argFTys of
         SomeAssign' argTys Refl _ ->
-          makePolymorphicLLVMOverride $
-            basic_llvm_override $
-              LLVMOverride
-                { llvmOverride_declare = decl,
-                  llvmOverride_args = argTys Ctx.:> CTy.VectorRepr CTy.AnyRepr,
-                  llvmOverride_ret = toCrucibleReturnType modCtx retTy,
-                  llvmOverride_def =
-                    \mvar (args Ctx.:> _) ->
-                      Override.modifyGlobal mvar (\mem -> liftIO (impl fs mem args))
-                }
+          basic_llvm_override $
+            LLVMOverride
+              { llvmOverride_declare = decl,
+                llvmOverride_args = argTys Ctx.:> CTy.VectorRepr CTy.AnyRepr,
+                llvmOverride_ret = toCrucibleReturnType modCtx retTy,
+                llvmOverride_def =
+                  \mvar (args Ctx.:> _) ->
+                    Override.modifyGlobal mvar (\mem -> liftIO (impl fs mem args))
+              }
     Some fs@(FuncSigRepr VA.NotVarArgsRepr argFTys retTy) ->
       case assignmentToCrucibleType modCtx argFTys of
         SomeAssign' argTys Refl _ ->
-          makePolymorphicLLVMOverride $
-            basic_llvm_override $
-              LLVMOverride
-                { llvmOverride_declare = decl,
-                  llvmOverride_args = argTys,
-                  llvmOverride_ret = toCrucibleReturnType modCtx retTy,
-                  llvmOverride_def =
-                    \mvar args ->
-                      Override.modifyGlobal mvar (\mem -> liftIO (impl fs mem args))
-                }
+          basic_llvm_override $
+            LLVMOverride
+              { llvmOverride_declare = decl,
+                llvmOverride_args = argTys,
+                llvmOverride_ret = toCrucibleReturnType modCtx retTy,
+                llvmOverride_def =
+                  \mvar args ->
+                    Override.modifyGlobal mvar (\mem -> liftIO (impl fs mem args))
+              }
   where decl = modCtx ^. moduleDecls . funcSymbol funcSymb
 
 
@@ -226,7 +223,7 @@ createSkipOverride ::
   UPostcond m ->
   -- | Function to be overridden
   FuncSymbol m ->
-  PolymorphicLLVMOverride arch (personality sym) sym
+  OverrideTemplate (personality sym) sym LLVM arch
 createSkipOverride modCtx bak usedRef annotationRef postcond funcSymb =
   mkOverride modCtx (Just bak) funcSymb $
     \fs mem args ->


### PR DESCRIPTION
Figuring out whether a given override should apply to a given `define`
or `declare` in an LLVM module is not as easy as seeing if their names
match. For some C++ overrides, for example, checking if the override
should apply requires demangling the function name, which is an
expensive proposition.

For this reason, override matching happens in two "phases" in
Crucible-LLVM: first, there is an initial, fast, string-based
`TemplateMatcher` that is used to filter out overrides that definitely
*don't* apply. Then, if any remain, there is a second phase that
inspects the declaration in more detail to see if the override matches.

Previously, this second phase consisted of a `RegOverrideM` (i.e.,
`OverrideSim`) action that would actually perform the registration.
This is unnecessarily flexible. The second phase is only really supposed
to perform the inspection of the declaration, construct an override, and
register it. Therefore, it's been replaced by a pure function that
returns a `Maybe (SomeLLVMOverride ...)`, which can then be registered
by client code, if desired.

This more restrictive type should help clarify the intent of the
override matching code, and reduce the potential for superfluous use
of `OverrideSim` effects.
