### PR TITLE
Dockerfiles: Revert from Ubuntu 24.04 to 22.04

### DIFF
--- a/.github/Dockerfile-crux-llvm
+++ b/.github/Dockerfile-crux-llvm
@@ -2,7 +2,9 @@
 # LINUX_LLVM_VER in .github/ci.sh (in the install_llvm() function).
 ARG LLVM_VER=14
 
-FROM ubuntu:24.04 AS build
+# Note that we intentionally do not use ubuntu:24.04 or later pending a
+# resolution to https://github.com/coder/coder/issues/17316.
+FROM ubuntu:22.04 AS build
 ARG LLVM_VER
 
 RUN apt-get update && \
@@ -59,7 +61,7 @@ RUN case ${TARGETPLATFORM} in \
         printf "Unsupported architecture: %s\n" "${TARGETPLATFORM}" >&2 \
         exit 1 ;; \
     esac && \
-    curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20250326/ubuntu-24.04-${WHAT4_SOLVERS_ARCH}-bin.zip"
+    curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20250326/ubuntu-22.04-${WHAT4_SOLVERS_ARCH}-bin.zip"
 RUN unzip solvers.zip && rm solvers.zip && chmod +x *
 
 WORKDIR /crux-llvm
@@ -92,7 +94,7 @@ RUN cabal update && \
 USER root
 RUN chown -R root:root /crux-llvm/rootfs
 
-FROM ubuntu:24.04
+FROM ubuntu:22.04
 ARG LLVM_VER
 
 RUN apt-get update && \

--- a/.github/Dockerfile-crux-mir
+++ b/.github/Dockerfile-crux-mir
@@ -3,7 +3,9 @@
 ARG RUST_TOOLCHAIN="nightly-2023-01-23"
 ARG CRUX_BUILD_DIR=/crux-mir/build
 
-FROM ubuntu:24.04 AS build
+# Note that we intentionally do not use ubuntu:24.04 or later pending a
+# resolution to https://github.com/coder/coder/issues/17316.
+FROM ubuntu:22.04 AS build
 ARG RUST_TOOLCHAIN
 ARG CRUX_BUILD_DIR
 
@@ -64,7 +66,7 @@ RUN case ${TARGETPLATFORM} in \
         printf "Unsupported architecture: %s\n" "${TARGETPLATFORM}" >&2 \
         exit 1 ;; \
     esac && \
-    curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20250326/ubuntu-24.04-${WHAT4_SOLVERS_ARCH}-bin.zip"
+    curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20250326/ubuntu-22.04-${WHAT4_SOLVERS_ARCH}-bin.zip"
 RUN unzip solvers.zip && rm solvers.zip && chmod +x *
 
 WORKDIR /crux-mir
@@ -95,7 +97,7 @@ RUN cabal update && \
 USER root
 RUN chown -R root:root /crux-mir/rootfs
 
-FROM ubuntu:24.04
+FROM ubuntu:22.04
 ARG CRUX_BUILD_DIR
 
 RUN apt-get update && \


### PR DESCRIPTION
A stopgap measure intended to allow the Docker images to be useful pending a resolution to https://github.com/coder/coder/issues/17316.

Fixes #1366.