### PR TITLE
`crucible-mir`: Followups from #1396

### DIFF
--- a/crucible-mir/src/Mir/JSON.hs
+++ b/crucible-mir/src/Mir/JSON.hs
@@ -445,7 +445,6 @@ instance FromJSON CastKind where
                         case lookupKM "kind" v' of
                             Just (String "ReifyFnPointer") -> pure ReifyFnPointer
                             Just (String "UnsafeFnPointer") -> pure UnsafeFnPointer
-                            -- TODO: ClosureFnPointer
                             Just (String "MutToConstPointer") -> pure MutToConstPointer
                             Just (String "ArrayToPointer") -> pure Misc
                             Just (String "Unsize") -> pure Unsize

--- a/crucible-mir/src/Mir/JSON.hs
+++ b/crucible-mir/src/Mir/JSON.hs
@@ -398,26 +398,24 @@ instance FromJSON UnOp where
 instance FromJSON BinOp where
     parseJSON = withObject "BinOp" $ \v ->
         case lookupKM "kind" v of
-            -- `AddUnchecked` is like `Add`, but is UB on overflow.
-            -- TODO: distinguish these cases so we can emit UB checks
             Just (String "Add") -> pure Add
-            Just (String "AddUnchecked") -> pure Add
-            Just (String "AddWithOverflow") -> pure $ Checked Add
+            Just (String "AddUnchecked") -> pure $ Unchecked Add
+            Just (String "AddWithOverflow") -> pure $ WithOverflow Add
             Just (String "Sub") -> pure Sub
-            Just (String "SubUnchecked") -> pure Sub
-            Just (String "SubWithOverflow") -> pure $ Checked Sub
+            Just (String "SubUnchecked") -> pure $ Unchecked Sub
+            Just (String "SubWithOverflow") -> pure $ WithOverflow Sub
             Just (String "Mul") -> pure Mul
-            Just (String "MulUnchecked") -> pure Mul
-            Just (String "MulWithOverflow") -> pure $ Checked Mul
+            Just (String "MulUnchecked") -> pure $ Unchecked Mul
+            Just (String "MulWithOverflow") -> pure $ WithOverflow Mul
             Just (String "Div") -> pure Div
             Just (String "Rem") -> pure Rem
             Just (String "BitXor") -> pure BitXor
             Just (String "BitAnd") -> pure BitAnd
             Just (String "BitOr") -> pure BitOr
             Just (String "Shl") -> pure Shl
-            Just (String "ShlUnchecked") -> pure Shl
+            Just (String "ShlUnchecked") -> pure $ Unchecked Shl
             Just (String "Shr") -> pure Shr
-            Just (String "ShrUnchecked") -> pure Shr
+            Just (String "ShrUnchecked") -> pure $ Unchecked Shr
             Just (String "Eq") -> pure Beq
             Just (String "Lt") -> pure Lt
             Just (String "Le") -> pure Le

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -479,6 +479,8 @@ data BinOp =
       | Offset
       | Cmp
       | Checked BinOp
+        -- ^ A variant of a 'BinOp' that returns @(T, bool)@ of both the wrapped
+        -- result and a @bool@ indicating whether it overflowed.
   deriving (Show,Eq, Ord, Generic)
 
 data VtableItem = VtableItem

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -478,7 +478,9 @@ data BinOp =
       | Gt
       | Offset
       | Cmp
-      | Checked BinOp
+      | Unchecked BinOp
+        -- ^ A variant of a 'BinOp' for which overflow is undefined behavior.
+      | WithOverflow BinOp
         -- ^ A variant of a 'BinOp' that returns @(T, bool)@ of both the wrapped
         -- result and a @bool@ indicating whether it overflowed.
   deriving (Show,Eq, Ord, Generic)
@@ -753,7 +755,8 @@ instance TypeOf Rvalue where
             -- ptr::offset
             Offset -> ty
             Cmp -> CTyOrdering
-            Checked op'' -> TyTuple [f op'', TyBool]
+            Unchecked op'' -> f op''
+            WithOverflow op'' -> TyTuple [f op'', TyBool]
     in f op
   typeOf (NullaryOp op _ty) = case op of
     SizeOf -> TyUint USize

--- a/crucible-mir/src/Mir/PP.hs
+++ b/crucible-mir/src/Mir/PP.hs
@@ -306,7 +306,8 @@ instance Pretty BinOp where
       Gt -> pretty ">"
       Offset -> pretty "Offset"
       Cmp -> pretty "Cmp"
-      Checked op' -> pretty op' <> pretty "?"
+      Unchecked op' -> pretty op' <> pretty "!"
+      WithOverflow op' -> pretty op' <> pretty "?"
 
 instance Pretty CastKind where
     pretty = viaShow

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -685,6 +685,7 @@ transNullaryOp M.SizeOf _ = do
 transNullaryOp M.UbChecks _ = do
     -- Disable undefined behavior checks.
     -- TODO: re-enable this later, and fix the tests that break
