### PR TITLE
Give Docker images non-root users, give `crux-mir` image a C compiler (#1261, #1262)

### DIFF
--- a/.github/Dockerfile-crux-llvm
+++ b/.github/Dockerfile-crux-llvm
@@ -86,6 +86,7 @@ RUN cp -r c-src /usr/local/
 
 RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && \
     locale-gen
+USER crux-llvm
 ENV LD_LIBRARY_PATH=/usr/local/lib
 ENV CLANG=clang-${LLVM_VER}
 ENV LLVM_LINK=llvm-link-${LLVM_VER}

--- a/.github/Dockerfile-crux-mir
+++ b/.github/Dockerfile-crux-mir
@@ -78,7 +78,9 @@ FROM ubuntu:22.04
 USER root
 RUN apt-get update && \
     apt-get install -y \
-      libgmp10 zlib1g libcurl4
+      libgmp10 zlib1g libcurl4 \
+      # A C toolchain (needed to build crates that require a C compiler)
+      clang
 
 ARG DIR=/crux-mir
 COPY --from=mir_json /usr/local/cargo /usr/local/cargo

--- a/.github/Dockerfile-crux-mir
+++ b/.github/Dockerfile-crux-mir
@@ -89,6 +89,7 @@ RUN mkdir -p ${DIR}/workspace
 
 WORKDIR ${DIR}/workspace
 
+USER crux-mir
 ENV CARGO_HOME=/usr/local/cargo \
     RUSTUP_HOME=/usr/local/rustup \
     CRUX_RUST_LIBRARY_PATH=/crux-mir/rlibs \


### PR DESCRIPTION
A couple of minor improvements to the Docker images:

* Default to non-root users in the Docker images. Fixes #1261.
* Provide a C compiler in the `crux-mir` Docker image. Fixes #1262.