### PR TITLE
llvm-syntax: Overrides for manipulating C-style null-terminated strings

### DIFF
--- a/crucible-cli/CHANGELOG.md
+++ b/crucible-cli/CHANGELOG.md
@@ -1,6 +1,7 @@
 # next
 
-Nothing yet.
+* Remove `resolveForwardDeclarationsHook`. Instead, use `bindFnHandle` in
+  `setupHook`.
 
 # 0.1 -- 2024-02-05
 

--- a/crucible-llvm-cli/src/Lang/Crucible/LLVM/CLI.hs
+++ b/crucible-llvm-cli/src/Lang/Crucible/LLVM/CLI.hs
@@ -24,6 +24,7 @@ import Lang.Crucible.CLI (SimulateProgramHooks(..), defaultSimulateProgramHooks)
 
 import Lang.Crucible.Syntax.Concrete (ParserHooks)
 import Lang.Crucible.Syntax.Overrides (setupOverrides)
+import Lang.Crucible.Syntax.Prog (assertNoForwardDecs)
 
 import Lang.Crucible.LLVM (llvmExtensionImpl)
 import Lang.Crucible.LLVM.DataLayout (EndianForm(LittleEndian), defaultDataLayout)
@@ -54,7 +55,8 @@ withLlvmHooks k = do
   let ?parserHooks = llvmParserHooks (typeAliasParserHooks x86_64LinuxTypes) mvar
   let simulationHooks =
         defaultSimulateProgramHooks
