### PR TITLE
crucible-mir: fix Crucible signature of `extern "rust-call"` functions

### DIFF
--- a/crucible-mir/src/Mir/GenericOps.hs
+++ b/crucible-mir/src/Mir/GenericOps.hs
@@ -131,6 +131,7 @@ instance GenericOps Mutability
 instance GenericOps Collection
 instance GenericOps Fn
 instance GenericOps Abi
+instance GenericOps RustCallBodyInfo
 instance GenericOps MirBody
 instance GenericOps BasicBlock
 instance GenericOps BasicBlockData

--- a/crucible-mir/src/Mir/JSON.hs
+++ b/crucible-mir/src/Mir/JSON.hs
@@ -140,11 +140,9 @@ instance FromJSON Instance where
 instance FromJSON FnSig where
     parseJSON =
       withObject "FnSig" $ \v -> do
-         let spread = return Nothing
          FnSig <$> v .: "inputs"
                <*> v .: "output"
                <*> v .: "abi"
-               <*> spread
 
 instance FromJSON Adt where
     parseJSON = withObject "Adt" $ \v -> Adt
@@ -232,10 +230,17 @@ instance FromJSON Collection where
 instance FromJSON Fn where
     parseJSON = withObject "Fn" $ \v -> do
       args <- v .: "args"
+      abi <- v .: "abi" >>= \abi -> case abi of
+        RustCall _ -> do
+          spreadArg <- v .: "spread_arg"
+          case spreadArg of
+            Just i -> return $ RustCall (RcSpreadArg i)
+            Nothing -> return $ RustCall RcNoSpreadArg
+        _ -> return abi
+
       let sig = FnSig <$> return (map typeOf args)
                       <*> v .: "return_ty"
-                      <*> v .: "abi"
-                      <*> v .: "spread_arg"
+                      <*> return abi
 
       Fn
         <$> v .: "name"
@@ -247,7 +252,10 @@ instance FromJSON Abi where
     parseJSON = withObject "Abi" $ \v -> case lookupKM "kind" v of
         Just (String "Rust") -> pure RustAbi
         Just (String "RustIntrinsic") -> pure RustIntrinsic
-        Just (String "RustCall") -> pure RustCall
+        -- For `RustCall`, defaut to `RcNoBody`.  The spread_arg info will be
+        -- added while parsing the `Fn`, if this `Abi` is part of a `Fn`'s
+        -- signature.
+        Just (String "RustCall") -> pure $ RustCall RcNoBody
         Just (String _) -> pure OtherAbi
         x -> fail $ "bad abi: " ++ show x
 

--- a/crucible-mir/src/Mir/JSON.hs
+++ b/crucible-mir/src/Mir/JSON.hs
@@ -230,13 +230,15 @@ instance FromJSON Collection where
 instance FromJSON Fn where
     parseJSON = withObject "Fn" $ \v -> do
       args <- v .: "args"
-      abi <- v .: "abi" >>= \abi -> case abi of
+
+      origAbi <- v .: "abi"
+      abi <- case origAbi of
         RustCall _ -> do
           spreadArg <- v .: "spread_arg"
           case spreadArg of
             Just i -> return $ RustCall (RcSpreadArg i)
             Nothing -> return $ RustCall RcNoSpreadArg
-        _ -> return abi
+        _ -> return origAbi
 
       let sig = FnSig <$> return (map typeOf args)
                       <*> v .: "return_ty"

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -146,18 +146,18 @@ data Abi
 data RustCallBodyInfo
     = RcNoBody
     -- ^ The `FnSig` containing this `RustCall` `Abi` isn't the signature of a
-    -- `Fn` body.  For example, `extern "rust-call"` function pointers always
-    -- have an ABI of `RustCall RcNoBody`.
+    -- `Fn` body.  For example, @extern "rust-call"@ function pointers always
+    -- have an ABI of @`RustCall` `RcNoBody`@.
     | RcNoSpreadArg
-    -- ^ The `FnSig` is associated with a body, but the body's `spread_arg`
+    -- ^ The `FnSig` is associated with a body, but the body's @spread_arg@
     -- field is unset.  This applies to closure implementations, which are
-    -- are `extern "rust-call"` and are called with tupled arguments, but are
-    -- defined with un-tupled arguments (and no `spread_arg`).  For such
+    -- are @extern "rust-call"@ and are called with tupled arguments, but are
+    -- defined with un-tupled arguments (and no @spread_arg@).  For such
     -- functions, `fsarg_tys` will contain the un-tupled arguments, and the ABI
