### PR TITLE
ci: Simplify Cabal/GHC compatibility check

### DIFF
--- a/.github/workflows/crucible-go-build.yml
+++ b/.github/workflows/crucible-go-build.yml
@@ -24,7 +24,7 @@ jobs:
             cabal: 3.10.3.0
             ghc: 9.8.2
     name: crucible-go - GHC v${{ matrix.ghc }} - ${{ matrix.os }}
-    uses: GaloisInc/.github/.github/workflows/haskell-ci.yml@v1.4
+    uses: GaloisInc/.github/.github/workflows/haskell-ci.yml@v1.4.2
     with:
       build-targets: pkg:crucible-go
       cabal: ${{ matrix.cabal }}

--- a/.github/workflows/crucible-go-build.yml
+++ b/.github/workflows/crucible-go-build.yml
@@ -24,7 +24,7 @@ jobs:
             cabal: 3.10.3.0
             ghc: 9.8.2
     name: crucible-go - GHC v${{ matrix.ghc }} - ${{ matrix.os }}
-    uses: GaloisInc/.github/.github/workflows/haskell-ci.yml@v1.4.2
+    uses: GaloisInc/.github/.github/workflows/haskell-ci.yml@v1
     with:
       build-targets: pkg:crucible-go
       cabal: ${{ matrix.cabal }}

--- a/.github/workflows/crucible-jvm-build.yml
+++ b/.github/workflows/crucible-jvm-build.yml
@@ -24,7 +24,7 @@ jobs:
             cabal: 3.10.3.0
             ghc: 9.8.2
     name: crucible-jvm - GHC v${{ matrix.ghc }} - ${{ matrix.os }}
-    uses: GaloisInc/.github/.github/workflows/haskell-ci.yml@v1.4
+    uses: GaloisInc/.github/.github/workflows/haskell-ci.yml@v1.4.2
     with:
       build-targets: pkg:crucible-jvm
       cabal: ${{ matrix.cabal }}

--- a/.github/workflows/crucible-jvm-build.yml
+++ b/.github/workflows/crucible-jvm-build.yml
@@ -24,7 +24,7 @@ jobs:
             cabal: 3.10.3.0
             ghc: 9.8.2
     name: crucible-jvm - GHC v${{ matrix.ghc }} - ${{ matrix.os }}
-    uses: GaloisInc/.github/.github/workflows/haskell-ci.yml@v1.4.2
+    uses: GaloisInc/.github/.github/workflows/haskell-ci.yml@v1
     with:
       build-targets: pkg:crucible-jvm
       cabal: ${{ matrix.cabal }}

--- a/.github/workflows/crucible-wasm-build.yml
+++ b/.github/workflows/crucible-wasm-build.yml
@@ -24,7 +24,7 @@ jobs:
             cabal: 3.10.3.0
             ghc: 9.8.2
     name: crucible-wasm - GHC v${{ matrix.ghc }} - ${{ matrix.os }}
-    uses: GaloisInc/.github/.github/workflows/haskell-ci.yml@v1.4
+    uses: GaloisInc/.github/.github/workflows/haskell-ci.yml@v1.4.2
     with:
       build-targets: pkg:crucible-wasm
       cabal: ${{ matrix.cabal }}

--- a/.github/workflows/crucible-wasm-build.yml
+++ b/.github/workflows/crucible-wasm-build.yml
@@ -24,7 +24,7 @@ jobs:
             cabal: 3.10.3.0
             ghc: 9.8.2
     name: crucible-wasm - GHC v${{ matrix.ghc }} - ${{ matrix.os }}
-    uses: GaloisInc/.github/.github/workflows/haskell-ci.yml@v1.4.2
+    uses: GaloisInc/.github/.github/workflows/haskell-ci.yml@v1
     with:
       build-targets: pkg:crucible-wasm
       cabal: ${{ matrix.cabal }}

--- a/.github/workflows/crux-llvm-build.yml
+++ b/.github/workflows/crux-llvm-build.yml
@@ -204,56 +204,28 @@ jobs:
             dist-newstyle
           key: ${{ steps.cache.outputs.cache-primary-key }}
 
-      # The following block happens here for two reasons:
+      # We support older Cabal versions so that users can build the project even
+      # if they lack access to the latest Cabal package, e.g., when using the
+      # version provided by their OS package manager on older systems.
       #
