### PR TITLE
`crucible-llvm`: Skip `llvm.experimental.noalias.scope.decl` and `llvm.dbg.assign`

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Instruction.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Instruction.hs
@@ -1942,6 +1942,8 @@ callFunction defSet instr tailCall_ fnTy fn args assign_f
                  , "llvm.dbg.declare"
                  , "llvm.dbg.addr"
                  , "llvm.dbg.value"
+                 , "llvm.dbg.assign" -- Added in LLVM 16
+                 , "llvm.experimental.noalias.scope.decl" -- Added in LLVM 12
                  , "llvm.lifetime.start"
                  , "llvm.lifetime.start.p0"
                  , "llvm.lifetime.start.p0i8"

--- a/crux-llvm/test-data/golden/T1196.c
+++ b/crux-llvm/test-data/golden/T1196.c
@@ -1,0 +1,14 @@
+void foo(int* restrict p0, int* restrict p1) {
+	*p0 = *p1;
+}
+
+__attribute__((noinline)) void test_inline_foo(int* p0, int* p1) {
+	foo(p0, p1);
+}
+
+int main(void) {
+    int p0 = 0;
+    int p1 = 1;
+    test_inline_foo(&p0, &p1);
+    return 0;
+}

--- a/crux-llvm/test-data/golden/T1196.z3.good
+++ b/crux-llvm/test-data/golden/T1196.z3.good
@@ -1,0 +1,1 @@
+[Crux] Overall status: Valid.

--- a/crux-llvm/test-data/golden/T1204.c
+++ b/crux-llvm/test-data/golden/T1204.c
@@ -1,0 +1,8 @@
+__attribute__((noinline)) int foo(int x[2]) {
+  return x[0];
+}
+
+int main(void) {
+  int x[2] = { 0, 0 };
+  return foo(x);
+}

--- a/crux-llvm/test-data/golden/T1204.z3.good
+++ b/crux-llvm/test-data/golden/T1204.z3.good
@@ -1,0 +1,1 @@
+[Crux] Overall status: Valid.


### PR DESCRIPTION
This adds `llvm.experimental.noalias.scope.decl` and `llvm.dbg.assign` to the list of LLVM intrinsics that `crucible-llvm` skips over during simulation. Doing so unlocks more support for recent LLVM versions.

It is conceivable that we may want to reason about these intrinsics at a deeper level some day. If so, see:

* https://github.com/GaloisInc/crucible/issues/1196#issuecomment-2129665566 for how this would be done for `llvm.experimental.noalias.scope.decl`
* https://github.com/GaloisInc/crucible/issues/1204#issue-2315526875 for how this would be done for `llvm.dbg.assign`

Fixes #1196. Fixes #1204.