### PR TITLE
`test1451.rs`: Fix up function names

### DIFF
--- a/crux-mir/test/conc_eval/intTest/test1451.rs
+++ b/crux-mir/test/conc_eval/intTest/test1451.rs
@@ -31,19 +31,19 @@ rol_test!(i64_rol_test, i64);
 rol_test!(i128_rol_test, i128);
 rol_test!(isize_rol_test, isize);
 
-rol_test!(i8_ror_test, i8);
-rol_test!(i16_ror_test, i16);
-rol_test!(i32_ror_test, i32);
-rol_test!(i64_ror_test, i64);
-rol_test!(i128_ror_test, i128);
-rol_test!(isize_ror_test, isize);
+ror_test!(i8_ror_test, i8);
+ror_test!(i16_ror_test, i16);
+ror_test!(i32_ror_test, i32);
+ror_test!(i64_ror_test, i64);
+ror_test!(i128_ror_test, i128);
+ror_test!(isize_ror_test, isize);
 
-ror_test!(u8_rol_test, u8);
-ror_test!(u16_rol_test, u16);
-ror_test!(u32_rol_test, u32);
-ror_test!(u64_rol_test, u64);
-ror_test!(u128_rol_test, u128);
-ror_test!(usize_rol_test, usize);
+rol_test!(u8_rol_test, u8);
+rol_test!(u16_rol_test, u16);
+rol_test!(u32_rol_test, u32);
+rol_test!(u64_rol_test, u64);
+rol_test!(u128_rol_test, u128);
+rol_test!(usize_rol_test, usize);
 
 ror_test!(u8_ror_test, u8);
 ror_test!(u16_ror_test, u16);


### PR DESCRIPTION
Address some mismatched function names, spotted by @samcowger in https://github.com/GaloisInc/crucible/pull/1452#discussion_r2183975739.

Related to #1451.