### PR TITLE
`crucible-mir`: More robust handling for `&dyn Trait`

### DIFF
--- a/crucible-mir/src/Mir/Generator.hs
+++ b/crucible-mir/src/Mir/Generator.hs
@@ -138,21 +138,6 @@ data MirExp s where
 -- result of lvalue evaluation.
 data MirPlace s where
     MirPlace :: C.TypeRepr ty -> R.Expr MIR s MirReferenceType -> PtrMetadata s -> MirPlace s
-    -- | This is a hack used to support @&dyn Trait@ references. Unlike other
-    -- reference types, trait objects do not use 'MirReferenceType', instead
-    -- using a custom 'AnyType' representation that wraps a
-    -- @'MirReferenceType' t@ (for some unknown @t@). The only 'MirPlaceDynRef'
-    -- operation that is currently supported is @addrOfPlace@, which supports
-    -- code that looks like @&*x@ (where @x: &dyn Trait@). This sort of
-    -- operation does arise in @rustc@-compiled MIR, even in the standard
-    -- libraries, so we must have /some/ level of support for it.
-    --
-    -- All other 'MirPlaceDynRef' operations (e.g., @readPlace@ and
-    -- @evalPlaceProj@) are unsupported and will throw an exception if
-    -- encountered. To implement these operations, we will need to change the
-    -- encoding of trait objects to use 'MirReferenceType' in a more standard
-    -- way. See <https://github.com/GaloisInc/crucible/issues/1092>.
-    MirPlaceDynRef :: R.Expr MIR s DynRefType -> MirPlace s
 
 -- | MIR supports a notion of "unsized places" - for example, it generates code
 -- like `(*s)[i]` where `s` is a slice.  To handle this, we attach the metadata
@@ -164,7 +149,8 @@ data MirPlace s where
 -- we may need to add `PtrMetadata` to `MirExp`s at some point as well.
 data PtrMetadata s =
       NoMeta
-    | SliceMeta (R.Expr MIR s UsizeType)
+    | SliceMeta (R.Expr MIR s UsizeType) -- ^ The slice length
+    | DynMeta (R.Expr MIR s Core.AnyType) -- ^ The trait object's vtable
   deriving Show
 
 ---------------------------------------------------------------------------------
@@ -400,7 +386,6 @@ instance Show (MirExp s) where
 
 instance Show (MirPlace s) where
     show (MirPlace tr e m) = show e ++ ", " ++ show m ++ ": & " ++ show tr
-    show (MirPlaceDynRef e) = "dyn reference " ++ show e
 
 instance Show MirHandle where
     show (MirHandle _nm sig c) =

--- a/crucible-mir/src/Mir/Intrinsics.hs
+++ b/crucible-mir/src/Mir/Intrinsics.hs
@@ -832,14 +832,14 @@ data MIR
 type instance ExprExtension MIR = EmptyExprExtension
 type instance StmtExtension MIR = MirStmt
 
--- First `Any` is the data pointer - either an immutable or mutable reference.
--- Second `Any` is the vtable.
-type DynRefType = StructType (EmptyCtx ::> AnyType ::> AnyType)
+-- | The 'MirReferenceType' is the data pointer - either an immutable or mutable
+-- reference. The 'AnyType' is the vtable.
+type DynRefType = StructType (EmptyCtx ::> MirReferenceType ::> AnyType)
 
-dynRefDataIndex :: Index (EmptyCtx ::> AnyType ::> AnyType) AnyType
+dynRefDataIndex :: Index (EmptyCtx ::> MirReferenceType ::> AnyType) MirReferenceType
 dynRefDataIndex = skipIndex baseIndex
 
-dynRefVtableIndex :: Index (EmptyCtx ::> AnyType ::> AnyType) AnyType
+dynRefVtableIndex :: Index (EmptyCtx ::> MirReferenceType ::> AnyType) AnyType
 dynRefVtableIndex = lastIndex (incSize $ incSize zeroSize)
 
 

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -411,6 +411,7 @@ derefExp pointeeTy (MirExp MirSliceRepr e) = do
     let ptr = getSlicePtr e
     let len = getSliceLen e
     return $ MirPlace tpr ptr (SliceMeta len)
+-- TODO RGS: Do we need a case for trait objects?
 derefExp pointeeTy (MirExp tpr _) = mirFail $ "don't know how to deref " ++ show tpr
 
 readPlace :: HasCallStack => MirPlace s -> MirGenerator h s ret (MirExp s)
