### PR TITLE
llvm: Export more "low-level" string-loading functionality

### DIFF
--- a/crucible-llvm/CHANGELOG.md
+++ b/crucible-llvm/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Two new functions for loading C-style null-terminated strings from
   LLVM memory were added to `Lang.Crucible.LLVM.MemModel.Strings`:
   `loadConcretelyNullTerminatedString` and `loadSymbolicString`.
+* Add a new "low-level" API for loading strings to
+  `Lang.Crucible.LLVM.MemModel.Strings`: `ByteLoader`, `ByteChecker`, and
+  `loadBytes`.
 
 # 0.7.1 -- 2025-03-21
 


### PR DESCRIPTION
This is necessary for effectively loading strings via the Macaw memory model, which uses `doReadMemModel` rather than `doLoad`. We should add a module like `Strings` to macaw-symbolic that wraps these low-level APIs much the same way `Strings` does. I might do this (and use it in GREASE) before un-drafting this PR, but feel free to review in the meantime.