### PR TITLE
`{crucible,crux}-llvm`: Fix lower version bounds in `.cabal` files

### DIFF
--- a/crucible-llvm/crucible-llvm.cabal
+++ b/crucible-llvm/crucible-llvm.cabal
@@ -40,7 +40,7 @@ library
     containers >= 0.5.8.0,
     crucible >= 0.5,
     crucible-symio,
-    what4 >= 0.4.1,
+    what4 >= 0.5,
     extra,
     lens,
     itanium-abi >= 0.1.1.1 && < 0.2,

--- a/crux-llvm/crux-llvm.cabal
+++ b/crux-llvm/crux-llvm.cabal
@@ -97,7 +97,7 @@ library
     config-schema >= 1.2.2.0,
     logict,
     llvm-pretty,
-    llvm-pretty-bc-parser,
+    llvm-pretty-bc-parser >= 0.5,
     mtl,
     parameterized-utils,
     prettyprinter >= 1.7.0


### PR DESCRIPTION
This corrects the lower version bounds on `what4` and `llvm-pretty-bc-parser` in `crucible-llvm` and `crux-llvm`, respectively, to reflect what versions they actually require at a minimum.

Fixes #1345.