### PR TITLE
crucible-mir: add debug helpers

### DIFF
--- a/crucible-debug/src/Lang/Crucible/Pretty.hs
+++ b/crucible-debug/src/Lang/Crucible/Pretty.hs
@@ -33,6 +33,7 @@ import           Data.Parameterized.TraversableFC (toListFC)
 
 -- what4
 import qualified What4.Interface as W4
+import qualified What4.Partial as W4
 
 -- crucible
 import qualified Lang.Crucible.FunctionHandle as C
@@ -103,6 +104,10 @@ ppRegVal iFns tp (C.RV v) =
 
     -- More complex cases
     C.FunctionHandleRepr args ret -> ppFnVal args ret v
+    C.MaybeRepr tpr -> case v of
+      W4.Unassigned -> "Nothing"
+      W4.PE cond v' ->
+        "Just" PP.<+> ppRegVal iFns tpr (C.RV v') PP.<+> "if" PP.<+> W4.printSymExpr cond
     _ -> "<unsupported>"
 
 ppFnVal ::

--- a/crucible-mir/src/Mir/FancyMuxTree.hs
+++ b/crucible-mir/src/Mir/FancyMuxTree.hs
@@ -136,6 +136,9 @@ import           Unsafe.Coerce
 -- returning Nothing.
 newtype FancyMuxTree sym a = FancyMuxTree (Map (Skeleton a) (a, Pred sym))
 
+instance (Show a, IsSymInterface sym) => Show (FancyMuxTree sym a) where
+  show (FancyMuxTree m) = show [(x, printSymExpr y) | (x, y) <- Map.elems m]
+
 
 class OrdSkel t where
     compareSkel :: t -> t -> Ordering

--- a/crucible-mir/src/Mir/Intrinsics.hs
+++ b/crucible-mir/src/Mir/Intrinsics.hs
@@ -437,8 +437,11 @@ instance IsSymInterface sym => Show (MirReferencePath sym tp tp') where
     show (ArrayAsMirVector_RefPath btpr p) = "(ArrayAsMirVector_RefPath " ++ show btpr ++ " " ++ show p ++ ")"
 
 instance IsSymInterface sym => Show (MirReference sym) where
-    show (MirReference _ root path) = "(MirReference " ++ show root ++ " " ++ show path ++ ")"
+    show (MirReference tpr root path) = "(MirReference " ++ show tpr ++ " " ++ show (refRootType root) ++ " " ++ show root ++ " " ++ show path ++ ")"
     show (MirReference_Integer _) = "(MirReference_Integer _)"
+
+instance IsSymInterface sym => Show (MirReferenceMux sym) where
+  show (MirReferenceMux tree) = show tree
 
 instance OrdSkel (MirReference sym) where
     compareSkel = cmpRef

--- a/crux-mir/crux-mir.cabal
+++ b/crux-mir/crux-mir.cabal
@@ -30,6 +30,7 @@ library
                  time,
                  crucible,
                  crucible-concurrency,
+                 crucible-debug,
                  crucible-mir,
                  parameterized-utils >= 1.0.8,
                  containers,

--- a/crux-mir/src/Mir/Overrides.hs
+++ b/crux-mir/src/Mir/Overrides.hs
@@ -439,7 +439,7 @@ bindFn symOnline cs name cfg
         RegMap (Empty :> RegEntry _ strRef) <- getOverrideArgs
         str <- getString strRef >>= \x -> case x of
             Just x -> return x
-            Nothing -> fail $ "print_str: desc string must be concrete"
+            Nothing -> fail "print_str: desc string must be concrete"
         liftIO $ outputLn $ Text.unpack str
 
   | hasInstPrefix ["crucible", "dump_what4"] explodedName
@@ -461,7 +461,7 @@ bindFn symOnline cs name cfg
         RegMap (Empty :> RegEntry _ strRef :> RegEntry _ expr) <- getOverrideArgs
         str <- getString strRef >>= \x -> case x of
             Just x -> return x
-            Nothing -> fail $ "dump_rv: desc string must be concrete"
+            Nothing -> fail "dump_rv: desc string must be concrete"
         liftIO $ outputLn $ Text.unpack str ++ " = " ++ showRV tpr expr
 
   where

--- a/crux-mir/test/symb_eval/debug/dump_rv.good
+++ b/crux-mir/test/symb_eval/debug/dump_rv.good
@@ -1,0 +1,6 @@
+test dump_rv/<DISAMB>::test[0]: a = {Just 0x7b:[32] if true, Just 0x1c8:[32] if true}
+b = {Just cxy@1:bv if true, Just cxy@2:bv if true}
+c = {cxy@1:bv, cxy@2:bv}
+ok
+
+[Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/debug/dump_rv.rs
+++ b/crux-mir/test/symb_eval/debug/dump_rv.rs
@@ -1,0 +1,15 @@
+extern crate crucible;
+use crucible::{dump_rv, Symbolic};
+
+struct S {
+    x: u32,
+    y: u32,
+}
+
+#[crux::test]
+fn test() {
+    dump_rv("a", (123, 456));
+    let xy = <(u32, u32)>::symbolic_where("xy", |&(x, y)| x < 100 && y < 100);
+    dump_rv("b", xy);
+    dump_rv("c", S { x: xy.0, y: xy.1 });
+}

--- a/crux-mir/test/symb_eval/debug/dump_what4.good
+++ b/crux-mir/test/symb_eval/debug/dump_what4.good
@@ -1,0 +1,6 @@
+test dump_what4/<DISAMB>::test[0]: a = 0x7b:[32]
+b = bvSum cx@1:bv 0x1:[32]
+c = eq 0x0:[32] cx@1:bv
+ok
+
+[Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/debug/dump_what4.rs
+++ b/crux-mir/test/symb_eval/debug/dump_what4.rs
@@ -1,0 +1,10 @@
+extern crate crucible;
+use crucible::{dump_what4, Symbolic};
+
+#[crux::test]
+fn test() {
+    dump_what4("a", 123);
+    let x = u32::symbolic_where("x", |&x| x < 100);
+    dump_what4("b", x + 1);
+    dump_what4("c", x == 0);
+}

--- a/crux-mir/test/symb_eval/debug/print_str.good
+++ b/crux-mir/test/symb_eval/debug/print_str.good
@@ -1,0 +1,6 @@
+test print_str/<DISAMB>::test[0]: hello
+foo
+bar
+ok
+
+[Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/debug/print_str.rs
+++ b/crux-mir/test/symb_eval/debug/print_str.rs
@@ -1,0 +1,13 @@
+extern crate crucible;
+use crucible::{print_str, Symbolic};
+
+#[crux::test]
+fn test() {
+    print_str("hello");
+    let b = bool::symbolic("b");
+    if b {
+        print_str("foo");
+    } else {
+        print_str("bar");
+    }
+}


### PR DESCRIPTION
This adds some debugging functions for inspecting parts of crux-mir's internal representation, based on the ones @glguy and I used to investigate GaloisInc/saw-script#2477.  The main function is `dump_any`, which takes any Rust value and prints its representation as a Crucible `RegValue`.  It also adds `print_str`, which prints a string during symbolic execution; this is mainly for use with `MethodSpec::pretty_print` which returns its result as `&str`.

Fixes #1311