### PR TITLE
MIR: Add custom override for `bitreverse` intrinsic

### DIFF
--- a/crucible-mir/CHANGELOG.md
+++ b/crucible-mir/CHANGELOG.md
@@ -11,6 +11,9 @@ This release supports [version
 * The Semigroup and Monoid instances for Collection, CollectionState, and
   RustModule have been removed. It is not expected that there are any
   downstream users.
+* Add a custom override for the
+  [`bitreverse`](https://doc.rust-lang.org/std/intrinsics/fn.bitreverse.html)
+  intrinsic.
 
 # 0.3 -- 2024-08-30
 

--- a/crux-mir/test/conc_eval/prim/bitreverse.rs
+++ b/crux-mir/test/conc_eval/prim/bitreverse.rs
@@ -1,0 +1,12 @@
+#[cfg_attr(crux, crux::test)]
+pub fn crux_test() -> u32 {
+    let x: u32 = 0x12345678;
+    let y: u32 = x.reverse_bits();
+    assert_eq!(y, 0x1e6a2c48);
+    assert_eq!(y.reverse_bits(), x);
+    y
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}


### PR DESCRIPTION
This contains the necessary changes needed to allow `crucible-mir` to symbolically execute the [`bitreverse`](https://doc.rust-lang.org/std/intrinsics/fn.bitreverse.html) compiler intrinsic, which in turn powers the [`reverse_bits`](https://doc.rust-lang.org/std/primitive.u32.html#method.reverse_bits) family of functions. This will form the basis of a fix for GaloisInc/saw-script#2257.