### PR TITLE
`crucible-mir`: erase pointee type from `MirReferenceType` ("opaque pointers")

### DIFF
--- a/crucible-mir/CHANGELOG.md
+++ b/crucible-mir/CHANGELOG.md
@@ -10,6 +10,8 @@ This release supports [version
 * Improve source position tracking for `Statement`s and `Terminator`s during
   the translation to Crucible. This should result in more precise error messages
   in certain situations.
+* The `CTyBv{128,256,512}` pattern synonyms have been removed. It is not
+  expected that there are any downstream users.
 
 # 0.4 -- 2025-03-21
 

--- a/crucible-mir/src/Mir/Intrinsics.hs
+++ b/crucible-mir/src/Mir/Intrinsics.hs
@@ -1030,20 +1030,20 @@ instance OrdFC MirStmt where
 
 instance TypeApp MirStmt where
   appType = \case
-    MirNewRef tp    -> MirReferenceRepr
+    MirNewRef _    -> MirReferenceRepr
     MirIntegerToRef _ -> MirReferenceRepr
-    MirGlobalRef gv -> MirReferenceRepr
-    MirConstRef tp _ -> MirReferenceRepr
+    MirGlobalRef _ -> MirReferenceRepr
+    MirConstRef _ _ -> MirReferenceRepr
     MirReadRef tp _ -> tp
     MirWriteRef _ _ _ -> UnitRepr
     MirDropRef _    -> UnitRepr
-    MirSubanyRef tp _ -> MirReferenceRepr
-    MirSubfieldRef ctx _ idx -> MirReferenceRepr
-    MirSubvariantRef _ ctx _ idx -> MirReferenceRepr
-    MirSubindexRef tp _ _ -> MirReferenceRepr
-    MirSubjustRef tp _ -> MirReferenceRepr
-    MirRef_VectorAsMirVector tp _ -> MirReferenceRepr
-    MirRef_ArrayAsMirVector btp _ -> MirReferenceRepr
+    MirSubanyRef _ _ -> MirReferenceRepr
+    MirSubfieldRef _ _ _ -> MirReferenceRepr
+    MirSubvariantRef _ _ _ _ -> MirReferenceRepr
+    MirSubindexRef _ _ _ -> MirReferenceRepr
+    MirSubjustRef _ _ -> MirReferenceRepr
+    MirRef_VectorAsMirVector _ _ -> MirReferenceRepr
+    MirRef_ArrayAsMirVector _ _ -> MirReferenceRepr
     MirRef_Eq _ _ -> BoolRepr
     MirRef_Offset _ _ -> MirReferenceRepr
     MirRef_OffsetWrap _ _ -> MirReferenceRepr
@@ -1182,6 +1182,12 @@ dropRefRoot _bak _gs (Const_RefRoot tpr _) =
     leafAbort $ GenericSimError $
         "Cannot drop Const_RefRoot (of type " ++ show tpr ++ ")"
 
+-- | Helper for defining a `MuxLeafT` operation that works only for
+-- `MirReference`s with a specific pointee type `tp`.  If the `MirReference`
+-- argument is a valid reference (not `MirReference_Integer`) with pointee type
+-- `tp`, this calls `k` on the reference's parts; otherwise, this fails.
+-- `desc` is a human-readable description of the operation, which is used in
+-- the `leafAbort` error message.
 typedLeafOp ::
     Monad m =>
     String ->
@@ -2070,7 +2076,7 @@ subindexMirRefIO bak iTypes tpr ref x =
 mirRef_offsetSim :: IsSymInterface sym =>
     TypeRepr tp -> MirReferenceMux sym -> RegValue sym IsizeType ->
     OverrideSim m sym MIR rtp args ret (MirReferenceMux sym)
-mirRef_offsetSim tpr ref off =
+mirRef_offsetSim _tpr ref off =
     ovrWithBackend $ \bak ->
       modifyRefMuxSim (\ref' -> mirRef_offsetWrapLeaf bak ref' off) ref
 

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -1124,15 +1124,15 @@ evalPlaceProj ty pl@(MirPlace tpr ref NoMeta) M.Deref = do
         dynRef <- readMirRef tpr ref
         return $ MirPlaceDynRef dynRef
     doRef ty' | MirReferenceRepr <- tpr = do
-        -- This use of `tyToRepr` is okay because `TyDynamic` and other unsized
-        -- cases are handled above.
+        -- This use of `tyToReprM` is okay because `TyDynamic` and other
+        -- unsized cases are handled above.
         Some tpr' <- tyToReprM ty'
         MirPlace tpr' <$> readMirRef tpr ref <*> pure NoMeta
     doRef _ = mirFail $ "deref: bad repr for " ++ show ty ++ ": " ++ show tpr
 
     doSlice ty' ref' = do
-        -- This use of `tyToRepr` is okay because we know the element type of a
-        -- slice is always sized.
+        -- This use of `tyToReprM` is okay because we know the element type of
+        -- a slice is always sized.
         Some tpr' <- tyToReprM ty'
         slice <- readMirRef MirSliceRepr ref'
         let ptr = getSlicePtr slice

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -167,8 +167,8 @@ transConstVal _ty (Some (IsizeRepr)) (ConstInt i) =
 -- staticSlicePlace does the first four of these actions; addrOfPlace
 -- does the last two.
 --
-transConstVal (M.TyRef _ _) (Some (MirSliceRepr tpr)) (M.ConstSliceRef defid len) = do
-    place <- staticSlicePlace tpr len defid
+transConstVal (M.TyRef _ _) (Some MirSliceRepr) (M.ConstSliceRef defid len) = do
+    place <- staticSlicePlace len defid
     addr <- addrOfPlace place
     return addr
 
@@ -215,8 +215,8 @@ transConstVal ty _ ConstZST = initialValue ty >>= \case
     Just x -> return x
     Nothing -> mirFail $
         "failed to evaluate ZST constant of type " ++ show ty ++ " (initialValue failed)"
-transConstVal _ty (Some (MirReferenceRepr tpr)) (ConstRawPtr i) =
-    MirExp (MirReferenceRepr tpr) <$> integerToMirRef tpr (R.App $ usizeLit i)
+transConstVal _ty (Some MirReferenceRepr) (ConstRawPtr i) =
+    MirExp MirReferenceRepr <$> integerToMirRef (R.App $ usizeLit i)
 transConstVal ty@(M.TyAdt aname _ _) tpr (ConstStruct fields) = do
     adt <- findAdt aname
     col <- use $ cs . collection
@@ -240,12 +240,14 @@ transConstVal ty@(M.TyAdt aname _ _) tpr (ConstEnum variant fields) = do
             let fieldTys = map (\f -> f ^. fty) fieldDefs
             exps <- zipWithM (\val ty -> transConstVal ty (tyToRepr col ty) val) fields fieldTys
             buildEnum adt variant exps
-transConstVal ty (Some (MirReferenceRepr tpr)) init = do
-    MirExp tpr' val <- transConstVal (M.typeOfProj M.Deref ty) (Some tpr) init
+transConstVal ty (Some MirReferenceRepr) init = do
+    let pointeeTy = M.typeOfProj M.Deref ty
+    Some tpr <- tyToReprM pointeeTy
+    MirExp tpr' val <- transConstVal pointeeTy (Some tpr) init
     Refl <- testEqualityOrFail tpr tpr' $
         "transConstVal returned wrong type: expected " ++ show tpr ++ ", got " ++ show tpr'
     ref <- constMirRef tpr val
-    return $ MirExp (MirReferenceRepr tpr) ref
+    return $ MirExp MirReferenceRepr ref
 transConstVal _ty (Some tpr@(C.FunctionHandleRepr argTys retTy)) (ConstFnPtr inst) = do
     let did = inst^.inDefId
     mbHndl <- resolveFn did
@@ -328,7 +330,7 @@ readVar :: C.TypeRepr tp -> VarInfo s tp -> MirGenerator h s ret (R.Expr MIR s t
 readVar tpr vi = do
     case vi of
         VarRegister reg -> G.readReg reg
-        VarReference reg -> G.readReg reg >>= readMirRef tpr
+        VarReference _ reg -> G.readReg reg >>= readMirRef tpr
         VarAtom a -> return $ R.AtomExpr a
 
 varExp :: HasCallStack => M.Var -> MirGenerator h s ret (MirExp s)
@@ -343,7 +345,7 @@ varPlace (M.Var vname _ vty _) = do
     Some tpr <- tyToReprM vty
     vi <- typedVarInfo vname tpr
     r <- case vi of
-        VarReference reg -> G.readReg reg
+        VarReference _ reg -> G.readReg reg
         -- TODO: these cases won't be needed once immutable ref support is done
         -- - make them report an error instead
         VarRegister reg -> do
@@ -365,15 +367,16 @@ staticPlace did = do
 
 -- variant of staticPlace for slices
 -- tpr is the element type; len is the length
-staticSlicePlace :: HasCallStack => C.TypeRepr tp -> Int -> M.DefId -> MirGenerator h s ret (MirPlace s)
-staticSlicePlace tpr len did = do
+staticSlicePlace :: HasCallStack => Int -> M.DefId -> MirGenerator h s ret (MirPlace s)
+staticSlicePlace len did = do
     sm <- use $ cs.staticMap
     case Map.lookup did sm of
         Just (StaticVar gv) -> do
             let tpr_found = G.globalType gv
-            Refl <- testEqualityOrFail (MirVectorRepr tpr) tpr_found $
-                "staticSlicePlace: wrong type: expected vector of " ++
-                show tpr ++ ", found " ++ show tpr_found
+            Some tpr <- case tpr_found of
+                MirVectorRepr tpr -> return $ Some tpr
+                _ -> mirFail $
+                    "staticSlicePlace: wrong type: expected vector, found " ++ show tpr_found
             ref <- globalMirRef gv
             ref' <- subindexRef tpr ref (R.App $ usizeLit 0)
             let len' = R.App $ usizeLit $ fromIntegral len
@@ -399,13 +402,16 @@ evalOperand (M.Temp rv) = evalRval rv
 
 -- | Dereference a `MirExp` (which must be `MirReferenceRepr` or other `TyRef`
 -- representation), producing a `MirPlace`.
-derefExp :: HasCallStack => MirExp s -> MirGenerator h s ret (MirPlace s)
-derefExp (MirExp (MirReferenceRepr tpr) e) = return $ MirPlace tpr e NoMeta
-derefExp (MirExp (MirSliceRepr tpr) e) = do
+derefExp :: HasCallStack => M.Ty -> MirExp s -> MirGenerator h s ret (MirPlace s)
+derefExp pointeeTy (MirExp MirReferenceRepr e) = do
+    Some tpr <- tyToReprM pointeeTy
+    return $ MirPlace tpr e NoMeta
+derefExp pointeeTy (MirExp MirSliceRepr e) = do
+    Some tpr <- tyToReprM pointeeTy
     let ptr = getSlicePtr e
     let len = getSliceLen e
     return $ MirPlace tpr ptr (SliceMeta len)
-derefExp (MirExp tpr _) = mirFail $ "don't know how to deref " ++ show tpr
+derefExp pointeeTy (MirExp tpr _) = mirFail $ "don't know how to deref " ++ show tpr
 
 readPlace :: HasCallStack => MirPlace s -> MirGenerator h s ret (MirExp s)
 readPlace (MirPlace tpr r NoMeta) = MirExp tpr <$> readMirRef tpr r
@@ -417,9 +423,9 @@ readPlace MirPlaceDynRef{} =
     mirFail "readPlace not supported for dyn references"
 
 addrOfPlace :: HasCallStack => MirPlace s -> MirGenerator h s ret (MirExp s)
-addrOfPlace (MirPlace tpr r NoMeta) = return $ MirExp (MirReferenceRepr tpr) r
+addrOfPlace (MirPlace tpr r NoMeta) = return $ MirExp MirReferenceRepr r
 addrOfPlace (MirPlace tpr r (SliceMeta len)) =
-    return $ MirExp (MirSliceRepr tpr) $ mkSlice tpr r len
+    return $ MirExp MirSliceRepr $ mkSlice r len
 addrOfPlace (MirPlaceDynRef dynRef) =
     return $ MirExp DynRefRepr dynRef
 
@@ -580,8 +586,7 @@ evalBinOp bop mat me1 me2 =
 
             _ -> mirFail $ "No translation for real number binop: " ++ fmt bop
 
-      (MirExp (MirReferenceRepr tpr1) e1, MirExp (MirReferenceRepr tpr2) e2)
-        | Just Refl <- testEquality tpr1 tpr2 ->
+      (MirExp MirReferenceRepr e1, MirExp MirReferenceRepr e2) ->
           case bop of
             M.Beq -> do
                 eq <- mirRef_eq e1 e2
@@ -591,9 +596,9 @@ evalBinOp bop mat me1 me2 =
                 return (MirExp C.BoolRepr $ S.app $ E.Not eq, noOverflow)
             _ -> mirFail $ "No translation for pointer binop: " ++ fmt bop
 
-      (MirExp (MirReferenceRepr tpr) e1, MirExp UsizeRepr e2) -> do
-          newRef <- mirRef_offsetWrap tpr e1 e2
-          return (MirExp (MirReferenceRepr tpr) newRef, noOverflow)
+      (MirExp MirReferenceRepr e1, MirExp UsizeRepr e2) -> do
+          newRef <- mirRef_offsetWrap e1 e2
+          return (MirExp MirReferenceRepr newRef, noOverflow)
 
       (_, _) -> mirFail $ "bad or unimplemented type: " ++ (fmt bop) ++ ", " ++ (show me1) ++ ", " ++ (show me2)
 
@@ -873,27 +878,27 @@ evalCast' ck ty1 e ty2  = do
       -- supported.
       (M.Misc, M.TyInt _, M.TyRawPtr ty _)
         | MirExp (C.BVRepr w) val <- e -> do
-          Some tpr <- tyToReprM ty
           let int = sbvToUsize w R.App val
-          MirExp (MirReferenceRepr tpr) <$> integerToMirRef tpr int
+          MirExp MirReferenceRepr <$> integerToMirRef int
       (M.Misc, M.TyUint _, M.TyRawPtr ty _)
         | MirExp (C.BVRepr w) val <- e -> do
-          Some tpr <- tyToReprM ty
           let int = bvToUsize w R.App val
-          MirExp (MirReferenceRepr tpr) <$> integerToMirRef tpr int
+          MirExp MirReferenceRepr <$> integerToMirRef int
 
       --  *const [T] -> *T (discards the length and returns only the pointer)
       (M.Misc, M.TyRawPtr (M.TySlice t1) m1, M.TyRawPtr t2 m2)
-        | t1 == t2, m1 == m2, MirExp (MirSliceRepr tpr) e' <- e
-        -> return $ MirExp (MirReferenceRepr tpr) (getSlicePtr e')
+        | t1 == t2, m1 == m2, MirExp MirSliceRepr e' <- e
+        -> return $ MirExp MirReferenceRepr (getSlicePtr e')
       (M.Misc, M.TyRawPtr M.TyStr m1, M.TyRawPtr (M.TyUint M.B8) m2)
-        | m1 == m2, MirExp (MirSliceRepr tpr) e' <- e
-        -> return $ MirExp (MirReferenceRepr tpr) (getSlicePtr e')
+        | m1 == m2, MirExp MirSliceRepr e' <- e
+        -> return $ MirExp MirReferenceRepr (getSlicePtr e')
 
       --  *const [T; N] -> *const T (get first element)
       (M.Misc, M.TyRawPtr (M.TyArray t1 _) m1, M.TyRawPtr t2 m2)
-        | t1 == t2, m1 == m2, MirExp (MirReferenceRepr (MirVectorRepr tpr)) e' <- e
-        -> MirExp (MirReferenceRepr tpr) <$> subindexRef tpr e' (R.App $ usizeLit 0)
+        | t1 == t2, m1 == m2, MirExp MirReferenceRepr e' <- e
+        -> do
+          Some tpr <- tyToReprM t1
+          MirExp MirReferenceRepr <$> subindexRef tpr e' (R.App $ usizeLit 0)
 
       --  *const [u8] <-> *const str (no-ops)
       (M.Misc, M.TyRawPtr (M.TySlice (M.TyUint M.B8)) m1, M.TyRawPtr M.TyStr m2)
@@ -923,14 +928,15 @@ evalCast' ck ty1 e ty2  = do
       _ -> mirFail $ "unimplemented cast: " ++ (show ck) ++
         "\n  ty: " ++ (show ty1) ++ "\n  as: " ++ (show ty2)
   where
-    unsizeArray tp sz tp'
-      | tp == tp', MirExp (MirReferenceRepr (MirVectorRepr elem_tp)) ref <- e
+    unsizeArray ty sz ty'
+      | ty == ty', MirExp MirReferenceRepr ref <- e
       = do
+        Some elem_tp <- tyToReprM ty
         let len   = R.App $ usizeLit (fromIntegral sz)
         ref' <- subindexRef elem_tp ref (R.App $ usizeLit 0)
-        let tup   = S.mkStruct (mirSliceCtxRepr elem_tp)
+        let tup   = S.mkStruct mirSliceCtxRepr
                         (Ctx.Empty Ctx.:> ref' Ctx.:> len)
-        return $ MirExp (MirSliceRepr elem_tp) tup
+        return $ MirExp MirSliceRepr tup
       | otherwise = mirFail $
         "Type mismatch in cast: " ++ show ck ++ " " ++ show ty1 ++ " as " ++ show ty2
 
@@ -1112,17 +1118,23 @@ evalPlaceProj ty pl@(MirPlace tpr ref NoMeta) M.Deref = do
         CTyBox t -> doRef t
         _ -> mirFail $ "deref not supported on " ++ show ty
   where
-    doRef (M.TySlice _) | MirSliceRepr tpr' <- tpr = doSlice tpr' ref
-    doRef M.TyStr | MirSliceRepr tpr' <- tpr = doSlice tpr' ref
+    doRef (M.TySlice ty') | MirSliceRepr <- tpr = doSlice ty' ref
+    doRef M.TyStr | MirSliceRepr <- tpr = doSlice (M.TyUint M.B8) ref
     doRef (M.TyDynamic _) | DynRefRepr <- tpr = do
         dynRef <- readMirRef tpr ref
         return $ MirPlaceDynRef dynRef
-    doRef _ | MirReferenceRepr tpr' <- tpr = do
+    doRef ty' | MirReferenceRepr <- tpr = do
+        -- This use of `tyToRepr` is okay because `TyDynamic` and other unsized
+        -- cases are handled above.
+        Some tpr' <- tyToReprM ty'
         MirPlace tpr' <$> readMirRef tpr ref <*> pure NoMeta
     doRef _ = mirFail $ "deref: bad repr for " ++ show ty ++ ": " ++ show tpr
 
-    doSlice tpr' ref' = do
-        slice <- readMirRef (MirSliceRepr tpr') ref'
+    doSlice ty' ref' = do
+        -- This use of `tyToRepr` is okay because we know the element type of a
+        -- slice is always sized.
+        Some tpr' <- tyToReprM ty'
+        slice <- readMirRef MirSliceRepr ref'
         let ptr = getSlicePtr slice
         let len = getSliceLen slice
         return $ MirPlace tpr' ptr (SliceMeta len)
@@ -1176,7 +1188,7 @@ evalPlaceProj ty (MirPlace tpr ref meta) (M.Index idxVar) = case (ty, tpr, meta)
         idx <- getIdx idxVar
         G.assertExpr (R.App $ usizeLt idx len)
             (S.litExpr "Index out of range for access to slice")
-        MirPlace elemTpr <$> mirRef_offset elemTpr ref idx <*> pure NoMeta
+        MirPlace elemTpr <$> mirRef_offset ref idx <*> pure NoMeta
 
     _ -> mirFail $ "indexing not supported on " ++ show (ty, tpr, meta)
   where
@@ -1196,7 +1208,7 @@ evalPlaceProj ty (MirPlace tpr ref meta) (M.ConstantIndex idx _minLen fromEnd) =
         idx <- getIdx idx len fromEnd
         G.assertExpr (R.App $ usizeLt idx len)
             (S.litExpr "Index out of range for access to slice")
-        MirPlace elemTpr <$> mirRef_offset elemTpr ref idx <*> pure NoMeta
+        MirPlace elemTpr <$> mirRef_offset ref idx <*> pure NoMeta
 
     _ -> mirFail $ "indexing not supported on " ++ show (ty, tpr, meta)
   where
@@ -1257,7 +1269,7 @@ doAssign lv (MirExp tpr val) = do
             Refl <- testEqualityOrFail tpr tpr' $
                 "ill-typed assignment of " ++ show tpr ++ " to " ++ show tpr'
                     ++ " (" ++ show (M.typeOf lv) ++ ") " ++ show lv
-            writeMirRef ref val
+            writeMirRef tpr ref val
 
 
 transStatement :: HasCallStack => M.Statement -> MirGenerator h s ret ()
@@ -1302,11 +1314,12 @@ transStatementKind (M.StmtIntrinsic ndi) =
             srcExp <- evalOperand srcOp
             destExp <- evalOperand destOp
             countExp <- evalOperand countOp
+            let elemTy = M.typeOfProj M.Deref $ M.typeOf srcOp
+            Some tpr <- tyToReprM elemTy
             case (srcExp, destExp, countExp) of
-                ( MirExp (MirReferenceRepr tpr) src,
-                  MirExp (MirReferenceRepr tpr') dest,
+                ( MirExp MirReferenceRepr src,
+                  MirExp MirReferenceRepr dest,
                   MirExp UsizeRepr count )
-                    |  Just Refl <- testEquality tpr tpr'
                     -> void $ copyNonOverlapping tpr src dest count
                 _   -> mirFail $ unlines
                          [ "bad arguments for intrinsics::copy_nonoverlapping: "
@@ -1683,9 +1696,9 @@ initLocals localVars addrTaken = forM_ localVars $ \v -> do
             ref <- newMirRef tpr
             case optVal of
                 Nothing -> return ()
-                Just val -> writeMirRef ref val
+                Just val -> writeMirRef tpr ref val
             reg <- G.newReg ref
-            return $ Some $ VarReference reg
+            return $ Some $ VarReference tpr reg
         False -> do
             reg <- case optVal of
                 Nothing -> G.newUnassignedReg tpr
@@ -1698,7 +1711,7 @@ cleanupLocals :: MirGenerator h s ret ()
 cleanupLocals = do
     vm <- use varMap
     forM_ (Map.elems vm) $ \(Some vi) -> case vi of
-        VarReference reg -> G.readReg reg >>= dropMirRef
+        VarReference _ reg -> G.readReg reg >>= dropMirRef
         _ -> return ()
 
 -- | Look at all of the assignments in the basic block and return
@@ -1812,9 +1825,9 @@ genFn (M.Fn fname argvars _ body@(MirBody localvars blocks _)) rettype inputs = 
                         show (R.typeOfAtom input) ++ " != " ++ show (varInfoRepr vi)
                 case vi of
                     VarRegister reg -> G.assignReg reg $ R.AtomExpr input
-                    VarReference refReg -> do
+                    VarReference tpr refReg -> do
                         ref <- G.readReg refReg
-                        writeMirRef ref $ R.AtomExpr input
+                        writeMirRef tpr ref $ R.AtomExpr input
                     VarAtom _ -> mirFail $ "unexpected VarAtom"
                 initArgs inputs' vars'
             _ -> mirFail $ "mismatched argument count for " ++ show fname
@@ -2372,7 +2385,7 @@ transStatics colState halloc = do
 -- Generate a loop that copies `len` elements starting at `ptr0` into a vector.
 --
 vectorCopy :: C.TypeRepr tp ->
-              G.Expr MIR s (MirReferenceType tp) ->
+              G.Expr MIR s MirReferenceType ->
               G.Expr MIR s UsizeType ->
               MirGenerator h s ret (G.Expr MIR s (C.VectorType tp))
 vectorCopy tpr ptr0 len = do
@@ -2396,7 +2409,7 @@ vectorCopy tpr ptr0 len = do
                      out <- G.readRef outRef
                      elt <- readMirRef tpr ptr
                      let i' = S.app $ usizeAdd i (S.app $ usizeLit 1)
-                     ptr' <- mirRef_offset tpr ptr (S.app $ usizeLit 1)
+                     ptr' <- mirRef_offset ptr (S.app $ usizeLit 1)
                      let out' = S.app $ vectorSetUsize tpr R.App out i elt
                      G.writeRef iRef i'
                      G.writeRef ptrRef ptr'
@@ -2407,8 +2420,8 @@ vectorCopy tpr ptr0 len = do
 
 ptrCopy ::
     C.TypeRepr tp ->
-    G.Expr MIR s (MirReferenceType tp) ->
-    G.Expr MIR s (MirReferenceType tp) ->
+    G.Expr MIR s MirReferenceType ->
+    G.Expr MIR s MirReferenceType ->
     G.Expr MIR s UsizeType ->
     MirGenerator h s ret ()
 ptrCopy tpr src dest len = do
@@ -2417,18 +2430,18 @@ ptrCopy tpr src dest len = do
     G.while (pos, do i <- G.readRef iRef
                      return (G.App $ usizeLt i len))
             (pos, do i <- G.readRef iRef
-                     src' <- mirRef_offset tpr src i
-                     dest' <- mirRef_offset tpr dest i
+                     src' <- mirRef_offset src i
+                     dest' <- mirRef_offset dest i
                      val <- readMirRef tpr src'
-                     writeMirRef dest' val
+                     writeMirRef tpr dest' val
                      let i' = S.app $ usizeAdd i (S.app $ usizeLit 1)
                      G.writeRef iRef i')
     G.dropRef iRef
 
 copyNonOverlapping ::
     C.TypeRepr tp ->
-    R.Expr MIR s (MirReferenceType tp) ->
-    R.Expr MIR s (MirReferenceType tp) ->
+    R.Expr MIR s MirReferenceType ->
+    R.Expr MIR s MirReferenceType ->
     R.Expr MIR s UsizeType ->
     MirGenerator h s ret (MirExp s)
 copyNonOverlapping tpr src dest count = do

--- a/crux-mir/src/Mir/Overrides.hs
+++ b/crux-mir/src/Mir/Overrides.hs
@@ -263,11 +263,13 @@ regEval bak baseEval tpr v = go tpr v
         ref' <- case ref of
             MirReference tpr root path ->
                 MirReference tpr <$> goMirReferenceRoot root <*> goMirReferencePath path
-            (MirReference_Integer i) ->
+            MirReference_Integer i ->
                 MirReference_Integer <$> go UsizeRepr i
         return $ MirReferenceMux $ toFancyMuxTree sym ref'
     go (MirVectorRepr tpr') vec = case vec of
         MirVector_Vector v -> MirVector_Vector <$> go (VectorRepr tpr') v
+        MirVector_PartialVector pv ->
+            MirVector_PartialVector <$> go (VectorRepr (MaybeRepr tpr')) pv
         MirVector_Array a
           | AsBaseType btpr' <- asBaseType tpr' ->
             MirVector_Array <$> go (UsizeArrayRepr btpr') a


### PR DESCRIPTION
Currently, `MirReferenceType` has a type index indicating the Crucible type of the location it points to.  For example, the Rust type `*const i32` is represented by `MirReferenceType (BVType 32)`.  The pointee type is required to match the type of the pointee location, so a reference whose `MirReferencePath` points to a location of type `BVType 32` must have type `MirReferenceType (BVType 32)`.  This prevents us from implementing certain casts, such as `*const i32 -> *const ()`: `MirReferenceType (BVType 32)` and `MirReferenceType UnitType` require pointees of type `BVType 32` and `UnitType` respectively, and thus it's impossible to have two such references that point to the same location.

This branch removes the type index from `MirReferenceType`, so all Rust pointers and references are simply `MirReferenceType` with no further (static) distinction.  This allows crucible-mir to support a variety of raw-pointer casts that are currently unsupported, such as casting `*mut T -> *mut () -> *mut T` to temporarily type-erase a pointer.  Casts like this appear in several places in the standard library, notably in the implementation of `RawVec`.

With this change, a few operations, notably `writeMirRef`, now require a `TypeRepr`, since the Crucible type of the pointee can no longer be inferred from the index of the `MirReferenceType`.  In most cases, the `TypeRepr` was already available at the call site for other reasons.  In a few places, only the `Mir.Ty` was available, so I had to add a new call to `tyToRepr` to get the `TypeRepr`; calling `tyToRepr` on a pointee type will fail if the pointee is dynamically sized (a slice or `dyn Trait`), but I think all the places where I added it are only reachable for sized pointees (`&[_]` and `&dyn Trait` take different code paths from sized `&T` in most of the translation).

Fixes #1385