### PR TITLE
`crucible-mir`: Make union type support slightly more error-resistant

### DIFF
--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -227,7 +227,16 @@ tyToRepr col t0 = case t0 of
         SomeRustEnumRepr _ ctx <- enumVariants col adt
         Right (Some (RustEnumRepr discrTp ctx))
       M.Union ->
-        Left ("Union types are unsupported, for " ++ show name)
+        -- This is a hack. crucible-mir doesn't _actually_ support union types,
+        -- and if you try simulating a code that performs an operation on a
+        -- union-typed value, then it will fail at simulation time.
+        -- Nevertheless, we intentionally choose to use Any as a placeholder
+        -- type instead of failing so that crucible-mir can translate type
+        -- signatures mentioning union types without crashing during MIR
+        -- translation (e.g., in Mir.Trans.mkHandleMap).
+        --
+        -- See #1429 for the larger issue of properly supporting union types.
+        Right (Some C.AnyRepr)
   M.TyDowncast _adt _i   -> Right (Some C.AnyRepr)
 
   M.TyFloat _ -> Right (Some C.RealValRepr)

--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -512,7 +512,7 @@ reprsToCtx rs f = go rs Ctx.empty
 tyListToCtxMaybe :: forall a. TransTyConstraint =>
   M.Collection -> [M.Ty] -> (forall ctx. C.CtxRepr ctx -> Either String a) -> Either String a
 tyListToCtxMaybe col ts f = do
-    rs <- traverse (tyToRepr col) ts 
+    rs <- traverse (tyToRepr col) ts
     go rs Ctx.empty
  where go :: forall ctx. [Some C.TypeRepr] -> C.CtxRepr ctx -> Either String a
        go []       ctx      = f ctx

--- a/crux-mir/test/conc_eval/resilience/ignore_unused_union_in_type_sig.rs
+++ b/crux-mir/test/conc_eval/resilience/ignore_unused_union_in_type_sig.rs
@@ -1,0 +1,26 @@
+#[repr(C)]
+union MyUnion {
+    f1: u32,
+    f2: f32,
+}
+
+fn f() -> MyUnion {
+    MyUnion { f1: 1 }
+}
+
+fn g(x: bool) -> u32 {
+    if x {
+        unsafe { f().f1 }
+    } else {
+        2
+    }
+}
+
+#[cfg_attr(crux, crux::test)]
+pub fn crux_test() -> u32 {
+    g(false)
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}


### PR DESCRIPTION
This follows up on the work in https://github.com/GaloisInc/crucible/pull/1461 such that one can now load MIR code in `crucible-mir` where functions have type signatures mentioning union types, provided that these functions are never called during simulation. Previously, this would cause `crucible-mir` to crash outright before simulation begins, as `crucible-mir` must make a map of all function handles before starting simulation, and failing to translate a union type in a function type signature would cause the whole thing to come to a screeching halt.

In order to allow translating unused functions with union types in their type signatures, we use `Any` as a placeholder type for unions. Attempting to translate any operations on union-typed values (e.g., constructing them or projecting out union fields) will still cause a simulation-time error.

See https://github.com/GaloisInc/crucible/issues/1429 for the larger task of supporting union types properly.