### PR TITLE
Use `Seq` instead of lists when concretizing `SymSequence`

### DIFF
--- a/crucible/CHANGELOG.md
+++ b/crucible/CHANGELOG.md
@@ -1,3 +1,7 @@
+# next
+
+* Deprecate `concreteizeSymSequence` in favor of `concretizeSymSequence`
+
 # 0.7 -- 2024-02-05
 
 * Add `TypedOverride`, `SomeTypedOverride`, and `runTypedOverride` to


### PR DESCRIPTION
To avoid the slow `++`. Fixes #1212.