### PR TITLE
crucible: Add a `GlobalPair` to `AbortedExit`

### DIFF
--- a/crucible-symio/tests/TestMain.hs
+++ b/crucible-symio/tests/TestMain.hs
@@ -158,7 +158,7 @@ runFSTest' bak (FSTest fsTest) = do
 showAbortedResult :: CS.AbortedResult c d -> String
 showAbortedResult ar = case ar of
   CS.AbortedExec reason _ -> show reason
-  CS.AbortedExit code -> show code
+  CS.AbortedExit code _ -> show code
   CS.AbortedBranch _ _ res' res'' -> "BRANCH: " <> showAbortedResult res' <> "\n" <> showAbortedResult res''
 
 data FSTest (wptr :: Nat)   where

--- a/crucible/CHANGELOG.md
+++ b/crucible/CHANGELOG.md
@@ -1,6 +1,7 @@
 # next
 
 * Add a `GlobalPair` argument to `AbortedExit`.
+* Add new helpers for extracting `SymGlobalState`s: `exec{Result,State}Globals`.
 
 # 0.7.2 -- 2025-03-21
 

--- a/crucible/CHANGELOG.md
+++ b/crucible/CHANGELOG.md
@@ -1,6 +1,6 @@
 # next
 
-Nothing yet.
+* Add a `GlobalPair` argument to `AbortedExit`.
 
 # 0.7.2 -- 2025-03-21
 

--- a/crucible/src/Lang/Crucible/Simulator/ExecutionTree.hs
+++ b/crucible/src/Lang/Crucible/Simulator/ExecutionTree.hs
@@ -229,9 +229,10 @@ data AbortedResult sym ext where
     !(GlobalPair sym (SimFrame sym ext l args)) ->
     AbortedResult sym ext
 
-  -- | An aborted execution that was ended by a call to 'exit'.
+  -- | An aborted execution that was ended by a call to @exit@.
   AbortedExit ::
     !ExitCode ->
+    !(GlobalPair sym (SimFrame sym ext l args)) ->
     AbortedResult sym ext
 
   -- | Two separate threads of execution aborted after a symbolic branch,
@@ -260,7 +261,9 @@ arFrames :: Simple Traversal (AbortedResult sym ext) (SomeFrame (SimFrame sym ex
 arFrames h (AbortedExec e p) =
   (\(SomeFrame f') -> AbortedExec e (p & gpValue .~ f'))
      <$> h (SomeFrame (p^.gpValue))
-arFrames _ (AbortedExit ec) = pure (AbortedExit ec)
+arFrames h (AbortedExit ec p) =
+  (\(SomeFrame f') -> AbortedExit ec (p & gpValue .~ f'))
+     <$> h (SomeFrame (p^.gpValue))
 arFrames h (AbortedBranch predicate loc r s) =
   AbortedBranch predicate loc <$> arFrames h r
                               <*> arFrames h s

--- a/crucible/src/Lang/Crucible/Simulator/Operations.hs
+++ b/crucible/src/Lang/Crucible/Simulator/Operations.hs
@@ -125,8 +125,8 @@ mergeAbortedResult ::
   AbortedResult sym ext ->
   AbortedResult sym ext ->
   AbortedResult sym ext
-mergeAbortedResult _ _ (AbortedExit ec) _ = AbortedExit ec
-mergeAbortedResult _ _ _ (AbortedExit ec) = AbortedExit ec
+mergeAbortedResult _ _ ae@(AbortedExit {}) _ = ae
+mergeAbortedResult _ _ _ ae@(AbortedExit {}) = ae
 mergeAbortedResult loc pred q r = AbortedBranch loc pred q r
 
 mergePartialAndAbortedResult ::

--- a/crucible/src/Lang/Crucible/Simulator/OverrideSim.hs
+++ b/crucible/src/Lang/Crucible/Simulator/OverrideSim.hs
@@ -156,8 +156,14 @@ newtype OverrideSim p sym ext rtp (args :: Ctx CrucibleType) (ret :: CrucibleTyp
 -- | Exit from the current execution by ignoring the continuation
 --   and immediately returning an aborted execution result.
 exitExecution :: IsSymInterface sym => ExitCode -> OverrideSim p sym ext rtp args r a
-exitExecution ec = Sim $ StateContT $ \_c s ->
-  return $ ResultState $ AbortedResult (s^.stateContext) (AbortedExit ec)
+exitExecution ec = do
+  ActiveTree _ctx ar0 <- use stateTree
+  let gp =
+        case ar0 of
+          TotalRes e -> e
+          PartialRes _loc _pred ex _ar1 -> ex
+  Sim $ StateContT $ \_c s ->
+    return $ ResultState $ AbortedResult (s^.stateContext) (AbortedExit ec gp)
 
 bindOverrideSim ::
   OverrideSim p sym ext rtp args r a ->


### PR DESCRIPTION
Of all of the constructors of `ExecState`, `ResultState` of `AbortedExit` was the only one from which one could not obtain a `SymGlobalState`. Not sure why this was, it doesn't seem necessary.

Fixes #1326.