### PR TITLE
CI: Support Ubuntu 24.04, drop 20.04 support

### DIFF
--- a/.github/Dockerfile-crux-llvm
+++ b/.github/Dockerfile-crux-llvm
@@ -2,7 +2,7 @@
 # LINUX_LLVM_VER in .github/ci.sh (in the install_llvm() function).
 ARG LLVM_VER=14
 
-FROM ubuntu:22.04 AS build
+FROM ubuntu:24.04 AS build
 ARG LLVM_VER
 
 RUN apt-get update && \
@@ -45,7 +45,7 @@ WORKDIR rootfs/usr/local/bin
 # The URL here is based on the same logic used to specify BUILD_TARGET_OS and
 # BUILD_TARGET_ARCH in `.github/workflow/crux-llvm-build.yml`, but specialized
 # to x86-64 Ubuntu.
-RUN curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20240212/ubuntu-22.04-X64-bin.zip"
+RUN curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20250326/ubuntu-24.04-X64-bin.zip"
 RUN unzip solvers.zip && rm solvers.zip && chmod +x *
 
 WORKDIR /crux-llvm
@@ -69,7 +69,7 @@ RUN cabal v2-update && \
 USER root
 RUN chown -R root:root /crux-llvm/rootfs
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 ARG LLVM_VER
 
 RUN apt-get update && \

--- a/.github/Dockerfile-crux-mir
+++ b/.github/Dockerfile-crux-mir
@@ -3,7 +3,7 @@
 ARG RUST_TOOLCHAIN="nightly-2023-01-23"
 ARG CRUX_BUILD_DIR=/crux-mir/build
 
-FROM ubuntu:22.04 AS build
+FROM ubuntu:24.04 AS build
 ARG RUST_TOOLCHAIN
 ARG CRUX_BUILD_DIR
 
@@ -46,7 +46,7 @@ WORKDIR /crux-mir/rootfs/usr/local/bin
 # The URL here is based on the same logic used to specify BUILD_TARGET_OS and
 # BUILD_TARGET_ARCH in `.github/workflow/crux-mir-build.yml`, but specialized
 # to x86-64 Ubuntu.
-RUN curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20240212/ubuntu-22.04-X64-bin.zip"
+RUN curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20250326/ubuntu-24.04-X64-bin.zip"
 RUN unzip solvers.zip && rm solvers.zip && chmod +x *
 
 WORKDIR /crux-mir
@@ -70,7 +70,7 @@ RUN cabal v2-update && \
 USER root
 RUN chown -R root:root /crux-mir/rootfs
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 ARG CRUX_BUILD_DIR
 
 RUN apt-get update && \

