### PR TITLE
MIR: recoverably fail on unsupported type

### DIFF
--- a/crucible-mir/CHANGELOG.md
+++ b/crucible-mir/CHANGELOG.md
@@ -25,6 +25,9 @@ This release supports [version
 * Generalize the custom overrides for `rotate_{left,right}` to work on integer
   types besides `i32` or `u32`.
 * Support clone shims for function pointers and closures.
+* Type translation functions like `tyToRepr` now fail gracefully
+  so that failed translations can be handled by upstream tooling
+  instead of failing using `error`
 
 # 0.4 -- 2025-03-21
 

--- a/crux-mir/test/conc_eval/resilience/ignore_unused_union.rs
+++ b/crux-mir/test/conc_eval/resilience/ignore_unused_union.rs
@@ -1,0 +1,27 @@
+#[repr(C)]
+union MyUnion {
+    f1: u32,
+    f2: f32,
+}
+
+fn f() -> u32 {
+    let u = MyUnion { f1: 1 };
+    unsafe { u.f1 }
+}
+
+fn g(x: bool) -> u32 {
+    if x {
+        f()
+    } else {
+        2
+    }
+}
+
+#[cfg_attr(crux, crux::test)]
+pub fn crux_test() -> u32 {
+    g(false)
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}


### PR DESCRIPTION
The updates tyToRepr to report a recoverable error when we encounter a type we don't support.

This allows us to emit a symbolic-execution runtime assertion failure for code that uses types we don't support. Treating these as soft failures allow us to verify other aspects of the program that don't execute the unsupported portion both through assumption and through overrides.