@@ -418,16 +419,15 @@ readPlace (MirPlace tpr r NoMeta) = MirExp tpr <$> readMirRef tpr r
 readPlace (MirPlace tpr _ meta) =
     mirFail $ "don't know how to read from place with metadata " ++ show meta
         ++ " (type " ++ show tpr ++ ")"
-readPlace MirPlaceDynRef{} =
-    -- See https://github.com/GaloisInc/crucible/issues/1092
-    mirFail "readPlace not supported for dyn references"
 
 addrOfPlace :: HasCallStack => MirPlace s -> MirGenerator h s ret (MirExp s)
 addrOfPlace (MirPlace tpr r NoMeta) = return $ MirExp MirReferenceRepr r
 addrOfPlace (MirPlace tpr r (SliceMeta len)) =
     return $ MirExp MirSliceRepr $ mkSlice r len
-addrOfPlace (MirPlaceDynRef dynRef) =
-    return $ MirExp DynRefRepr dynRef
+addrOfPlace (MirPlace _tpr r (DynMeta vtable)) =
+    return $ MirExp DynRefRepr $
+      R.App $ E.MkStruct DynRefCtx $
+      Ctx.Empty Ctx.:> r Ctx.:> vtable
 
 
 -- Given two bitvectors, extend the length of the shorter one so that they
@@ -1030,9 +1030,6 @@ evalRval (M.Len lv) =
             place <- evalPlace lv
             meta <- case place of
                 MirPlace _tpr _ref meta -> pure meta
-                MirPlaceDynRef{} ->
-                    -- See https://github.com/GaloisInc/crucible/issues/1092
-                    mirFail "evalRval (length of slice) not supported for dyn references"
             case meta of
                 SliceMeta len -> return $ MirExp UsizeRepr len
                 _ -> mirFail $ "bad metadata " ++ show meta ++ " for reference to " ++ show ty
@@ -1122,7 +1119,10 @@ evalPlaceProj ty pl@(MirPlace tpr ref NoMeta) M.Deref = do
     doRef M.TyStr | MirSliceRepr <- tpr = doSlice (M.TyUint M.B8) ref
     doRef (M.TyDynamic _) | DynRefRepr <- tpr = do
         dynRef <- readMirRef tpr ref
-        return $ MirPlaceDynRef dynRef
+        let dynRefData = S.getStruct dynRefDataIndex dynRef
+        let dynRefVtable = S.getStruct dynRefVtableIndex dynRef
+        -- TODO RGS: Is AnyRepr the correct type here?
+        return $ MirPlace C.AnyRepr dynRefData (DynMeta dynRefVtable)
     doRef ty' | MirReferenceRepr <- tpr = do
         -- This use of `tyToReprM` is okay because `TyDynamic` and other
         -- unsized cases are handled above.
@@ -1221,9 +1221,6 @@ evalPlaceProj ty (MirPlace tpr ref meta) (M.ConstantIndex idx _minLen fromEnd) =
 evalPlaceProj _ pl (M.Downcast _idx) = return pl
 evalPlaceProj ty (MirPlace _ _ meta) proj =
     mirFail $ "projection " ++ show proj ++ " not yet implemented for " ++ show (ty, meta)
-evalPlaceProj _ MirPlaceDynRef{} _ =
-    -- See https://github.com/GaloisInc/crucible/issues/1092
-    mirFail "evalPlaceProj not supported for dyn references"
 
 --------------------------------------------------------------------------------------
 -- ** Statements
@@ -1262,9 +1259,6 @@ doAssign :: HasCallStack => M.Lvalue -> MirExp s -> MirGenerator h s ret ()
 doAssign lv (MirExp tpr val) = do
     place <- evalPlace lv
     case place of
-        MirPlaceDynRef{} ->
-            -- See https://github.com/GaloisInc/crucible/issues/1092
-            mirFail "doAssign not supported for dyn references"
         MirPlace tpr' ref _ -> do
             Refl <- testEqualityOrFail tpr tpr' $
                 "ill-typed assignment of " ++ show tpr ++ " to " ++ show tpr'

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -1011,7 +1011,7 @@ mkTraitObject traitName vtableName e = do
                 "of trait", show traitName, ":", show vtableTy, "!=", show vtableTy']
 
     return $ buildTuple
