### PR TITLE
crucible-mir: override `crucible_slice_from_{ref,mut}_hook`

### DIFF
--- a/crux-mir/test/conc_eval/slice/from_mut.rs
+++ b/crux-mir/test/conc_eval/slice/from_mut.rs
@@ -1,0 +1,12 @@
+#[cfg_attr(crux, crux::test)]
+fn crux_test() -> i32 {
+    let mut foo: i32 = 42;
+    let mut foo_slice: &mut [i32] = core::slice::from_mut(&mut foo);
+    foo_slice[0] = 43;
+    assert!(foo == 43);
+    foo
+}
+
+fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/conc_eval/slice/from_ref.rs
+++ b/crux-mir/test/conc_eval/slice/from_ref.rs
@@ -1,0 +1,23 @@
+use std::cell::Cell;
+
+#[cfg_attr(crux, crux::test)]
+fn crux_test() -> i32 {
+    // We want to check that our override of `crucible_slice_from_ref_hook`
+    // properly aliases its input and output. We do so by making the conversion
+    // source mutable via `Cell`, and checking that writes to that source can be
+    // observed by reading the conversion target, and vice versa.
+    let foo: Cell<i32> = Cell::new(42);
+    let foo_slice: &[Cell<i32>] = core::slice::from_ref(&foo);
+
+    foo.set(43);
+    assert_eq!(foo_slice[0].get(), 43);
+
+    foo_slice[0].set(44);
+    assert_eq!(foo.get(), 44);
+
+    foo.into_inner()
+}
+
+fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/conc_eval/slice/from_ref_iter.rs
+++ b/crux-mir/test/conc_eval/slice/from_ref_iter.rs
@@ -1,0 +1,19 @@
+// FAIL: pointer arithmetic on a non-array
+
+#[cfg_attr(crux, crux::test)]
+fn crux_test() -> i32 {
+    let foo: i32 = 42;
+    let foo_slice: &[i32] = core::slice::from_ref(&foo);
+
+    let mut res: i32 = 0;
+    for i in foo_slice.iter() {
+        res += i;
+    }
+
+    assert_eq!(res, 42);
+    res
+}
+
+fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/conc_eval/slice/from_ref_subslice.rs
+++ b/crux-mir/test/conc_eval/slice/from_ref_subslice.rs
@@ -1,0 +1,14 @@
+// FAIL: pointer arithmetic on a non-array
+
+#[cfg_attr(crux, crux::test)]
+fn crux_test() {
+    let foo: i32 = 42;
+    let foo_slice: &[i32] = core::slice::from_ref(&foo);
+
+    let foo_subslice = &foo_slice[1..];
+    assert!(foo_subslice.is_empty());
+}
+
+fn main() {
+    println!("{:?}", crux_test());
+}


### PR DESCRIPTION
This approach is akin to the `core::array::from_ref` override in https://github.com/GaloisInc/crucible/pull/1478, but because it operates on slices, it avoids the aliasing issue in that override.