### PR TITLE
crucible-mir: adjust `cloneShimTuple`'s representation of unit expressions

### DIFF
--- a/crucible-mir/src/Mir/TransCustom.hs
+++ b/crucible-mir/src/Mir/TransCustom.hs
@@ -1956,6 +1956,12 @@ cloneShimDef ty parts = CustomOp $ \_ _ -> mirFail $ "cloneShimDef not implement
 
 -- | Create an 'IkCloneShim' implementation for a tuple or closure type.
 cloneShimTuple :: [Ty] -> [M.DefId] -> CustomOp
+cloneShimTuple [] [] = CustomMirOp $ \_ops ->
+    -- We're cloning unit, i.e. `()`. Without this case, deferring to
+    -- `buildTupleMaybeM` to construct `()` results in a struct-like expression
+    -- with an empty `StructRepr`. In this particular case, that's wrong - what
+    -- we need to produce is a `UnitRepr` expression.
+    pure $ MirExp C.UnitRepr $ R.App E.EmptyApp
 cloneShimTuple tys parts = CustomMirOp $ \ops -> do
     when (length tys /= length parts) $ mirFail "cloneShimTuple: expected tys and parts to match"
     lv <- case ops of

--- a/crux-mir/test/conc_eval/tuple/clone_unit.rs
+++ b/crux-mir/test/conc_eval/tuple/clone_unit.rs
@@ -1,0 +1,19 @@
+//! Test that the clone shim generated for unit values is appropriately typed.
+//! All we really want to do is clone `()` - we only use the generalized
+//! `my_clone`, rather than e.g. `().clone()`, to ensure rustc doesn't optimize
+//! out the faulty clone shim.
+
+fn my_clone<T: Clone>(x: &T) -> T {
+    x.clone()
+}
+
+#[cfg_attr(crux, crux::test)]
+pub fn f() {
+    let x = ();
+    let y = my_clone(&x);
+    assert!(x == y);
+}
+
+fn main() {
+    println!("{:?}", f());
+}


### PR DESCRIPTION
Before, it would represent units as empty struct-like expressions (using `StructRepr`s). This leads to problems in cases like this PR's `clone_unit.rs` test, whose `my_clone` function yields this MIR:

```
fn clone_unit/43042312::my_clone[0]::_inst581cc2350a9a65a8[0](_1 : &()) -> () {
   let mut _0 : ();
   bb0: {
      call( core/7bc31080::clone[0]::Clone[0]::clone[0]::_shim581cc2350a9a65a8[0]( _1 )
      , (_0, bb1) )
   }
   bb1: {
      return;
   }
}
```

`bb0`'s assignment of the clone shim's output to `_0` would trigger a translation error, complaining about this `StructRepr`/`UnitRepr` mismatch:

```
Translation error in <...my_clone...>: ill-typed assignment of StructRepr [] to UnitRepr (TyTuple []) LBase (Var {_varname = "_0", _varmut = Mut, _varty = TyTuple [], _varIsZST = True})
```