-        [ packAny e
+        [ e
         , packAny vtable
         ]
 
@@ -2182,7 +2182,7 @@ transVirtCall colState intrName methName dynTraitName methIndex
         let (recv, args) = splitMethodArgs argsA (Ctx.size argTys)
 
         -- Extract data and vtable parts of the `&dyn` receiver
-        let recvData = R.App $ E.GetStruct recv dynRefDataIndex C.AnyRepr
+        let recvData = R.App $ E.GetStruct recv dynRefDataIndex MirReferenceRepr
         let recvVtable = R.App $ E.GetStruct recv dynRefVtableIndex C.AnyRepr
 
         -- Downcast the vtable to its proper struct type
@@ -2202,7 +2202,7 @@ transVirtCall colState intrName methName dynTraitName methIndex
                 (C.FunctionHandleRepr (C.AnyRepr <: argTys) retTy)
 
         -- Call it
-        G.tailCall vtsFH (recvData <: args)
+        G.tailCall vtsFH (R.App (E.PackAny MirReferenceRepr recvData) <: args)
 
 withSome :: Some f -> (forall tp. f tp -> r) -> r
 withSome s k = viewSome k s

--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -190,7 +190,7 @@ tyToRepr col t0 = case t0 of
   M.TyUint base -> baseSizeToNatCont base $ \n -> Some $ C.BVRepr n
 
   -- These definitions are *not* compositional
-  M.TyRef (M.TySlice t) _ -> tyToReprCont col t $ \repr -> Some MirSliceRepr
+  M.TyRef (M.TySlice _) _ -> Some MirSliceRepr
   M.TyRef M.TyStr _       -> Some MirSliceRepr
 
   -- Both `&dyn Tr` and `&mut dyn Tr` use the same representation: a pair of a
@@ -202,10 +202,10 @@ tyToRepr col t0 = case t0 of
     Ctx.empty Ctx.:> C.AnyRepr Ctx.:> C.AnyRepr
 
   -- TODO: DSTs not behind a reference - these should never appear in real code
-  M.TySlice t -> tyToReprCont col t $ \repr -> Some MirSliceRepr
+  M.TySlice _ -> Some MirSliceRepr
   M.TyStr -> Some MirSliceRepr
 
-  M.TyRef t _       -> tyToReprCont col t $ \repr -> Some MirReferenceRepr
+  M.TyRef _ _       -> Some MirReferenceRepr
   -- Raw pointers are represented like references, including the fat pointer
   -- cases that are special-cased above.
   M.TyRawPtr t mutbl -> tyToRepr col (M.TyRef t mutbl)

--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -194,12 +194,10 @@ tyToRepr col t0 = case t0 of
   M.TyRef M.TyStr _       -> Some MirSliceRepr
 
   -- Both `&dyn Tr` and `&mut dyn Tr` use the same representation: a pair of a
-  -- data value (which is either `&Ty` or `&mut Ty`) and a vtable.  Both are
-  -- type-erased (`AnyRepr`), the first because it has to be, and the second
-  -- because we'd need to thread the `Collection` into this function (which we
-  -- don't want to do) in order to construct the precise vtable type.
+  -- data value (which is either `&Ty` or `&mut Ty`) and a vtable. The vtable
+  -- is type-erased (`AnyRepr`).
   M.TyRef (M.TyDynamic _) _ -> Some $ C.StructRepr $
-    Ctx.empty Ctx.:> C.AnyRepr Ctx.:> C.AnyRepr
+    Ctx.empty Ctx.:> MirReferenceRepr Ctx.:> C.AnyRepr
 
   -- TODO: DSTs not behind a reference - these should never appear in real code
   M.TySlice _ -> Some MirSliceRepr
@@ -241,8 +239,8 @@ tyToRepr col t0 = case t0 of
   _ -> error $ unwords ["unknown type?", show t0]
 
 
-pattern DynRefCtx :: () => (ctx ~ (Ctx.EmptyCtx Ctx.::> C.AnyType Ctx.::> C.AnyType)) => Ctx.Assignment C.TypeRepr ctx
-pattern DynRefCtx = Ctx.Empty Ctx.:> C.AnyRepr Ctx.:> C.AnyRepr
+pattern DynRefCtx :: () => (ctx ~ (Ctx.EmptyCtx Ctx.::> MirReferenceType Ctx.::> C.AnyType)) => Ctx.Assignment C.TypeRepr ctx
+pattern DynRefCtx = Ctx.Empty Ctx.:> MirReferenceRepr Ctx.:> C.AnyRepr
 
 pattern DynRefRepr :: () => (tp ~ DynRefType) => C.TypeRepr tp
 pattern DynRefRepr = C.StructRepr DynRefCtx


### PR DESCRIPTION
This PR:

* Translates the data field of trait objects to a `MirReference` instead of an `Any` value.
* Removes the `MirPlaceDynRef` hack.

Fixes #1092.