### PR TITLE
 `crucible-mir`: use `rustc`-generated function pointer shims

### DIFF
--- a/crucible-mir/src/Mir/Generator.hs
+++ b/crucible-mir/src/Mir/Generator.hs
@@ -211,7 +211,6 @@ data CollectionState
 
 data CustomOpMap = CustomOpMap
     { _opDefs :: Map ExplodedDefId CustomRHS
-    , _fnPtrShimOp :: Ty -> CustomOp
     , _cloneShimOp :: Ty -> [DefId] -> CustomOp
     , _cloneFromShimOp :: Ty -> [DefId] -> CustomOp
     }
@@ -529,9 +528,6 @@ resolveCustom instDefId = do
     case optIntr of
         Nothing -> return Nothing
         Just intr -> case intr ^. intrInst . inKind of
-            IkFnPtrShim ty -> do
-                f <- use $ customOps . fnPtrShimOp
-                return $ Just $ f ty
             IkCloneShim ty parts
               | idKey (intr ^. intrInst . inDefId) == ["core", "clone", "Clone", "clone"] -> do
                 f <- use $ customOps . cloneShimOp

--- a/crux-mir/test/conc_eval/fnptr/dyn.rs
+++ b/crux-mir/test/conc_eval/fnptr/dyn.rs
@@ -1,0 +1,29 @@
+fn make_i32() -> i32 {
+    42
+}
+
+fn call_closure<F: Fn() -> i32>(f: F) -> i32 {
+    f()
+}
+
+fn call_closure_once<F: FnOnce() -> i32>(f: F) -> i32 {
+    f()
+}
+
+#[cfg_attr(crux, crux::test)]
+fn crux_test() -> i32 {
+    let f: fn() -> i32 = make_i32;
+    let g: &dyn Fn() -> i32 = &f;
+    let h: &dyn Fn() -> i32 = &make_i32;
+
+    call_closure(g) + call_closure_once(g)
+    // Calling `h` in particular tests that `transTerminatorKind`'s `Call`
+    // behavior is amenable to non-`Constant`-shaped `TyFnDef` values, as `h` is
+    // a `TyFnDef` and (at press time, anyway) is represented in MIR not as a
+    // `Constant`.
+    + call_closure(h) + call_closure_once(h)
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}


### PR DESCRIPTION
Rather than our own `CustomOp` shims, as we did before. This required updating `mir-json` to translate those shims according to the appropriate ABI (https://github.com/GaloisInc/mir-json/pull/145), and generalizing the behavior of `transTerminatorKind` to accept more forms of `Call` expressions to accommodate `rustc`'s translation choices.

Marked as draft until https://github.com/GaloisInc/mir-json/pull/145 is merged.