### PR TITLE
`crucible-mir`: Add type layout info and fix `align_of`/`size_of` implementation

### DIFF
--- a/crucible-mir/CHANGELOG.md
+++ b/crucible-mir/CHANGELOG.md
@@ -33,6 +33,8 @@ This release supports [version
   simulate correctly.
 * Add a new map `layouts` in `Collection` to store layout information of sized
   types as exported by `mir-json`.
+* Implement the `SizeOf` and `AlignOf` nullary ops correctly using the layout
+  information.
 
 # 0.4 -- 2025-03-21
 

--- a/crucible-mir/CHANGELOG.md
+++ b/crucible-mir/CHANGELOG.md
@@ -33,8 +33,8 @@ This release supports [version
   simulate correctly.
 * Add a new map `layouts` in `Collection` to store layout information of sized
   types as exported by `mir-json`.
-* Implement the `SizeOf` and `AlignOf` nullary ops correctly using the layout
-  information.
+* Implement the `size_of` and `(min_)align_of` nullary ops and intrinsics
+  correctly using the layout information.
 
 # 0.4 -- 2025-03-21
 

--- a/crucible-mir/CHANGELOG.md
+++ b/crucible-mir/CHANGELOG.md
@@ -1,7 +1,7 @@
 # next -- TBA
 
 This release supports [version
-2](https://github.com/GaloisInc/mir-json/blob/master/SCHEMA_CHANGELOG.md#2) of
+3](https://github.com/GaloisInc/mir-json/blob/master/SCHEMA_CHANGELOG.md#3) of
 `mir-json`'s schema.
 
 * Support simulating Rust code up to version 1.86.
@@ -31,6 +31,8 @@ This release supports [version
 * Fix a bug in which static items with non-constant initializer expressions that
   depend on static items with constant initializer expressions would fail to
   simulate correctly.
+* Add a new map `layouts` in `Collection` to store layout information of sized
+  types as exported by `mir-json`.
 
 # 0.4 -- 2025-03-21
 

--- a/crucible-mir/src/Mir/GenericOps.hs
+++ b/crucible-mir/src/Mir/GenericOps.hs
@@ -161,6 +161,7 @@ instance GenericOps Intrinsic
 instance GenericOps Instance
 instance GenericOps InstanceKind
 instance GenericOps NamedTy
+instance GenericOps Layout
 instance GenericOps LangItem
 instance GenericOps NonDivergingIntrinsic
 

--- a/crucible-mir/src/Mir/JSON.hs
+++ b/crucible-mir/src/Mir/JSON.hs
@@ -228,8 +228,8 @@ instance FromJSON Collection where
         (foldr (\ x m -> Map.insert (x^.sName) x m)     Map.empty statics)
         (foldr (\ x m -> Map.insert (x^.vtName) x m)    Map.empty vtables)
         (foldr (\ x m -> Map.insert (x^.intrName) x m)  Map.empty intrinsics)
-        (foldr (\ x m -> Map.insert (x^.ntName) (x^.ntTy) m) Map.empty tys)
-        (foldr (\ x m -> Map.insert (x^.ntTy) (x^.ntLayout) m) Map.empty tys)
+        (foldr (\ x m -> Map.insert (x^.ntName) (x^.ntTy, x^.ntLayout) m) Map.empty tys)
+        Map.empty -- layouts map has Tys as keys, so it needs to be populated after uninterning
         (foldr (\ x m -> Map.insert (x^.liOrigDefId) (x^.liLangItemDefId) m) Map.empty langItems)
         roots
 

--- a/crucible-mir/src/Mir/JSON.hs
+++ b/crucible-mir/src/Mir/JSON.hs
@@ -108,7 +108,13 @@ instance FromJSON InlineTy where
 
 instance FromJSON NamedTy where
     parseJSON = withObject "NamedTy" $ \v ->
-        NamedTy <$> v .: "name" <*> (getInlineTy <$> v .: "ty")
+        NamedTy <$> v .: "name"
+                <*> (getInlineTy <$> v .: "ty")
+                <*> v .:? "layout"
+
+instance FromJSON Layout where
+    parseJSON = withObject "Layout" $ \v ->
+        Layout <$> v .: "align" <*> v .: "size"
 
 instance FromJSON LangItem where
     parseJSON = withObject "LangItem" $ \v ->
@@ -223,6 +229,7 @@ instance FromJSON Collection where
         (foldr (\ x m -> Map.insert (x^.vtName) x m)    Map.empty vtables)
         (foldr (\ x m -> Map.insert (x^.intrName) x m)  Map.empty intrinsics)
         (foldr (\ x m -> Map.insert (x^.ntName) (x^.ntTy) m) Map.empty tys)
+        (foldr (\ x m -> Map.insert (x^.ntTy) (x^.ntLayout) m) Map.empty tys)
         (foldr (\ x m -> Map.insert (x^.liOrigDefId) (x^.liLangItemDefId) m) Map.empty langItems)
         roots
 

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -279,9 +279,13 @@ data Collection = Collection {
     _statics   :: !(Map DefId Static),
     _vtables   :: !(Map VtableName Vtable),
     _intrinsics :: !(Map IntrinsicName Intrinsic),
+    -- | This corresponds to the @tys@ table from @mir-json@ and is cleared
+    -- after uninterning. The @TyName -> Ty@ mappings are used for uninterning
+    -- the types in the rest of the 'Collection', and the uninterned @(Ty, Maybe
+    -- Layout)@ pairs are saved into '_layouts'.
     _namedTys  :: !(Map TyName (Ty, Maybe Layout)),
     -- | Layouts for known types. If the value is 'Nothing' then the type is
-    -- unsized.
+    -- unsized. This is not populated until uninterning.
     _layouts   :: !(Map Ty (Maybe Layout)),
     -- | Map the original 'DefId's for lang items to their custom, @$lang@-based
     -- 'DefId's (e.g., map @core::option::Option@ to @$lang/Option@).

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -118,7 +118,21 @@ data Ty =
       | TyInterned TyName
       deriving (Eq, Ord, Show, Generic)
 
-data NamedTy = NamedTy { _ntName :: Text, _ntTy :: Ty }
+data NamedTy = NamedTy
+  { _ntName :: Text
+  , _ntTy :: Ty
+    -- | If 'Nothing' then the type is unsized.
+  , _ntLayout :: Maybe Layout
+  }
+  deriving (Eq, Ord, Show, Generic)
+
+-- | Layout of a type.
+data Layout = Layout
+  { -- | ABI alignment in bytes
+    _layAlign :: Word64
+    -- | Size in bytes
+  , _laySize :: Word64
+  }
   deriving (Eq, Ord, Show, Generic)
 
 data LangItem = LangItem
@@ -266,6 +280,9 @@ data Collection = Collection {
     _vtables   :: !(Map VtableName Vtable),
     _intrinsics :: !(Map IntrinsicName Intrinsic),
     _namedTys  :: !(Map TyName Ty),
+    -- | Layouts for known types. If the value is 'Nothing' then the type is
+    -- unsized.
+    _layouts   :: !(Map Ty (Maybe Layout)),
     -- | Map the original 'DefId's for lang items to their custom, @$lang@-based
     -- 'DefId's (e.g., map @core::option::Option@ to @$lang/Option@).
     _langItems :: !(Map DefId DefId),
@@ -631,6 +648,7 @@ makeLenses ''Vtable
 makeLenses ''Intrinsic
 makeLenses ''Instance
 makeLenses ''NamedTy
+makeLenses ''Layout
 makeLenses ''LangItem
 makeLenses ''Statement
 makeLenses ''Terminator

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -279,7 +279,7 @@ data Collection = Collection {
     _statics   :: !(Map DefId Static),
     _vtables   :: !(Map VtableName Vtable),
     _intrinsics :: !(Map IntrinsicName Intrinsic),
-    _namedTys  :: !(Map TyName Ty),
+    _namedTys  :: !(Map TyName (Ty, Maybe Layout)),
     -- | Layouts for known types. If the value is 'Nothing' then the type is
     -- unsized.
     _layouts   :: !(Map Ty (Maybe Layout)),

--- a/crucible-mir/src/Mir/ParseTranslate.hs
+++ b/crucible-mir/src/Mir/ParseTranslate.hs
@@ -20,6 +20,7 @@ import Control.Monad (unless, when)
 import qualified Data.Aeson as J
 import qualified Data.ByteString.Lazy as B
 import qualified Data.Map as M
+import Data.Word (Word64)
 
 import GHC.Stack
 
@@ -39,6 +40,11 @@ import qualified Mir.TransCustom as Mir (customOps)
 import Debug.Trace
 
 
+-- If you update the supported mir-json schema version below, make sure to also
+-- update the crux-mir README accordingly.
+supportedSchemaVersion :: Word64
+supportedSchemaVersion = 2
+
 parseMIR :: (HasCallStack, ?debug::Int) =>
             FilePath
          -> B.ByteString
@@ -48,13 +54,12 @@ parseMIR path f = do
   case c of
       Left msg -> fail $ "JSON Decoding of " ++ path ++ " failed: " ++ msg
       Right col -> do
-        -- If you update the supported mir-json schema version below, make sure
-        -- to also update the crux-mir README accordingly.
-        unless (col^.version == 2) $
+        unless (col^.version == supportedSchemaVersion) $
           fail $ unlines
             [ path ++ " uses an unsupported mir-json schema version: "
                    ++ show (col^. version)
-            , "This crux-mir release only supports schema version 2."
+            , "This crux-mir release only supports schema version "
+              ++ show supportedSchemaVersion ++ "."
             , "(See https://github.com/GaloisInc/mir-json/blob/master/SCHEMA_CHANGELOG.md"
             , "for more details on what the schema version means.)"
             ]

--- a/crucible-mir/src/Mir/ParseTranslate.hs
+++ b/crucible-mir/src/Mir/ParseTranslate.hs
@@ -43,7 +43,7 @@ import Debug.Trace
 -- If you update the supported mir-json schema version below, make sure to also
 -- update the crux-mir README accordingly.
 supportedSchemaVersion :: Word64
-supportedSchemaVersion = 2
+supportedSchemaVersion = 3
 
 parseMIR :: (HasCallStack, ?debug::Int) =>
             FilePath

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -2918,6 +2918,7 @@ mkCrateHashesMap
                 staticsM vtablesM intrinsicsM
                 -- namedTys ranges over type names, which aren't full DefIds.
                 _namedTysM
+                _layoutsM
                 langItemsM
                 -- The roots are duplicates of other Maps' DefIds.
                 _rootsM) =

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -70,6 +70,7 @@ import qualified Data.Text as Text
 import qualified Data.Traversable as Trav
 import qualified Data.Vector as V
 import Data.String (fromString)
+import Data.Word (Word64)
 import Numeric
 import Numeric.Natural()
 
@@ -694,11 +695,12 @@ transNullaryOp nop ty =
       -- (see https://github.com/GaloisInc/mir-json/issues/107)
       return $ MirExp C.BoolRepr $ R.App $ E.BoolLit False
   where
-    lookupLayout layField = do
+    lookupLayout :: Getter Layout Word64 -> MirGenerator h s ret (MirExp s)
+    lookupLayout layFieldLens = do
       lays <- use (cs . collection . layouts)
       case Map.lookup ty lays of
         Just (Just lay) -> return $
-          MirExp UsizeRepr $ R.App $ usizeLit $ toInteger $ lay ^. layField
+          MirExp UsizeRepr $ R.App $ usizeLit $ toInteger $ lay ^. layFieldLens
         Just Nothing -> mirFail $ fmt nop ++ " on unsized type " ++ fmt ty
         Nothing -> mirFail $ fmt nop ++ ": no layout info for " ++ fmt ty
 

--- a/crucible-mir/src/Mir/TransCustom.hs
+++ b/crucible-mir/src/Mir/TransCustom.hs
@@ -1078,24 +1078,14 @@ type_id = (["core","intrinsics", "type_id"],
 
 size_of :: (ExplodedDefId, CustomRHS)
 size_of = (["core", "intrinsics", "size_of"], \substs -> case substs of
-    Substs [t] -> Just $ CustomOp $ \_ _ -> do
-        lays <- use (cs . collection . layouts)
-        case Map.lookup t lays of
-            Just (Just lay) -> return $
-                MirExp UsizeRepr $ R.App $ usizeLit $ toInteger $ lay ^. laySize
-            Just Nothing -> mirFail $ "size_of on unsized type " ++ show t
-            Nothing -> mirFail $ "size_of: no layout info for " ++ show t
+    Substs [t] -> Just $ CustomOp $ \_ _ ->
+        getLayoutFieldAsMirExp "size_of" laySize t
     )
 
 min_align_of :: (ExplodedDefId, CustomRHS)
 min_align_of = (["core", "intrinsics", "min_align_of"], \substs -> case substs of
-    Substs [t] -> Just $ CustomOp $ \_ _ -> do
-        lays <- use (cs . collection . layouts)
-        case Map.lookup t lays of
-            Just (Just lay) -> return $
-                MirExp UsizeRepr $ R.App $ usizeLit $ toInteger $ lay ^. layAlign
-            Just Nothing -> mirFail $ "min_align_of on unsized type " ++ show t
-            Nothing -> mirFail $ "min_align_of: no layout info for " ++ show t
+    Substs [t] -> Just $ CustomOp $ \_ _ ->
+        getLayoutFieldAsMirExp "min_align_of" layAlign t
     )
 
 -- mem::swap is used pervasively (both directly and via mem::replace), but it

--- a/crucible-mir/src/Mir/TransCustom.hs
+++ b/crucible-mir/src/Mir/TransCustom.hs
@@ -1078,16 +1078,24 @@ type_id = (["core","intrinsics", "type_id"],
 
 size_of :: (ExplodedDefId, CustomRHS)
 size_of = (["core", "intrinsics", "size_of"], \substs -> case substs of
-    Substs [t] -> Just $ CustomOp $ \_ _ ->
-        -- TODO: return the actual size, once mir-json exports size/layout info
-        return $ MirExp UsizeRepr $ R.App $ usizeLit 1
+    Substs [t] -> Just $ CustomOp $ \_ _ -> do
+        lays <- use (cs . collection . layouts)
+        case Map.lookup t lays of
+            Just (Just lay) -> return $
+                MirExp UsizeRepr $ R.App $ usizeLit $ toInteger $ lay ^. laySize
+            Just Nothing -> mirFail $ "size_of on unsized type " ++ show t
+            Nothing -> mirFail $ "size_of: no layout info for " ++ show t
     )
 
 min_align_of :: (ExplodedDefId, CustomRHS)
 min_align_of = (["core", "intrinsics", "min_align_of"], \substs -> case substs of
-    Substs [t] -> Just $ CustomOp $ \_ _ ->
-        -- TODO: return the actual alignment, once mir-json exports size/layout info
-        return $ MirExp UsizeRepr $ R.App $ usizeLit 1
+    Substs [t] -> Just $ CustomOp $ \_ _ -> do
+        lays <- use (cs . collection . layouts)
+        case Map.lookup t lays of
+            Just (Just lay) -> return $
+                MirExp UsizeRepr $ R.App $ usizeLit $ toInteger $ lay ^. layAlign
+            Just Nothing -> mirFail $ "min_align_of on unsized type " ++ show t
+            Nothing -> mirFail $ "min_align_of: no layout info for " ++ show t
     )
 
 -- mem::swap is used pervasively (both directly and via mem::replace), but it

--- a/crux-mir/CHANGELOG.md
+++ b/crux-mir/CHANGELOG.md
@@ -1,7 +1,7 @@
 # next -- TBA
 
 This release supports [version
-2](https://github.com/GaloisInc/mir-json/blob/master/SCHEMA_CHANGELOG.md#2) of
+3](https://github.com/GaloisInc/mir-json/blob/master/SCHEMA_CHANGELOG.md#3) of
 `mir-json`'s schema.
 
 * Additional overrides by the simulator may maintain an external state

--- a/crux-mir/README.md
+++ b/crux-mir/README.md
@@ -49,7 +49,7 @@ Next, navigate to the `crucible/dependencies/mir-json` directory. Install
 [the `mir-json` README][mir-json-readme].
 
 Currently, `crux-mir` supports [version
-2](https://github.com/GaloisInc/mir-json/blob/master/SCHEMA_CHANGELOG.md#2) of
+3](https://github.com/GaloisInc/mir-json/blob/master/SCHEMA_CHANGELOG.md#3) of
 `mir-json`'s schema. Note that the schema versions produced by `mir-json` can
 change over time as dictated by internal requirements and upstream changes. To
 help smooth this over:

--- a/crux-mir/test/conc_eval/mem/align_of.rs
+++ b/crux-mir/test/conc_eval/mem/align_of.rs
@@ -1,0 +1,8 @@
+#[cfg_attr(crux, crux::test)]
+fn crux_test() -> usize {
+    align_of::<u8>()
+}
+
+pub fn main() {
+    println!("{}", crux_test());
+}

--- a/crux-mir/test/conc_eval/mem/align_of.rs
+++ b/crux-mir/test/conc_eval/mem/align_of.rs
@@ -1,8 +1,13 @@
+struct Thing {
+    x: u32,
+    y: i128,
+}
+
 #[cfg_attr(crux, crux::test)]
-fn crux_test() -> usize {
-    align_of::<u8>()
+fn crux_test() -> [usize; 4] {
+    [align_of::<u8>(), align_of::<(i16, i32)>(), align_of::<[u64; 3]>(), align_of::<Thing>()]
 }
 
 pub fn main() {
-    println!("{}", crux_test());
+    println!("{:?}", crux_test());
 }

--- a/crux-mir/test/conc_eval/mem/size_of.rs
+++ b/crux-mir/test/conc_eval/mem/size_of.rs
@@ -1,0 +1,8 @@
+#[cfg_attr(crux, crux::test)]
+fn crux_test() -> usize {
+    size_of::<i32>()
+}
+
+pub fn main() {
+    println!("{}", crux_test());
+}

--- a/crux-mir/test/conc_eval/mem/size_of.rs
+++ b/crux-mir/test/conc_eval/mem/size_of.rs
@@ -1,8 +1,13 @@
+struct Thing {
+    x: u32,
+    y: i128,
+}
+
 #[cfg_attr(crux, crux::test)]
-fn crux_test() -> usize {
-    size_of::<i32>()
+fn crux_test() -> [usize; 4] {
+    [size_of::<u8>(), size_of::<(i16, i32)>(), size_of::<[u64; 3]>(), size_of::<Thing>()]
 }
 
 pub fn main() {
-    println!("{}", crux_test());
+    println!("{:?}", crux_test());
 }


### PR DESCRIPTION
Incorporates the layout information added in GaloisInc/mir-json#152 by storing it in a new field `layouts :: Map Ty (Maybe Layout)` in `Collection`.

Also fixes the implementation of the `align_of` and `size_of` nullops and intrinsics to use the actual layout information instead of placeholder values.

This bumps the required `mir-json` schema version to 3 for `crucible-mir` and `crux-mir`.