-    -- will be `RustCall RcNoSpreadArg`.
+    -- will be @`RustCall` `RcNoSpreadArg`@.
     | RcSpreadArg Int
-    -- ^ The `FnSig` is associated with a body, and the body has a `spread_arg`
-    -- index.  This applies to various `extern "rust-call"` closure-related
+    -- ^ The `FnSig` is associated with a body, and the body has a @spread_arg@
+    -- index.  This applies to various @extern "rust-call"@ closure-related
     -- shims and vtable methods, which are both called and defined with a
     -- tupled signature.
     deriving (Show, Eq, Ord, Generic)

--- a/crucible-mir/src/Mir/PP.hs
+++ b/crucible-mir/src/Mir/PP.hs
@@ -387,11 +387,6 @@ instance Pretty FnSig where
   pretty fs =
     tupled (map pretty (fs^.fsarg_tys)) <+> arrow <+> pretty (fs^.fsreturn_ty)
                 <+> brackets (pretty (fs^.fsabi))
-                <+> maybeSpreadArg
-    where
-        maybeSpreadArg = case fs^.fsspreadarg of
-            Nothing -> mempty
-            Just i -> braces (pretty "spread_arg" <+> pretty i)
 
 instance Pretty Abi where
     pretty = viaShow

--- a/crucible-mir/src/Mir/PP.hs
+++ b/crucible-mir/src/Mir/PP.hs
@@ -135,12 +135,15 @@ pretty_temp (Var vn vm vty _vzst) =
 
 instance Pretty Fn where
     pretty (Fn fname1 fargs1 fs fbody1) =
