### PR TITLE
`crucible-mir`: Remove `AnyType` from struct/enum representations

### DIFF
--- a/.github/workflows/crucible-go-build.yml
+++ b/.github/workflows/crucible-go-build.yml
@@ -40,6 +40,8 @@ jobs:
       # eight bytes: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00")
       cache-key-prefix: 1-go
       check: false
+      # https://github.com/GaloisInc/.github/issues/55
+      check-freeze: false
       ghc: ${{ matrix.ghc }}
       os: ${{ matrix.os }}
       pre-hook: |

--- a/.github/workflows/crucible-jvm-build.yml
+++ b/.github/workflows/crucible-jvm-build.yml
@@ -40,6 +40,8 @@ jobs:
       # eight bytes: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00")
       cache-key-prefix: 1-jvm
       check: false
+      # https://github.com/GaloisInc/.github/issues/55
+      check-freeze: false
       ghc: ${{ matrix.ghc }}
       os: ${{ matrix.os }}
       pre-hook: |

--- a/.github/workflows/crucible-wasm-build.yml
+++ b/.github/workflows/crucible-wasm-build.yml
@@ -40,6 +40,8 @@ jobs:
       # eight bytes: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00")
       cache-key-prefix: 1-wasm
       check: false
+      # https://github.com/GaloisInc/.github/issues/55
+      check-freeze: false
       ghc: ${{ matrix.ghc }}
       os: ${{ matrix.os }}
       pre-hook: |

--- a/crucible-mir/CHANGELOG.md
+++ b/crucible-mir/CHANGELOG.md
@@ -13,6 +13,10 @@ This release supports [version
   in certain situations.
 * The `CTyBv{128,256,512}` pattern synonyms have been removed. It is not
   expected that there are any downstream users.
+* Struct and enum types are now translated directly to `StructType` and
+  `RustEnumType` instead of `AnyType`. As a result of these changes,
+  `Any_RefPath`, `MirSubanyRef`, `subanyRef`, and similar functions have been
+  removed, as they no longer serve a useful purpose.
 
 # 0.4 -- 2025-03-21
 

--- a/crucible-mir/src/Mir/Generator.hs
+++ b/crucible-mir/src/Mir/Generator.hs
@@ -650,12 +650,6 @@ writeMirRef ::
   MirGenerator h s ret ()
 writeMirRef tp ref x = void $ G.extensionStmt (MirWriteRef tp ref x)
 
-subanyRef ::
-  C.TypeRepr tp ->
-  R.Expr MIR s MirReferenceType ->
-  MirGenerator h s ret (R.Expr MIR s MirReferenceType)
-subanyRef tpr ref = G.extensionStmt (MirSubanyRef tpr ref)
-
 subfieldRef ::
   C.CtxRepr ctx ->
   R.Expr MIR s MirReferenceType ->

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -1329,13 +1329,13 @@ evalPlaceProj ty pl@(MirPlace tpr ref NoMeta) (M.PField idx _mirTy) = do
     M.TyAdt nm _ _ -> do
         adt <- findAdt nm
         case adt^.adtkind of
-            Struct -> structFieldRef adt idx tpr ref
+            Struct -> structFieldRef adt idx ref
             Enum _ -> mirFail $ "tried to access field of non-downcast " ++ show ty
             Union -> mirFail $ "evalPlace (PField, Union) NYI"
 
     M.TyDowncast (M.TyAdt nm _ _) i -> do
         adt <- findAdt nm
-        enumFieldRef adt (fromInteger i) idx tpr ref
+        enumFieldRef adt (fromInteger i) idx ref
 
     M.TyTuple ts -> tupleFieldRef ts idx tpr ref
     M.TyClosure ts -> tupleFieldRef ts idx tpr ref

--- a/crux-mir/src/Mir/Concurrency.hs
+++ b/crux-mir/src/Mir/Concurrency.hs
@@ -139,7 +139,6 @@ mirPathName :: C.IsSymInterface sym => MirReferencePath sym tpr t -> String
 mirPathName p =
   case p of
     Empty_RefPath -> ""
-    Any_RefPath _ p -> mirPathName p
     Field_RefPath _ p idx -> mirPathName p ++ "." ++ show (indexVal idx)
     Variant_RefPath _ _ p idx -> mirPathName p ++ "." ++ show (indexVal idx)
     Index_RefPath _ p idx -> mirPathName p

--- a/crux-mir/src/Mir/Overrides.hs
+++ b/crux-mir/src/Mir/Overrides.hs
@@ -358,8 +358,6 @@ regEval bak baseEval tpr v = go tpr v
         OverrideSim p sym MIR rtp args ret (MirReferencePath sym tp_base tp')
     goMirReferencePath Empty_RefPath =
         pure Empty_RefPath
-    goMirReferencePath (Any_RefPath tpr p) =
-        Any_RefPath tpr <$> goMirReferencePath p
     goMirReferencePath (Field_RefPath ctx p idx) =
         Field_RefPath ctx <$> goMirReferencePath p <*> pure idx
     goMirReferencePath (Variant_RefPath discrTp ctx p idx) =


### PR DESCRIPTION
We now translate struct or enum types directly to `StructType` or `RustEnumType`, respectively, instead of using `AnyType`. As a result of this change, we no longer need `Any_RefPath`, `MirSubanyRef`, or `subanyRef`, so these have been removed.

Fixes #1414.