### PR TITLE
`crucible-mir`: Print vtables in `Pretty Collection` instance

### DIFF
--- a/crucible-mir/CHANGELOG.md
+++ b/crucible-mir/CHANGELOG.md
@@ -20,6 +20,8 @@ This release supports [version
 * Added an intrinsic for [`read_volatile`](https://doc.rust-lang.org/std/ptr/fn.read_volatile.html)
   and [`write_volatile`](https://doc.rust-lang.org/std/ptr/fn.write_volatile.html)
 * Support raw-pointer and `CoerceUnsized` casts that introduce vtable metadata.
+* Add `Pretty` instances for `Vtable` and `VtableItem`, and make the `Pretty`
+  instance for `Collection` print its vtables.
 
 # 0.4 -- 2025-03-21
 

--- a/crucible-mir/src/Mir/PP.hs
+++ b/crucible-mir/src/Mir/PP.hs
@@ -310,6 +310,15 @@ instance Pretty BinOp where
       Unchecked op' -> pretty op' <> pretty "!"
       WithOverflow op' -> pretty op' <> pretty "?"
 
+instance Pretty VtableItem where
+  pretty (VtableItem fn def) = tupled [pretty fn, pretty def] <> semi
+
+instance Pretty Vtable where
+  pretty (Vtable name items) =
+    vcat [pretty "vtable" <+> pretty name <+> lbrace ,
+          indent 3 (vcat (map pretty items)),
+          rbrace]
+
 instance Pretty CastKind where
     pretty = viaShow
 
@@ -415,6 +424,8 @@ instance Pretty Collection where
           map pretty (Map.elems (col^.adts)) ++
           [pretty "TRAITs"] ++
           map pretty (Map.elems (col^.traits)) ++
+          [pretty "VTABLEs"] ++
+          map pretty (Map.elems (col^.vtables)) ++
           [pretty "INTRINSICSs"] ++
           map pretty (Map.elems (col^.intrinsics)) ++
           [pretty "STATICS"] ++

--- a/crucible-mir/src/Mir/PP.hs
+++ b/crucible-mir/src/Mir/PP.hs
@@ -311,7 +311,11 @@ instance Pretty BinOp where
       WithOverflow op' -> pretty op' <> pretty "?"
 
 instance Pretty VtableItem where
-  pretty (VtableItem fn def) = tupled [pretty fn, pretty def] <> semi
+  pretty (VtableItem fn def) =
+    vcat
+      [ pretty "(" <+> pretty fn
+      , pretty "," <+> pretty def <+> pretty ");"
+      ]
 
 instance Pretty Vtable where
   pretty (Vtable name items) =

--- a/crucible-mir/src/Mir/PP.hs
+++ b/crucible-mir/src/Mir/PP.hs
@@ -313,8 +313,8 @@ instance Pretty BinOp where
 instance Pretty VtableItem where
   pretty (VtableItem fn def) =
     vcat
-      [ pretty "(" <+> pretty fn
-      , pretty "," <+> pretty def <+> pretty ");"
+      [ pretty "( " <+> pretty def
+      , pretty "=>" <+> pretty fn <+> pretty ");"
       ]
 
 instance Pretty Vtable where


### PR DESCRIPTION
This causes `crux-mir`'s `--print-mir` flag to print vtable information when displaying a MIR JSON collection. Example output from the program in https://github.com/GaloisInc/crucible/issues/1222#issuecomment-2233313541:

```
VTABLEs
vtable core/c7248340::ops[0]::function[0]::Fn[0]::_vtblefc1a1550237cdbd[0] {
   ( core/c7248340::ops[0]::function[0]::FnOnce[0]::call_once[0]::_callonce579d6f58bdd54617[0]
   , core/c7248340::ops[0]::function[0]::FnOnce[0]::call_once[0] );
   ( test/ab048184::bar[0]::{closure#0}[0]::_inst485a3c886f64d386[0]
   , test/ab048184::bar[0]::{closure#0}[0] );
   ( test/ab048184::bar[0]::{closure#0}[0]::_inst485a3c886f64d386[0]
   , test/ab048184::bar[0]::{closure#0}[0] );
}
```

Fixes #1443.