### PR TITLE
crucible-mir: override `core::array::from_ref::crucible_array_from_ref_hook`

### DIFF
--- a/crux-mir/test/conc_eval/array/from_ref.rs
+++ b/crux-mir/test/conc_eval/array/from_ref.rs
@@ -1,0 +1,13 @@
+//! Test `crucible-mir`'s override of `core::array::from_ref` via
+//! `crucible_array_from_ref_hook`.
+
+#[cfg_attr(crux, crux::test)]
+fn crux_test() -> i32 {
+    let foo: i32 = 42;
+    let foo_array: &[i32; 1] = core::array::from_ref(&foo);
+    foo_array[0]
+}
+
+fn main() {
+    println!("{:?}", crux_test());
+}


### PR DESCRIPTION
Without this override, crux-mir fails to simulate `core::array::from_ref` (and `core::slice::from_ref`, a notable caller of `array::from_ref`) properly, and errors out with a message like:

```
[Crux] Found counterexample for verification goal
[Crux]   crux-mir/test/conc_eval/array/from_ref.rs:8:5: 8:17: error: in from_ref/a38569f9::crux_test[0]
[Crux]   subindex requires a reference to IntrinsicRepr MirVector [BVRepr 32], but got a reference to BVRepr 32
[Crux] Found counterexample for verification goal
[Crux]   crux-mir/test/conc_eval/array/from_ref.rs:8:5: 8:17: error: in from_ref/a38569f9::crux_test[0]
[Crux]   attempted to read empty mux tree
```

To handle this, we take a similar approach to the one taken in `core::slice::as_array::crucible_array_from_slice_hook`: we define and override a hook function in `from_ref` to avoid simulating its non-`crucible`-compatible cast.

`core::array::from_ref::crucible_array_from_ref_hook` was defined in https://github.com/GaloisInc/mir-json/pull/147.