### PR TITLE
Add `TraversableF` instances for `CrucibleEvent` and `CrucibleAssumption{,s}`

### DIFF
--- a/crucible/CHANGELOG.md
+++ b/crucible/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Add `typedOverride` for constructing `TypedOverride`s with statically-known
   signatures.
 * Add `bindTypedOverride` for binding `TypedOverride`s to `FnHandle`s.
+* Add `FunctorF`, `FoldableF`, and `TraversableF` instances for `CrucibleEvent`,
+  `CrucibleAssumption`, and `CrucibleAssumptions`.
 
 # 0.7.2 -- 2025-03-21
 


### PR DESCRIPTION
I found these instances useful when debugging `ProofGoal`s. The module already defines most of what is needed to traverse over these data structures anyway, so implementing these instances proves straightforward.