### PR TITLE
crux-mir: add tests for Arc<dyn Fn> and Rc<dyn Fn>

### DIFF
--- a/crux-mir/test/conc_eval/clos/fn_dyn_arc.rs
+++ b/crux-mir/test/conc_eval/clos/fn_dyn_arc.rs
@@ -1,0 +1,15 @@
+use std::sync::Arc;
+
+fn call_closure_arc(mut f: Arc<dyn Fn(i32, i32) -> i32>) -> i32 {
+    let r = f(1, 2);
+    r
+}
+
+#[cfg_attr(crux, crux::test)]
+fn crux_test() -> i32 {
+    call_closure_arc(Arc::new(|x, y| x + y))
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/conc_eval/clos/fn_dyn_rc.rs
+++ b/crux-mir/test/conc_eval/clos/fn_dyn_rc.rs
@@ -1,0 +1,16 @@
+// FAIL: `Rc` uses standard (untyped) allocation functions
+use std::rc::Rc;
+
+fn call_closure_rc(mut f: Rc<dyn Fn(i32, i32) -> i32>) -> i32 {
+    let r = f(1, 2);
+    r
+}
+
+#[cfg_attr(crux, crux::test)]
+fn crux_test() -> i32 {
+    call_closure_rc(Rc::new(|x, y| x + y))
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/conc_eval/rc/rc_basic.rs
+++ b/crux-mir/test/conc_eval/rc/rc_basic.rs
@@ -1,0 +1,12 @@
+// FAIL: `Rc` uses `mem::size_of_val`
+use std::rc::Rc;
+
+#[cfg_attr(crux, crux::test)]
+fn crux_test() -> i32 {
+    let x = Rc::new(123);
+    *x
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}


### PR DESCRIPTION
We fixed #1399 with the goal of making `Arc<dyn Fn>` work, but never added a test for `Arc<dyn Fn>` specifically (though we do have separate tests for `&dyn Fn`, `Box<dyn Fn>`, and `Arc<dyn Trait>`).  This branch adds one.

This branch also adds a test for `Rc<dyn Fn>` and an even more basic test that uses `Rc<i32>`, both of which currently fail due to the implementation of `Rc` using unsupported features (unrelated to the features we needed for `Arc<dyn Fn>`).