### PR TITLE
`crux-mir` Dockerfile: Fix broken command substitution in `CRUX_RUST_LIBRARY_PATH`

### DIFF
--- a/.github/Dockerfile-crux-mir
+++ b/.github/Dockerfile-crux-mir
@@ -43,7 +43,7 @@ RUN cargo install --locked && \
     ./translate_libs.sh
 # Define `CRUX_RUST_LIBRARY_PATH` this for the benefit of
 # `crux v2-test crux-mir` below.
-ENV CRUX_RUST_LIBRARY_PATH=$(pwd)/rlibs
+ENV CRUX_RUST_LIBRARY_PATH=${CRUX_BUILD_DIR}/dependencies/mir-json/rlibs
 
 RUN mkdir -p /crux-mir/rootfs/usr/local/bin
 WORKDIR /crux-mir/rootfs/usr/local/bin


### PR DESCRIPTION
Previously, the first stage of the `crux-mir` Dockerfile was attempting to define `CRUX_RUST_LIBRARY_PATH` like so:

```
ENV CRUX_RUST_LIBRARY_PATH=$(pwd)/rlibs
```

But this will not work as intended, as Dockerfile will not substitute commands like `$(pwd)` when defining environment variables. Apparently, command substitution only happens in a limited number of Dockerfile instructions (e.g., `RUN` instructions that invoke a shell command), and `ENV` is not one of these instructions.

Rather than rely on the value of `$(pwd)`, we fix this issue by instead using:

```
ENV CRUX_RUST_LIBRARY_PATH=${CRUX_BUILD_DIR}/dependencies/mir-json/rlibs
```

A little more verbose, but it avoids needing to substitute a shell command.

Fixes #1357.