-          { setupHook = \bak _ha -> do
+          { setupHook = \bak _ha fds -> do
+              liftIO (assertNoForwardDecs fds)
               mem <- liftIO (Mem.emptyMem LittleEndian)
               writeGlobal mvar mem
               let ?recordLLVMAnnotation = \_ _ _ -> pure ()
@@ -81,4 +83,4 @@ withLlvmHooks k = do
           }
   let ext _ = let ?recordLLVMAnnotation = \_ _ _ -> pure ()
               in pure (llvmExtensionImpl Mem.defaultMemOptions)
-  k ext simulationHooks 
+  k ext simulationHooks

--- a/crucible-llvm-cli/src/Lang/Crucible/LLVM/CLI.hs
+++ b/crucible-llvm-cli/src/Lang/Crucible/LLVM/CLI.hs
@@ -9,22 +9,28 @@ module Lang.Crucible.LLVM.CLI
   ( withLlvmHooks
   ) where
 
+import qualified Control.Monad as Monad
 import Control.Monad.IO.Class (liftIO)
 import qualified Data.IntMap as IntMap
 import qualified Data.Map as Map
+import qualified Data.Text as Text
+import Data.Type.Equality ((:~:)(Refl), testEquality)
 
 import Data.Parameterized.NatRepr (knownNat)
 
+import qualified What4.FunctionName as W4
+
 import Lang.Crucible.Backend (IsSymBackend)
 import Lang.Crucible.FunctionHandle (newHandleAllocator)
+import qualified Lang.Crucible.FunctionHandle as C
 import Lang.Crucible.Simulator.ExecutionTree (ExtensionImpl)
 import Lang.Crucible.Simulator.OverrideSim (writeGlobal)
+import qualified Lang.Crucible.Simulator as C
 
 import Lang.Crucible.CLI (SimulateProgramHooks(..), defaultSimulateProgramHooks)
 
 import Lang.Crucible.Syntax.Concrete (ParserHooks)
 import Lang.Crucible.Syntax.Overrides (setupOverrides)
-import Lang.Crucible.Syntax.Prog (assertNoForwardDecs)
 
 import Lang.Crucible.LLVM (llvmExtensionImpl)
 import Lang.Crucible.LLVM.DataLayout (EndianForm(LittleEndian), defaultDataLayout)
@@ -37,7 +43,21 @@ import Lang.Crucible.LLVM.TypeContext (mkTypeContext)
 
 import Lang.Crucible.LLVM.Syntax (llvmParserHooks)
 import Lang.Crucible.LLVM.Syntax.Overrides (registerLLVMOverrides)
+import qualified Lang.Crucible.LLVM.Syntax.Overrides.String as StrOv
 import Lang.Crucible.LLVM.Syntax.TypeAlias (typeAliasParserHooks, x86_64LinuxTypes)
+
+tryBindTypedOverride ::
+  C.FnHandle args ret ->
+  C.TypedOverride p sym ext args' ret' ->
+  C.OverrideSim p sym ext rtp args'' ret'' ()
+tryBindTypedOverride hdl ov = do
+  let err = fail ("Ill-typed declaration for " ++ Text.unpack (W4.functionName (C.handleName hdl)))
+  case testEquality (C.handleArgTypes hdl) (C.typedOverrideArgs ov) of
+    Nothing -> err
+    Just Refl ->
+      case testEquality (C.handleReturnType hdl) (C.typedOverrideRet ov) of
+        Nothing -> err
+        Just Refl -> C.bindTypedOverride hdl ov
 
 -- | Small helper for providing LLVM language-specific hooks, e.g., for use with
 -- 'Lang.Crucible.CLI.execCommand'.
@@ -56,7 +76,6 @@ withLlvmHooks k = do
   let simulationHooks =
         defaultSimulateProgramHooks
           { setupHook = \bak _ha fds -> do
-              liftIO (assertNoForwardDecs fds)
               mem <- liftIO (Mem.emptyMem LittleEndian)
               writeGlobal mvar mem
               let ?recordLLVMAnnotation = \_ _ _ -> pure ()
@@ -78,6 +97,13 @@ withLlvmHooks k = do
               let ?memOpts = Mem.defaultMemOptions
               let ?intrinsicsOpts = defaultIntrinsicsOptions
               _ <- registerLLVMOverrides bak llvmCtx
+              Monad.forM_ (Map.toList fds) $ \(nm, C.SomeHandle hdl) -> do
+                case nm of
+                  "read-bytes" -> tryBindTypedOverride hdl (StrOv.readBytesOverride mvar)
+                  "read-c-string" -> tryBindTypedOverride hdl (StrOv.readCStringOverride mvar)
+                  "write-bytes" -> tryBindTypedOverride hdl (StrOv.writeBytesOverride mvar)
+                  "write-c-string" -> tryBindTypedOverride hdl (StrOv.writeCStringOverride mvar)
+                  _ -> pure ()
               return ()
           , setupOverridesHook = setupOverrides
           }

--- a/crucible-llvm-cli/test-data/string.cbl
+++ b/crucible-llvm-cli/test-data/string.cbl
@@ -1,0 +1,19 @@
+(declare @read-bytes ((x Pointer)) (Vector (Bitvector 8)))
+(declare @read-c-string ((x Pointer)) (String Unicode))
+(declare @write-bytes ((dest Pointer) (src (Vector (Bitvector 8)))) Unit)
+(declare @write-c-string ((dst Pointer) (src (String Unicode))) Unit)
+
+(defun @main () Unit
+  (start start:
+
+    (let p (alloca none (bv 64 6)))
+    (funcall @write-c-string p "hello")
+    (let s (funcall @read-c-string p))
+    (assert! (equal? s "hello") "strings should be equal")
+
+    (let q (alloca none (bv 64 4)))
+	(let v (vector (bv 8 4) (bv 8 9) (bv 8 0)))
+    (funcall @write-bytes q v)
+    (let b (funcall @read-bytes p))
+
+    (return ())))

--- a/crucible-llvm-cli/test-data/string.out.good
+++ b/crucible-llvm-cli/test-data/string.out.good
@@ -1,0 +1,4 @@
+==== Begin Simulation ====
+
+==== Finish Simulation ====
+==== No proof obligations ====

--- a/crucible-llvm-syntax/CHANGELOG.md
+++ b/crucible-llvm-syntax/CHANGELOG.md
@@ -1,6 +1,7 @@
 # next
 
-Nothing yet.
+* Add overrides for string-manipulation `{read,write}-bytes` and
+  `{read,write}-c-string`.
 
 # 0.1 -- 2024-02-05
 

--- a/crucible-llvm-syntax/CHANGELOG.md
+++ b/crucible-llvm-syntax/CHANGELOG.md
@@ -1,6 +1,6 @@
 # next
 
-* Add overrides for string-manipulation `{read,write}-bytes` and
+* Add overrides for string-manipulation: `{read,write}-bytes` and
   `{read,write}-c-string`.
 
 # 0.1 -- 2024-02-05

--- a/crucible-llvm-syntax/README.md
+++ b/crucible-llvm-syntax/README.md
@@ -46,6 +46,30 @@ If the numeral `w` is the width of a pointer and `n` is an arbitrary numeral,
 are no C- or LLVM-like `Type`s such as `i8*` or `size_t`, but rather the base
 Crucible types as defined by `crucible-syntax`, and `(Ptr n)`.
 
+## String manipulation
+
+This package also provides the following overrides for convenient manipulation
+of C-style null-terminated strings:
+
+* `read-bytes :: Pointer -> Vector (Bitvector 8)` reads a concrete,
+  null-terminated sequence of bytes from the `Pointer`. Unlike `read-c-string`,
+  this function reads the raw bytes without converting to a particular text
+  encoding.
+* `read-c-string :: Pointer -> String Unicode` reads a concrete,
+  null-terminated, UTF-8–encoded string from the `Pointer` and converts it to
+  a `String`. Representing it as a `String` can be more convenient in the syntax
+  override language, as it is easier to manipulate and check for equality.
+* `write-bytes :: Vector (Bitvector 8) -> Pointer` writes a sequence of bytes
+  to a `Pointer`, including a null terminator (which does not need to be in the
+  `Vector`). The null terminator written at the end will be concrete, but the
+  preceding bytes may be symbolic. Unlike `write-c-string`, this function writes
+  the raw bytes without converting to a particular text encoding. For example,
+  to write the string `"abc"`, supply `(vector (bv 8 97) (bv 8 98) (bv 8 99))`
+  as an argument, as the bytes `97`, `98`, and `99` correspond to the numeric
+  values of the `a`, `b`, and `c` characters, respectively.
+* `write-c-string :: Pointer -> String Unicode -> Unit` writes a concrete,
+  UTF-8–encoded string to a `Pointer`, including a null terminator.
+
 ## Further extensions
 
 The LLVM parser hooks can be further customized by passing yet another `ParserHooks`

--- a/crucible-llvm-syntax/crucible-llvm-syntax.cabal
+++ b/crucible-llvm-syntax/crucible-llvm-syntax.cabal
@@ -115,6 +115,8 @@ library
 
   build-depends:
     base >= 4.13,
+    bv-sized,
+    bytestring,
     containers,
     crucible >= 0.1,
     crucible-llvm,
@@ -124,6 +126,7 @@ library
     parameterized-utils >= 0.1.7,
     prettyprinter,
     text,
+    vector,
     what4,
 
   hs-source-dirs: src
@@ -131,6 +134,7 @@ library
   exposed-modules:
     Lang.Crucible.LLVM.Syntax
     Lang.Crucible.LLVM.Syntax.Overrides
+    Lang.Crucible.LLVM.Syntax.Overrides.String
     Lang.Crucible.LLVM.Syntax.TypeAlias
 
 test-suite crucible-llvm-syntax-tests

--- a/crucible-llvm-syntax/src/Lang/Crucible/LLVM/Syntax/Overrides/String.hs
+++ b/crucible-llvm-syntax/src/Lang/Crucible/LLVM/Syntax/Overrides/String.hs
@@ -1,0 +1,199 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+
+-- | Overrides related to C strings
+module Lang.Crucible.LLVM.Syntax.Overrides.String
+  ( readBytesOverride
+  , readCStringOverride
+  , writeBytesOverride
+  , writeCStringOverride
+  ) where
+
+import Control.Monad.IO.Class (liftIO)
+import Data.BitVector.Sized qualified as BV
+import Data.ByteString qualified as BS
+import Data.Parameterized.Context qualified as Ctx
+import Data.Parameterized.NatRepr qualified as DPN
+import Data.Text qualified as DT
+import Data.Text.Encoding qualified as DTE
+import Data.Text.Encoding.Error qualified as DTEE
+import Data.Vector qualified as Vec
+import Lang.Crucible.Backend qualified as LCB
+import Lang.Crucible.LLVM.MemModel qualified as LCLM
+import Lang.Crucible.LLVM.MemModel.Strings qualified as LCLMS
+import Lang.Crucible.Simulator qualified as C
+import Lang.Crucible.Simulator qualified as LCS
+import Lang.Crucible.Types qualified as LCT
+import What4.Interface qualified as WI
+
+-- | Override for @read-bytes@.
+--
+-- The loaded string must be concrete. If a symbolic character is encountered
+-- while loading, this function will generate an assertion failure.
+readBytesOverride ::
+  ( LCLM.HasLLVMAnn sym
+  , LCLM.HasPtrWidth w
+  , ?memOpts :: LCLM.MemOptions
+  ) =>
+  C.GlobalVar LCLM.Mem ->
+  LCS.TypedOverride p sym ext (Ctx.EmptyCtx Ctx.::> LCLM.LLVMPointerType w) (LCT.VectorType (LCT.BVType 8))
+readBytesOverride memVar =
+  WI.withKnownNat ?ptrWidth $
+    LCS.typedOverride (Ctx.uncurryAssignment (readBytes memVar))
+
+-- | Implementation of the @read-bytes@ override.
+--
+-- The loaded string must be concrete. If a symbolic character is encountered
+-- while loading, this function will generate an assertion failure.
+readBytes ::
+  ( LCLM.HasLLVMAnn sym
+  , LCLM.HasPtrWidth w
+  , ?memOpts :: LCLM.MemOptions
+  ) =>
+  C.GlobalVar LCLM.Mem ->
+  LCS.RegValue' sym (LCLM.LLVMPointerType w) ->
+  LCS.OverrideSim p sym ext r args ret (LCS.RegValue sym (LCT.VectorType (LCT.BVType 8)))
+readBytes memVar ptr =
+  LCS.ovrWithBackend $ \bak -> do
+    let sym = LCB.backendGetSym bak
+    mem <- LCS.readGlobal memVar
+    bytes <- liftIO (LCLMS.loadString bak mem (C.unRV ptr) Nothing)
+    Vec.fromList <$>
+      liftIO (mapM (WI.bvLit sym (DPN.knownNat @8) . BV.word8) bytes)
+
+-- | Override for @read-c-string@.
+--
+-- Note that:
+--
+-- * The loaded string must be concrete. If a symbolic character is encountered
+--   while loading, this function will generate an assertion failure.
+--
+-- * The loaded string should be UTF-8–encoded. Any invalid code points in the
+--   string will be replaced with the Unicode replacement character @U+FFFD@.
+readCStringOverride ::
+  ( LCLM.HasLLVMAnn sym
+  , LCLM.HasPtrWidth w
+  , ?memOpts :: LCLM.MemOptions
+  ) =>
+  C.GlobalVar LCLM.Mem ->
+  LCS.TypedOverride p sym ext (Ctx.EmptyCtx Ctx.::> LCLM.LLVMPointerType w) (LCT.StringType WI.Unicode)
+readCStringOverride memVar =
+  WI.withKnownNat ?ptrWidth $
+    LCS.typedOverride (Ctx.uncurryAssignment (readCString memVar))
+
+-- | Implementation of the @read-c-string@ override.
+-- Note that:
+--
+-- * The loaded string must be concrete. If a symbolic character is encountered
+--   while loading, this function will generate an assertion failure.
+--
+-- * The loaded string should be UTF-8–encoded. Any invalid code points in the
+--   string will be replaced with the Unicode replacement character @U+FFFD@.
+readCString ::
+  ( LCLM.HasLLVMAnn sym
+  , LCLM.HasPtrWidth w
+  , ?memOpts :: LCLM.MemOptions
+  ) =>
+  C.GlobalVar LCLM.Mem ->
+  LCS.RegValue' sym (LCLM.LLVMPointerType w) ->
+  LCS.OverrideSim p sym ext r args ret (LCS.RegValue sym (LCT.StringType WI.Unicode))
+readCString memVar ptr =
+  LCS.ovrWithBackend $ \bak -> do
+    let sym = LCB.backendGetSym bak
+    mem <- LCS.readGlobal memVar
+    bytes <- liftIO (LCLMS.loadString bak mem (C.unRV ptr) Nothing)
+    let lit = DTE.decodeUtf8With DTEE.lenientDecode (BS.pack bytes)
+    liftIO (WI.stringLit sym (WI.UnicodeLiteral lit))
+
+-- | Override for @write-bytes@.
+writeBytesOverride ::
+  ( LCLM.HasLLVMAnn sym
+  , LCLM.HasPtrWidth w
+  , ?memOpts :: LCLM.MemOptions
+  ) =>
+  C.GlobalVar LCLM.Mem ->
+  LCS.TypedOverride p sym ext (Ctx.EmptyCtx Ctx.::> LCLM.LLVMPointerType w Ctx.::> LCT.VectorType (LCT.BVType 8)) LCT.UnitType
+writeBytesOverride memVar =
+  WI.withKnownNat ?ptrWidth $
+    LCS.typedOverride (Ctx.uncurryAssignment (writeBytes memVar))
+
+-- | Implementation of the @write-bytes@ override.
+writeBytes ::
+  ( LCLM.HasLLVMAnn sym
+  , LCLM.HasPtrWidth w
+  , ?memOpts :: LCLM.MemOptions
+  ) =>
+  C.GlobalVar LCLM.Mem ->
+  LCS.RegValue' sym (LCLM.LLVMPointerType w) ->
+  LCS.RegValue' sym (LCT.VectorType (LCT.BVType 8)) ->
+  LCS.OverrideSim p sym ext r args ret ()
+writeBytes memVar ptr bytes =
+  LCS.ovrWithBackend $ \bak ->
+    LCS.modifyGlobal memVar $ \mem -> do
+      mem' <- liftIO (LCLMS.storeString bak mem (C.unRV ptr) (C.unRV bytes))
+      pure ((), mem')
+
+-- | Override for @write-c-string@.
+--
+-- Note:
+--
+-- * The string argument must be concrete. If given a symbolic string, this
+--   override will generate an assertion failure.
+--
+-- * The string will be UTF-8–encoded when written.
+writeCStringOverride ::
+  ( WI.IsExpr (WI.SymExpr sym)
+  , LCB.IsSymInterface sym
+  , LCLM.HasLLVMAnn sym
+  , LCLM.HasPtrWidth w
+  , ?memOpts :: LCLM.MemOptions
+  ) =>
+  C.GlobalVar LCLM.Mem ->
+  LCS.TypedOverride p sym ext (Ctx.EmptyCtx Ctx.::> LCLM.LLVMPointerType w Ctx.::> LCT.StringType WI.Unicode) LCT.UnitType
+writeCStringOverride memVar =
+  WI.withKnownNat ?ptrWidth $
+    LCS.typedOverride (Ctx.uncurryAssignment (writeCString memVar))
+
+-- | Implementation of the @write-c-string@ override.
+--
+-- Note:
+--
+-- * The string argument must be concrete. If given a symbolic string, this
+--   override will generate an assertion failure.
+--
+-- * The string will be UTF-8–encoded when written.
+writeCString ::
+  ( WI.IsExpr (WI.SymExpr sym)
+  , LCB.IsSymInterface sym
+  , LCLM.HasLLVMAnn sym
+  , LCLM.HasPtrWidth w
+  , ?memOpts :: LCLM.MemOptions
+  ) =>
+  C.GlobalVar LCLM.Mem ->
+  LCS.RegValue' sym (LCLM.LLVMPointerType w) ->
+  LCS.RegValue' sym (LCT.StringType WI.Unicode) ->
+  LCS.OverrideSim p sym ext r args ret ()
+writeCString memVar ptr str =
+  case WI.asString (C.unRV str) of
+    Just (WI.UnicodeLiteral txt) -> do
+      -- Convert any escaped unicode characters into actual unicode
+      let txt' = read ("\"" ++ DT.unpack txt ++ "\"") :: String
+
+      -- Convert to bytes and write out
+      let bytes = BS.unpack $ DTE.encodeUtf8 $ DT.pack txt'
+      LCS.ovrWithBackend $ \bak -> do
+        let sym = LCB.backendGetSym bak
+        LCS.modifyGlobal memVar $ \mem -> do
+          bytes' <- liftIO (mapM (WI.bvLit sym (DPN.knownNat @8) . BV.word8) bytes)
+          mem' <- liftIO (LCLMS.storeString bak mem (C.unRV ptr) (Vec.fromList bytes'))
+          pure ((), mem')
+    Nothing ->
+      LCS.overrideError $
+        LCS.AssertFailureSimError "Call to @write-c-string with symbolic string" ""

--- a/crucible-llvm-syntax/src/Lang/Crucible/LLVM/Syntax/Overrides/String.hs
+++ b/crucible-llvm-syntax/src/Lang/Crucible/LLVM/Syntax/Overrides/String.hs
@@ -37,6 +37,7 @@ import What4.Interface qualified as WI
 --
 -- The loaded string must be concrete. If a symbolic character is encountered
 -- while loading, this function will generate an assertion failure.
+-- (TODO(#1061))
 readBytesOverride ::
   ( LCLM.HasLLVMAnn sym
   , LCLM.HasPtrWidth w
@@ -52,6 +53,7 @@ readBytesOverride memVar =
 --
 -- The loaded string must be concrete. If a symbolic character is encountered
 -- while loading, this function will generate an assertion failure.
+-- (TODO(#1061))
 readBytes ::
   ( LCLM.HasLLVMAnn sym
   , LCLM.HasPtrWidth w
@@ -74,6 +76,7 @@ readBytes memVar ptr =
 --
 -- * The loaded string must be concrete. If a symbolic character is encountered
 --   while loading, this function will generate an assertion failure.
+--   (TODO(#1061))
 --
 -- * The loaded string should be UTF-8–encoded. Any invalid code points in the
 --   string will be replaced with the Unicode replacement character @U+FFFD@.
@@ -93,6 +96,7 @@ readCStringOverride memVar =
 --
 -- * The loaded string must be concrete. If a symbolic character is encountered
 --   while loading, this function will generate an assertion failure.
+--   (TODO(#1061))
 --
 -- * The loaded string should be UTF-8–encoded. Any invalid code points in the
 --   string will be replaced with the Unicode replacement character @U+FFFD@.
@@ -149,8 +153,7 @@ writeBytes memVar ptr bytes =
 --
 -- * The string will be UTF-8–encoded when written.
 writeCStringOverride ::
-  ( WI.IsExpr (WI.SymExpr sym)
-  , LCB.IsSymInterface sym
+  ( LCB.IsSymInterface sym
   , LCLM.HasLLVMAnn sym
   , LCLM.HasPtrWidth w
   , ?memOpts :: LCLM.MemOptions

--- a/crucible-llvm/CHANGELOG.md
+++ b/crucible-llvm/CHANGELOG.md
@@ -1,6 +1,7 @@
 # next
 
-Nothing yet.
+* `Lang.Crucible.LLVM.MemModel.{loadString,loadMaybeString,strLen}`
+  should now be imported from `Lang.Crucible.LLVM.MemModel.Strings`.
 
 # 0.7.1 -- 2025-03-21
 

--- a/crucible-llvm/crucible-llvm.cabal
+++ b/crucible-llvm/crucible-llvm.cabal
@@ -85,6 +85,7 @@ library
     Lang.Crucible.LLVM.MemModel.MemLog
     Lang.Crucible.LLVM.MemModel.Partial
     Lang.Crucible.LLVM.MemModel.Pointer
+    Lang.Crucible.LLVM.MemModel.Strings
     Lang.Crucible.LLVM.MemType
     Lang.Crucible.LLVM.PrettyPrint
     Lang.Crucible.LLVM.Printf

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
@@ -83,9 +83,13 @@ module Lang.Crucible.LLVM.MemModel
   , doArrayStoreUnbounded
   , doArrayConstStore
   , doArrayConstStoreUnbounded
-  , loadString
-  , loadMaybeString
-  , strLen
+  -- TODO(#1308): When GHC 9.6 support is dropped, deprecate these imports
+  , -- {-# DEPRECATED "Exported from Crucible.LLVM.MemModel.Strings instead" #-}
+    loadString
+  , -- {-# DEPRECATED "Exported from Crucible.LLVM.MemModel.Strings instead" #-}
+    loadMaybeString
+  , -- {-# DEPRECATED "Exported from Crucible.LLVM.MemModel.Strings instead" #-}
+    strLen
   , uncheckedMemcpy
 
     -- * \"Raw\" operations with LLVMVal

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
@@ -84,6 +84,8 @@ module Lang.Crucible.LLVM.MemModel
   , doArrayConstStore
   , doArrayConstStoreUnbounded
   -- TODO(#1308): When GHC 9.6 support is dropped, deprecate these imports
+  -- TOOD(#1406): After they have been deprecated for a while, move the
+  -- implementations to `Strings` and remove these exports.
   , -- {-# DEPRECATED "Exported from Crucible.LLVM.MemModel.Strings instead" #-}
     loadString
   , -- {-# DEPRECATED "Exported from Crucible.LLVM.MemModel.Strings instead" #-}

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Strings.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Strings.hs
@@ -1,5 +1,5 @@
--- TODO(TODO: file an issue, put number here): Move the definitions of the
--- deprecated imports into this module, and remove the exports from MemModel.
+-- TODO(#1406): Move the definitions of the deprecated imports into this module,
+-- and remove the exports from MemModel.
 {-# OPTIONS_GHC -Wno-warnings-deprecations #-}
 
 {-# LANGUAGE DataKinds #-}

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Strings.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Strings.hs
@@ -1,0 +1,13 @@
+-- TODO(TODO: file an issue, put number here): Move the definitions of the
+-- deprecated imports into this module, and remove the exports from MemModel.
+{-# OPTIONS_GHC -Wno-warnings-deprecations #-}
+
+-- | Manipulating C-style null-terminated strings
+module Lang.Crucible.LLVM.MemModel.Strings
+  ( Mem.loadString
+  , Mem.loadMaybeString
+  , Mem.strLen
+  ) where
+
+import qualified Lang.Crucible.LLVM.MemModel as Mem
+

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Strings.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Strings.hs
@@ -2,12 +2,51 @@
 -- deprecated imports into this module, and remove the exports from MemModel.
 {-# OPTIONS_GHC -Wno-warnings-deprecations #-}
 
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
 -- | Manipulating C-style null-terminated strings
 module Lang.Crucible.LLVM.MemModel.Strings
   ( Mem.loadString
   , Mem.loadMaybeString
   , Mem.strLen
+  , storeString
   ) where
 
+import qualified Data.Parameterized.NatRepr as DPN
+import qualified Data.Vector as Vec
+import qualified Lang.Crucible.Backend as LCB
+import qualified Lang.Crucible.LLVM.DataLayout as CLD
+import qualified Lang.Crucible.LLVM.MemModel as LCLM
 import qualified Lang.Crucible.LLVM.MemModel as Mem
+import qualified What4.Interface as WI
 
+-- | Store a string to memory, adding a null terminator at the end.
+storeString ::
+  forall sym bak w.
+  ( LCB.IsSymBackend sym bak
+  , WI.IsExpr (WI.SymExpr sym)
+  , LCLM.HasPtrWidth w
+  , LCLM.HasLLVMAnn sym
+  , ?memOpts :: LCLM.MemOptions
+  ) =>
+  bak ->
+  LCLM.MemImpl sym ->
+  -- | Pointer to write string to
+  LCLM.LLVMPtr sym w ->
+  -- | The bytes of the string to write (null terminator not included)
+  Vec.Vector (WI.SymBV sym 8) ->
+  IO (LCLM.MemImpl sym)
+storeString bak mem ptr bytesBvs = do
+  let sym = LCB.backendGetSym bak
+  zeroNat <- WI.natLit sym 0
+  let bytes = Vec.map (Mem.LLVMValInt zeroNat) bytesBvs
+  zeroByte <- Mem.LLVMValInt zeroNat <$> WI.bvZero sym (DPN.knownNat @8)
+  let nullTerminatedBytes = Vec.snoc bytes zeroByte
+  let val = Mem.LLVMValArray (Mem.bitvectorType 1) nullTerminatedBytes
+  let storTy = Mem.llvmValStorableType @sym val
+  Mem.storeRaw bak mem ptr storTy CLD.noAlignment val

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Value.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Value.hs
@@ -108,7 +108,7 @@ data LLVMVal sym where
   LLVMValUndef :: StorageType -> LLVMVal sym
 
 
-llvmValStorableType :: IsExprBuilder sym => LLVMVal sym -> StorageType
+llvmValStorableType :: IsExpr (SymExpr sym) => LLVMVal sym -> StorageType
 llvmValStorableType v =
   case v of
     LLVMValInt _ bv -> bitvectorType (bitsToBytes (natValue (bvWidth bv)))

--- a/crucible-llvm/src/Lang/Crucible/LLVM/SymIO.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/SymIO.hs
@@ -102,6 +102,7 @@ import qualified Lang.Crucible.Simulator.GlobalState as LCSG
 
 import           Lang.Crucible.LLVM.Bytes (toBytes)
 import           Lang.Crucible.LLVM.MemModel
+import qualified Lang.Crucible.LLVM.MemModel.Strings as CStr
 import           Lang.Crucible.LLVM.Extension ( ArchWidth )
 import           Lang.Crucible.LLVM.DataLayout ( noAlignment )
 import           Lang.Crucible.LLVM.Intrinsics
@@ -380,7 +381,7 @@ loadFileIdent
 loadFileIdent memOps filename_ptr =
   ovrWithBackend $ \bak ->
    do mem <- readGlobal memOps
-      filename_bytes <- liftIO $ loadString bak mem filename_ptr Nothing
+      filename_bytes <- liftIO $ CStr.loadString bak mem filename_ptr Nothing
       liftIO $ W4.stringLit (backendGetSym bak) (W4.Char8Literal (BS.pack filename_bytes))
 
 returnIOError32

--- a/crucible/CHANGELOG.md
+++ b/crucible/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Add new helpers for extracting `SymGlobalState`s: `exec{Result,State}Globals`.
 * Add `typedOverride` for constructing `TypedOverride`s with statically-known
   signatures.
+* Add `bindTypedOverride` for binding `TypedOverride`s to `FnHandle`s.
 
 # 0.7.2 -- 2025-03-21
 

--- a/crucible/CHANGELOG.md
+++ b/crucible/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Add a `GlobalPair` argument to `AbortedExit`.
 * Add new helpers for extracting `SymGlobalState`s: `exec{Result,State}Globals`.
+* Add `typedOverride` for constructing `TypedOverride`s with statically-known
+  signatures.
 
 # 0.7.2 -- 2025-03-21
 

--- a/crucible/src/Lang/Crucible/Simulator/OverrideSim.hs
+++ b/crucible/src/Lang/Crucible/Simulator/OverrideSim.hs
@@ -75,6 +75,7 @@ module Lang.Crucible.Simulator.OverrideSim
   , useIntrinsic
     -- * Typed overrides
   , TypedOverride(..)
+  , typedOverride
   , SomeTypedOverride(..)
   , runTypedOverride
     -- * Re-exports
@@ -695,6 +696,21 @@ data TypedOverride p sym ext args ret
     , typedOverrideArgs :: CtxRepr args
     , typedOverrideRet :: TypeRepr ret
     }
+
+-- | Create a 'TypedOverride' with a statically-known signature
+typedOverride ::
+  KnownRepr (Ctx.Assignment TypeRepr) args =>
+  KnownRepr TypeRepr ret =>
+  (forall rtp args' ret'.
+    Ctx.Assignment (RegValue' sym) args ->
+    OverrideSim p sym ext rtp args' ret' (RegValue sym ret)) ->
+  TypedOverride p sym ext args ret
+typedOverride handler =
+  TypedOverride
+  { typedOverrideHandler = handler
+  , typedOverrideArgs = knownRepr
+  , typedOverrideRet = knownRepr
+  }
 
 -- | A 'TypedOverride' with the type parameters @args@, @ret@ existentially
 -- quantified

--- a/crucible/src/Lang/Crucible/Simulator/OverrideSim.hs
+++ b/crucible/src/Lang/Crucible/Simulator/OverrideSim.hs
@@ -78,6 +78,7 @@ module Lang.Crucible.Simulator.OverrideSim
   , typedOverride
   , SomeTypedOverride(..)
   , runTypedOverride
+  , bindTypedOverride
     -- * Re-exports
   , Lang.Crucible.Simulator.ExecutionTree.Override
   ) where
@@ -725,3 +726,11 @@ runTypedOverride ::
 runTypedOverride nm typedOvr = mkOverride' nm (typedOverrideRet typedOvr) $ do
   RegMap args <- getOverrideArgs
   typedOverrideHandler typedOvr (fmapFC (RV . regValue) args)
+
+-- | Bind a 'TypedOverride' to a 'FnHandle'
+bindTypedOverride ::
+  FnHandle args ret ->
+  TypedOverride p sym ext args ret ->
+  OverrideSim p sym ext rtp args' ret' ()
+bindTypedOverride hdl ov =
+  bindFnHandle hdl (UseOverride (runTypedOverride (handleName hdl) ov))


### PR DESCRIPTION
Fixes #1393, see that issue for motivation.

Along the way:

- Create a new Crucible-LLVM module for housing string-manipulation functions. Currently just adds one function beyond what was already available, but would provide a convenient home for future functionality around strings, e.g., `strcpy`/`strcmp`-like functions. Re-export existing string-manipulating code there, with the idea of moving it out of the mega-module `MemModel` in the future.
- Simplify the `crucible-cli` API by merging the "hook" that resolves forward declarations into the "setup hook". For LLVM, this means that we can bind forward declarations to overrides that use the memory model.
- New helpers for `TypedOverride`
- Finally, port the `ambient-verifier` S-expression string-manipulation overrides and wire them through `crucible-llvm-{cli,syntax}`.