-      vcat $ [pretty "fn" <+> pretty fname1 <> tupled (map pretty_arg fargs1)
+      vcat $ [extern <> pretty "fn" <+> pretty fname1 <> tupled (map pretty_arg fargs1)
                   <+> arrow <+> pretty rty <+> lbrace]
             ++ [indent 3 (pretty fbody1),
                 rbrace]
       where
         rty    = fs^.fsreturn_ty
+        extern = case fs^.fsabi of
+          RustAbi -> mempty
+          abi -> pretty "extern" <+> viaShow abi <+> mempty
 
 instance Pretty MirBody where
     pretty (MirBody mvs mbs _) =

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -1880,7 +1880,7 @@ initLocals localVars addrTaken = forM_ localVars $ \v -> do
         Just (MirExp tpr' val) -> do
             Refl <- testEqualityOrFail tpr tpr' $
                 "initialValue produced " ++ show tpr' ++ " instead of " ++ show tpr
-                  ++ ", for " ++ show ty
+                  ++ ", for " ++ show (pretty ty)
             return $ Just val
 
     -- FIXME: temporary hack to put every local behind a MirReference, to work
@@ -2036,12 +2036,11 @@ genFn (M.Fn fname argvars sig body@(MirBody localvars blocks _)) rettype inputs 
     initArgs inputs vars =
         case (inputs, vars) of
             ([], []) -> return ()
-            (input : inputs', var : vars') -> do
+            (MirExp inputTpr inputExpr : inputs', var : vars') -> do
                 mvi <- use $ varMap . at (var ^. varname)
                 Some vi <- case mvi of
                     Just x -> return x
                     Nothing -> mirFail $ "no varinfo for arg " ++ show (var ^. varname)
-                MirExp inputTpr inputExpr <- return input
                 Refl <- testEqualityOrFail inputTpr (varInfoRepr vi) $
                     "type mismatch in initialization of " ++ show (var ^. varname) ++ ": " ++
                         show inputTpr ++ " != " ++ show (varInfoRepr vi)

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -2645,12 +2645,12 @@ transCollection col halloc = do
     hmap2 <- mkShimHandleMap col halloc
     let hmap = hmap1 <> hmap2
 
-    --forM_ (Map.toList hmap) $ \(name, mh) -> do
-    --  MirHandle _ sig handle <- return mh
-    --  traceM $ "function " ++ show name ++ ":"
-    --  traceM $ "  sig = " ++ show sig
-    --  traceM $ "  handle = " ++ show (FH.handleType handle)
-
+    when (?debug > 3) $ do
+      forM_ (Map.toList hmap) $ \(name, mh) -> do
+        MirHandle _ sig handle <- return mh
+        traceM $ "function " ++ show name ++ ":"
+        traceM $ "  sig = " ++ show (pretty sig)
+        traceM $ "  handle = " ++ show (FH.handleType handle)
 
     vm <- mkVtableMap col halloc
 

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -1880,6 +1880,7 @@ initLocals localVars addrTaken = forM_ localVars $ \v -> do
         Just (MirExp tpr' val) -> do
             Refl <- testEqualityOrFail tpr tpr' $
                 "initialValue produced " ++ show tpr' ++ " instead of " ++ show tpr
+                  ++ ", for " ++ show ty
             return $ Just val
 
     -- FIXME: temporary hack to put every local behind a MirReference, to work
@@ -2002,7 +2003,9 @@ genFn (M.Fn fname argvars sig body@(MirBody localvars blocks _)) rettype inputs 
         [M.TyTuple tys] -> return tys
         _ -> mirFail $ "expected tuple at position " ++ show splitIndex
           ++ ", but got " ++ show argvars
-      tupleExp <- buildTupleMaybeM tupleFieldTys (map Just tupleFieldExps)
+      tupleExp <- case tupleFieldTys of
+        [] -> return $ MirExp C.UnitRepr (R.App E.EmptyApp)
+        _ -> buildTupleMaybeM tupleFieldTys (map Just tupleFieldExps)
       return $ selfExps ++ [tupleExp]
     _ -> return inputExps
   initArgs inputExps' argvars

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -1989,10 +1989,9 @@ genFn (M.Fn fname argvars sig body@(MirBody localvars blocks _)) rettype inputs 
       -- form, but `inputExps` follows the untupled form.  Here we convert
       -- `inputExps` to match `argvars` by tupling up some of the arguments.
       --
-      -- Arguments from `spreadArg` onward need to be tupled.  Note that
-      -- `fsspreadarg` is 1-based (it's a MIR `Local` ID, and the first
-      -- argument is local `_1`), but we convert to a 0-based index for
-      -- convenience.
+      -- Arguments from `splitIndex` onward need to be tupled.  Note that
+      -- `spreadArg` is 1-based (it's a MIR `Local` ID, and the first argument
+      -- is local `_1`), but we convert to a 0-based index for convenience.
       let splitIndex = spreadArg - 1
       when (splitIndex > length inputExps) $
         mirFail $ "split index " ++ show splitIndex ++ " out of range for "

--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -315,10 +315,9 @@ isZeroSized col ty = go ty
       _ -> False
 
 
--- | Get the "ABI-level" function arguments for `sig`, which determines the
--- arguments we use for the Crucible `FnHandle`.  This applies a special
--- adjustment for `extern "rust-call"` functions, like the one rustc applies
--- when converting a `FnSig` to `FnAbi`.
+-- | Get the "ABI-level" function arguments for @sig@, which determines the
+-- arguments we use for the Crucible @FnHandle@.  This includes the necessary
+-- adjustments for `extern "rust-call"` functions.
 abiFnArgs :: HasCallStack => M.FnSig -> [M.Ty]
 abiFnArgs sig = case sig ^. M.fsabi of
   M.RustCall M.RcNoBody -> untupledArgs
@@ -328,6 +327,8 @@ abiFnArgs sig = case sig ^. M.fsabi of
   where
     normalArgs = sig ^. M.fsarg_tys
     untupledArgs = case normalArgs of
+      -- This is similar to the adjustment rustc applies when lowering an
+      -- `extern "rust-call"` `FnSig` to a `FnAbi`.
       [M.TyTuple tys] -> tys
       [selfTy, M.TyTuple tys] -> selfTy : tys
       _ -> error $

--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -31,6 +31,7 @@ import Data.List (findIndices)
 import           Data.String (fromString)
 import           Data.Text (Text)
 import qualified Data.Vector as V
+import Prettyprinter (Pretty(..))
 
 import GHC.Stack
 
@@ -332,8 +333,8 @@ abiFnArgs sig = case sig ^. M.fsabi of
       [M.TyTuple tys] -> tys
       [selfTy, M.TyTuple tys] -> selfTy : tys
       _ -> error $
-          "unexpected argument list for " ++ show (sig ^. M.fsabi) ++  ": "
-            ++ show (sig ^. M.fsarg_tys)
+          "unexpected argument list for " ++ show (pretty $ sig ^. M.fsabi) ++  ": "
+            ++ show (pretty $ sig ^. M.fsarg_tys)
 
 
 -- | Look up the `Adt` definition, if this `Ty` is `TyAdt`.

--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -232,7 +232,7 @@ tyToRepr col t0 = case t0 of
   M.TyFloat _ -> Some C.RealValRepr
 
   -- non polymorphic function types go to FunctionHandleRepr
-  M.TyFnPtr sig@(M.FnSig args ret _abi _spread) ->
+  M.TyFnPtr sig@(M.FnSig args ret _abi) ->
      tyListToCtx col args $ \argsr  ->
      tyToReprCont col ret $ \retr ->
         Some (C.FunctionHandleRepr argsr retr)

--- a/crux-mir/CHANGELOG.md
+++ b/crux-mir/CHANGELOG.md
@@ -13,6 +13,8 @@ This release supports [version
 * Improve source position tracking for MIR statements during the translation to
   Crucible. This should result in more precise error messages in certain
   situations.
+* Support using `dyn Fn` and `dyn FnMut` for closures.  Using `dyn FnOnce` is
+  not yet supported.
 
 # 0.10 -- 2025-03-21
 

--- a/crux-mir/test/conc_eval/clos/fn_dyn.rs
+++ b/crux-mir/test/conc_eval/clos/fn_dyn.rs
@@ -1,4 +1,3 @@
-// FAIL: call_once shim (in `dyn Fn` vtable)
 #![cfg_attr(not(with_main), no_std)]
 fn call_with_one(some_closure: &dyn Fn(i32) -> i32) -> i32 {
     some_closure(1)

--- a/crux-mir/test/conc_eval/clos/fn_dyn_box.rs
+++ b/crux-mir/test/conc_eval/clos/fn_dyn_box.rs
@@ -1,0 +1,13 @@
+// FAIL: standalone use of `dyn` in the receiver of `call_once`
+fn call_closure_box(f: Box<dyn FnOnce(i32, i32) -> i32>) -> i32 {
+    f(1, 2)
+}
+
+#[cfg_attr(crux, crux::test)]
+fn crux_test() -> i32 {
+    call_closure_box(Box::new(|x, y| x + y))
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/conc_eval/clos/fn_dyn_box_mut.rs
+++ b/crux-mir/test/conc_eval/clos/fn_dyn_box_mut.rs
@@ -1,0 +1,16 @@
+fn call_closure_box(mut f: Box<dyn FnMut(i32, i32) -> i32>) -> i32 {
+    let r = f(1, 2);
+    // TODO: remove `forget` once `drop_in_place` works for `Box<dyn Trait>` (currently it enters
+    // an infinite loop).
+    std::mem::forget(f);
+    r
+}
+
+#[cfg_attr(crux, crux::test)]
+fn crux_test() -> i32 {
+    call_closure_box(Box::new(|x, y| x + y))
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/conc_eval/clos/fn_dyn_mut.rs
+++ b/crux-mir/test/conc_eval/clos/fn_dyn_mut.rs
@@ -1,0 +1,12 @@
+pub fn foo(f: &mut dyn FnMut(i16, i32) -> i32) -> i32 {
+    f(27, 42)
+}
+
+#[cfg_attr(crux, crux::test)]
+fn crux_test() -> i32 {
+    foo(&mut |x, y| x as i32 + y as i32)
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/conc_eval/clos/fn_dyn_nullary.rs
+++ b/crux-mir/test/conc_eval/clos/fn_dyn_nullary.rs
@@ -1,0 +1,13 @@
+fn call_with_one(some_closure: &dyn Fn() -> i32) -> i32 {
+    some_closure()
+}
+
+#[cfg_attr(crux, crux::test)]
+fn crux_test() -> i32 {
+    let x = 123;
+    call_with_one(&|| x + 123)
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}


### PR DESCRIPTION
The unstable `extern "rust-call"` ABI used for closures is normally compiled by untupling the last argument: `extern "rust-call" fn(T, (U, V))` is compiled roughly the same as `fn(T, U, V)`.  Some parts of rustc's MIR code generation depend on this equivalence to perform operations that would otherwise be invalid.  This branch replaces our previous workaround (the "`spread_arg` hack") with a new implementation that behaves more like rustc's existing backends.  In particular, with this branch, the tupled and untupled signatures now map to the same Crucible function signature.  This also lets us add support for calling closures through `&dyn Fn`.

With this change, the handling of `extern "rust-call"` functions in crux-mir is more consistent, but there is still one tricky case.  At the MIR level, `extern "rust-call"` functions are normally defined with a tupled signature and called by passing a tuple of arguments.  However, the implementation functions of closures (e.g. for `|x| x + 1`, the MIR function that computes `x + 1`) are defined with an untupled signature, but are still passed a tuple at the call site.  This case is detected by looking for the combination of `"abi": {"kind": "RustCall"}` and `"spread_arg": null` on the function definition, and it's handled separately from `RustCall` with non-null `spread_arg` in some places.

Fixes #1222