### PR TITLE
CI: Consistently use `macos-14` in all workflows

### DIFF
--- a/.github/workflows/crucible-go-build.yml
+++ b/.github/workflows/crucible-go-build.yml
@@ -30,7 +30,7 @@ jobs:
         cabal: ["3.10.3.0"]
         ghc: ["9.4.8", "9.6.5", "9.8.2"]
         include:
-          - os: macos-12
+          - os: macos-14
             cabal: 3.10.3.0
             ghc: 9.8.2
           - os: windows-2019

--- a/.github/workflows/crucible-jvm-build.yml
+++ b/.github/workflows/crucible-jvm-build.yml
@@ -30,7 +30,7 @@ jobs:
         cabal: ["3.10.3.0"]
         ghc: ["9.4.8", "9.6.5", "9.8.2"]
         include:
-          - os: macos-12
+          - os: macos-14
             cabal: 3.10.3.0
             ghc: 9.8.2
           - os: windows-2019

--- a/.github/workflows/crucible-wasm-build.yml
+++ b/.github/workflows/crucible-wasm-build.yml
@@ -30,7 +30,7 @@ jobs:
         cabal: ["3.10.3.0"]
         ghc: ["9.4.8", "9.6.5", "9.8.2"]
         include:
-          - os: macos-12
+          - os: macos-14
             cabal: 3.10.3.0
             ghc: 9.8.2
           - os: windows-2019


### PR DESCRIPTION
The `crux-llvm` and `crux-mir` CI workflows were using `macos-14` (i.e., ARM64), but the remaining workflows (`crucible-go`, `crucible-jvm`, and `crucible-wasm`) were using `macos-12` (i.e., X64). This updates the latter ones to use `macos-14` so that we are consistent.