### PR TITLE
llvm: Assume previous bytes were non-null when loading strings

### DIFF
--- a/crucible-llvm-cli/test-data/T1463-read-bytes.cbl
+++ b/crucible-llvm-cli/test-data/T1463-read-bytes.cbl
@@ -1,0 +1,34 @@
+; A regression test for #1463, wherein some string-handling functions generated
+; imprecise assertions that could spurriously fail because the safety assertions
+; for loads of later bytes in strings didn't have access to the assumption that
+; earlier bytes were nonzero.
+;
+; If `read-bytes` were subject to that bug, then this particular test-case
+; would cause an assertion failure. In the case that the fresh byte is zero,
+; then the first byte of the string is zero and `read-bytes` should immediately
+; stop reading without generating further assertions. Otherwise, the byte would
+; have been written to both the first and second positions of the string, so an
+; uninitialized read should be impossible.
+
+(declare @read-bytes ((x Pointer)) (Vector (Bitvector 8)))
+
+(defun @main () Unit
+  (start start:
+    (let bv0 (fresh (Bitvector 8)))
+    (let byte0 (ptr 8 0 bv0))
+
+    ; create a null-terminated string of length 3
+    (let beginning (alloca none (bv 64 3)))
+    (let middle (ptr-add-offset beginning (bv 64 1)))
+    (let end (ptr-add-offset middle (bv 64 1)))
+    (let z (ptr 8 0 (bv 8 0)))
+    (store none i8 end z)
+
+    (store none i8 beginning byte0)
+    (branch (equal? bv0 (bv 8 0)) end: nonzero:))
+  (defblock nonzero:
+    (store none i8 middle byte0)
+    (jump end:))
+  (defblock end:
+    (let _ (funcall @read-bytes beginning))
+    (return ())))

--- a/crucible-llvm-cli/test-data/T1463-read-bytes.out.good
+++ b/crucible-llvm-cli/test-data/T1463-read-bytes.out.good
@@ -1,0 +1,10 @@
+==== Begin Simulation ====
+
+==== Finish Simulation ====
+==== Proof obligations ====
+
+Prove:
+  test-data/T1463-read-bytes.cbl:33:12: error: in main
+  Error during memory load
+  not (and (eq 0x0:[8] cbv0@0:bv) (not cnoSatisfyingWrite@27:b))
+COUNTEREXAMPLE

--- a/crucible-llvm-cli/test-data/T1463-read-bytes.out.good
+++ b/crucible-llvm-cli/test-data/T1463-read-bytes.out.good
@@ -2,9 +2,11 @@
 
 ==== Finish Simulation ====
 ==== Proof obligations ====
-
+Assuming:
+* The branch in main at test-data/T1463-read-bytes.cbl:33:12
+    not (eq 0x0:[8] cbv0@0:bv)
 Prove:
   test-data/T1463-read-bytes.cbl:33:12: error: in main
   Error during memory load
-  not (and (eq 0x0:[8] cbv0@0:bv) (not cnoSatisfyingWrite@27:b))
-COUNTEREXAMPLE
+  not (and (eq 0x0:[8] cbv0@0:bv) (not cnoSatisfyingWrite@29:b))
+PROVED

--- a/crucible-llvm-cli/test-data/T1463-strlen.cbl
+++ b/crucible-llvm-cli/test-data/T1463-strlen.cbl
@@ -1,0 +1,37 @@
+; A regression test for #1463, wherein some string-handling functions generated
+; imprecise assertions that could spurriously fail because the safety assertions
+; for loads of later bytes in strings didn't have access to the assumption that
+; earlier bytes were nonzero.
+;
+; If `strlen` were subject to that bug, then this particular test-case would cause
+; an assertion failure. In the case that the fresh byte is zero, then the first
+; byte of the string is zero and `strlen` should immediately stop reading without
+; generating further assertions. Otherwise, the byte would have been written to
+; both the first and second positions of the string, so an uninitialized read
+; should be impossible.
+;
+; In point of fact, `strlen` was never subject to this bug, but this still
+; serves as a regression test for it.
+
+(defun @main () Unit
+  (start start:
+    (let g (resolve-global "strlen"))
+    (let h (load-handle (Ptr 64) ((Ptr 64)) g))
+    (let bv0 (fresh (Bitvector 8)))
+    (let byte0 (ptr 8 0 bv0))
+
+    ; create a null-terminated string of length 3
+    (let beginning (alloca none (bv 64 3)))
+    (let middle (ptr-add-offset beginning (bv 64 1)))
+    (let end (ptr-add-offset middle (bv 64 1)))
+    (let z (ptr 8 0 (bv 8 0)))
+    (store none i8 end z)
+
+    (store none i8 beginning byte0)
+    (branch (equal? bv0 (bv 8 0)) end: nonzero:))
+  (defblock nonzero:
+    (store none i8 middle byte0)
+    (jump end:))
+  (defblock end:
+    (funcall h beginning)
+    (return ())))

--- a/crucible-llvm-cli/test-data/T1463-strlen.out.good
+++ b/crucible-llvm-cli/test-data/T1463-strlen.out.good
@@ -1,0 +1,14 @@
+==== Begin Simulation ====
+
+==== Finish Simulation ====
+==== Proof obligations ====
+
+Prove:
+  test-data/T1463-strlen.cbl:36:5: error: in main
+  Error during memory load: strlen
+  let -- test-data/T1463-strlen.cbl:31:13
+      v13 = eq 0x0:[8] cbv0@0:bv
+      -- test-data/T1463-strlen.cbl:36:5
+      v37 = and v13 (not (eq 0x0:[8] cbv0@0:bv)) (not cnoSatisfyingWrite@29:b)
+   in not v37
+PROVED


### PR DESCRIPTION
Fixes #1463, though I'm not super confident in it... it looks pretty different from the existing logic in `strLen`, but I think it should generate the same proof goals?

Also seems a bit tricky to make a test-case for, the safety assertion for loading a particular byte would have to depend integrally on the non-zero-ness of a previous byte...