### PR TITLE
CI: copy the crux-mir rlibs tree with tar

### DIFF
--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -158,7 +158,14 @@ bundle_crux_mir_files() {
   setup_dist
   extract_exe crux-mir dist/bin
   cp crux-mir/README.md dist/doc
-  cp -r crux-mir/rlibs dist
+  # rlibs is a symlink into rlibs_real; we can't just copy the symlink
+  # though because (currently at least) it's an absolute path that
+  # won't work in the output artefact.
+  #
+  # Use tar to copy (not cp -r, which isn't very safe) and descend
+  # into rlibs explicitly first as a cheap way to follow that symlink.
+  mkdir dist/rlibs
+  (cd crux-mir/rlibs && tar -cf - .) | (cd dist/rlibs && tar -xvf -)
   # It's less fragile to have users install mir-json themselves
   # (cd dependencies/mir-json && cargo install --locked --force --root ../../dist)
   VERSION=${VERSION:-$DATE}


### PR DESCRIPTION
Pull #1339 onto the 0.10 release branch and fixes #1338 there.