-      # 1. It rarely fails, going last can save some time if earlier steps fail
-      # 2. It must come after we save the Cabal cache as 'Package's Cabal/GHC
-      #    compatibility' runs `cabal clean`
-      - name: Install Nix
-        if: runner.os == 'Linux'
-        uses: cachix/install-nix-action@v16
-        with:
-          nix_path: nixpkgs=channel:21.11
-          install_url: https://releases.nixos.org/nix/nix-2.10.3/install
-          # This token usage is to avoid GH rate-limiting; see commit
-          # 1696558326a8c57e1a9f0848aaaa1b8440294954. Apparently it'll
-          # work for anyone.
-          extra_nix_config: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-      - name: Setup Environment Vars
-        if: runner.os == 'Linux'
-        run: |
-          GHC=haskell.compiler.ghc$(echo ${{ matrix.ghc }} | sed -e s,\\.,,g)
-          case ${{ matrix.ghc }} in
-            9.4.8) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-24.05 ;;
-            9.6.5) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-24.05 ;;
-            9.8.2) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-24.05 ;;
-            *)     GHC_NIXPKGS=github:nixos/nixpkgs/21.11 ;;
-          esac
-          echo NS="nix shell ${GHC_NIXPKGS}#cabal-install ${GHC_NIXPKGS}#${GHC} nixpkgs#gmp nixpkgs#zlib nixpkgs#zlib.dev" >> $GITHUB_ENV
-      - name: Package's Cabal/GHC compatibility
+      # Rather than running the whole CI workflow with multiple Cabal versions
+      # (e.g., in the `matrix`), we run the equivalent of `cabal clean`, but
+      # using the version of the Cabal library that is bundled with GHC. This is
+      # sufficient to check that the bundled version of Cabal can parse the Cabal
+      # configuration files (`.cabal`, `cabal.project{,freeze}`). This guarantees
+      # that our package can be built with the versions of Cabal that are likely to
+      # be available alongside the supported versions of GHC.
+      #
+      # We run this after `actions/cache/save` since it deletes most of
+      # `dist-newstyle`.
+      - name: Check Cabal/GHC compatibility
         shell: bash
-        if: runner.os == 'Linux'
-        # Using setup will use the cabal library installed with GHC
-        # instead of the cabal library of the Cabal-install tool to
-        # verify the cabal file is compatible with the associated
-        # GHC cabal library version.  Cannot run configure or build,
-        # because dependencies aren't present, but a clean is
-        # sufficient to cause parsing/validation of the cabal file.
         run: |
-          defsetup()  { echo import Distribution.Simple; echo main = defaultMain; }
-          setup_src() { if [ ! -f Setup.hs ] ; then defsetup > DefSetup.hs; fi; ls *Setup.hs; }
-          setup_bin() { echo setup.${{ matrix.ghc }}; }
-          with_ghc()  { $NS -c ${@}; }
-          (cd crucible;             with_ghc ghc -o $(setup_bin) $(setup_src) && ./$(setup_bin) clean)
-          (cd crucible-cli;         with_ghc ghc -o $(setup_bin) $(setup_src) && ./$(setup_bin) clean)
-          (cd crucible-debug;       with_ghc ghc -o $(setup_bin) $(setup_src) && ./$(setup_bin) clean)
-          (cd crucible-llvm;        with_ghc ghc -o $(setup_bin) $(setup_src) && ./$(setup_bin) clean)
-          (cd crucible-llvm-cli;    with_ghc ghc -o $(setup_bin) $(setup_src) && ./$(setup_bin) clean)
-          (cd crucible-llvm-debug;  with_ghc ghc -o $(setup_bin) $(setup_src) && ./$(setup_bin) clean)
-          (cd crucible-llvm-syntax; with_ghc ghc -o $(setup_bin) $(setup_src) && ./$(setup_bin) clean)
-          (cd crux;                 with_ghc ghc -o $(setup_bin) $(setup_src) && ./$(setup_bin) clean)
-          (cd crux-llvm;            with_ghc ghc -o $(setup_bin) $(setup_src) && ./$(setup_bin) clean)
+          for dir in crucible{,-cli,-debug,-llvm,-llvm-cli,-llvm-debug,-llvm-syntax} crux{,-llvm}; do
+            cd "${GITHUB_WORKSPACE}/${dir}"
+            echo 'import Distribution.Simple; main = defaultMain' > Setup.hs
+            runhaskell Setup.hs clean
+          done
 
       - name: Create binary artifact
         shell: bash

