### PR TITLE
ci: Don't install LLVM in workflows that don't need it

### DIFF
--- a/.github/workflows/crucible-go-build.yml
+++ b/.github/workflows/crucible-go-build.yml
@@ -68,7 +68,7 @@ jobs:
             ${{ env.CACHE_VERSION }}-cabal-${{ matrix.os }}-${{ matrix.ghc }}-${{ hashFiles(format('cabal.GHC-{0}.config', matrix.ghc)) }}-
 
       - shell: bash
-        run: .github/ci.sh install_system_deps
+        run: .github/ci.sh install_solvers
         env:
           SOLVER_PKG_VERSION: "snapshot-20250326"
           BUILD_TARGET_OS: ${{ matrix.os }}

--- a/.github/workflows/crucible-jvm-build.yml
+++ b/.github/workflows/crucible-jvm-build.yml
@@ -68,7 +68,7 @@ jobs:
             ${{ env.CACHE_VERSION }}-cabal-${{ matrix.os }}-${{ matrix.ghc }}-${{ hashFiles(format('cabal.GHC-{0}.config', matrix.ghc)) }}-
 
       - shell: bash
-        run: .github/ci.sh install_system_deps
+        run: .github/ci.sh install_solvers
         env:
           SOLVER_PKG_VERSION: "snapshot-20250326"
           BUILD_TARGET_OS: ${{ matrix.os }}

--- a/.github/workflows/crucible-wasm-build.yml
+++ b/.github/workflows/crucible-wasm-build.yml
@@ -68,7 +68,7 @@ jobs:
             ${{ env.CACHE_VERSION }}-cabal-${{ matrix.os }}-${{ matrix.ghc }}-${{ hashFiles(format('cabal.GHC-{0}.config', matrix.ghc)) }}-
 
       - shell: bash
-        run: .github/ci.sh install_system_deps
+        run: .github/ci.sh install_solvers
         env:
           SOLVER_PKG_VERSION: "snapshot-20250326"
           BUILD_TARGET_OS: ${{ matrix.os }}


### PR DESCRIPTION
Fixes #1370. Not quite sure if crux-mir will end up needing it, but removed until proven necessary.