### PR TITLE
`crucible-mir`: Always store source positions in `Statement`s/`Terminator`s

### DIFF
--- a/crucible-mir/CHANGELOG.md
+++ b/crucible-mir/CHANGELOG.md
@@ -1,6 +1,15 @@
-# next
+# next -- TBA
 
-Nothing yet.
+This release supports [version
+1](https://github.com/GaloisInc/mir-json/blob/master/SCHEMA_CHANGELOG.md#1) of
+`mir-json`'s schema.
+
+* Split out the `StatementKind` and `TerminatorKind` data types from `Statement`
+  and `Terminator`, respectively. `{Statement,Terminator}` now contain a pair
+  of `{Statement,Terminator}Kind` and its source position.
+* Improve source position tracking for `Statement`s and `Terminator`s during
+  the translation to Crucible. This should result in more precise error messages
+  in certain situations.
 
 # 0.4 -- 2025-03-21
 

--- a/crucible-mir/src/Mir/GenericOps.hs
+++ b/crucible-mir/src/Mir/GenericOps.hs
@@ -77,7 +77,7 @@ adtIndices (Adt _aname _kind vars _ _ _ _) col = go 0 vars
 
     getDiscr _ (Variant name (Explicit did) _fields _knd _ _) = case Map.lookup did (_functions col) of
         Just fn -> case fn^.fbody.mblocks of
-            ( BasicBlock _info (BasicBlockData [Assign _lhs (Use (OpConstant (Constant _ty (ConstInt i)))) _loc] _term) ):_ ->
+            ( BasicBlock _info (BasicBlockData [Statement (Assign _lhs (Use (OpConstant (Constant _ty (ConstInt i))))) _loc] _term) ):_ ->
                 fromIntegerLit i
 
             _ -> error ("enum discriminant constant should only have one basic block [variant id:" ++ show _aname ++ " discr index:" ++ show name ++ "]")
@@ -135,9 +135,11 @@ instance GenericOps MirBody
 instance GenericOps BasicBlock
 instance GenericOps BasicBlockData
 instance GenericOps Statement
+instance GenericOps StatementKind
 instance GenericOps Rvalue
 instance GenericOps AdtAg
 instance GenericOps Terminator
+instance GenericOps TerminatorKind
 instance GenericOps Operand
 instance GenericOps Constant
 instance GenericOps PlaceElem

--- a/crucible-mir/src/Mir/JSON.hs
+++ b/crucible-mir/src/Mir/JSON.hs
@@ -254,27 +254,33 @@ instance FromJSON BasicBlockData where
         <*> v .: "terminator"
 
 instance FromJSON Statement where
-    parseJSON = withObject "Statement" $ \v -> case lookupKM "kind" v of
-                             Just (String "Assign") ->  Assign <$> v.: "lhs" <*> v .: "rhs" <*> v .: "pos"
-                             Just (String "SetDiscriminant") -> SetDiscriminant <$> v .: "lvalue" <*> v .: "variant_index"
-                             Just (String "StorageLive") -> StorageLive <$> v .: "slvar"
-                             Just (String "StorageDead") -> StorageDead <$> v .: "sdvar"
-                             Just (String "Nop") -> pure Nop
-                             Just (String "Deinit") -> pure Deinit
-                             Just (String "Intrinsic") -> do
-                                kind <- v .: "intrinsic_kind"
-                                ndi <- case kind of
-                                    "Assume" -> NDIAssume <$> v .: "operand"
-                                    "CopyNonOverlapping" ->
-                                        NDICopyNonOverlapping <$> v .: "src"
-                                                              <*> v .: "dst"
-                                                              <*> v .: "count"
-                                    _ -> fail $ "unknown Intrinsic kind" ++ kind
+    parseJSON j =
+      Statement
+        <$> parseJSON j
+        <*> withObject "Statement" (.: "pos") j
 
-                                return $ StmtIntrinsic ndi
+instance FromJSON StatementKind where
+    parseJSON = withObject "StatementKind" $ \v -> do
+      case lookupKM "kind" v of
+        Just (String "Assign") ->  Assign <$> v.: "lhs" <*> v .: "rhs"
+        Just (String "SetDiscriminant") -> SetDiscriminant <$> v .: "lvalue" <*> v .: "variant_index"
+        Just (String "StorageLive") -> StorageLive <$> v .: "slvar"
+        Just (String "StorageDead") -> StorageDead <$> v .: "sdvar"
+        Just (String "Nop") -> pure Nop
+        Just (String "Deinit") -> pure Deinit
+        Just (String "Intrinsic") -> do
+           kind <- v .: "intrinsic_kind"
+           ndi <- case kind of
+               "Assume" -> NDIAssume <$> v .: "operand"
+               "CopyNonOverlapping" ->
+                   NDICopyNonOverlapping <$> v .: "src"
+                                         <*> v .: "dst"
+                                         <*> v .: "count"
+               _ -> fail $ "unknown Intrinsic kind" ++ kind
 
-                             k -> fail $ "kind not found for statement: " ++ show k
+           return $ StmtIntrinsic ndi
 
+        k -> fail $ "kind not found for statement: " ++ show k
 
 data RustcPlace = RustcPlace Var [PlaceElem]
 
@@ -318,24 +324,31 @@ instance FromJSON Rvalue where
                                               k -> fail $ "unsupported RValue " ++ show k
 
 instance FromJSON Terminator where
-    parseJSON = withObject "Terminator" $ \v -> case lookupKM "kind" v of
-                                                  Just (String "Goto") -> Goto <$> v .: "target"
-                                                  Just (String "SwitchInt") ->
-                                                    let  q :: Aeson.Parser [Maybe Integer]
-                                                         q = do
-                                                               lmt <- v .: "values"
-                                                               mapM (mapM convertIntegerText) lmt
-                                                    in
-                                                    SwitchInt <$> v .: "discr" <*> v .: "switch_ty" <*> q <*> v .: "targets" <*> v .: "discr_span"
-                                                  Just (String "Resume") -> pure Resume
-                                                  Just (String "Abort") -> pure Abort
-                                                  Just (String "Return") -> pure Return
-                                                  Just (String "Unreachable") -> pure Unreachable
-                                                  Just (String "Drop") -> Drop <$> v .: "location" <*> v .: "target" <*> v .: "unwind" <*> v .: "drop_fn"
-                                                  Just (String "DropAndReplace") -> DropAndReplace <$> v .: "location" <*> v .: "value" <*> v .: "target" <*> v .: "unwind" <*> v .: "drop_fn"
-                                                  Just (String "Call") ->  Call <$> v .: "func" <*> v .: "args" <*> v .: "destination" <*> v .: "cleanup"
-                                                  Just (String "Assert") -> Assert <$> v .: "cond" <*> v .: "expected" <*> v .: "msg" <*> v .: "target" <*> v .: "cleanup"
-                                                  k -> fail $ "unsupported terminator" ++ show k
+    parseJSON j =
+      Terminator
+        <$> parseJSON j
+        <*> withObject "Terminator" (.: "pos") j
+
+instance FromJSON TerminatorKind where
+    parseJSON = withObject "TerminatorKind" $ \v -> do
+      case lookupKM "kind" v of
+        Just (String "Goto") -> Goto <$> v .: "target"
+        Just (String "SwitchInt") ->
+          let  q :: Aeson.Parser [Maybe Integer]
+               q = do
+                     lmt <- v .: "values"
+                     mapM (mapM convertIntegerText) lmt
+          in
+          SwitchInt <$> v .: "discr" <*> v .: "switch_ty" <*> q <*> v .: "targets" <*> v .: "discr_span"
+        Just (String "Resume") -> pure Resume
+        Just (String "Abort") -> pure Abort
+        Just (String "Return") -> pure Return
+        Just (String "Unreachable") -> pure Unreachable
+        Just (String "Drop") -> Drop <$> v .: "location" <*> v .: "target" <*> v .: "unwind" <*> v .: "drop_fn"
+        Just (String "DropAndReplace") -> DropAndReplace <$> v .: "location" <*> v .: "value" <*> v .: "target" <*> v .: "unwind" <*> v .: "drop_fn"
+        Just (String "Call") ->  Call <$> v .: "func" <*> v .: "args" <*> v .: "destination" <*> v .: "cleanup"
+        Just (String "Assert") -> Assert <$> v .: "cond" <*> v .: "expected" <*> v .: "msg" <*> v .: "target" <*> v .: "cleanup"
+        k -> fail $ "unsupported terminator kind" ++ show k
 
 instance FromJSON Operand where
     parseJSON = withObject "Operand" $ \v -> case lookupKM "kind" v of

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -289,10 +289,16 @@ data BasicBlockData = BasicBlockData {
 }
     deriving (Show,Eq, Ord, Generic)
 
+-- | A pair of a 'StatementKind' and its source position.
+data Statement = Statement
+    { _stmtKind :: StatementKind
+    , _stmtPos :: Text
+    }
+    deriving (Eq, Ord, Show, Generic)
 
-data Statement =
-      Assign { _alhs :: Lvalue, _arhs :: Rvalue, _apos :: Text }
-      -- TODO: the rest of these variants also have positions
+-- | The various kinds of statements that can appear in MIR.
+data StatementKind =
+      Assign { _alhs :: Lvalue, _arhs :: Rvalue }
       | SetDiscriminant { _sdlv :: Lvalue, _sdvi :: Int }
       | StorageLive { _slv :: Var }
       | StorageDead { _sdv :: Var }
@@ -360,11 +366,18 @@ data Rvalue =
 data AdtAg = AdtAg { _agadt :: Adt, _avgariant :: Integer, _aops :: [Operand], _adtagty :: Ty }
     deriving (Show, Eq, Ord, Generic)
 
+-- | A pair of a 'TerminatorKind' and its source position.
+data Terminator = Terminator
+    { _termKind :: TerminatorKind
+    , _termPos :: Text
+    }
+    deriving (Eq, Ord, Show, Generic)
 
-data Terminator =
+-- | The various kinds of terminators, representing ways of exiting from a basic
+-- block.
+data TerminatorKind =
         Goto { _gbb :: BasicBlockInfo}
         -- ^ normal control flow
-      -- TODO: the rest of these variants also have positions
       | SwitchInt { _sdiscr    :: Operand,
                     _switch_ty :: Ty,
                     _svalues   :: [Maybe Integer],
@@ -585,6 +598,8 @@ makeLenses ''Vtable
 makeLenses ''Intrinsic
 makeLenses ''Instance
 makeLenses ''NamedTy
+makeLenses ''Statement
+makeLenses ''Terminator
 makeWrapped ''Substs
 
 --------------------------------------------------------------------------------------

--- a/crucible-mir/src/Mir/PP.hs
+++ b/crucible-mir/src/Mir/PP.hs
@@ -160,7 +160,10 @@ instance Pretty BasicBlockData where
 
 
 instance Pretty Statement where
-    pretty (Assign lhs rhs _) = pretty lhs <+> equals <+> pretty rhs <> semi
+  pretty stmt = pretty (stmt ^. stmtKind)
+
+instance Pretty StatementKind where
+    pretty (Assign lhs rhs) = pretty lhs <+> equals <+> pretty rhs <> semi
     pretty (SetDiscriminant lhs rhs) =
       pretty "discr(" <> pretty lhs <> pretty ")" <+> equals <+> pretty rhs <> semi
     pretty (StorageLive l) = pretty_fn1 "StorageLive" l <> semi
@@ -214,6 +217,9 @@ instance Pretty AdtAg where
 
 
 instance Pretty Terminator where
+  pretty term = pretty (term ^. termKind)
+
+instance Pretty TerminatorKind where
     pretty (Goto g) = pretty_fn1 "goto" g <> semi
     pretty (SwitchInt op ty vs bs _pos) =
       pretty "switchint" <+> pretty op <+> colon <> pretty ty <+>

--- a/crucible-mir/src/Mir/Pass/AllocateEnum.hs
+++ b/crucible-mir/src/Mir/Pass/AllocateEnum.hs
@@ -61,25 +61,34 @@ lookupAdt defid = find (\adt -> _adtname adt == defid) (?col^.adts)
 
 
 isAdtFieldUpdate :: Statement -> Maybe FieldUpdate
-isAdtFieldUpdate (Assign (LProj (LProj lv (Downcast j)) (PField i ty)) (Use rhs) pos) =
-  Just (FieldUpdate lv j i ty rhs pos)
-isAdtFieldUpdate _ = Nothing
+isAdtFieldUpdate stmt =
+  case stmt ^. stmtKind of
+    Assign (LProj (LProj lv (Downcast j)) (PField i ty)) (Use rhs) ->
+      Just (FieldUpdate lv j i ty rhs (stmt ^. stmtPos))
+    _ ->
+      Nothing
 
 -- NB: Despite the name, the second argument to SetDiscriminant is a variant
 -- index, not a discriminant value.  The `Int` returned from this function
 -- similarly is a variant index.
 isSetDiscriminant :: (?col :: Collection) => Statement -> Maybe (Lvalue, Int, Adt)
-isSetDiscriminant (SetDiscriminant lv i) =
-  case typeOf lv of
-    TyAdt defid _ _ -> case (lookupAdt defid) of
-                          Just adt -> Just (lv,i,adt)
-                          Nothing  -> Nothing
-    _ -> Nothing
-isSetDiscriminant _ = Nothing
+isSetDiscriminant stmt =
+  case stmt ^. stmtKind of
+    SetDiscriminant lv i ->
+      case typeOf lv of
+        TyAdt defid _ _ -> case (lookupAdt defid) of
+                              Just adt -> Just (lv,i,adt)
+                              Nothing  -> Nothing
+        _ -> Nothing
+    _ ->
+      Nothing
 
 makeAggregate :: (?col :: Collection) => [FieldUpdate] -> (Lvalue, Int, Adt) -> Statement
 makeAggregate updates (lv, k, adt) =
-    (Assign lv (RAdtAg (AdtAg adt (toInteger k) ops ty)) pos) where
+    Statement
+      { _stmtKind = Assign lv (RAdtAg (AdtAg adt (toInteger k) ops ty))
+      , _stmtPos = pos
+      } where
   adt_did = _adtname adt
   ty  = typeOf lv
   pos = case updates of

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -1261,16 +1261,20 @@ doAssign lv (MirExp tpr val) = do
 
 
 transStatement :: HasCallStack => M.Statement -> MirGenerator h s ret ()
-transStatement (M.Assign lv rv pos) = do
+transStatement (M.Statement skind spos) = do
+  setPosition spos
+  transStatementKind skind
+
+transStatementKind :: HasCallStack => M.StatementKind -> MirGenerator h s ret ()
+transStatementKind (M.Assign lv rv) = do
   col <- use $ cs . collection
   -- Skip writes to zero-sized fields, as they are effectively no-ops.
   when (not $ isZeroSized col $ typeOf lv) $ do
-    setPosition pos
     re <- evalRval rv
     doAssignCoerce lv (M.typeOf rv) re
-transStatement (M.StorageLive lv) = return ()
-transStatement (M.StorageDead lv) = return ()
-transStatement (M.SetDiscriminant lv i) = do
+transStatementKind (M.StorageLive lv) = return ()
+transStatementKind (M.StorageDead lv) = return ()
+transStatementKind (M.SetDiscriminant lv i) = do
   case M.typeOf lv of
     -- Currently we require that all uses of `SetDiscriminant` get bundled up
     -- with related field writes into an `RAdtAg` assignment during the
@@ -1282,9 +1286,9 @@ transStatement (M.SetDiscriminant lv i) = do
     -- allowing an enum value to have multiple initialized variants
     -- simultaneously), then we could remove AllocateEnum.
     ty -> mirFail $ "don't know how to set discriminant of " ++ show ty
-transStatement M.Nop = return ()
-transStatement M.Deinit = return ()
-transStatement (M.StmtIntrinsic ndi) =
+transStatementKind M.Nop = return ()
+transStatementKind M.Deinit = return ()
+transStatementKind (M.StmtIntrinsic ndi) =
     case ndi of
         -- rustc uses assumptions from `assume` to optimize code. If we
         -- encounter an occurrence of `assume` in MIR code, we should check
@@ -1406,11 +1410,11 @@ switchIsDropFlagCheck [0] [f, t] = do
     trueBb <- case optTrueBb of
         Just x -> return $ x
         Nothing -> mirFail $ "bad switch target " ++ show t
-    let stmtsOk = case trueBb ^. bbstmts of
-            [Assign (LBase _) (Use (OpConstant (Constant TyBool (ConstBool False)))) _] ->
+    let stmtsOk = case map _stmtKind (trueBb ^. bbstmts) of
+            [Assign (LBase _) (Use (OpConstant (Constant TyBool (ConstBool False))))] ->
                 True
             _ -> False
-    let termOk = case trueBb ^. bbterminator of
+    let termOk = case trueBb ^. bbterminator . termKind of
             Drop _ dest _ _ -> dest == f
             _ -> False
     return $ stmtsOk && termOk
@@ -1598,28 +1602,32 @@ doCall funid cargs cdest retRepr = do
             -- TODO: is this the correct behavior?
             G.reportError (S.app $ E.StringLit $ fromString "Program terminated.")
 
-
 transTerminator :: HasCallStack => M.Terminator -> C.TypeRepr ret -> MirGenerator h s ret a
-transTerminator (M.Goto bbi) _ =
+transTerminator (M.Terminator tkind tpos) tr = do
+    setPosition tpos
+    transTerminatorKind tkind tr
+
+transTerminatorKind :: HasCallStack => M.TerminatorKind -> C.TypeRepr ret -> MirGenerator h s ret a
+transTerminatorKind (M.Goto bbi) _tr =
     jumpToBlock bbi
-transTerminator (M.SwitchInt swop _swty svals stargs spos) _ | all Maybe.isJust svals = do
+transTerminatorKind (M.SwitchInt swop _swty svals stargs spos) _tr | all Maybe.isJust svals = do
     s <- evalOperand swop
     transSwitch spos s (Maybe.catMaybes svals) stargs
-transTerminator (M.Return) tr =
+transTerminatorKind (M.Return) tr =
     doReturn tr
-transTerminator (M.DropAndReplace dlv dop dtarg _ dropFn) _ = do
+transTerminatorKind (M.DropAndReplace dlv dop dtarg _ dropFn) _tr = do
     let ptrOp = M.Temp $ M.Cast M.Misc
             (M.Temp $ M.AddressOf M.Mut dlv) (M.TyRawPtr (M.typeOf dlv) M.Mut)
     maybe (return ()) (\f -> void $ callExp f [ptrOp]) dropFn
-    transStatement (M.Assign dlv (M.Use dop) "<dummy pos>")
+    transStatementKind (M.Assign dlv (M.Use dop))
     jumpToBlock dtarg
 
-transTerminator (M.Call (M.OpConstant (M.Constant (M.TyFnDef funid) _)) cargs cretdest _) tr = do
+transTerminatorKind (M.Call (M.OpConstant (M.Constant (M.TyFnDef funid) _)) cargs cretdest _) tr = do
     isCustom <- resolveCustom funid
     doCall funid cargs cretdest tr -- cleanup ignored
 
 
-transTerminator (M.Call funcOp cargs cretdest _) tr = do
+transTerminatorKind (M.Call funcOp cargs cretdest _) tr = do
     func <- evalOperand funcOp
     ret <- callHandle func RustAbi Nothing cargs
     case cretdest of
@@ -1629,25 +1637,25 @@ transTerminator (M.Call funcOp cargs cretdest _) tr = do
       Nothing -> do
           G.reportError (S.app $ E.StringLit $ fromString "Program terminated.")
 
-transTerminator (M.Assert cond expected msg target _cleanup) _ = do
+transTerminatorKind (M.Assert cond expected msg target _cleanup) _tr = do
     MirExp tpr e <- evalOperand cond
     Refl <- testEqualityOrFail tpr C.BoolRepr "expected Assert cond to be BoolType"
     G.assertExpr (S.app $ E.BoolEq e (S.app $ E.BoolLit expected)) $
         S.app $ E.StringLit $ W4.UnicodeLiteral $ msg
     jumpToBlock target
-transTerminator (M.Resume) tr =
+transTerminatorKind (M.Resume) tr =
     doReturn tr -- resume happens when unwinding
-transTerminator (M.Drop dlv dt _dunwind dropFn) _ = do
+transTerminatorKind (M.Drop dlv dt _dunwind dropFn) _tr = do
     let ptrOp = M.Temp $ M.Cast M.Misc
             (M.Temp $ M.AddressOf M.Mut dlv) (M.TyRawPtr (M.typeOf dlv) M.Mut)
     maybe (return ()) (\f -> void $ callExp f [ptrOp]) dropFn
     jumpToBlock dt
-transTerminator M.Abort tr =
+transTerminatorKind M.Abort tr =
     G.reportError (S.litExpr "process abort in unwinding")
-transTerminator M.Unreachable tr = do
+transTerminatorKind M.Unreachable tr = do
     recordUnreachable
     G.reportError (S.litExpr "Unreachable!!!!!")
-transTerminator t _tr =
+transTerminatorKind t _tr =
     mirFail $ "unknown terminator: " ++ (show t)
 
 
@@ -1696,9 +1704,9 @@ cleanupLocals = do
 -- | Look at all of the assignments in the basic block and return
 -- the set of variables that have their addresses computed
 addrTakenVars :: M.BasicBlock -> Set Text.Text
-addrTakenVars bb = mconcat (map f (M._bbstmts (M._bbdata bb)))
+addrTakenVars bb = mconcat (map (f . M._stmtKind) (M._bbstmts (M._bbdata bb)))
  where
- f (M.Assign _ (M.Ref _ lv _) _) = g lv
+ f (M.Assign _ (M.Ref _ lv _)) = g lv
  f _ = mempty
 
  g (M.LBase (M.Var nm _ _ _)) = Set.singleton nm

--- a/crux-mir/CHANGELOG.md
+++ b/crux-mir/CHANGELOG.md
@@ -1,10 +1,13 @@
-# next
+# next -- TBA
 
 * The modified copies of the Rust standard libraries that `mir-json` depends on
   (and `crux-mir` therefore ingests) now live in the `mir-json` repo rather
   than in the `crucible` repo. See the [`mir-json`
   README](https://github.com/GaloisInc/mir-json/blob/master/README.md) for
   details.
+* Improve source position tracking for MIR statements during the translation to
+  Crucible. This should result in more precise error messages in certain
+  situations.
 
 # 0.10 -- 2025-03-21
 

--- a/crux-mir/test/symb_eval/any/downcast_fail.good
+++ b/crux-mir/test/symb_eval/any/downcast_fail.good
@@ -4,7 +4,7 @@ failures:
 
 ---- downcast_fail/<DISAMB>::crux_test[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   test/symb_eval/any/downcast_fail.rs:10:14: 10:15: error: in downcast_fail/<DISAMB>::crux_test[0]
+[Crux]   test/symb_eval/any/downcast_fail.rs:10:14: 10:33: error: in downcast_fail/<DISAMB>::crux_test[0]
 [Crux]   failed to downcast Any as BVRepr 32
 
 [Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/bytes/put_overflow.good
+++ b/crux-mir/test/symb_eval/bytes/put_overflow.good
@@ -4,7 +4,7 @@ failures:
 
 ---- put_overflow/<DISAMB>::f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   internal: error: in bytes/<DISAMB>::{impl#4}[0]::put_slice[0]
+[Crux]   ./libs/core/src/panic.rs:57:9: 57:73 !libs/bytes.rs:201:9: 202:49: error: in bytes/<DISAMB>::{impl#4}[0]::put_slice[0]
 [Crux]   panicking::panic_fmt, called from bytes/<DISAMB>::{impl#4}[0]::put_slice[0]
 
 [Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/concretize/assert.good
+++ b/crux-mir/test/symb_eval/concretize/assert.good
@@ -4,7 +4,7 @@ failures:
 
 ---- assert/<DISAMB>::crux_test[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:17: 48:82 !test/symb_eval/concretize/assert.rs:10:5: 10:81: error: in assert/<DISAMB>::crux_test[0]
+[Crux]   ./libs/crucible/lib.rs:45:13: 52:14 !test/symb_eval/concretize/assert.rs:10:5: 10:81: error: in assert/<DISAMB>::crux_test[0]
 [Crux]   MIR assertion at test/symb_eval/concretize/assert.rs:10:5:
 [Crux]   	100 + 157 == 1
 

--- a/crux-mir/test/symb_eval/crux/early_fail.good
+++ b/crux-mir/test/symb_eval/crux/early_fail.good
@@ -5,12 +5,12 @@ failures:
 
 ---- early_fail/<DISAMB>::fail1[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   internal: error: in early_fail/<DISAMB>::fail1[0]
+[Crux]   ./libs/core/src/panic.rs:57:9: 57:73 !test/symb_eval/crux/early_fail.rs:11:5: 11:20: error: in early_fail/<DISAMB>::fail1[0]
 [Crux]   panicking::panic_fmt, called from early_fail/<DISAMB>::fail1[0]
 
 ---- early_fail/<DISAMB>::fail2[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:38:41: 38:58 !test/symb_eval/crux/early_fail.rs:17:5: 17:29: error: in early_fail/<DISAMB>::fail2[0]
+[Crux]   ./libs/crucible/lib.rs:41:9: 41:79 !test/symb_eval/crux/early_fail.rs:17:5: 17:29: error: in early_fail/<DISAMB>::fail2[0]
 [Crux]   MIR assertion at test/symb_eval/crux/early_fail.rs:17:5:
 [Crux]   	x == 0
 

--- a/crux-mir/test/symb_eval/crux/fail_return.good
+++ b/crux-mir/test/symb_eval/crux/fail_return.good
@@ -8,7 +8,7 @@ failures:
 [Crux]   test/symb_eval/crux/fail_return.rs:8:22: 8:27: error: in fail_return/<DISAMB>::fail1[0]
 [Crux]   attempt to compute `move _4 + const 1_u8`, which would overflow
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:38:41: 38:58 !test/symb_eval/crux/fail_return.rs:8:5: 8:32: error: in fail_return/<DISAMB>::fail1[0]
+[Crux]   ./libs/crucible/lib.rs:41:9: 41:79 !test/symb_eval/crux/fail_return.rs:8:5: 8:32: error: in fail_return/<DISAMB>::fail1[0]
 [Crux]   MIR assertion at test/symb_eval/crux/fail_return.rs:8:5:
 [Crux]   	x + 1 > x
 
@@ -17,7 +17,7 @@ failures:
 [Crux]   test/symb_eval/crux/fail_return.rs:15:22: 15:27: error: in fail_return/<DISAMB>::fail2[0]
 [Crux]   attempt to compute `move _5 + const 1_u8`, which would overflow
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:38:41: 38:58 !test/symb_eval/crux/fail_return.rs:15:5: 15:32: error: in fail_return/<DISAMB>::fail2[0]
+[Crux]   ./libs/crucible/lib.rs:41:9: 41:79 !test/symb_eval/crux/fail_return.rs:15:5: 15:32: error: in fail_return/<DISAMB>::fail2[0]
 [Crux]   MIR assertion at test/symb_eval/crux/fail_return.rs:15:5:
 [Crux]   	x + 1 > x
 

--- a/crux-mir/test/symb_eval/crux/mixed_fail.good
+++ b/crux-mir/test/symb_eval/crux/mixed_fail.good
@@ -10,7 +10,7 @@ failures:
 [Crux]   test/symb_eval/crux/mixed_fail.rs:8:22: 8:27: error: in mixed_fail/<DISAMB>::fail1[0]
 [Crux]   attempt to compute `move _5 + const 1_u8`, which would overflow
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:38:41: 38:58 !test/symb_eval/crux/mixed_fail.rs:8:5: 8:32: error: in mixed_fail/<DISAMB>::fail1[0]
+[Crux]   ./libs/crucible/lib.rs:41:9: 41:79 !test/symb_eval/crux/mixed_fail.rs:8:5: 8:32: error: in mixed_fail/<DISAMB>::fail1[0]
 [Crux]   MIR assertion at test/symb_eval/crux/mixed_fail.rs:8:5:
 [Crux]   	x + 1 > x
 
@@ -19,7 +19,7 @@ failures:
 [Crux]   test/symb_eval/crux/mixed_fail.rs:14:22: 14:27: error: in mixed_fail/<DISAMB>::fail2[0]
 [Crux]   attempt to compute `move _5 + const 2_u8`, which would overflow
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:38:41: 38:58 !test/symb_eval/crux/mixed_fail.rs:14:5: 14:32: error: in mixed_fail/<DISAMB>::fail2[0]
+[Crux]   ./libs/crucible/lib.rs:41:9: 41:79 !test/symb_eval/crux/mixed_fail.rs:14:5: 14:32: error: in mixed_fail/<DISAMB>::fail2[0]
 [Crux]   MIR assertion at test/symb_eval/crux/mixed_fail.rs:14:5:
 [Crux]   	x + 2 > x
 

--- a/crux-mir/test/symb_eval/crux/multi.good
+++ b/crux-mir/test/symb_eval/crux/multi.good
@@ -9,18 +9,18 @@ failures:
 [Crux]   test/symb_eval/crux/multi.rs:8:22: 8:27: error: in multi/<DISAMB>::fail1[0]
 [Crux]   attempt to compute `move _5 + const 1_u8`, which would overflow
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:38:41: 38:58 !test/symb_eval/crux/multi.rs:8:5: 8:32: error: in multi/<DISAMB>::fail1[0]
+[Crux]   ./libs/crucible/lib.rs:41:9: 41:79 !test/symb_eval/crux/multi.rs:8:5: 8:32: error: in multi/<DISAMB>::fail1[0]
 [Crux]   MIR assertion at test/symb_eval/crux/multi.rs:8:5:
 [Crux]   	x + 1 > x
 
 ---- multi/<DISAMB>::fail2[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   internal: error: in multi/<DISAMB>::fail2[0]
+[Crux]   ./libs/core/src/panic.rs:57:9: 57:73 !test/symb_eval/crux/multi.rs:15:9: 15:22: error: in multi/<DISAMB>::fail2[0]
 [Crux]   panicking::panic_fmt, called from multi/<DISAMB>::fail2[0]
 
 ---- multi/<DISAMB>::fail3[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:38:41: 38:58 !test/symb_eval/crux/multi.rs:20:5: 20:29: error: in multi/<DISAMB>::assert_zero[0]
+[Crux]   ./libs/crucible/lib.rs:41:9: 41:79 !test/symb_eval/crux/multi.rs:20:5: 20:29: error: in multi/<DISAMB>::assert_zero[0]
 [Crux]   MIR assertion at test/symb_eval/crux/multi.rs:20:5:
 [Crux]   	x == 0
 

--- a/crux-mir/test/symb_eval/crypto/bytes.good
+++ b/crux-mir/test/symb_eval/crypto/bytes.good
@@ -4,23 +4,23 @@ failures:
 
 ---- bytes/<DISAMB>::f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:38:41: 38:58 !test/symb_eval/crypto/bytes.rs:85:7: 85:37: error: in bytes/<DISAMB>::f[0]
+[Crux]   ./libs/crucible/lib.rs:41:9: 41:79 !test/symb_eval/crypto/bytes.rs:85:7: 85:37: error: in bytes/<DISAMB>::f[0]
 [Crux]   MIR assertion at test/symb_eval/crypto/bytes.rs:85:7:
 [Crux]   	a[i] == b[i]
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:38:41: 38:58 !test/symb_eval/crypto/bytes.rs:85:7: 85:37: error: in bytes/<DISAMB>::f[0]
+[Crux]   ./libs/crucible/lib.rs:41:9: 41:79 !test/symb_eval/crypto/bytes.rs:85:7: 85:37: error: in bytes/<DISAMB>::f[0]
 [Crux]   MIR assertion at test/symb_eval/crypto/bytes.rs:85:7:
 [Crux]   	a[i] == b[i]
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:38:41: 38:58 !test/symb_eval/crypto/bytes.rs:85:7: 85:37: error: in bytes/<DISAMB>::f[0]
+[Crux]   ./libs/crucible/lib.rs:41:9: 41:79 !test/symb_eval/crypto/bytes.rs:85:7: 85:37: error: in bytes/<DISAMB>::f[0]
 [Crux]   MIR assertion at test/symb_eval/crypto/bytes.rs:85:7:
 [Crux]   	a[i] == b[i]
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:38:41: 38:58 !test/symb_eval/crypto/bytes.rs:85:7: 85:37: error: in bytes/<DISAMB>::f[0]
+[Crux]   ./libs/crucible/lib.rs:41:9: 41:79 !test/symb_eval/crypto/bytes.rs:85:7: 85:37: error: in bytes/<DISAMB>::f[0]
 [Crux]   MIR assertion at test/symb_eval/crypto/bytes.rs:85:7:
 [Crux]   	a[i] == b[i]
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:38:41: 38:58 !test/symb_eval/crypto/bytes.rs:85:7: 85:37: error: in bytes/<DISAMB>::f[0]
+[Crux]   ./libs/crucible/lib.rs:41:9: 41:79 !test/symb_eval/crypto/bytes.rs:85:7: 85:37: error: in bytes/<DISAMB>::f[0]
 [Crux]   MIR assertion at test/symb_eval/crypto/bytes.rs:85:7:
 [Crux]   	a[i] == b[i]
 

--- a/crux-mir/test/symb_eval/overrides/bad_symb1.good
+++ b/crux-mir/test/symb_eval/overrides/bad_symb1.good
@@ -4,7 +4,7 @@ failures:
 
 ---- bad_symb1/<DISAMB>::crux_test[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   libs/crucible/symbolic.rs:24:64: 24:68 !libs/crucible/symbolic.rs:30:1: 36:2: error: in crucible/<DISAMB>::symbolic[0]::{impl#1}[0]::symbolic[0]
+[Crux]   libs/crucible/symbolic.rs:24:58: 24:69 !libs/crucible/symbolic.rs:30:1: 36:2: error: in crucible/<DISAMB>::symbolic[0]::{impl#1}[0]::symbolic[0]
 [Crux]   symbolic variable name must be a concrete string
 
 [Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/overrides/bad_symb2.good
+++ b/crux-mir/test/symb_eval/overrides/bad_symb2.good
@@ -4,7 +4,7 @@ failures:
 
 ---- bad_symb2/<DISAMB>::crux_test[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   libs/crucible/symbolic.rs:24:64: 24:68 !libs/crucible/symbolic.rs:30:1: 36:2: error: in crucible/<DISAMB>::symbolic[0]::{impl#1}[0]::symbolic[0]
+[Crux]   libs/crucible/symbolic.rs:24:58: 24:69 !libs/crucible/symbolic.rs:30:1: 36:2: error: in crucible/<DISAMB>::symbolic[0]::{impl#1}[0]::symbolic[0]
 [Crux]   invalid symbolic variable name "\NUL:., /": Identifier must start with a letter.
 
 [Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/overrides/override2.good
+++ b/crux-mir/test/symb_eval/overrides/override2.good
@@ -4,7 +4,7 @@ failures:
 
 ---- override2/<DISAMB>::f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:38:41: 38:58 !test/symb_eval/overrides/override2.rs:9:5: 9:49: error: in override2/<DISAMB>::f[0]
+[Crux]   ./libs/crucible/lib.rs:41:9: 41:79 !test/symb_eval/overrides/override2.rs:9:5: 9:49: error: in override2/<DISAMB>::f[0]
 [Crux]   MIR assertion at test/symb_eval/overrides/override2.rs:9:5:
 [Crux]   	foo.wrapping_add(1) == foo
 

--- a/crux-mir/test/symb_eval/overrides/override5.good
+++ b/crux-mir/test/symb_eval/overrides/override5.good
@@ -4,7 +4,7 @@ failures:
 
 ---- override5/<DISAMB>::f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:38:41: 38:58 !test/symb_eval/overrides/override5.rs:10:5: 10:47: error: in override5/<DISAMB>::f[0]
+[Crux]   ./libs/crucible/lib.rs:41:9: 41:79 !test/symb_eval/overrides/override5.rs:10:5: 10:47: error: in override5/<DISAMB>::f[0]
 [Crux]   MIR assertion at test/symb_eval/overrides/override5.rs:10:5:
 [Crux]   	foo.wrapping_add(1) != 0
 

--- a/crux-mir/test/symb_eval/sym_bytes/construct.good
+++ b/crux-mir/test/symb_eval/sym_bytes/construct.good
@@ -4,7 +4,7 @@ failures:
 
 ---- construct/<DISAMB>::crux_test[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:38:41: 38:58 !test/symb_eval/sym_bytes/construct.rs:13:5: 13:35: error: in construct/<DISAMB>::crux_test[0]
+[Crux]   ./libs/crucible/lib.rs:41:9: 41:79 !test/symb_eval/sym_bytes/construct.rs:13:5: 13:35: error: in construct/<DISAMB>::crux_test[0]
 [Crux]   MIR assertion at test/symb_eval/sym_bytes/construct.rs:13:5:
 [Crux]   	sym2[0] == 0
 


### PR DESCRIPTION
Fixes #1388.