### PR TITLE
`crucible-mir`: Support clone shims for function pointers and closures 

### DIFF
--- a/crucible-mir/CHANGELOG.md
+++ b/crucible-mir/CHANGELOG.md
@@ -24,6 +24,7 @@ This release supports [version
   instance for `Collection` print its vtables.
 * Generalize the custom overrides for `rotate_{left,right}` to work on integer
   types besides `i32` or `u32`.
+* Support clone shims for function pointers and closures.
 
 # 0.4 -- 2025-03-21
 

--- a/crucible-mir/src/Mir/TransCustom.hs
+++ b/crucible-mir/src/Mir/TransCustom.hs
@@ -1855,21 +1855,7 @@ fnPtrShimDef ty = CustomOp $ \_ _ -> mirFail $ "fnPtrShimDef not implemented for
 -- the `clone`/`clone_from` methods of the individual fields or array elements.
 
 cloneShimDef :: Ty -> [M.DefId] -> CustomOp
-cloneShimDef (TyTuple tys) parts = CustomMirOp $ \ops -> do
-    when (length tys /= length parts) $ mirFail "cloneShimDef: expected tys and parts to match"
-    lv <- case ops of
-        [Move lv] -> return lv
-        [Copy lv] -> return lv
-        [op] -> mirFail $ "cloneShimDef: expected lvalue operand, but got " ++ show op
-        _ -> mirFail $ "cloneShimDef: expected exactly one argument, but got " ++ show (length ops)
-    -- The argument to the clone shim is `&(A, B, C)`.  The clone methods for
-    -- the individual parts require `&A`, `&B`, `&C`, computed as `&arg.0`.
-    let fieldRefRvs = zipWith (\ty i ->
-            Ref Shared (LProj (LProj lv Deref) (PField i ty)) "_") tys [0..]
-    fieldRefExps <- mapM evalRval fieldRefRvs
-    fieldRefOps <- zipWithM (\ty exp -> makeTempOperand (TyRef ty Immut) exp) tys fieldRefExps
-    clonedExps <- zipWithM (\part op -> callExp part [op]) parts fieldRefOps
-    buildTupleMaybeM tys (map Just clonedExps)
+cloneShimDef (TyTuple tys) parts = cloneShimTuple tys parts
 cloneShimDef (TyArray ty len) parts
   | [part] <- parts = CustomMirOp $ \ops -> do
     lv <- case ops of
@@ -1889,6 +1875,24 @@ cloneShimDef (TyArray ty len) parts
   | otherwise = CustomOp $ \_ _ -> mirFail $
     "expected exactly one clone function for in array clone shim, but got " ++ show parts
 cloneShimDef ty parts = CustomOp $ \_ _ -> mirFail $ "cloneShimDef not implemented for " ++ show ty
+
+-- | Create an 'IkCloneShim' implementation for a tuple type.
+cloneShimTuple :: [Ty] -> [M.DefId] -> CustomOp
+cloneShimTuple tys parts = CustomMirOp $ \ops -> do
+    when (length tys /= length parts) $ mirFail "cloneShimTuple: expected tys and parts to match"
+    lv <- case ops of
+        [Move lv] -> return lv
+        [Copy lv] -> return lv
+        [op] -> mirFail $ "cloneShimTuple: expected lvalue operand, but got " ++ show op
+        _ -> mirFail $ "cloneShimTuple: expected exactly one argument, but got " ++ show (length ops)
+    -- The argument to the clone shim is `&(A, B, C)`.  The clone methods for
+    -- the individual parts require `&A`, `&B`, `&C`, computed as `&arg.0`.
+    let fieldRefRvs = zipWith (\ty i ->
+            Ref Shared (LProj (LProj lv Deref) (PField i ty)) "_") tys [0..]
+    fieldRefExps <- mapM evalRval fieldRefRvs
+    fieldRefOps <- zipWithM (\ty exp -> makeTempOperand (TyRef ty Immut) exp) tys fieldRefExps
+    clonedExps <- zipWithM (\part op -> callExp part [op]) parts fieldRefOps
+    buildTupleMaybeM tys (map Just clonedExps)
 
 cloneFromShimDef :: Ty -> [M.DefId] -> CustomOp
 cloneFromShimDef ty parts = CustomOp $ \_ _ -> mirFail $ "cloneFromShimDef not implemented for " ++ show ty

--- a/crucible-mir/src/Mir/TransCustom.hs
+++ b/crucible-mir/src/Mir/TransCustom.hs
@@ -1856,6 +1856,7 @@ fnPtrShimDef ty = CustomOp $ \_ _ -> mirFail $ "fnPtrShimDef not implemented for
 
 cloneShimDef :: Ty -> [M.DefId] -> CustomOp
 cloneShimDef (TyTuple tys) parts = cloneShimTuple tys parts
+cloneShimDef (TyClosure upvar_tys) parts = cloneShimTuple upvar_tys parts
 cloneShimDef (TyArray ty len) parts
   | [part] <- parts = CustomMirOp $ \ops -> do
     lv <- case ops of
@@ -1874,9 +1875,20 @@ cloneShimDef (TyArray ty len) parts
     buildArrayLit tpr clonedExps
   | otherwise = CustomOp $ \_ _ -> mirFail $
     "expected exactly one clone function for in array clone shim, but got " ++ show parts
+cloneShimDef (TyFnPtr _) parts
+  -- Function pointers do not have any fields, so implementing a clone shim for
+  -- a function pointer is as simple as dereferencing it.
+  | [] <- parts = CustomOp $ \opTys ops ->
+    case (opTys, ops) of
+      ([TyRef ty _], [eRef]) -> do
+        e <- derefExp ty eRef
+        readPlace e
+      _ -> mirFail $ "cloneShimDef: expected exactly one argument, but got " ++ show (opTys, ops)
+  | otherwise = CustomOp $ \_ _ -> mirFail $
+    "expected no clone functions in function pointer clone shim, but got " ++ show parts
 cloneShimDef ty parts = CustomOp $ \_ _ -> mirFail $ "cloneShimDef not implemented for " ++ show ty
 
--- | Create an 'IkCloneShim' implementation for a tuple type.
+-- | Create an 'IkCloneShim' implementation for a tuple or closure type.
 cloneShimTuple :: [Ty] -> [M.DefId] -> CustomOp
 cloneShimTuple tys parts = CustomMirOp $ \ops -> do
     when (length tys /= length parts) $ mirFail "cloneShimTuple: expected tys and parts to match"

--- a/crux-mir/test/conc_eval/clos/clone_shim.rs
+++ b/crux-mir/test/conc_eval/clos/clone_shim.rs
@@ -1,0 +1,22 @@
+// A regression test for #1455. Ensure that crucible-mir is able to translate
+// clone shims for function pointers (f1) and closures (f2).
+
+pub fn f1(x: fn() -> i32) -> i32 {
+    let y = x.clone();
+    y()
+}
+
+pub fn f2(x: i32) -> i32 {
+    let y = || x;
+    let z = y.clone();
+    z()
+}
+
+#[cfg_attr(crux, crux::test)]
+pub fn crux_test() -> i32 {
+    f1(|| 42) + f2(42)
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}


### PR DESCRIPTION
Fixes https://github.com/GaloisInc/crucible/issues/1455.