### PR TITLE
`crux-llvm`: Bump release version to 0.10, development version to `0.10.0.0.99`

### DIFF
--- a/crux-llvm/CHANGELOG.md
+++ b/crux-llvm/CHANGELOG.md
@@ -1,3 +1,7 @@
+# next
+
+Nothing yet.
+
 # 0.10 -- 2025-03-24
 
 * Sync the version number with `crux-mir-0.10` as part of the overall Crux 0.10

--- a/crux-llvm/CHANGELOG.md
+++ b/crux-llvm/CHANGELOG.md
@@ -1,6 +1,7 @@
-# next
+# 0.10 -- 2025-03-24
 
-Nothing yet.
+* Sync the version number with `crux-mir-0.10` as part of the overall Crux 0.10
+  release.
 
 # 0.9.1 -- 2025-03-21
 

--- a/crux-llvm/crux-llvm.cabal
+++ b/crux-llvm/crux-llvm.cabal
@@ -1,6 +1,6 @@
 Cabal-version: 2.2
 Name:          crux-llvm
-Version:       0.9.1.0.99
+Version:       0.10
 Author:        Galois Inc.
 Maintainer:    rscott@galois.com, kquick@galois.com, langston@galois.com
 Copyright:     (c) Galois, Inc 2014-2022

--- a/crux-llvm/crux-llvm.cabal
+++ b/crux-llvm/crux-llvm.cabal
@@ -1,6 +1,6 @@
 Cabal-version: 2.2
 Name:          crux-llvm
-Version:       0.10
+Version:       0.10.0.0.99
 Author:        Galois Inc.
 Maintainer:    rscott@galois.com, kquick@galois.com, langston@galois.com
 Copyright:     (c) Galois, Inc 2014-2022


### PR DESCRIPTION
One part of a fix for #1340.