### PR TITLE
Export bindLLVMFunPtr

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/Functions.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Functions.hs
@@ -49,6 +49,7 @@ module Lang.Crucible.LLVM.Functions
   , allocLLVMFunPtr
   , allocLLVMFunPtrs
   , registerFunPtr
+  , bindLLVMFunPtr
   , bindLLVMHandle
   , bindLLVMCFG
   , bindLLVMFunc


### PR DESCRIPTION
PR #1198 moved `bindLLVMFunPtr` to `Lang.Crucible.LLVM.Functions`, but it did not export it publicly. This function is used by SAW, so it would be nice to continue to offer it as part of the public API.