### PR TITLE
CI: Switch from LLVM 12 to 14

### DIFF
--- a/.github/Dockerfile-crux-llvm
+++ b/.github/Dockerfile-crux-llvm
@@ -7,6 +7,10 @@ RUN apt-get update && \
       # Crux dependencies \
       pkg-config zlib1g-dev \
       # LLVM toolchain
+      #
+      # If you update the version numbers below, make sure to update the
+      # value of LINUX_LLVM_VER in .github/ci.sh (in the install_llvm()
+      # function).
       clang-14 llvm-14-tools \
       # Miscellaneous
       locales unzip wget

--- a/.github/Dockerfile-crux-llvm
+++ b/.github/Dockerfile-crux-llvm
@@ -7,7 +7,7 @@ RUN apt-get update && \
       # Crux dependencies \
       pkg-config zlib1g-dev \
       # LLVM toolchain
-      clang-12 llvm-12-tools \
+      clang-14 llvm-14-tools \
       # Miscellaneous
       locales unzip wget
 RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && \
@@ -45,7 +45,7 @@ ADD crux-llvm ${DIR}/build/crux-llvm
 ADD dependencies ${DIR}/build/dependencies
 ADD .github/cabal.project.crux-llvm ${DIR}/build/cabal.project
 ADD cabal.GHC-9.4.8.config ${DIR}/build/cabal.project.freeze
-# Workaround until we have an LLVM 12 build available
+# Workaround until we have an LLVM 14 build available
 RUN cp $DIR/build/crux-llvm/c-src/libcxx-7.1.0.bc $DIR/build/crux-llvm/c-src/libcxx-12.0.1.bc
 
 WORKDIR ${DIR}/build

--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -64,13 +64,13 @@ test() {
 
 install_llvm() {
   if [[ "$RUNNER_OS" = "Linux" ]]; then
-    sudo apt-get update -q && sudo apt-get install -y clang-12 llvm-12-tools
-    echo "LLVM_LINK=llvm-link-12" >> "$GITHUB_ENV"
-    echo "LLVM_AS=llvm-as-12" >> "$GITHUB_ENV"
-    echo "CLANG=clang-12" >> "$GITHUB_ENV"
+    sudo apt-get update -q && sudo apt-get install -y clang-14 llvm-14-tools
+    echo "LLVM_LINK=llvm-link-14" >> "$GITHUB_ENV"
+    echo "LLVM_AS=llvm-as-14" >> "$GITHUB_ENV"
+    echo "CLANG=clang-14" >> "$GITHUB_ENV"
   elif [[ "$RUNNER_OS" = "macOS" ]]; then
-    brew install llvm@12
-    echo "$(brew --prefix)/opt/llvm@12/bin" >> "$GITHUB_PATH"
+    brew install llvm@14
+    echo "$(brew --prefix)/opt/llvm@14/bin" >> "$GITHUB_PATH"
   elif [[ "$RUNNER_OS" = "Windows" ]]; then
     choco install llvm
   else

--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -64,13 +64,27 @@ test() {
 
 install_llvm() {
   if [[ "$RUNNER_OS" = "Linux" ]]; then
-    sudo apt-get update -q && sudo apt-get install -y clang-14 llvm-14-tools
-    echo "LLVM_LINK=llvm-link-14" >> "$GITHUB_ENV"
-    echo "LLVM_AS=llvm-as-14" >> "$GITHUB_ENV"
-    echo "CLANG=clang-14" >> "$GITHUB_ENV"
+    # Different Ubuntu versions include different LLVM versions in the package
+    # manager, so we select the appropriate LLVM version below.
+    #
+    # If you update the value of LINUX_LLVM_VER below, make sure to also update
+    # the corresponding LLVM version in .github/Dockerfile-crux-llvm.
+    if [[ "$BUILD_TARGET_OS" = "ubuntu-22.04" ]]; then
+      LINUX_LLVM_VER=14
+    elif [[ "$BUILD_TARGET_OS" = "ubuntu-20.04" ]]; then
+      LINUX_LLVM_VER=12
+    else
+      echo "Don't know what LLVM version to use for $LINUX_LLVM_VER."
+      exit 1
+    fi
+    sudo apt-get update -q && sudo apt-get install -y "clang-$LINUX_LLVM_VER" "llvm-$LINUX_LLVM_VER-tools"
+    echo "LLVM_LINK=llvm-link-$LINUX_LLVM_VER" >> "$GITHUB_ENV"
+    echo "LLVM_AS=llvm-as-$LINUX_LLVM_VER" >> "$GITHUB_ENV"
+    echo "CLANG=clang-$LINUX_LLVM_VER" >> "$GITHUB_ENV"
   elif [[ "$RUNNER_OS" = "macOS" ]]; then
-    brew install llvm@14
-    echo "$(brew --prefix)/opt/llvm@14/bin" >> "$GITHUB_PATH"
+    MACOS_LLVM_VER=14
+    brew install "llvm@$MACOS_LLVM_VER"
+    echo "$(brew --prefix)/opt/llvm@$MACOS_LLVM_VER/bin" >> "$GITHUB_PATH"
   elif [[ "$RUNNER_OS" = "Windows" ]]; then
     choco install llvm
   else


### PR DESCRIPTION
The primary motivation for doing so is to avoid using Homebrew's `llvm@12` package, which appears to now be broken (#1255).

Fixes #1255.