### PR TITLE
Rearrange the handling of constant slices.

### DIFF
--- a/crucible-mir/src/Mir/Generator.hs
+++ b/crucible-mir/src/Mir/Generator.hs
@@ -167,7 +167,7 @@ data PtrMetadata s =
 
 instance Show (PtrMetadata s) where
     show NoMeta = "NoMeta"
-    show (SliceMeta _) = "SliceMeta"
+    show (SliceMeta len) = "SliceMeta " ++ show len
 
 ---------------------------------------------------------------------------------
 

--- a/crucible-mir/src/Mir/Generator.hs
+++ b/crucible-mir/src/Mir/Generator.hs
@@ -164,10 +164,7 @@ data MirPlace s where
 data PtrMetadata s =
       NoMeta
     | SliceMeta (R.Expr MIR s UsizeType)
-
-instance Show (PtrMetadata s) where
-    show NoMeta = "NoMeta"
-    show (SliceMeta len) = "SliceMeta " ++ show len
+  deriving Show
 
 ---------------------------------------------------------------------------------
 

--- a/crucible-mir/src/Mir/JSON.hs
+++ b/crucible-mir/src/Mir/JSON.hs
@@ -495,11 +495,6 @@ instance FromJSON ConstVal where
             len <- v.: "len"
             return $ ConstSliceRef def_id len
 
-        Just (String "str") -> do
-            def_id <- v .: "def_id"
-            len <- v.: "len"
-            return $ ConstStrRef def_id len
-
         Just (String "strbody") -> do
             elements <- v .: "elements"
             let f sci = case Scientific.toBoundedInteger sci of

--- a/crucible-mir/src/Mir/JSON.hs
+++ b/crucible-mir/src/Mir/JSON.hs
@@ -495,8 +495,9 @@ instance FromJSON ConstVal where
             len <- v.: "len"
             return $ ConstSliceRef def_id len
 
+        -- FUTURE: this is the same as "array" and can be removed
         Just (String "slicebody") ->
-            ConstSliceBody <$> v .: "elements"
+            ConstArray <$> v .: "elements"
 
         Just (String "str") -> do
             def_id <- v .: "def_id"

--- a/crucible-mir/src/Mir/JSON.hs
+++ b/crucible-mir/src/Mir/JSON.hs
@@ -495,10 +495,6 @@ instance FromJSON ConstVal where
             len <- v.: "len"
             return $ ConstSliceRef def_id len
 
-        -- FUTURE: this is the same as "array" and can be removed
-        Just (String "slicebody") ->
-            ConstArray <$> v .: "elements"
-
         Just (String "str") -> do
             def_id <- v .: "def_id"
             len <- v.: "len"

--- a/crucible-mir/src/Mir/JSON.hs
+++ b/crucible-mir/src/Mir/JSON.hs
@@ -491,23 +491,25 @@ instance FromJSON ConstVal where
             pure $ ConstFloat $ FloatLit fk (T.unpack val)
 
         Just (String "slice") -> do
-            ConstSlice <$> v .: "elements"
+            def_id <- v .: "def_id"
+            len <- v.: "len"
+            return $ ConstSliceRef def_id len
+
+        Just (String "slicebody") ->
+            ConstSliceBody <$> v .: "elements"
 
         Just (String "str") -> do
-            val <- v .: "val"
+            def_id <- v .: "def_id"
+            len <- v.: "len"
+            return $ ConstStrRef def_id len
+
+        Just (String "strbody") -> do
+            elements <- v .: "elements"
             let f sci = case Scientific.toBoundedInteger sci of
                     Just b -> pure (b :: Word8)
                     Nothing -> fail $ "cannot read " ++ show sci
-            bytes <- mapM (withScientific "byte" f) val
-            return $ ConstStr $ BS.pack bytes
-
-        Just (String "bstr") -> do
-            val <- v .: "val"
-            let f sci = case Scientific.toBoundedInteger sci of
-                    Just b -> pure (ConstInt $ U8 $ toInteger (b :: Int))
-                    Nothing -> fail $ "cannot read " ++ show sci
-            bytes <- mapM (withScientific "byte" f) val
-            return $ ConstArray $ V.toList bytes
+            bytes <- mapM (withScientific "byte" f) elements
+            return $ ConstStrBody $ BS.pack bytes
 
         Just (String "struct") ->
             ConstStruct <$> v .: "fields"

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -496,7 +496,6 @@ data FloatLit
 data ConstVal =
     ConstFloat FloatLit
   | ConstInt IntLit
-  | ConstSliceBody [ConstVal]
   | ConstSliceRef DefId Int
   | ConstStrBody B.ByteString
   | ConstStrRef DefId Int

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -498,7 +498,6 @@ data ConstVal =
   | ConstInt IntLit
   | ConstSliceRef DefId Int
   | ConstStrBody B.ByteString
-  | ConstStrRef DefId Int
   | ConstBool Bool
   | ConstChar Char
   | ConstVariant DefId

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -496,9 +496,10 @@ data FloatLit
 data ConstVal =
     ConstFloat FloatLit
   | ConstInt IntLit
