### PR TITLE
Mir personality support

### DIFF
--- a/crucible-concurrency/src/Cruces/CrucesMain.hs
+++ b/crucible-concurrency/src/Cruces/CrucesMain.hs
@@ -129,7 +129,7 @@ run (cruxOpts, opts) =
                   (IsSymBackend s bak, IsExprBuilder s) =>
                   bak ->
                   IO ( FnVal s Ctx.EmptyCtx C.UnitType
-                     , ExplorePrimitives (ThreadExec() DPOR s () C.UnitType) s ()
+                     , ExplorePrimitives (ThreadExec () DPOR s () C.UnitType) s ()
                      , [Some GlobalVar]
                      , FunctionBindings (ThreadExec () DPOR s () C.UnitType) s ()
                      )

--- a/crucible-concurrency/src/Cruces/CrucesMain.hs
+++ b/crucible-concurrency/src/Cruces/CrucesMain.hs
@@ -129,9 +129,9 @@ run (cruxOpts, opts) =
                   (IsSymBackend s bak, IsExprBuilder s) =>
                   bak ->
                   IO ( FnVal s Ctx.EmptyCtx C.UnitType
-                     , ExplorePrimitives (ThreadExec DPOR s () C.UnitType) s ()
+                     , ExplorePrimitives (ThreadExec() DPOR s () C.UnitType) s ()
                      , [Some GlobalVar]
-                     , FunctionBindings (ThreadExec DPOR s () C.UnitType) s ()
+                     , FunctionBindings (ThreadExec () DPOR s () C.UnitType) s ()
                      )
                 mkSym _bak =
                   do exploreBuiltins <- mkExplorePrims ha (pedantic opts) (Some nonceGen)
@@ -162,7 +162,7 @@ run (cruxOpts, opts) =
                                 )
             res <- Crux.runSimulator cruxOpts { Crux.solver = "yices"
                                               , Crux.pathSatSolver = Just "yices" } $
-                     exploreCallback cruxOpts ha (view Crux.outputHandle ?outputConfig) mkSym -- fns gvs mainHdl
+                     exploreCallback cruxOpts () ha (view Crux.outputHandle ?outputConfig) mkSym -- fns gvs mainHdl
             case res of
               CruxSimulationResult ProgramIncomplete _ ->
                 putStrLn "INCOMPLETE"

--- a/crucible-concurrency/src/Cruces/ExploreCrux.hs
+++ b/crucible-concurrency/src/Cruces/ExploreCrux.hs
@@ -47,22 +47,23 @@ import           Crux.Goal (proveGoalsOnline)
 import           Crux.Types (totalProcessedGoals, provedGoals)
 
 -- | Callback for crucible-syntax exploration
-exploreCallback :: forall alg.
+exploreCallback :: forall p alg.
   (?bound::Int, SchedulingAlgorithm alg) =>
   Crux.Logs Crux.CruxLogMessage =>
   Crux.CruxOptions ->
+  p ->
   HandleAllocator ->
   Handle ->
   (forall s bak.
    IsSymBackend s bak =>
    bak ->
         IO ( FnVal s Ctx.EmptyCtx C.UnitType
-           , ExplorePrimitives (ThreadExec alg s () C.UnitType) s ()
+           , ExplorePrimitives (ThreadExec p alg s () C.UnitType) s ()
            , [Some C.GlobalVar]
-           , FunctionBindings (ThreadExec alg s () C.UnitType) s ())
+           , FunctionBindings (ThreadExec p alg s () C.UnitType) s ())
            ) ->
   Crux.SimulatorCallbacks Crux.CruxLogMessage Crux.Types.CruxSimulationResult
-exploreCallback cruxOpts ha outh mkSym =
+exploreCallback cruxOpts p ha outh mkSym =
   Crux.withCruxLogMessage $
   Crux.SimulatorCallbacks $
     return $
