### PR TITLE
`crucible-llvm`: Add an `LLVMValString` case for `unpackMemValue`

### DIFF
--- a/crucible-llvm/CHANGELOG.md
+++ b/crucible-llvm/CHANGELOG.md
@@ -1,3 +1,8 @@
+# next -- TBA
+
+* Fix a bug in which the memory model would panic when attempting to unpack
+  constant string literals.
+
 # 0.7 -- 2024-08-30
 
 * Add support for GHC 9.8

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
@@ -1538,6 +1538,12 @@ unpackMemValue sym (StructRepr ctx) (LLVMValStruct xs)
 unpackMemValue sym (VectorRepr tpr) (LLVMValArray _tp xs)
   = traverse (unpackMemValue sym tpr) xs
 
+-- LLVM string literals are syntactic shorthand for [<N> x i8] arrays, so we
+-- defer to the LLVMValArray case above.
+unpackMemValue sym tpr@(VectorRepr _) (LLVMValString str)
+  = do explodedVal <- explodeStringValue sym str
+       unpackMemValue sym tpr explodedVal
+
 unpackMemValue _sym ctp@(BVRepr _) lval@(LLVMValInt _ _) =
     panic "MemModel.unpackMemValue"
       [ "Cannot unpack an integer LLVM value to a crucible bitvector type"


### PR DESCRIPTION
This is largely inspired by a similar change needed for https://github.com/GaloisInc/saw-script/pull/2149.

Fixes #1304.