-  | ConstSlice [ConstVal]
-  | ConstStr B.ByteString
-  | ConstByteStr B.ByteString
+  | ConstSliceBody [ConstVal]
+  | ConstSliceRef DefId Int
+  | ConstStrBody B.ByteString
+  | ConstStrRef DefId Int
   | ConstBool Bool
   | ConstChar Char
   | ConstVariant DefId

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -496,7 +496,11 @@ data FloatLit
 data ConstVal =
     ConstFloat FloatLit
   | ConstInt IntLit
+  -- | A reference to a static allocation for a slice (type is `&[T]` or `&str`)
+  -- The DefId can lead to either a ConstArray or a ConstStrBody.
   | ConstSliceRef DefId Int
+  -- | A string body, of type [u8]. Currently only arises from string literals,
+  -- but might in the future be used for all [u8]s.
   | ConstStrBody B.ByteString
   | ConstBool Bool
   | ConstChar Char

--- a/crucible-mir/src/Mir/PP.hs
+++ b/crucible-mir/src/Mir/PP.hs
@@ -312,8 +312,8 @@ instance Pretty Substs where
 instance Pretty ConstVal where
     pretty (ConstFloat i)   = pretty i
     pretty (ConstInt i)     = pretty i
-    pretty (ConstStr i)     = dquotes (viaShow i)
-    pretty (ConstByteStr i) = viaShow i
+    pretty (ConstStrBody i) = dquotes (viaShow i)
+    pretty (ConstStrRef a len) = pretty "&" <> pr_id a <> (viaShow len)
     pretty (ConstBool i)    = pretty i
     pretty (ConstChar i)    = pretty i
     pretty (ConstVariant i) = pr_id i
@@ -328,7 +328,8 @@ instance Pretty ConstVal where
     pretty (ConstRawPtr a) = pretty a
     pretty (ConstStruct fs) = pretty "struct" <> list (map pretty fs)
     pretty (ConstEnum v fs) = pretty "enum" <> list ((pretty "variant" <+> pretty v) : map pretty fs)
-    pretty (ConstSlice cs)  = list (map pretty cs)
+    pretty (ConstSliceBody cs)  = list (map pretty cs)
+    pretty (ConstSliceRef a len) = pretty "&" <> pr_id a <> (viaShow len)
     pretty (ConstFnPtr i)   = pretty "fn_ptr" <> brackets (pretty i)
 
 instance Pretty AggregateKind where

--- a/crucible-mir/src/Mir/PP.hs
+++ b/crucible-mir/src/Mir/PP.hs
@@ -313,7 +313,6 @@ instance Pretty ConstVal where
     pretty (ConstFloat i)   = pretty i
     pretty (ConstInt i)     = pretty i
     pretty (ConstStrBody i) = dquotes (viaShow i)
-    pretty (ConstStrRef a len) = pretty "&" <> pr_id a <> (viaShow len)
     pretty (ConstBool i)    = pretty i
     pretty (ConstChar i)    = pretty i
     pretty (ConstVariant i) = pr_id i

--- a/crucible-mir/src/Mir/PP.hs
+++ b/crucible-mir/src/Mir/PP.hs
@@ -328,7 +328,6 @@ instance Pretty ConstVal where
     pretty (ConstRawPtr a) = pretty a
     pretty (ConstStruct fs) = pretty "struct" <> list (map pretty fs)
     pretty (ConstEnum v fs) = pretty "enum" <> list ((pretty "variant" <+> pretty v) : map pretty fs)
-    pretty (ConstSliceBody cs)  = list (map pretty cs)
     pretty (ConstSliceRef a len) = pretty "&" <> pr_id a <> (viaShow len)
     pretty (ConstFnPtr i)   = pretty "fn_ptr" <> brackets (pretty i)
 

--- a/crucible-mir/src/Mir/PP.hs
+++ b/crucible-mir/src/Mir/PP.hs
@@ -327,7 +327,7 @@ instance Pretty ConstVal where
     pretty (ConstRawPtr a) = pretty a
     pretty (ConstStruct fs) = pretty "struct" <> list (map pretty fs)
     pretty (ConstEnum v fs) = pretty "enum" <> list ((pretty "variant" <+> pretty v) : map pretty fs)
-    pretty (ConstSliceRef a len) = pretty "&" <> pr_id a <> (viaShow len)
+    pretty (ConstSliceRef a _len) = pretty "&" <> pr_id a
     pretty (ConstFnPtr i)   = pretty "fn_ptr" <> brackets (pretty i)
 
 instance Pretty AggregateKind where

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -372,7 +372,7 @@ varPlace (M.Var vname _ vty _) = do
     vi <- typedVarInfo vname tpr
     r <- case vi of
         VarReference reg -> G.readReg reg
-        -- TODO: these cases won't be needed once immutabe ref support is done
+        -- TODO: these cases won't be needed once immutable ref support is done
         -- - make them report an error instead
         VarRegister reg -> do
             x <- G.readReg reg


### PR DESCRIPTION
The idea is to split the slice into a reference and a separate static allocation for the body the reference points to. This then allows us to treat the references as normal references to memory, which in turn avoids problems in SAW that arise when it goes to try to enforce disjointness.

Requires accompanying changes in mir-json that produce the new output we read. (These are in [mir-json #73](https://github.com/GaloisInc/mir-json/pull/73).)

See [saw-script #2064](https://github.com/GaloisInc/saw-script/issues/2064) for background.