@@ -70,7 +71,7 @@ exploreCallback cruxOpts ha outh mkSym =
         { Crux.setupHook =
             \bak symOnline ->
               do (mainHdl, prims, globs, fns) <- mkSym bak
-                 let simCtx = initSimContext bak emptyIntrinsicTypes ha outh fns emptyExtensionImpl emptyExploration
+                 let simCtx = initSimContext bak emptyIntrinsicTypes ha outh fns emptyExtensionImpl (emptyExploration p)
 
                      st0  = InitialState simCtx emptyGlobals defaultAbortHandler C.UnitRepr $
                                 runOverrideSim
@@ -90,13 +91,15 @@ exploreCallback cruxOpts ha outh mkSym =
 
 
 -- | Empty exploration state
-emptyExploration :: SchedulingAlgorithm alg => Exploration alg ext C.UnitType sym
-emptyExploration = Exploration { _exec      = initialExecutions
-                               , _scheduler = s0
-                               , _schedAlg  = initialAlgState
-                               , _num       = 0
-                               , _gVars     = mempty
-                               }
+emptyExploration :: SchedulingAlgorithm alg => p -> Exploration p alg ext C.UnitType sym
+emptyExploration p =
+  Exploration { _exec      = initialExecutions
+              , _scheduler = s0
+              , _schedAlg  = initialAlgState
+              , _num       = 0
+              , _gVars     = mempty
+              , _personality = p
+              }
   where
     s0 = Scheduler { _threads      = V.fromList [EmptyThread]
                    , _retRepr      = C.UnitRepr
@@ -107,15 +110,15 @@ emptyExploration = Exploration { _exec      = initialExecutions
 
 -- | Wrap an override to produce a NEW override that will explore the executions of a concurrent program.
 -- Must also use the 'scheduleFeature' 'ExecutionFeature'
-exploreOvr :: forall sym bak ext alg ret rtp msgs.
+exploreOvr :: forall p sym bak ext alg ret rtp msgs.
   Crux.Logs msgs =>
   Crux.SupportsCruxLogMessage msgs =>
   (?bound::Int, IsSymBackend sym bak, IsSyntaxExtension ext, SchedulingAlgorithm alg, RegValue sym ret ~ ()) =>
   bak ->
   Maybe (Crux.SomeOnlineSolver sym bak) ->
   Crux.CruxOptions ->
-  (forall rtp'. OverrideSim (Exploration alg ext ret sym) sym ext rtp' Ctx.EmptyCtx ret (RegValue sym ret)) ->
-  OverrideSim (Exploration alg ext ret sym) sym ext rtp Ctx.EmptyCtx ret (RegValue sym ret)
+  (forall rtp'. OverrideSim (Exploration p alg ext ret sym) sym ext rtp' Ctx.EmptyCtx ret (RegValue sym ret)) ->
+  OverrideSim (Exploration p alg ext ret sym) sym ext rtp Ctx.EmptyCtx ret (RegValue sym ret)
 exploreOvr bak symOnline cruxOpts mainAct =
   do assmSt  <- liftIO $ saveAssumptionState bak
      verbOpt <- liftIO $ getOptionSetting verbosity $ getConfiguration sym
@@ -128,13 +131,13 @@ exploreOvr bak symOnline cruxOpts mainAct =
     loop ::
       Int ->
       AssumptionState sym ->
-      forall r. OverrideSim (Exploration alg ext ret sym) sym ext r Ctx.EmptyCtx ret (RegValue sym ret)
+      forall r. OverrideSim (Exploration p alg ext ret sym) sym ext r Ctx.EmptyCtx ret (RegValue sym ret)
     loop verb assmSt =
       do reset verb assmSt
          exploreAPath
          retH verb assmSt
 
-    checkGoals :: forall r. OverrideSim (Exploration alg ext ret sym) sym ext r Ctx.EmptyCtx ret Bool
+    checkGoals :: forall r. OverrideSim (Exploration p alg ext ret sym) sym ext r Ctx.EmptyCtx ret Bool
     checkGoals =
       Crux.withCruxLogMessage $
       case symOnline of
@@ -150,7 +153,7 @@ exploreOvr bak symOnline cruxOpts mainAct =
            return provedAll
       Nothing -> return True
 
-    retH :: Int -> AssumptionState sym -> forall r. OverrideSim (Exploration alg ext ret sym) sym ext r Ctx.EmptyCtx ret (RegValue sym ret)
+    retH :: Int -> AssumptionState sym -> forall r. OverrideSim (Exploration p alg ext ret sym) sym ext r Ctx.EmptyCtx ret (RegValue sym ret)
     retH verb assmSt =
      do stateExpl.num %= (+1)
         exc          <- use stateExec
@@ -170,10 +173,10 @@ exploreOvr bak symOnline cruxOpts mainAct =
         else
           loop verb assmSt
 
-    exploreAPath :: forall r. OverrideSim (Exploration alg ext ret sym) sym ext r Ctx.EmptyCtx ret (RegValue sym ret)
+    exploreAPath :: forall r. OverrideSim (Exploration p alg ext ret sym) sym ext r Ctx.EmptyCtx ret (RegValue sym ret)
     exploreAPath = mainAct
 
-    reset ::  Int -> AssumptionState sym -> forall r. OverrideSim (Exploration alg ext ret sym) sym ext r Ctx.EmptyCtx ret (RegValue sym ret)
+    reset ::  Int -> AssumptionState sym -> forall r. OverrideSim (Exploration p alg ext ret sym) sym ext r Ctx.EmptyCtx ret (RegValue sym ret)
     reset verb assmSt =
       do stateExec.currentEventID .= 0
          -- Reset scheduler state

--- a/crucible-mir/src/Mir/Intrinsics.hs
+++ b/crucible-mir/src/Mir/Intrinsics.hs
@@ -2287,14 +2287,14 @@ class MethodSpecImpl sym ms where
     msPrettyPrint ::
         forall p rtp args ret.
         ms ->
-        OverrideSim (p sym) sym MIR rtp args ret (RegValue sym MirSlice)
+        OverrideSim p sym MIR rtp args ret (RegValue sym MirSlice)
 
     -- | Enable the MethodSpec for use as an override for the remainder of the
     -- current test.
     msEnable ::
         forall p rtp args ret.
         ms ->
-        OverrideSim (p sym) sym MIR rtp args ret ()
+        OverrideSim p sym MIR rtp args ret ()
 
 data MethodSpec sym = forall ms. MethodSpecImpl sym ms => MethodSpec {
     msData :: ms,
@@ -2325,19 +2325,19 @@ instance IsSymInterface sym => IntrinsicClass sym MethodSpecSymbol where
 class MethodSpecBuilderImpl sym msb where
     msbAddArg :: forall p rtp args ret tp.
         TypeRepr tp -> MirReferenceMux sym -> msb ->
-        OverrideSim (p sym) sym MIR rtp args ret msb
+        OverrideSim p sym MIR rtp args ret msb
     msbSetReturn :: forall p rtp args ret tp.
         TypeRepr tp -> MirReferenceMux sym -> msb ->
-        OverrideSim (p sym) sym MIR rtp args ret msb
+        OverrideSim p sym MIR rtp args ret msb
     msbGatherAssumes :: forall p rtp args ret.
         msb ->
-        OverrideSim (p sym) sym MIR rtp args ret msb
+        OverrideSim p sym MIR rtp args ret msb
     msbGatherAsserts :: forall p rtp args ret.
         msb ->
-        OverrideSim (p sym) sym MIR rtp args ret msb
+        OverrideSim p sym MIR rtp args ret msb
     msbFinish :: forall p rtp args ret.
         msb ->
-        OverrideSim (p sym) sym MIR rtp args ret (MethodSpec sym)
+        OverrideSim p sym MIR rtp args ret (MethodSpec sym)
 
 data MethodSpecBuilder sym = forall msb. MethodSpecBuilderImpl sym msb => MethodSpecBuilder msb
 

--- a/crux-llvm/src/Crux/LLVM/Simulate.hs
+++ b/crux-llvm/src/Crux/LLVM/Simulate.hs
@@ -107,7 +107,7 @@ setupSimCtxt ::
   bak ->
   MemOptions ->
   GlobalVar Mem ->
-  SimCtxt Crux sym LLVM
+  SimCtxt (Crux sym) sym LLVM
 setupSimCtxt halloc bak mo memVar =
   initSimContext bak
                  (MapF.union llvmIntrinsicTypes llvmSymIOIntrinsicTypes)
@@ -140,7 +140,7 @@ registerFunctions ::
   LLVM.Module ->
   ModuleTranslation arch ->
   Maybe (LLVMFileSystem ptrW) ->
-  OverM Crux sym LLVM ()
+  OverM (Crux sym) sym LLVM ()
 registerFunctions llvmOpts llvm_module mtrans fs0 =
   do let llvm_ctx = mtrans ^. transContext
      let ?lc = llvm_ctx ^. llvmTypeCtx

--- a/crux-mir/src/Mir/Overrides.hs
+++ b/crux-mir/src/Mir/Overrides.hs
@@ -96,7 +96,7 @@ getString (Empty :> RV mirPtr :> RV lenExpr) = runMaybeT $ do
 makeSymbolicVar ::
     IsSymInterface sym =>
     BaseTypeRepr btp ->
-    TypedOverride (p sym) sym MIR (EmptyCtx ::> MirSlice) (BaseToType btp)
+    TypedOverride p sym MIR (EmptyCtx ::> MirSlice) (BaseToType btp)
 makeSymbolicVar btpr =
   Crux.baseFreshOverride btpr strrepr $ \(RV strSlice) -> do
     mstr <- getString strSlice
@@ -114,7 +114,7 @@ array_symbolic ::
   forall sym rtp btp p .
   (IsSymInterface sym) =>
   BaseTypeRepr btp ->
-  TypedOverride (p sym) sym MIR (EmptyCtx ::> MirSlice) (UsizeArrayType btp)
+  TypedOverride p sym MIR (EmptyCtx ::> MirSlice) (UsizeArrayType btp)
 array_symbolic btpr = makeSymbolicVar (BaseArrayRepr (Empty :> BaseUsizeRepr) btpr)
 
 concretize ::
@@ -377,7 +377,7 @@ overrideRust ::
   (IsSymInterface sym) =>
   CollectionState ->
   Text ->
-  OverrideSim (p sym) sym MIR rtp args ret ()
+  OverrideSim p sym MIR rtp args ret ()
 overrideRust cs name = do
   let tyArgs = cs ^? collection . M.intrinsics . ix (textId name) .
         M.intrInst . M.inSubsts . _Wrapped
@@ -411,7 +411,7 @@ bindFn ::
   CollectionState ->
   Text ->
   CFG MIR blocks args ret ->
-  OverrideSim (p sym) sym MIR rtp a r ()
+  OverrideSim p sym MIR rtp a r ()
 bindFn symOnline cs name cfg
   | hasInstPrefix ["crucible", "array", "symbolic"] explodedName
   , Empty :> MirSliceRepr <- cfgArgTypes cfg
@@ -472,8 +472,8 @@ bindFn _symOnline _cs fn cfg =
       ExplodedDefId -> CtxRepr args -> TypeRepr ret ->
       (forall rtp args' ret'.
         Ctx.Assignment (RegValue' sym) args ->
-        OverrideSim (p sym) sym MIR rtp args' ret' (RegValue sym ret)) ->
-      (ExplodedDefId, SomeTypedOverride (p sym) sym MIR)
+        OverrideSim p sym MIR rtp args' ret' (RegValue sym ret)) ->
+      (ExplodedDefId, SomeTypedOverride p sym MIR)
     override edid args ret act =
         ( edid
         , SomeTypedOverride (TypedOverride act args ret)
@@ -490,12 +490,12 @@ bindFn _symOnline _cs fn cfg =
 
     symb_bv :: forall n . (1 <= n)
             => ExplodedDefId -> NatRepr n
-            -> (ExplodedDefId, SomeTypedOverride (p sym) sym MIR)
+            -> (ExplodedDefId, SomeTypedOverride p sym MIR)
     symb_bv edid n = (edid, SomeTypedOverride $ makeSymbolicVar (BaseBVRepr n))
 
     overrides :: IsSymBackend sym bak'
               => bak'
-              -> Map ExplodedDefId (SomeTypedOverride (p sym) sym MIR)
+              -> Map ExplodedDefId (SomeTypedOverride p sym MIR)
     overrides bak =
       let sym = backendGetSym bak in
       fromList [ override ["crucible", "one"] Empty (BVRepr (knownNat @8)) $ \_args ->

--- a/crux/src/Crux.hs
+++ b/crux/src/Crux.hs
@@ -98,15 +98,15 @@ import           Crux.Log as Log
 import           Crux.Report
 import           Crux.Types
 
-pattern RunnableState :: forall sym . () => forall ext personality . (IsSyntaxExtension ext) => ExecState (personality sym) sym ext (RegEntry sym UnitType) -> RunnableState sym
+pattern RunnableState :: forall sym . () => forall ext personality . (IsSyntaxExtension ext) => ExecState personality sym ext (RegEntry sym UnitType) -> RunnableState sym
 pattern RunnableState es = RunnableStateWithExtensions es []
 
 -- | A crucible @ExecState@ that is ready to be passed into the simulator.
 --   This will usually, but not necessarily, be an @InitialState@.
 data RunnableState sym where
   RunnableStateWithExtensions :: (IsSyntaxExtension ext)
-                              => ExecState (personality sym) sym ext (RegEntry sym UnitType)
-                              -> [ExecutionFeature (personality sym) sym ext (RegEntry sym UnitType)]
+                              => ExecState personality sym ext (RegEntry sym UnitType)
+                              -> [ExecutionFeature personality sym ext (RegEntry sym UnitType)]
                               -> RunnableState sym
 
 -- | Individual crux tools will generally call the @runSimulator@ combinator to

--- a/crux/src/Crux/Overrides.hs
+++ b/crux/src/Crux/Overrides.hs
@@ -63,7 +63,7 @@ baseFreshOverride ::
   C.TypeRepr stringTy ->
   -- | Get the variable name as a concrete string from the override arguments
   (C.RegValue' sym stringTy -> OverM p sym ext W4.SolverSymbol) ->
-  C.TypedOverride (p sym) sym ext (C.EmptyCtx C.::> stringTy) (C.BaseToType bty)
+  C.TypedOverride p sym ext (C.EmptyCtx C.::> stringTy) (C.BaseToType bty)
 baseFreshOverride bty sty getStr =
   C.TypedOverride
   { C.typedOverrideHandler = \(Ctx.Empty Ctx.:> strVal) -> do

--- a/crux/src/Crux/Types.hs
+++ b/crux/src/Crux/Types.hs
@@ -17,14 +17,14 @@ import           Lang.Crucible.Simulator
 import           Lang.Crucible.Types
 
 -- | A simulator context
-type SimCtxt personality sym p = SimContext (personality sym) sym p
+type SimCtxt personality sym p = SimContext personality sym p
 
 -- | The instance of the override monad we use,
 -- when we don't care about the context of the surrounding function.
 type OverM personality sym ext a =
   forall r args ret.
   OverrideSim
-    (personality sym)  -- Extra data available in overrides (frontend-specific)
+    personality        -- Extra data available in overrides (frontend-specific)
     sym                -- The symbolic backend (usually a what4 ExprBuilder in some form)
     ext                -- The Crucible syntax extension for the target language
     r
@@ -36,7 +36,7 @@ type OverM personality sym ext a =
 type Fun personality sym ext args ret =
   forall r.
   OverrideSim
-    (personality sym)
+    personality
     sym                                    -- the backend
     ext
     r
@@ -45,7 +45,7 @@ type Fun personality sym ext args ret =
     (RegValue sym ret)
 
 data Result personality sym where
-  Result :: (ExecResult (personality sym) sym ext (RegEntry sym UnitType)) -> Result personality sym
+  Result :: (ExecResult personality sym ext (RegEntry sym UnitType)) -> Result personality sym
 
 
 data ProcessedGoals =


### PR DESCRIPTION
This PR adds support for custom user state to concurrent crux, and crux-mix.   This is in preparation for some changes to cryx-mir-comp, to add support for working with uninterpreted functions.