### PR TITLE
Fix `crux-mir` Docker image entrypoint

### DIFF
--- a/.github/Dockerfile-crux-mir
+++ b/.github/Dockerfile-crux-mir
@@ -92,4 +92,4 @@ ENV LANG=C.UTF-8 \
     PATH=/home/crux-mir/.cargo/bin:$PATH \
     CRUX_RUST_LIBRARY_PATH=/crux-mir/rlibs
 
-ENTRYPOINT ["/usr/local/bin/cargo", "crux-test"]
+ENTRYPOINT ["/home/crux-mir/.cargo/bin/cargo", "crux-test"]


### PR DESCRIPTION
This fixes an oversight introduced in #1265 where the location of `cargo` was moved to `/home/crux-mir/.cargo/bin/cargo` in the `crux-mir` Docker image, but the image entrypoint was not updated accordingly.

Fixes #1276.