+    -- (see https://github.com/GaloisInc/mir-json/issues/107)
     return $ MirExp C.BoolRepr $ R.App $ E.BoolLit False
 
 transUnaryOp :: M.UnOp -> M.Operand -> MirGenerator h s ret (MirExp s)

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -1822,7 +1822,7 @@ initLocals localVars addrTaken = forM_ localVars $ \v -> do
     -- FIXME: temporary hack to put every local behind a MirReference, to work
     -- around issues with `&fn()` variables.
     varinfo <-
-      if True --case Set.member name addrTaken of
+      if True -- if Set.member name addrTaken
         then do
           ref <- newMirRef tpr
           case optVal of

--- a/crux-mir/test/symb_eval/num/unchecked_arith.good
+++ b/crux-mir/test/symb_eval/num/unchecked_arith.good
@@ -1,0 +1,34 @@
+test unchecked_arith/<DISAMB>::add_test[0]: returned 44, FAILED
+test unchecked_arith/<DISAMB>::mul_test[0]: returned 32, FAILED
+test unchecked_arith/<DISAMB>::shl_test[0]: returned 0, FAILED
+test unchecked_arith/<DISAMB>::shr_test[0]: returned 0, FAILED
+test unchecked_arith/<DISAMB>::sub_test[0]: returned 156, FAILED
+
+failures:
+
+---- unchecked_arith/<DISAMB>::add_test[0] counterexamples ----
+[Crux] Found counterexample for verification goal
+[Crux]   ./libs/core/src/num/uint_macros.rs:572:17: 572:53 !./libs/core/src/num/mod.rs:436:5: 454:6: error: in core/<DISAMB>::num[0]::{impl#6}[0]::unchecked_add[0]
+[Crux]   Binary operation (+) would overflow
+
+---- unchecked_arith/<DISAMB>::mul_test[0] counterexamples ----
+[Crux] Found counterexample for verification goal
+[Crux]   ./libs/core/src/num/uint_macros.rs:945:17: 945:53 !./libs/core/src/num/mod.rs:436:5: 454:6: error: in core/<DISAMB>::num[0]::{impl#6}[0]::unchecked_mul[0]
+[Crux]   Binary operation (*) would overflow
+
+---- unchecked_arith/<DISAMB>::shl_test[0] counterexamples ----
+[Crux] Found counterexample for verification goal
+[Crux]   ./libs/core/src/num/uint_macros.rs:1558:17: 1558:53 !./libs/core/src/num/mod.rs:436:5: 454:6: error: in core/<DISAMB>::num[0]::{impl#6}[0]::unchecked_shl[0]
+[Crux]   Binary operation (<<) would overflow
+
+---- unchecked_arith/<DISAMB>::shr_test[0] counterexamples ----
+[Crux] Found counterexample for verification goal
+[Crux]   ./libs/core/src/num/uint_macros.rs:1679:17: 1679:53 !./libs/core/src/num/mod.rs:436:5: 454:6: error: in core/<DISAMB>::num[0]::{impl#6}[0]::unchecked_shr[0]
+[Crux]   Binary operation (>>) would overflow
+
+---- unchecked_arith/<DISAMB>::sub_test[0] counterexamples ----
+[Crux] Found counterexample for verification goal
+[Crux]   ./libs/core/src/num/uint_macros.rs:762:17: 762:53 !./libs/core/src/num/mod.rs:436:5: 454:6: error: in core/<DISAMB>::num[0]::{impl#6}[0]::unchecked_sub[0]
+[Crux]   Binary operation (-) would overflow
+
+[Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/num/unchecked_arith.rs
+++ b/crux-mir/test/symb_eval/num/unchecked_arith.rs
@@ -1,0 +1,31 @@
+#![feature(unchecked_shifts)]
+
+#[crux::test]
+fn add_test() -> u8 {
+    unsafe { 100u8.unchecked_add(200) }
+}
+
+#[crux::test]
+fn sub_test() -> u8 {
+    unsafe { 100u8.unchecked_sub(200) }
+}
+
+#[crux::test]
+fn mul_test() -> u8 {
+    unsafe { 100u8.unchecked_mul(200) }
+}
+
+#[crux::test]
+fn shl_test() -> u8 {
+    unsafe { 100u8.unchecked_shl(200) }
+}
+
+#[crux::test]
+fn shr_test() -> u8 {
+    unsafe { 100u8.unchecked_shr(200) }
+}
+
+pub fn main() {
+    println!("{:?} {:?} {:?} {:?} {:?}",
+             add_test(), sub_test(), mul_test(), shl_test(), shr_test());
+}


### PR DESCRIPTION
This resolves a variety of code review issues noticed during a review of https://github.com/GaloisInc/crucible/pull/1396 by @qsctr:

* Properly distinguish between "normal" arithmetic binary operators, `Unchecked` ones, and `WithOverflow` ones
* Make some commented-out code typecheck
* Cite https://github.com/GaloisInc/mir-json/issues/107 in a comment
* Remove an out-of-date TODO