### PR TITLE
CI: Migrate from `windows-2019` to `windows-2022` runners

### DIFF
--- a/.github/Dockerfile-crux-llvm
+++ b/.github/Dockerfile-crux-llvm
@@ -61,7 +61,7 @@ RUN case ${TARGETPLATFORM} in \
         printf "Unsupported architecture: %s\n" "${TARGETPLATFORM}" >&2 \
         exit 1 ;; \
     esac && \
-    curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20250326/ubuntu-22.04-${WHAT4_SOLVERS_ARCH}-bin.zip"
+    curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20250606/ubuntu-22.04-${WHAT4_SOLVERS_ARCH}-bin.zip"
 RUN unzip solvers.zip && rm solvers.zip && chmod +x *
 
 WORKDIR /crux-llvm

--- a/.github/Dockerfile-crux-mir
+++ b/.github/Dockerfile-crux-mir
@@ -66,7 +66,7 @@ RUN case ${TARGETPLATFORM} in \
         printf "Unsupported architecture: %s\n" "${TARGETPLATFORM}" >&2 \
         exit 1 ;; \
     esac && \
-    curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20250326/ubuntu-22.04-${WHAT4_SOLVERS_ARCH}-bin.zip"
+    curl -o solvers.zip -sL "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20250606/ubuntu-22.04-${WHAT4_SOLVERS_ARCH}-bin.zip"
 RUN unzip solvers.zip && rm solvers.zip && chmod +x *
 
 WORKDIR /crux-mir

--- a/.github/workflows/crucible-go-build.yml
+++ b/.github/workflows/crucible-go-build.yml
@@ -20,7 +20,7 @@ jobs:
           - os: macos-14
             cabal: 3.14.2.0
             ghc: 9.10.1
-          - os: windows-2019
+          - os: windows-2022
             cabal: 3.14.2.0
             ghc: 9.10.1
     name: crucible-go - GHC v${{ matrix.ghc }} - ${{ matrix.os }}
@@ -48,7 +48,7 @@ jobs:
         cp "cabal.GHC-${{ matrix.ghc }}.config" cabal.project.freeze
       pre-test-hook: |
         env \
-          SOLVER_PKG_VERSION="snapshot-20250326" \
+          SOLVER_PKG_VERSION="snapshot-20250606" \
           BUILD_TARGET_OS="${{ matrix.os }}" \
           BUILD_TARGET_ARCH="${RUNNER_ARCH}" \
           "${GITHUB_WORKSPACE}/.github/ci.sh" \

--- a/.github/workflows/crucible-jvm-build.yml
+++ b/.github/workflows/crucible-jvm-build.yml
@@ -20,7 +20,7 @@ jobs:
           - os: macos-14
             cabal: 3.14.2.0
             ghc: 9.10.1
-          - os: windows-2019
+          - os: windows-2022
             cabal: 3.14.2.0
             ghc: 9.10.1
     name: crucible-jvm - GHC v${{ matrix.ghc }} - ${{ matrix.os }}
@@ -48,7 +48,7 @@ jobs:
         cp "cabal.GHC-${{ matrix.ghc }}.config" cabal.project.freeze
       pre-test-hook: |
         env \
-          SOLVER_PKG_VERSION="snapshot-20250326" \
+          SOLVER_PKG_VERSION="snapshot-20250606" \
           BUILD_TARGET_OS="${{ matrix.os }}" \
           BUILD_TARGET_ARCH="${RUNNER_ARCH}" \
           "${GITHUB_WORKSPACE}/.github/ci.sh" \

--- a/.github/workflows/crucible-wasm-build.yml
+++ b/.github/workflows/crucible-wasm-build.yml
@@ -20,7 +20,7 @@ jobs:
           - os: macos-14
             cabal: 3.14.2.0
             ghc: 9.10.1
-          - os: windows-2019
+          - os: windows-2022
             cabal: 3.14.2.0
             ghc: 9.10.1
     name: crucible-wasm - GHC v${{ matrix.ghc }} - ${{ matrix.os }}
@@ -48,7 +48,7 @@ jobs:
         cp "cabal.GHC-${{ matrix.ghc }}.config" cabal.project.freeze
       pre-test-hook: |
         env \
-          SOLVER_PKG_VERSION="snapshot-20250326" \
+          SOLVER_PKG_VERSION="snapshot-20250606" \
           BUILD_TARGET_OS="${{ matrix.os }}" \
           BUILD_TARGET_ARCH="${RUNNER_ARCH}" \
           "${GITHUB_WORKSPACE}/.github/ci.sh" \

--- a/.github/workflows/crux-llvm-build.yml
+++ b/.github/workflows/crux-llvm-build.yml
@@ -77,7 +77,7 @@ jobs:
           - os: macos-14
             cabal: 3.14.2.0
             ghc: 9.10.1
-          - os: windows-2019
+          - os: windows-2022
             cabal: 3.14.2.0
             ghc: 9.10.1
     name: crux-llvm - GHC v${{ matrix.ghc }} - ${{ matrix.os }}
@@ -115,7 +115,7 @@ jobs:
 
       - run: .github/ci.sh install_system_deps
         env:
-          SOLVER_PKG_VERSION: "snapshot-20250326"
+          SOLVER_PKG_VERSION: "snapshot-20250606"
           BUILD_TARGET_OS: ${{ matrix.os }}
           BUILD_TARGET_ARCH: ${{ runner.arch }}
 

--- a/.github/workflows/crux-mir-build.yml
+++ b/.github/workflows/crux-mir-build.yml
@@ -130,7 +130,7 @@ jobs:
 
       - run: .github/ci.sh install_system_deps
         env:
-          SOLVER_PKG_VERSION: "snapshot-20250326"
+          SOLVER_PKG_VERSION: "snapshot-20250606"
           BUILD_TARGET_OS: ${{ matrix.os }}
           BUILD_TARGET_ARCH: ${{ runner.arch }}
 


### PR DESCRIPTION
Per https://github.com/actions/runner-images/issues/12045, GitHub Actions will be dropping support for its `windows-2019` runners soon. This migrates the CI to use `windows-2022` instead.