### PR TITLE
crucible-mir: `ctpop` intrinsic returns `u32` unconditionally

### DIFF
--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -38,6 +38,7 @@ module Mir.Trans(transCollection,transStatics,RustModule(..)
                 , callExp
                 , derefExp, readPlace, addrOfPlace
                 , transmuteExp
+                , extendUnsignedBV
                 ) where
 
 import Control.Monad

--- a/crucible-mir/src/Mir/TransCustom.hs
+++ b/crucible-mir/src/Mir/TransCustom.hs
@@ -1751,7 +1751,9 @@ ctpop = (["core", "intrinsics", "ctpop"],
     \(Substs substs) -> case substs of
         [_] -> Just $ CustomOp $ \_ ops -> case ops of
             [MirExp tpr@(C.BVRepr w) val] ->
-                return $ MirExp tpr $ R.App $ E.BVPopcount w val
+                Mir.Trans.extendUnsignedBV
+                    (MirExp tpr $ R.App $ E.BVPopcount w val)
+                    (knownNat @32)
             _ -> mirFail $ "bad arguments to intrinsics::ctpop: " ++ show ops
         _ -> Nothing)
 

--- a/crux-mir/test/conc_eval/num/ctpop.rs
+++ b/crux-mir/test/conc_eval/num/ctpop.rs
@@ -1,0 +1,32 @@
+#![cfg_attr(not(with_main), no_std)]
+#![feature(core_intrinsics)]
+
+extern crate core;
+use core::intrinsics::ctpop;
+
+#[cfg_attr(crux, crux::test)]
+fn ctpop_test() {
+    // Test at each of u{16,32,64} to ensure that zero-extension, identity, and
+    // truncation operations (respectively) work as expected.
+
+    assert_eq!(ctpop(0_u16), 0_u32);
+    assert_eq!(ctpop(0_u32), 0_u32);
+    assert_eq!(ctpop(0_u64), 0_u32);
+
+    assert_eq!(ctpop(1_u16), 1_u32);
+    assert_eq!(ctpop(1_u32), 1_u32);
+    assert_eq!(ctpop(1_u64), 1_u32);
+
+    assert_eq!(ctpop(5_u16), 2_u32);
+    assert_eq!(ctpop(5_u32), 2_u32);
+    assert_eq!(ctpop(5_u64), 2_u32);
+
+    assert_eq!(ctpop(u16::MAX), u16::BITS);
+    assert_eq!(ctpop(u32::MAX), u32::BITS);
+    assert_eq!(ctpop(u64::MAX), u64::BITS);
+}
+
+#[cfg(with_main)]
+pub fn main() {
+    println!("{:?}", ctpop_test());
+}


### PR DESCRIPTION
This matches Rust's type for this function.