### PR TITLE
llvm: Introduce predicate-building helpers `ptrSameAlloc` and `ptrIsBv`

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libc.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/Libc.hs
@@ -64,6 +64,7 @@ import           Lang.Crucible.LLVM.MemModel.CallStack (CallStack)
 import qualified Lang.Crucible.LLVM.MemModel.Type as G
 import qualified Lang.Crucible.LLVM.MemModel.Generic as G
 import           Lang.Crucible.LLVM.MemModel.Partial
+import qualified Lang.Crucible.LLVM.MemModel.Pointer as Ptr
 import           Lang.Crucible.LLVM.Printf
 import           Lang.Crucible.LLVM.QQ( llvmOvr )
 import           Lang.Crucible.LLVM.TypeContext
@@ -689,8 +690,8 @@ printfOps bak valist =
 
   , printfGetInteger = \i sgn _len ->
      case valist V.!? (i-1) of
-       Just (AnyValue (LLVMPointerRepr w) (LLVMPointer blk bv)) ->
-         do isBv <- liftIO (natEq sym blk =<< natLit sym 0)
+       Just (AnyValue (LLVMPointerRepr w) p@(LLVMPointer _blk bv)) ->
+         do isBv <- liftIO (Ptr.ptrIsBv sym p)
             liftIO $ assert bak isBv $
               AssertFailureSimError
                "Passed a pointer to printf where a bitvector was expected"

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Partial.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Partial.hs
@@ -92,7 +92,7 @@ import           Lang.Crucible.LLVM.Bytes (Bytes)
 import qualified Lang.Crucible.LLVM.Bytes as Bytes
 import           Lang.Crucible.LLVM.MemModel.MemLog (memState)
 import           Lang.Crucible.LLVM.MemModel.CallStack (CallStack, getCallStack)
-import           Lang.Crucible.LLVM.MemModel.Pointer ( pattern LLVMPointer, LLVMPtr )
+import           Lang.Crucible.LLVM.MemModel.Pointer ( pattern LLVMPointer, LLVMPtr, ptrIsBv )
 import           Lang.Crucible.LLVM.MemModel.Type (StorageType(..), StorageTypeF(..), Field(..))
 import qualified Lang.Crucible.LLVM.MemModel.Type as Type
 import           Lang.Crucible.LLVM.MemModel.Value (LLVMVal(..))
@@ -272,10 +272,10 @@ ptrToBv ::
   SimErrorReason ->
   LLVMPtr sym w ->
   IO (SymBV sym w)
-ptrToBv bak err (LLVMPointer blk bv) =
+ptrToBv bak err p@(LLVMPointer _blk bv) =
   do let sym = backendGetSym bak
-     p <- natEq sym blk =<< natLit sym 0
-     assert bak p err
+     isBv <- ptrIsBv sym p
+     assert bak isBv err
      return bv
 
 -- | Assert that the given LLVM pointer value is actually a raw bitvector and extract its value.

--- a/crucible-llvm/src/Lang/Crucible/LLVM/SimpleLoopInvariant.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/SimpleLoopInvariant.hs
@@ -518,7 +518,7 @@ safeBVLoad sym mem ptr st def align =
        C.Err _ -> return def
        C.NoErr p v ->
          do v' <- C.unpackMemValue sym (C.LLVMPointerRepr w) v
-            p0 <- W4.natEq sym (C.llvmPointerBlock v') =<< W4.natLit sym 0
+            p0 <- C.ptrIsBv sym v'
             p' <- W4.andPred sym p p0
             W4.bvIte sym p' (C.llvmPointerOffset v') def
 


### PR DESCRIPTION
These functions raise the level of the abstraction of code that manipulates LLVM pointers, focusing less on the representation of pointers and more on the condition to be tested.