### PR TITLE
syntax: Helper for extracting function bindings from `ParsedProgram`

### DIFF
--- a/crucible-syntax/CHANGELOG.md
+++ b/crucible-syntax/CHANGELOG.md
@@ -1,6 +1,7 @@
 # next
 
-Nothing yet.
+* Add `parsedProgramFnBindings` to a new module,
+  `Lang.Crucible.Syntax.ParsedProgram`.
 
 # 0.4.1 -- 2025-03-21
 

--- a/crucible-syntax/crucible-syntax.cabal
+++ b/crucible-syntax/crucible-syntax.cabal
@@ -136,6 +136,7 @@ library
     Lang.Crucible.Syntax.Overrides
     Lang.Crucible.Syntax.ExprParse
     Lang.Crucible.Syntax.Monad
+    Lang.Crucible.Syntax.ParsedProgram
     Lang.Crucible.Syntax.Prog
 
   ghc-options: -Wall -Werror=incomplete-patterns -Werror=missing-methods -Werror=overlapping-patterns

--- a/crucible-syntax/src/Lang/Crucible/Syntax/Concrete.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Concrete.hs
@@ -98,6 +98,7 @@ import What4.FunctionName
 import What4.Symbol
 import What4.Utils.StringLiteral
 
+import Lang.Crucible.Syntax.ParsedProgram (ParsedProgram(..))
 import Lang.Crucible.Syntax.SExpr (Syntax, pattern L, pattern A, toText, PrintRules(..), PrintStyle(..), syntaxPos, withPosFrom, showAtom)
 import Lang.Crucible.Syntax.Atoms hiding (atom)
 
@@ -210,23 +211,6 @@ data ParserHooks ext = ParserHooks {
 -- language.
 defaultParserHooks :: ParserHooks ()
 defaultParserHooks = ParserHooks empty empty
-
--- | The results of parsing a program.
-data ParsedProgram ext = ParsedProgram
-  { parsedProgGlobals :: Map GlobalName (Some GlobalVar)
-    -- ^ The parsed @defglobal@s.
-  , parsedProgExterns :: Map GlobalName (Some GlobalVar)
-    -- ^ For each parsed @extern@, map its name to its global variable. It is
-    --   the responsibility of the caller to insert each global variable into
-    --   the 'SymGlobalState' alongside an appropriate 'RegValue'.
-  , parsedProgCFGs :: [AnyCFG ext]
-    -- ^ The CFGs for each parsed @defun@.
-  , parsedProgForwardDecs :: Map FunctionName SomeHandle
-    -- ^ For each parsed @declare@, map its name to its function handle. It is
-    --   the responsibility of the caller to register each handle with an
-    --   appropriate 'FnState'.
-  }
-
 
 kw :: MonadSyntax Atomic m => Keyword -> m ()
 kw k = describe ("the keyword " <> showAtom (Kw k)) (atom (Kw k))

--- a/crucible-syntax/src/Lang/Crucible/Syntax/ParsedProgram.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/ParsedProgram.hs
@@ -1,0 +1,46 @@
+module Lang.Crucible.Syntax.ParsedProgram
+  ( ParsedProgram(..)
+  , parsedProgramFnBindings
+  ) where
+
+import Data.Map.Strict (Map)
+import Data.Parameterized.Some (Some)
+import Lang.Crucible.Analysis.Postdom (postdomInfo)
+import Lang.Crucible.CFG.Core (SomeCFG(SomeCFG), cfgHandle)
+import Lang.Crucible.CFG.Extension (IsSyntaxExtension)
+import Lang.Crucible.CFG.Generator (GlobalVar)
+import Lang.Crucible.CFG.Reg (AnyCFG(AnyCFG))
+import Lang.Crucible.CFG.SSAConversion (toSSA)
+import Lang.Crucible.FunctionHandle (SomeHandle)
+import Lang.Crucible.Simulator (FnBinding (FnBinding))
+import Lang.Crucible.Simulator.ExecutionTree (FnState(UseCFG))
+import Lang.Crucible.Syntax.Atoms (GlobalName)
+import What4.FunctionName (FunctionName)
+
+-- | The results of parsing a program.
+data ParsedProgram ext = ParsedProgram
+  { parsedProgGlobals :: Map GlobalName (Some GlobalVar)
+    -- ^ The parsed @defglobal@s.
+  , parsedProgExterns :: Map GlobalName (Some GlobalVar)
+    -- ^ For each parsed @extern@, map its name to its global variable. It is
+    --   the responsibility of the caller to insert each global variable into
+    --   the 'SymGlobalState' alongside an appropriate 'RegValue'.
+  , parsedProgCFGs :: [AnyCFG ext]
+    -- ^ The CFGs for each parsed @defun@.
+  , parsedProgForwardDecs :: Map FunctionName SomeHandle
+    -- ^ For each parsed @declare@, map its name to its function handle. It is
+    --   the responsibility of the caller to register each handle with an
+    --   appropriate 'FnState'.
+  }
+
+-- | Create a 'FnBinding' for each @defun@ CFG in the 'ParsedProgram'.
+parsedProgramFnBindings ::
+  IsSyntaxExtension ext =>
+  ParsedProgram ext ->
+  [FnBinding p sym ext]
+parsedProgramFnBindings prog = map mkBinding (parsedProgCFGs prog)
+  where
+    mkBinding (AnyCFG defCfg) =
+      case toSSA defCfg of
+        SomeCFG defSsa ->
+          FnBinding (cfgHandle defSsa) (UseCFG defSsa (postdomInfo defSsa))


### PR DESCRIPTION
Most consumers of a crucible-syntax `ParsedProgram` will want to bind all of the CFGs therein to their handles. Export a helper for this purpose. Also, use this new helper in crucible-cli. Fixes #1421.