--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -69,10 +69,10 @@ install_llvm() {
     #
     # If you update the value of LINUX_LLVM_VER below, make sure to also update
     # the corresponding LLVM version in .github/Dockerfile-crux-llvm.
-    if [[ "$BUILD_TARGET_OS" = "ubuntu-22.04" ]]; then
+    if [[ "$BUILD_TARGET_OS" = "ubuntu-24.04" ]]; then
       LINUX_LLVM_VER=14
-    elif [[ "$BUILD_TARGET_OS" = "ubuntu-20.04" ]]; then
-      LINUX_LLVM_VER=12
+    elif [[ "$BUILD_TARGET_OS" = "ubuntu-22.04" ]]; then
+      LINUX_LLVM_VER=14
     else
       echo "Don't know what LLVM version to use for $LINUX_LLVM_VER."
       exit 1

--- a/.github/workflows/crucible-go-build.yml
+++ b/.github/workflows/crucible-go-build.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
         cabal: ["3.10.3.0"]
         ghc: ["9.4.8", "9.6.5", "9.8.2"]
         include:
@@ -70,7 +70,7 @@ jobs:
       - shell: bash
         run: .github/ci.sh install_system_deps
         env:
-          SOLVER_PKG_VERSION: "snapshot-20240212"
+          SOLVER_PKG_VERSION: "snapshot-20250326"
           BUILD_TARGET_OS: ${{ matrix.os }}
           BUILD_TARGET_ARCH: ${{ runner.arch }}
 

--- a/.github/workflows/crucible-jvm-build.yml
+++ b/.github/workflows/crucible-jvm-build.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
         cabal: ["3.10.3.0"]
         ghc: ["9.4.8", "9.6.5", "9.8.2"]
         include:
@@ -70,7 +70,7 @@ jobs:
       - shell: bash
         run: .github/ci.sh install_system_deps
         env:
-          SOLVER_PKG_VERSION: "snapshot-20240212"
+          SOLVER_PKG_VERSION: "snapshot-20250326"
           BUILD_TARGET_OS: ${{ matrix.os }}
           BUILD_TARGET_ARCH: ${{ runner.arch }}
       - name: Configure

--- a/.github/workflows/crucible-wasm-build.yml
+++ b/.github/workflows/crucible-wasm-build.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
         cabal: ["3.10.3.0"]
         ghc: ["9.4.8", "9.6.5", "9.8.2"]
         include:
@@ -70,7 +70,7 @@ jobs:
       - shell: bash
         run: .github/ci.sh install_system_deps
         env:
-          SOLVER_PKG_VERSION: "snapshot-20240212"
+          SOLVER_PKG_VERSION: "snapshot-20250326"
           BUILD_TARGET_OS: ${{ matrix.os }}
           BUILD_TARGET_ARCH: ${{ runner.arch }}
 

--- a/.github/workflows/crux-llvm-build.yml
+++ b/.github/workflows/crux-llvm-build.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   config:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       name: ${{ steps.config.outputs.name }}
       crux-llvm-version: ${{ steps.config.outputs.crux-llvm-version }}
@@ -63,11 +63,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
         cabal: ["3.10.3.0"]
         ghc: ["9.4.8", "9.6.5", "9.8.2"]
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             cabal: 3.10.3.0
             ghc: 9.4.8
           - os: macos-14
@@ -110,7 +110,7 @@ jobs:
       - shell: bash
         run: .github/ci.sh install_system_deps
         env:
-          SOLVER_PKG_VERSION: "snapshot-20240212"
+          SOLVER_PKG_VERSION: "snapshot-20250326"
           BUILD_TARGET_OS: ${{ matrix.os }}
           BUILD_TARGET_ARCH: ${{ runner.arch }}
 
@@ -188,7 +188,7 @@ jobs:
       - shell: bash
         name: Test uc-crux-llvm (Linux)
         run: .github/ci.sh test uc-crux-llvm
-        if: matrix.os == 'ubuntu-22.04'
+        if: matrix.os == 'ubuntu-24.04'
 
       - uses: actions/cache/save@v4
         name: Save cabal store cache
@@ -286,7 +286,7 @@ jobs:
 
 
   build-push-image:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [config]
     if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.config.outputs.release == 'true') && github.repository_owner == 'GaloisInc'
     strategy:

--- a/.github/workflows/crux-mir-build.yml
+++ b/.github/workflows/crux-mir-build.yml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   config:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       name: ${{ steps.config.outputs.name }}
       crux-mir-version: ${{ steps.config.outputs.crux-mir-version }}
@@ -64,11 +64,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
         cabal: ["3.10.3.0"]
         ghc: ["9.4.8", "9.6.5", "9.8.2"]
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             cabal: 3.10.3.0
             ghc: 9.4.8
           - os: macos-14
@@ -125,7 +125,7 @@ jobs:
       - shell: bash
         run: .github/ci.sh install_system_deps
         env:
-          SOLVER_PKG_VERSION: "snapshot-20240212"
+          SOLVER_PKG_VERSION: "snapshot-20250326"
           BUILD_TARGET_OS: ${{ matrix.os }}
           BUILD_TARGET_ARCH: ${{ runner.arch }}
 
@@ -239,7 +239,7 @@ jobs:
           name: crux-mir-${{ matrix.os }}-${{ matrix.ghc }}
 
   build-push-image:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [config]
     if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.config.outputs.release == 'true') && github.repository_owner == 'GaloisInc'
     strategy:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: lint
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
GitHub Actions is removing its Ubuntu 20.04 runners soon (https://github.com/actions/runner-images/issues/11101), so this patch removes CI support for Ubuntu 20.04 and makes Ubuntu 24.04 the latest supported Ubuntu version.