### PR TITLE
`crucible-llvm`: Add integer-related `llvm.vector.reduce.*` intrinsics

### DIFF
--- a/crucible-llvm/CHANGELOG.md
+++ b/crucible-llvm/CHANGELOG.md
@@ -17,6 +17,7 @@
 * The `llvmOverride_def` field of `LLVMOverride` no longer takes a `bak`
   argument. To retrieve the current symbolic backend, use
   `Lang.Crucible.Simulator.OverrideSim.ovrWithBackend`.
+* Add overrides for integer-related `llvm.vector.reduce.*` intrinsics.
 
 # 0.6 -- 2024-02-05
 

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics.hs
@@ -179,6 +179,7 @@ declare_overrides =
   [ map (\(SomeLLVMOverride ov) -> basic_llvm_override ov) Libc.libc_overrides
   , map (\(SomeLLVMOverride ov) -> basic_llvm_override ov) LLVM.basic_llvm_overrides
   , map (\(pfx, LLVM.Poly1LLVMOverride ov) -> polymorphic1_llvm_override pfx ov) LLVM.poly1_llvm_overrides
+  , map (\(pfx, LLVM.Poly1VecLLVMOverride ov) -> polymorphic1_vec_llvm_override pfx ov) LLVM.poly1_vec_llvm_overrides
 
   -- C++ standard library functions
   , [ Libcxx.register_cpp_override Libcxx.endlOverride ]

--- a/crucible-llvm/src/Lang/Crucible/LLVM/QQ.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/QQ.hs
@@ -118,6 +118,12 @@ parseSeqType start end cnstr =
      void $ AT.char end
      return $! cnstr n tp
 
+parseVectorType :: AT.Parser QQType
+parseVectorType = parseSeqType '<' '>' QQVector
+
+parseArrayType :: AT.Parser QQType
+parseArrayType = parseSeqType '[' ']' QQArray
+
 parseCommaSeparatedTypes :: AT.Parser [QQType]
 parseCommaSeparatedTypes = AT.choice
   [ do AT.skipSpace
@@ -173,8 +179,8 @@ parseIntVar = T.unpack <$> (AT.char '#' *> AT.takeWhile1 varChar)
 parseType :: AT.Parser QQType
 parseType =
   do base <- AT.choice
-             [ parseSeqType '<' '>' QQVector
-             , parseSeqType '[' ']' QQArray
+             [ parseVectorType
+             , parseArrayType
              , parseStructType
              , parsePackedStructType
              , QQVar <$> parseVar

--- a/crux-llvm/test-data/golden/T1177.c
+++ b/crux-llvm/test-data/golden/T1177.c
@@ -1,0 +1,94 @@
+// A regression test for #1177. With Clang 12.0.0 or later, the `reduce_*`
+// functions below will compile to uses of `llvm.vector.reduce.*` intrinsics
+// with -O2, so this test checks that crucible-llvm's semantics for each of the
+// `llvm.vector.reduce.*` intrinsics behave as expected.
+#include <crucible.h>
+#include <stddef.h>
+#include <stdint.h>
+
+uint32_t add(uint32_t x, uint32_t y) {
+  return x + y;
+}
+
+uint32_t mul(uint32_t x, uint32_t y) {
+  return x * y;
+}
+
+uint32_t and(uint32_t x, uint32_t y) {
+  return x & y;
+}
+
+uint32_t or(uint32_t x, uint32_t y) {
+  return x | y;
+}
+
+uint32_t xor(uint32_t x, uint32_t y) {
+  return x ^ y;
+}
+
+uint32_t umin(uint32_t x, uint32_t y) {
+  return (x < y) ? x : y;
+}
+
+uint32_t umax(uint32_t x, uint32_t y) {
+  return (x > y) ? x : y;
+}
+
+#define REDUCE_OP_UNSIGNED(op, identity)                                        \
+uint32_t __attribute__((noinline)) reduce_##op(const uint8_t* in, size_t len) { \
+  uint32_t x = identity;                                                        \
+                                                                                \
+  for (size_t i = 0; i < len; i++) {                                            \
+    x = op(x, in[i]);                                                           \
+  }                                                                             \
+                                                                                \
+  return x;                                                                     \
+}
+
+REDUCE_OP_UNSIGNED(add, 0)
+REDUCE_OP_UNSIGNED(mul, 1)
+REDUCE_OP_UNSIGNED(and, -1)
+REDUCE_OP_UNSIGNED(or, 0)
+REDUCE_OP_UNSIGNED(xor, 0)
+REDUCE_OP_UNSIGNED(umin, UINT32_MAX)
+REDUCE_OP_UNSIGNED(umax, 0)
+
+int32_t smin(int32_t x, int32_t y) {
+  return (x < y) ? x : y;
+}
+
+int32_t smax(int32_t x, int32_t y) {
+  return (x > y) ? x : y;
+}
+
+#define REDUCE_OP_SIGNED(op, identity)                                        \
+int32_t __attribute__((noinline)) reduce_##op(const int8_t* in, size_t len) { \
+  int32_t x = identity;                                                       \
+                                                                              \
+  for (size_t i = 0; i < len; i++) {                                          \
+    x = op(x, in[i]);                                                         \
+  }                                                                           \
+                                                                              \
+  return x;                                                                   \
+}
+
+REDUCE_OP_SIGNED(smin, INT32_MAX)
+REDUCE_OP_SIGNED(smax, INT32_MIN)
+
+int main(void) {
+  const uint8_t unsigned_in1[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+  const uint8_t unsigned_in2[8] = {1, 2, 3, 4, 5, 6, 7, 8};
+  const uint8_t unsigned_in3[8] = {5, 5, 5, 5, 4, 5, 5, 5};
+  check(reduce_add(unsigned_in1, 8) == 28);
+  check(reduce_mul(unsigned_in2, 8) == 40320);
+  check(reduce_and(unsigned_in3, 8) == 4);
+  check(reduce_or(unsigned_in2, 8) == 15);
+  check(reduce_xor(unsigned_in2, 8) == 8);
+  check(reduce_umin(unsigned_in3, 8) == 4);
+  check(reduce_umax(unsigned_in1, 8) == 7);
+
+  const int8_t signed_in[8] = {-3, -2, -1, 0, 1, 2, 3, 4};
+  check(reduce_smin(signed_in, 8) == -3);
+  check(reduce_smax(signed_in, 8) == 4);
+  return 0;
+}

--- a/crux-llvm/test-data/golden/T1177.config
+++ b/crux-llvm/test-data/golden/T1177.config
@@ -1,0 +1,1 @@
+opt-level: 2

--- a/crux-llvm/test-data/golden/T1177.z3.good
+++ b/crux-llvm/test-data/golden/T1177.z3.good
@@ -1,0 +1,1 @@
+[Crux] Overall status: Valid.


### PR DESCRIPTION
This patch:

* Adds the ability to register polymorphic LLVM overrides involving vector types. (Previously, the polymorphic LLVM machinery was able to handle overrides that vary over a single integer type, but they did not handle vector types with varying sizes.)
* Adds polymorphic overrides for all of the integer-related `llvm.vector.reduce.*` intrinsics, which work over any vector or integer size.
* Adds a `T1177.c` test case to the `crux-llvm` test suite which provides some assurance that the `crucible-llvm` semantics work as expected.

Fixes https://github.com/GaloisInc/crucible/issues/1177.