--- a/.github/workflows/crux-llvm-build.yml
+++ b/.github/workflows/crux-llvm-build.yml
@@ -9,6 +9,10 @@ on:
     - cron: "0 10 * * *" # 10am UTC -> 2/3am PST
   workflow_dispatch:
 
+defaults:
+  run:
+    shell: bash
+
 # The CACHE_VERSION can be updated to force the use of a new cache if
 # the current cache contents become corrupted/invalid.  This can
 # sometimes happen when (for example) the OS version is changed but
@@ -89,7 +93,6 @@ jobs:
           cabal-version: ${{ matrix.cabal }}
 
       - name: Post-GHC installation fixups on Windows
-        shell: bash
         if: runner.os == 'Windows'
         run: |
           # A workaround for https://github.com/Mistuke/CabalChoco/issues/5
@@ -107,22 +110,18 @@ jobs:
           restore-keys: |
             ${{ env.CACHE_VERSION }}-cabal-${{ matrix.os }}-${{ matrix.ghc }}-${{ hashFiles(format('cabal.GHC-{0}.config', matrix.ghc)) }}-
 
-      - shell: bash
-        run: .github/ci.sh install_system_deps
+      - run: .github/ci.sh install_system_deps
         env:
           SOLVER_PKG_VERSION: "snapshot-20250326"
           BUILD_TARGET_OS: ${{ matrix.os }}
           BUILD_TARGET_ARCH: ${{ runner.arch }}
 
-      - shell: bash
-        run: .github/ci.sh configure
+      - run: .github/ci.sh configure
 
       - name: Generate source distributions
-        shell: bash
         run: cabal sdist crucible-symio crux-llvm crucible-{cli,debug} crucible-llvm{,-cli,-debug,-syntax}
 
-      - shell: bash
-        run: >
+      - run: >
           cabal build
           crucible
           crucible-cli
@@ -134,8 +133,7 @@ jobs:
           crucible-syntax
           crux-llvm
 
-      - shell: bash
-        name: Haddock
+      - name: Haddock
         # Note [--disable-documentation]
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         #
@@ -151,47 +149,38 @@ jobs:
         # tradeoff.
         run: cabal haddock --disable-documentation crucible-debug crucible-symio crucible-llvm{,-debug,-syntax} crux-llvm
 
-      - shell: bash
-        name: Test crucible
+      - name: Test crucible
         run: .github/ci.sh test crucible
 
-      - shell: bash
-        name: Test crucible-cli
+      - name: Test crucible-cli
         run: .github/ci.sh test crucible-cli
 
-      - shell: bash
-        name: Test crucible-debug
+      - name: Test crucible-debug
         run: cd crucible-debug && ../.github/ci.sh test pkg:crucible-debug
         # NOTE(lb): Not sure what's going on with these tests... and I don't
         # have a Windows machine to debug.
         if: runner.os != 'Windows'
 
-      - shell: bash
-        name: Test crucible-symio
+      - name: Test crucible-symio
         run: cabal test pkg:crucible-symio
         if: runner.os == 'Linux'
 
-      - shell: bash
-        name: Test crucible-llvm
+      - name: Test crucible-llvm
         run: .github/ci.sh test crucible-llvm
         if: runner.os == 'Linux' || runner.os == 'macOS'
 
-      - shell: bash
-        name: Test crucible-llvm-syntax
+      - name: Test crucible-llvm-syntax
         run: .github/ci.sh test crucible-llvm-syntax
         if: runner.os == 'Linux'
 
-      - shell: bash
-        name: Test crucible-llvm-cli
+      - name: Test crucible-llvm-cli
         run: .github/ci.sh test crucible-llvm-cli
         if: runner.os == 'Linux'
 
-      - shell: bash
-        name: Test crucible-llvm-debug
+      - name: Test crucible-llvm-debug
         run: .github/ci.sh test crucible-llvm-debug
 
