### PR TITLE
crux-mir: update mir-json to fix array::from_fn error

### DIFF
--- a/crux-mir/test/conc_eval/array/from_fn.rs
+++ b/crux-mir/test/conc_eval/array/from_fn.rs
@@ -1,0 +1,10 @@
+use std::array;
+
+#[cfg_attr(crux, crux::test)]
+pub fn crux_test() -> [usize; 3] {
+    array::from_fn(|i| i)
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/symb_eval/array/symbolic.good
+++ b/crux-mir/test/symb_eval/array/symbolic.good
@@ -1,0 +1,3 @@
+test symbolic/<DISAMB>::crux_test[0]: ok
+
+[Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/array/symbolic.rs
+++ b/crux-mir/test/symb_eval/array/symbolic.rs
@@ -1,0 +1,12 @@
+extern crate crucible;
+use crucible::*;
+
+#[crux::test]
+fn crux_test() {
+    let mut arr = <[i32; 3]>::symbolic("arr");
+    crucible_assume!(0 <= arr[0] && arr[0] <= 5);
+    crucible_assume!(0 <= arr[1] && arr[1] <= 5);
+    crucible_assume!(0 <= arr[2] && arr[2] <= 5);
+    let sum = arr.into_iter().sum::<i32>();
+    crucible_assert!(0 <= sum && sum <= 15);
+}


### PR DESCRIPTION
Also adds tests for `array::from_fn` and `<[T; N]>::symbolic`, the latter being the function that uncovered this bug.