### PR TITLE
Make `cabal sdist` work for `crucible-cli{,-llvm}`

### DIFF
--- a/.github/workflows/crucible-go-build.yml
+++ b/.github/workflows/crucible-go-build.yml
@@ -112,6 +112,9 @@ jobs:
       - name: Configure
         shell: bash
         run: .github/ci.sh configure crux-go
+      - name: Generate source distribution
+        shell: bash
+        run: cabal sdist crucible-go
       - name: Build
         shell: bash
         run: .github/ci.sh build exe:crux-go

--- a/.github/workflows/crucible-jvm-build.yml
+++ b/.github/workflows/crucible-jvm-build.yml
@@ -112,6 +112,9 @@ jobs:
       - name: Configure
         shell: bash
         run: .github/ci.sh configure crucible-jvm
+      - name: Generate source distribution
+        shell: bash
+        run: cabal sdist crucible-jvm
       - name: Build
         shell: bash
         run: .github/ci.sh build exe:crucible-jvm

--- a/.github/workflows/crucible-wasm-build.yml
+++ b/.github/workflows/crucible-wasm-build.yml
@@ -112,6 +112,9 @@ jobs:
       - name: Configure
         shell: bash
         run: .github/ci.sh configure crucible-wasm
+      - name: Generate source distribution
+        shell: bash
+        run: cabal sdist crucible-wasm
       - name: Build
         shell: bash
         run: .github/ci.sh build exe:crucible-wasm

--- a/.github/workflows/crux-llvm-build.yml
+++ b/.github/workflows/crux-llvm-build.yml
@@ -161,6 +161,10 @@ jobs:
       - shell: bash
         run: .github/ci.sh configure
 
+      - name: Generate source distributions
+        shell: bash
+        run: cabal sdist crucible-symio crucible-llvm crucible-llvm-syntax crux-llvm uc-crux-llvm crucible-cli crucible-llvm-cli
+
       - shell: bash
         run: |
           .github/ci.sh build exe:crucible

--- a/.github/workflows/crux-mir-build.yml
+++ b/.github/workflows/crux-mir-build.yml
@@ -162,6 +162,10 @@ jobs:
       - shell: bash
         run: .github/ci.sh configure
 
+      - name: Generate source distributions
+        shell: bash
+        run: cabal sdist crucible-syntax crucible-concurrency crucible-mir crux-mir
+
       - shell: bash
         run: .github/ci.sh build exe:crux-mir
 

--- a/crucible-cli/crucible-cli.cabal
+++ b/crucible-cli/crucible-cli.cabal
@@ -1,4 +1,4 @@
-Cabal-version: 2.2
+Cabal-version: 2.4
 Name:          crucible-cli
 Version:       0.1
 Author:        Galois Inc.
@@ -10,7 +10,7 @@ Category:      Language
 Synopsis:      A library for sharing code between Crucible CLI frontends
 -- Description:
 
-extra-doc-files: CHANGELOG.md, README.md
+extra-doc-files: CHANGELOG.md
 extra-source-files:
   test-data/**/*.cbl
   test-data/**/*.out.good

--- a/crucible-llvm-cli/crucible-llvm-cli.cabal
+++ b/crucible-llvm-cli/crucible-llvm-cli.cabal
@@ -10,7 +10,7 @@ Category:      Language
 Synopsis:      A Crucible CLI frontend for the LLVM language extension
 -- Description:
 
-extra-doc-files: CHANGELOG.md, README.md
+extra-doc-files: CHANGELOG.md
 extra-source-files:
   test-data/*.cbl
   test-data/*.out.good


### PR DESCRIPTION
* Neither package's `.cabal` file contains a `README.md` file, so remove mention of this file name from the `extra-doc-files`.

* `crucible-cli.cabal` uses double-star syntax (`test-data/**/*.cbl`) in its `extra-source-files`, which requires a `cabal-version` or `2.4` or greater. Make sure that `crucible-cli.cabal` properly declares this version dependency.

Fixes #1209.