-      - shell: bash
-        name: Test crux-llvm
+      - name: Test crux-llvm
         run: .github/ci.sh test crux-llvm
         if: runner.os == 'Linux' || runner.os == 'macOS'
 
@@ -219,7 +208,6 @@ jobs:
       # We run this after `actions/cache/save` since it deletes most of
       # `dist-newstyle`.
       - name: Check Cabal/GHC compatibility
-        shell: bash
         run: |
           for dir in crucible{,-cli,-debug,-llvm,-llvm-cli,-llvm-debug,-llvm-syntax} crux{,-llvm}; do
             cd "${GITHUB_WORKSPACE}/${dir}"
@@ -228,7 +216,6 @@ jobs:
           done
 
       - name: Create binary artifact
-        shell: bash
         run: |
           NAME="crux-llvm-${{ needs.config.outputs.crux-llvm-version }}-${{ matrix.os }}-${{ runner.arch }}"
           echo "NAME=$NAME" >> $GITHUB_ENV
@@ -247,7 +234,6 @@ jobs:
         # isn't sufficient to test the pull request info because this job is
         # also scheduled. See notes in README.md.
         if: github.event.pull_request.head.repo.fork == false && github.repository_owner == 'GaloisInc'
-        shell: bash
         env:
           SIGNING_PASSPHRASE: ${{ secrets.SIGNING_PASSPHRASE }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}

--- a/.github/workflows/crux-mir-build.yml
+++ b/.github/workflows/crux-mir-build.yml
@@ -8,6 +8,10 @@ on:
     - cron: "0 10 * * *" # 10am UTC -> 2/3am PST
   workflow_dispatch:
 
+defaults:
+  run:
+    shell: bash
+
 env:
   # The CABAL_CACHE_VERSION and CARGO_CACHE_VERSION environment variables can
   # be updated to force the use of a new cabal or cargo cache if the respective
@@ -89,7 +93,6 @@ jobs:
           cabal-version: ${{ matrix.cabal }}
 
       - name: Post-GHC installation fixups on Windows
-        shell: bash
         if: runner.os == 'Windows'
         run: |
           # A workaround for https://github.com/Mistuke/CabalChoco/issues/5
@@ -122,38 +125,31 @@ jobs:
           shared-key: "cargo-cache"
           workspaces: "dependencies/mir-json"
 
-      - shell: bash
-        run: .github/ci.sh install_system_deps
+      - run: .github/ci.sh install_system_deps
         env:
           SOLVER_PKG_VERSION: "snapshot-20250326"
           BUILD_TARGET_OS: ${{ matrix.os }}
           BUILD_TARGET_ARCH: ${{ runner.arch }}
 
       - name: Install mir-json
-        shell: bash
         working-directory: dependencies/mir-json
         run: |
           cargo install --locked --force
           bash ./translate_libs.sh
           echo "CRUX_RUST_LIBRARY_PATH=$(pwd)/rlibs" >> $GITHUB_ENV
 
-      - shell: bash
-        run: .github/ci.sh configure
+      - run: .github/ci.sh configure
 
       - name: Generate source distributions
-        shell: bash
         run: cabal sdist crucible-syntax crucible-concurrency crucible-mir crux-mir
 
-      - shell: bash
-        run: cabal build exe:crux-mir
+      - run: cabal build exe:crux-mir
 
-      - shell: bash
-        name: Haddock
+      - name: Haddock
         # See Note [--disable-documentation] in `crucible-go-build.yml`.
         run: cabal haddock --disable-documentation crucible-syntax crucible-concurrency crux-mir
 
-      - shell: bash
-        run: .github/ci.sh test crux-mir
+      - run: .github/ci.sh test crux-mir
 
       - uses: actions/cache/save@v4
         name: Save cabal store cache
@@ -179,14 +175,12 @@ jobs:
       # We run this after `actions/cache/save` since it deletes most of
       # `dist-newstyle`.
       - name: Check Cabal/GHC compatibility
-        shell: bash
         run: |
           cd crux-mir
           echo 'import Distribution.Simple; main = defaultMain' > Setup.hs
           runhaskell Setup.hs clean
 
       - name: Create binary artifact
-        shell: bash
         run: |
           NAME="crux-mir-${{ needs.config.outputs.crux-mir-version }}-${{ matrix.os }}-${{ runner.arch }}"
           echo "NAME=$NAME" >> $GITHUB_ENV
