### PR TITLE
`crucible-mir`: Translate "constant" statics before non-constant ones

### DIFF
--- a/crucible-mir/CHANGELOG.md
+++ b/crucible-mir/CHANGELOG.md
@@ -28,6 +28,9 @@ This release supports [version
 * Type translation functions like `tyToRepr` now fail gracefully
   so that failed translations can be handled by upstream tooling
   instead of failing using `error`
+* Fix a bug in which static items with non-constant initializer expressions that
+  depend on static items with constant initializer expressions would fail to
+  simulate correctly.
 
 # 0.4 -- 2025-03-21
 

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -2436,7 +2436,7 @@ mkVtableMap col halloc = mapM mkVtable (col^.vtables)
       | Just fn <- Map.lookup fnName (col^.functions) = do
         let shimSig = vtableShimSig vtableName fnName (fn ^. M.fsig)
             handleName = FN.functionNameFromText (vtableShimName vtableName fnName)
-        
+
         Some argctx <- case tyListToCtx col (abiFnArgs shimSig) (Right . Some) of
           Left err -> fail ("mkVtableMap: " ++ err)
           Right x -> return x
@@ -2671,7 +2671,7 @@ mkShimHandleMap col halloc = mconcat <$> mapM mkHandle (Map.toList $ col ^. M.in
         let returnTy = callMutSig ^. M.fsreturn_ty
         let fnPtrSig = M.FnSig untupledArgTys returnTy RustAbi
         let handleName = FN.functionNameFromText $ M.idText $ intr ^. M.intrName
-        
+
         Some argCtx <- case  tyListToCtx col untupledArgTys (Right . Some) of
           Left err -> fail ("mkShimHandleMap: " ++ err)
           Right x -> return x
@@ -2683,7 +2683,7 @@ mkShimHandleMap col halloc = mconcat <$> mapM mkHandle (Map.toList $ col ^. M.in
         h <- FH.mkHandle' halloc handleName argCtx retRepr
         let mh = MirHandle (intr ^. M.intrName) fnPtrSig h
         return $ Map.singleton name mh
-  
+
       | otherwise = return Map.empty
       where
 

--- a/crux-mir/test/conc_eval/statics/static_init_order.rs
+++ b/crux-mir/test/conc_eval/statics/static_init_order.rs
@@ -1,0 +1,20 @@
+// A test case which ensures that the static initializer for `Y` is translated
+// after the constant allocation `{{alloc}}[0]` that it depends on. This is one
+// very specific instance of #1108, which is a more general issue in how
+// crucible-mir translates static items.
+
+const X: &[u64] = &[42];
+pub static Y: u64 = X[0];
+
+pub fn f() -> &'static u64 {
+    &Y
+}
+
+#[cfg_attr(crux, crux::test)]
+pub fn crux_test() -> u64 {
+    *f()
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}


### PR DESCRIPTION
`mir-json` emits two types of static item definitions: ones with constant initializer expressions, and ones without them. It is possible to write a program where a non-constant static item's definition depends on a constant static item, and in order for `crucible-mir` to handle such a program, it is important that `crucible-mir` translate the constant static item _before_ the non-constant static item that uses it.

This is difficult to arrange for in the general case (see https://github.com/GaloisInc/crucible/issues/1108), but in the common case, we can make this much more likely to work by always translating every constant static item before every non-constant static item. This provides a partial workaround (but not a full fix) for https://github.com/GaloisInc/crucible/issues/1108.