### PR TITLE
`crucible-syntax`: Allow exotic characters in fresh atom names

### DIFF
--- a/crucible-syntax/test-data/exotic-fresh-names.cbl
+++ b/crucible-syntax/test-data/exotic-fresh-names.cbl
@@ -1,0 +1,10 @@
+; A regression test for #1024.
+
+(defun @exotic-fresh-names () Bool
+  (start start:
+    ; Although the list of allowable characters in What4 solver names is very
+    ; small, we can nevertheless define atom names with unallowable characters
+    ; by Z-encoding them under the hood.
+    (let ω (fresh Bool))                ; Fancy Unicode characters
+    (let hyphens-are-fine (fresh Bool)) ; Hyphens
+    (return (and ω hyphens-are-fine))))

--- a/crucible-syntax/test-data/exotic-fresh-names.out.good
+++ b/crucible-syntax/test-data/exotic-fresh-names.out.good
@@ -1,0 +1,17 @@
+(defun @exotic-fresh-names () Bool
+   (start start:
+      (let ω (fresh Bool))
+      (let hyphens-are-fine (fresh Bool))
+      (return (and ω hyphens-are-fine))))
+
+exotic-fresh-names
+%0
+  % 8:12
+  $0 = fresh BaseBoolRepr zenc!z3c9U
+  % 9:27
+  $1 = fresh BaseBoolRepr zenc!hyphenszmarezmfine
+  % 10:13
+  $2 = and($0, $1)
+  % 10:5
+  return $2
+  % no postdom


### PR DESCRIPTION
Previously, we used `userSymbol` to create fresh atom names, but `userSymbol` will fail if given any characters outside of the very narrow range of characters allowed in What4 solver names. Instead, we now use `safeSymbol`, which will Z-encode any unallowable characters into something that is allowed in a What4 solver name. This ensures (among other things) that we can write things like `(let i-3 (fresh Bool))`, as hyphens are not allowed in What4 solver names without Z-encoding them.

Fixes #1024.