### PR TITLE
Add an `EqF TypeRepr` instance

### DIFF
--- a/crucible/CHANGELOG.md
+++ b/crucible/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Add support for Bitwuzla as an online SMT solver backend.
 * Add a function `ppTypeRepr` to `Lang.Crucible.Types` for pretty-printing
   `TypeRepr`s. Modify the `Pretty` instance to use this function.
+* Add an `EqF TypeRepr` instance.
 
 # 0.7.1 -- 2024-08-30
 

--- a/crucible/src/Lang/Crucible/Types.hs
+++ b/crucible/src/Lang/Crucible/Types.hs
@@ -570,6 +570,8 @@ instance TestEquality TypeRepr where
                   )
 instance Eq (TypeRepr tp) where
   x == y = isJust (testEquality x y)
+instance EqF TypeRepr where
+  eqF x y = isJust (testEquality x y)
 
 instance OrdF TypeRepr where
   compareF = $(U.structuralTypeOrd [t|TypeRepr|]


### PR DESCRIPTION
There are many more `EqF` instances that we _could_ define in `crucible`, but defining them all would likely require coming up with a solution for GaloisInc/parameterized-utils#175 first. Until then, this patch adds an `EqF` instance for `TypeRepr` in particular, which is straightforward to define without any additional functionality and addresses the needs of a downstream project.