### PR TITLE
`crucible-llvm`: Improve error messages in a few pointer-to-bitvector casts

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Cast.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Cast.hs
@@ -99,7 +99,9 @@ castLLVMArgs fnm bak (rest' Ctx.:> tp') (rest Ctx.:> tp) =
                     pure (xs' Ctx.:> RegEntry tp' x')))
 castLLVMArgs _ _ _ _ = Left MismatchedShape
 
--- | Assert that the given LLVM pointer value is actually a raw bitvector and extract its value.
+-- | Assert that a pointer is actually a raw bitvector and extract its value.
+--
+-- Like 'projectLLVM_bv', but with a more specific error message.
 ptrToBv ::
   IsSymBackend sym bak =>
   -- | Only used in error messages

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Common.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Common.hs
@@ -155,14 +155,14 @@ build_llvm_override ::
 build_llvm_override fnm args ret args' ret' llvmOverride =
   ovrWithBackend $ \bak ->
   do fargs <-
-       case Cast.castLLVMArgs bak args args' of
+       case Cast.castLLVMArgs fnm bak args args' of
          Left err ->
            panic "Intrinsics.build_llvm_override"
              (Cast.printValCastError err ++
                [ "in function: " ++ Text.unpack (functionName fnm) ])
          Right f -> pure f
      fret <-
-       case Cast.castLLVMRet bak ret ret' of
+       case Cast.castLLVMRet fnm bak ret ret' of
          Left err ->
            panic "Intrinsics.build_llvm_override"
              (Cast.printValCastError err ++

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libc.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libc.hs
@@ -689,8 +689,12 @@ printfOps bak valist =
 
   , printfGetInteger = \i sgn _len ->
      case valist V.!? (i-1) of
-       Just (AnyValue (LLVMPointerRepr w) x) ->
-         do bv <- liftIO (projectLLVM_bv bak x)
+       Just (AnyValue (LLVMPointerRepr w) (LLVMPointer blk bv)) ->
+         do isBv <- liftIO (natEq sym blk =<< natLit sym 0)
+            liftIO $ assert bak isBv $
+              AssertFailureSimError
+               "Passed a pointer to printf where a bitvector was expected"
+               ""
             if sgn then
               return $ BV.asSigned w <$> asBV bv
             else

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
@@ -1136,7 +1136,7 @@ strLen bak mem = go (BV.zero PtrWidth) (truePred sym)
         do ast <- impliesPred sym cond loadok
            assert bak ast $ AssertFailureSimError "Error during memory load: strlen" ""
            v <- unpackMemValue sym (LLVMPointerRepr (knownNat @8)) llvmval
-           let err = AssertFailureSimError "Found pointer in string passed to `strlen`" ""
+           let err = AssertFailureSimError "Found pointer instead of byte in string passed to `strlen`" ""
            test <- bvIsNonzero sym =<< Partial.ptrToBv bak err v
            iteM bvIte sym
              test
@@ -1172,7 +1172,7 @@ loadString bak mem = go id
   go f _ (Just 0) = return $ f []
   go f p maxChars = do
      v <- doLoad bak mem p (bitvectorType 1) (LLVMPointerRepr (knownNat :: NatRepr 8)) noAlignment
-     let err = AssertFailureSimError "Found pointer when loading string" ""
+     let err = AssertFailureSimError "Found pointer instead of byte when loading string" ""
      x <- Partial.ptrToBv bak err v
      case BV.asUnsigned <$> asBV x of
        Just 0 -> return $ f []

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
@@ -59,6 +59,7 @@ module Lang.Crucible.LLVM.MemModel
   , G.ppPtr
   , G.ppTermExpr
   , llvmPointer_bv
+  , Partial.ptrToBv
   , Partial.projectLLVM_bv
 
     -- * Memory operations


### PR DESCRIPTION
Also, discourage the use of `projectLLVM_bv`, which provides an unhelpful, generic message when its assertion fails. Provide `ptrToBv`, an alternative that takes an error message as an argument.