@@ -205,7 +199,6 @@ jobs:
         # isn't sufficient to test the pull request info because this job is
         # also scheduled. See notes in README.md.
         if: github.event.pull_request.head.repo.fork == false && github.repository_owner == 'GaloisInc'
-        shell: bash
         env:
           SIGNING_PASSPHRASE: ${{ secrets.SIGNING_PASSPHRASE }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}

--- a/.github/workflows/crux-mir-build.yml
+++ b/.github/workflows/crux-mir-build.yml
@@ -164,48 +164,26 @@ jobs:
             dist-newstyle
           key: ${{ steps.cache.outputs.cache-primary-key }}
 
-      # The following block happens here for two reasons:
+      # We support older Cabal versions so that users can build the project even
+      # if they lack access to the latest Cabal package, e.g., when using the
+      # version provided by their OS package manager on older systems.
       #
-      # 1. It rarely fails, going last can save some time if earlier steps fail
-      # 2. It must come after we save the Cabal cache as 'Package's Cabal/GHC
-      #    compatibility' runs `cabal clean`
-      - name: Install Nix
-        if: runner.os == 'Linux'
-        uses: cachix/install-nix-action@v16
-        with:
-          nix_path: nixpkgs=channel:21.11
-          install_url: https://releases.nixos.org/nix/nix-2.10.3/install
-          # This token usage is to avoid GH rate-limiting; see commit
-          # 1696558326a8c57e1a9f0848aaaa1b8440294954. Apparently it'll
-          # work for anyone.
-          extra_nix_config: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-      - name: Setup Environment Vars
-        if: runner.os == 'Linux'
-        run: |
-          GHC=haskell.compiler.ghc$(echo ${{ matrix.ghc }} | sed -e s,\\.,,g)
-          case ${{ matrix.ghc }} in
-            9.4.8) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-24.05 ;;
-            9.6.5) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-24.05 ;;
-            9.8.2) GHC_NIXPKGS=github:nixos/nixpkgs/nixos-24.05 ;;
-            *)     GHC_NIXPKGS=github:nixos/nixpkgs/21.11 ;;
-          esac
-          echo NS="nix shell ${GHC_NIXPKGS}#cabal-install ${GHC_NIXPKGS}#${GHC} nixpkgs#gmp nixpkgs#zlib nixpkgs#zlib.dev" >> $GITHUB_ENV
-      - name: Package's Cabal/GHC compatibility
+      # Rather than running the whole CI workflow with multiple Cabal versions
+      # (e.g., in the `matrix`), we run the equivalent of `cabal clean`, but
+      # using the version of the Cabal library that is bundled with GHC. This is
+      # sufficient to check that the bundled version of Cabal can parse the Cabal
+      # configuration files (`.cabal`, `cabal.project{,freeze}`). This guarantees
+      # that our package can be built with the versions of Cabal that are likely to
+      # be available alongside the supported versions of GHC.
+      #
+      # We run this after `actions/cache/save` since it deletes most of
+      # `dist-newstyle`.
+      - name: Check Cabal/GHC compatibility
         shell: bash
-        if: runner.os == 'Linux'
-        # Using setup will use the cabal library installed with GHC
-        # instead of the cabal library of the Cabal-install tool to
-        # verify the cabal file is compatible with the associated
-        # GHC cabal library version.  Cannot run configure or build,
-        # because dependencies aren't present, but a clean is
-        # sufficient to cause parsing/validation of the cabal file.
         run: |
-          defsetup()  { echo import Distribution.Simple; echo main = defaultMain; }
-          setup_src() { if [ ! -f Setup.hs ] ; then defsetup > DefSetup.hs; fi; ls *Setup.hs; }
-          setup_bin() { echo setup.${{ matrix.ghc }}; }
-          with_ghc()  { $NS -c ${@}; }
-          (cd crux-mir;      with_ghc ghc -o $(setup_bin) $(setup_src) && ./$(setup_bin) clean)
+          cd crux-mir
+          echo 'import Distribution.Simple; main = defaultMain' > Setup.hs
+          runhaskell Setup.hs clean
 
       - name: Create binary artifact
         shell: bash


### PR DESCRIPTION
Fixes #1368. Also, set default shell to `bash` while we're in the neighborhood.