### PR TITLE
ci: Misc. version bumps

### DIFF
--- a/.github/Dockerfile-crux-llvm
+++ b/.github/Dockerfile-crux-llvm
@@ -76,7 +76,7 @@ RUN case ${TARGETPLATFORM} in \
         exit 1 ;; \
     esac && \
     mkdir -p /home/crux-llvm/.local/bin && \
-    curl -L https://downloads.haskell.org/~ghcup/0.1.17.7/${GHCUP_ARCH}-linux-ghcup-0.1.17.7 -o /home/crux-llvm/.local/bin/ghcup && \
+    curl -L https://downloads.haskell.org/~ghcup/0.1.50.1/${GHCUP_ARCH}-linux-ghcup-0.1.50.1 -o /home/crux-llvm/.local/bin/ghcup && \
     chmod +x /home/crux-llvm/.local/bin/ghcup
 RUN mkdir -p /home/crux-llvm/.ghcup && \
     ghcup --version && \

--- a/.github/Dockerfile-crux-llvm
+++ b/.github/Dockerfile-crux-llvm
@@ -80,7 +80,7 @@ RUN case ${TARGETPLATFORM} in \
     chmod +x /home/crux-llvm/.local/bin/ghcup
 RUN mkdir -p /home/crux-llvm/.ghcup && \
     ghcup --version && \
-    ghcup install cabal 3.10.3.0 && \
+    ghcup install cabal 3.14.2.0 && \
     ghcup install ghc 9.4.8 && \
     ghcup set ghc 9.4.8
 

--- a/.github/Dockerfile-crux-mir
+++ b/.github/Dockerfile-crux-mir
@@ -80,7 +80,7 @@ RUN case ${TARGETPLATFORM} in \
         exit 1 ;; \
     esac && \
     mkdir -p /home/crux-mir/.local/bin && \
-    curl -L https://downloads.haskell.org/~ghcup/0.1.17.7/${GHCUP_ARCH}-linux-ghcup-0.1.17.7 -o /home/crux-mir/.local/bin/ghcup && \
+    curl -L https://downloads.haskell.org/~ghcup/0.1.50.1/${GHCUP_ARCH}-linux-ghcup-0.1.50.1 -o /home/crux-mir/.local/bin/ghcup && \
     chmod +x /home/crux-mir/.local/bin/ghcup
 RUN mkdir -p /home/crux-mir/.ghcup && \
     ghcup --version && \

--- a/.github/Dockerfile-crux-mir
+++ b/.github/Dockerfile-crux-mir
@@ -84,7 +84,7 @@ RUN case ${TARGETPLATFORM} in \
     chmod +x /home/crux-mir/.local/bin/ghcup
 RUN mkdir -p /home/crux-mir/.ghcup && \
     ghcup --version && \
-    ghcup install cabal 3.10.3.0 && \
+    ghcup install cabal 3.14.2.0 && \
     ghcup install ghc 9.4.8 && \
     ghcup set ghc 9.4.8
 

--- a/.github/workflows/crucible-go-build.yml
+++ b/.github/workflows/crucible-go-build.yml
@@ -14,14 +14,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04]
-        cabal: ["3.10.3.0"]
+        cabal: ["3.14.2.0"]
         ghc: ["9.4.8", "9.6.5", "9.8.2"]
         include:
           - os: macos-14
-            cabal: 3.10.3.0
+            cabal: 3.14.2.0
             ghc: 9.8.2
           - os: windows-2019
-            cabal: 3.10.3.0
+            cabal: 3.14.2.0
             ghc: 9.8.2
     name: crucible-go - GHC v${{ matrix.ghc }} - ${{ matrix.os }}
     uses: GaloisInc/.github/.github/workflows/haskell-ci.yml@v1

--- a/.github/workflows/crucible-jvm-build.yml
+++ b/.github/workflows/crucible-jvm-build.yml
@@ -14,14 +14,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04]
-        cabal: ["3.10.3.0"]
+        cabal: ["3.14.2.0"]
         ghc: ["9.4.8", "9.6.5", "9.8.2"]
         include:
           - os: macos-14
-            cabal: 3.10.3.0
+            cabal: 3.14.2.0
             ghc: 9.8.2
           - os: windows-2019
-            cabal: 3.10.3.0
+            cabal: 3.14.2.0
             ghc: 9.8.2
     name: crucible-jvm - GHC v${{ matrix.ghc }} - ${{ matrix.os }}
     uses: GaloisInc/.github/.github/workflows/haskell-ci.yml@v1

--- a/.github/workflows/crucible-wasm-build.yml
+++ b/.github/workflows/crucible-wasm-build.yml
@@ -14,14 +14,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04]
-        cabal: ["3.10.3.0"]
+        cabal: ["3.14.2.0"]
         ghc: ["9.4.8", "9.6.5", "9.8.2"]
         include:
           - os: macos-14
-            cabal: 3.10.3.0
+            cabal: 3.14.2.0
             ghc: 9.8.2
           - os: windows-2019
-            cabal: 3.10.3.0
+            cabal: 3.14.2.0
             ghc: 9.8.2
     name: crucible-wasm - GHC v${{ matrix.ghc }} - ${{ matrix.os }}
     uses: GaloisInc/.github/.github/workflows/haskell-ci.yml@v1

--- a/.github/workflows/crux-llvm-build.yml
+++ b/.github/workflows/crux-llvm-build.yml
@@ -68,17 +68,17 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04]
-        cabal: ["3.10.3.0"]
+        cabal: ["3.14.2.0"]
         ghc: ["9.4.8", "9.6.5", "9.8.2"]
         include:
           - os: ubuntu-22.04
-            cabal: 3.10.3.0
+            cabal: 3.14.2.0
             ghc: 9.4.8
           - os: macos-14
-            cabal: 3.10.3.0
+            cabal: 3.14.2.0
             ghc: 9.4.8
           - os: windows-2019
-            cabal: 3.10.3.0
+            cabal: 3.14.2.0
             ghc: 9.4.8
     name: crux-llvm - GHC v${{ matrix.ghc }} - ${{ matrix.os }}
     steps:

--- a/.github/workflows/crux-mir-build.yml
+++ b/.github/workflows/crux-mir-build.yml
@@ -69,14 +69,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04]
-        cabal: ["3.10.3.0"]
+        cabal: ["3.14.2.0"]
         ghc: ["9.4.8", "9.6.5", "9.8.2"]
         include:
           - os: ubuntu-22.04
-            cabal: 3.10.3.0
+            cabal: 3.14.2.0
             ghc: 9.4.8
           - os: macos-14
-            cabal: 3.10.3.0
+            cabal: 3.14.2.0
             ghc: 9.4.8
 
           # We want Windows soon, but it doesn't need to be now

--- a/doc/dev.md
+++ b/doc/dev.md
@@ -35,5 +35,6 @@ When adding support for the new GHC version to Crucible itself, complete the fol
 ### Removing an old version
 
 - [ ] Remove the old version from the matrix in the GitHub Actions configuration
+- [ ] Remove the old version's `cabal.GHC-X.Y.Z.config` file
 - [ ] Remove outdated CPP `ifdef`s that refer to the dropped version
 - [ ] Remove outdated `if` stanzas in the Cabal files


### PR DESCRIPTION
Cherry-picking some commits from #1377 that aren't strictly related to the GHC version bump itself. Hopefully it will make that PR smaller and easier to review once it's rebased.