### PR TITLE
`crucible-mir`: implement `fnPtrShimDef` for `TyFnPtr`

### DIFF
--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -33,9 +33,11 @@ module Mir.Trans(transCollection,transStatics,RustModule(..)
                 , writeMirRef
                 , subindexRef
                 , evalBinOp
+                , evalOperand
                 , vectorCopy, ptrCopy, copyNonOverlapping
                 , evalRval
                 , callExp
+                , callHandle
                 , doVirtCall
                 , derefExp, readPlace, addrOfPlace
                 , transmuteExp

--- a/crucible-mir/src/Mir/TransCustom.hs
+++ b/crucible-mir/src/Mir/TransCustom.hs
@@ -1907,12 +1907,12 @@ fnPtrShimDef fnTy = case fnTy of
                     Copy lv -> return lv
                     Move lv -> return lv
                     _ -> mirFail $ "unsupported argument tuple operand " ++ show argTuple ++
-                        " for fnptr shim of " ++ show defId
+                        " for fnptr shim of type " ++ show fnTy
                 let argOps = zipWith (\ty i -> Move $ LProj argBase (PField i ty)) argTys [0..]
                 callExp defId argOps
             ty -> mirFail $ "unexpected argument tuple type " ++ show ty ++
-                " for fnptr shim of " ++ show defId
-        _ -> mirFail $ "unexpected arguments " ++ show ops ++ " for fnptr shim of " ++ show defId
+                " for fnptr shim of type " ++ show fnTy
+        _ -> mirFail $ "unexpected arguments " ++ show ops ++ " for fnptr shim of type " ++ show fnTy
     _ -> CustomOp $ \_ _ -> mirFail $ "fnPtrShimDef not implemented for " ++ show fnTy
 
 

--- a/crucible-mir/src/Mir/TransCustom.hs
+++ b/crucible-mir/src/Mir/TransCustom.hs
@@ -1909,8 +1909,9 @@ fnPtrShimDef fnTy = case fnTy of
         let fnRepr = C.FunctionHandleRepr argTys retTy
         fnExp <- case fnPtrExp of
             MirExp MirReferenceRepr fnRef -> MirExp fnRepr <$> readMirRef fnRepr fnRef
+            MirExp (C.FunctionHandleRepr _ _) _ -> pure fnPtrExp
             _ -> mirFail $
-                "fnPtrShimDef: expected fnptr to be reference, but it was " ++ show fnPtrExp
+                "fnPtrShimDef: expected fnptr to be reference or fn, but it was " ++ show fnPtrExp
         callHandle fnExp (sig ^. fsabi) argOps
     _ -> CustomOp $ \_ _ -> mirFail $ "fnPtrShimDef not implemented for " ++ show fnTy
   where

--- a/crucible-mir/src/Mir/TransCustom.hs
+++ b/crucible-mir/src/Mir/TransCustom.hs
@@ -1897,22 +1897,23 @@ ctpop = (["core", "intrinsics", "ctpop"],
 
 
 fnPtrShimDef :: Ty -> CustomOp
-fnPtrShimDef (TyFnDef defId) = CustomMirOp $ \ops -> case ops of
-    [_fnptr, argTuple] -> case typeOf argTuple of
-        TyTuple [] -> do
-            callExp defId []
-        TyTuple argTys -> do
-            argBase <- case argTuple of
-                Copy lv -> return lv
-                Move lv -> return lv
-                _ -> mirFail $ "unsupported argument tuple operand " ++ show argTuple ++
-                    " for fnptr shim of " ++ show defId
-            let argOps = zipWith (\ty i -> Move $ LProj argBase (PField i ty)) argTys [0..]
-            callExp defId argOps
-        ty -> mirFail $ "unexpected argument tuple type " ++ show ty ++
-            " for fnptr shim of " ++ show defId
-    _ -> mirFail $ "unexpected arguments " ++ show ops ++ " for fnptr shim of " ++ show defId
-fnPtrShimDef ty = CustomOp $ \_ _ -> mirFail $ "fnPtrShimDef not implemented for " ++ show ty
+fnPtrShimDef fnTy = case fnTy of
+    TyFnDef defId -> CustomMirOp $ \ops -> case ops of
+        [_fnPtr, argTuple] -> case typeOf argTuple of
+            TyTuple [] -> do
+                callExp defId []
+            TyTuple argTys -> do
+                argBase <- case argTuple of
+                    Copy lv -> return lv
+                    Move lv -> return lv
+                    _ -> mirFail $ "unsupported argument tuple operand " ++ show argTuple ++
+                        " for fnptr shim of " ++ show defId
+                let argOps = zipWith (\ty i -> Move $ LProj argBase (PField i ty)) argTys [0..]
+                callExp defId argOps
+            ty -> mirFail $ "unexpected argument tuple type " ++ show ty ++
+                " for fnptr shim of " ++ show defId
+        _ -> mirFail $ "unexpected arguments " ++ show ops ++ " for fnptr shim of " ++ show defId
+    _ -> CustomOp $ \_ _ -> mirFail $ "fnPtrShimDef not implemented for " ++ show fnTy
 
 
 --------------------------------------------------------------------------------------------------------------------------

--- a/crux-mir/test/conc_eval/fnptr/pass.rs
+++ b/crux-mir/test/conc_eval/fnptr/pass.rs
@@ -6,6 +6,10 @@ fn call_closure<F: Fn() -> i32>(f: F) -> i32 {
     f()
 }
 
+fn call_closure_once<F: FnOnce() -> i32>(f: F) -> i32 {
+    f()
+}
+
 #[cfg_attr(crux, crux::test)]
 fn crux_test() -> i32 {
     let f: fn() -> i32 = make_i32;
@@ -13,7 +17,7 @@ fn crux_test() -> i32 {
     // can interact with function _pointer_ shims in particular. It does not
     // suffice to pass `make_i32` directly, as this resolves to a function
     // item type, rather than a function pointer.
-    call_closure(f)
+    call_closure(f) + call_closure_once(f)
 }
 
 pub fn main() {

--- a/crux-mir/test/conc_eval/fnptr/pass.rs
+++ b/crux-mir/test/conc_eval/fnptr/pass.rs
@@ -1,0 +1,21 @@
+fn make_i32() -> i32 {
+    42
+}
+
+fn call_closure<F: Fn() -> i32>(f: F) -> i32 {
+    f()
+}
+
+#[cfg_attr(crux, crux::test)]
+fn crux_test() -> i32 {
+    let f: fn() -> i32 = make_i32;
+    // By passing `f`, a function pointer, we're ensuring that `call_closure`
+    // can interact with function _pointer_ shims in particular. It does not
+    // suffice to pass `make_i32` directly, as this resolves to a function
+    // item type, rather than a function pointer.
+    call_closure(f)
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}


### PR DESCRIPTION
This allows calling function _pointers_ via `Fn` call shims. This is distinct from calling function _handles_ via those same shims - see the included test for an illustration of this distinction.