### PR TITLE
`crucible-mir`: support `Subslice` projections on slices

### DIFF
--- a/crucible-mir/CHANGELOG.md
+++ b/crucible-mir/CHANGELOG.md
@@ -35,6 +35,7 @@ This release supports [version
   types as exported by `mir-json`.
 * Implement the `size_of` and `(min_)align_of` nullary ops and intrinsics
   correctly using the layout information.
+* Support translating `Subslice` projections on slices.
 
 # 0.4 -- 2025-03-21
 

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -361,6 +361,13 @@ data PlaceElem =
       | Index Var
       | ConstantIndex { _cioffset :: Int, _cimin_len :: Int, _cifrom_end :: Bool }
       | Subslice { _sfrom :: Int, _sto :: Int, _sfrom_end :: Bool }
+        -- ^ Project into a subslice of a sequence (i.e. slice or array). For a
+        -- sequence @s@, when @fromEnd@ is `False`, @Subslice from to fromEnd@
+        -- is like saying @s[from..to]@ in Rust - it selects elements in @s@ in
+        -- the half-open range @[from, to)@. When @fromEnd@ is `True`, @to@ is
+        -- interpreted relative to the end of the sequence, rather than the
+        -- beginning - so if @s@ has length @len@, elements are instead selected
+        -- from the (still half-open) range @[from, len - to)@.
       | Downcast Integer
       | Subtype Ty
       deriving (Show, Eq, Ord, Generic)

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -1628,21 +1628,7 @@ evalPlaceProj ty (MirPlace tpr ref meta) (M.Subslice fromIndex toIndex fromEnd) 
           newMeta = SliceMeta newLen
       in MirPlace elemTpr <$> mirRef_offset headRef firstIndex <*> pure newMeta
 
-    -- TODO: Crucible's representation of `MirReference`s to arrays is not
-    -- expressive enough to implement this case properly. A Crucible reference
-    -- to an array is a reference to the entire array, and cannot have
-    -- `mirRef_offset` applied to it - unlike slices, a Crucible reference to
-    -- which is represented as a reference to its first element.
-
-    -- A couple possible ways past this:
-    -- - Make Crucible array references actually point to the first element of
-    --   the array, mimicking Crucible's approach to slices and Rust itself's
-    --   approach to arrays. Then, they'd be amenable to `mirRef_offset`.
-    -- - Implement a new reference path extension, something like
-    --   "MirRef_Subarray". Such a path extension would behave somewhat like
-    --   `MirRef_Index`, but instead of offering read/write access to a single
-    --   element of the parent array, it would offer read/write access to a
-    --   subarray of elements of the parent array.
+    -- TODO: https://github.com/GaloisInc/crucible/issues/1494
     --
     -- NB: after implementing this, update `Mir.Mir.typeOfProj`, which currently
     -- declares that `Subslice` unconditionally yields a slice. This is

--- a/crux-mir/test/conc_eval/array/subslice.rs
+++ b/crux-mir/test/conc_eval/array/subslice.rs
@@ -1,0 +1,38 @@
+// FAIL: subslicing not yet supported on arrays
+
+#[cfg_attr(crux, crux::test)]
+fn crux_test() {
+    let mut xs: [u32; 6] = [1, 2, 3, 4, 5, 6];
+
+    let [_, rest @ ..] = xs;
+    assert_eq!(rest, [2, 3, 4, 5, 6]);
+
+    let [_, rest @ ..] = rest;
+    assert_eq!(rest, [3, 4, 5, 6]);
+    
+    let [_, _, rest @ ..] = xs;
+    assert_eq!(rest, [3, 4, 5, 6]);
+
+    let [first @ .., _] = xs;
+    assert_eq!(first, [1, 2, 3, 4, 5]);
+
+    let [first @ .., _] = first;
+    assert_eq!(first, [1, 2, 3, 4]);
+    
+    let [first @ .., _, _] = xs;
+    assert_eq!(first, [1, 2, 3, 4]);
+
+    let [_, middle @ .., _] = xs;
+    assert_eq!(middle, [2, 3, 4, 5]);
+
+    let [_, ref mut middle @ .., _] = xs;
+    *middle = [5, 4, 3, 2];
+
+    let [_, middle @ .., _] = xs;
+    assert_eq!(middle, [5, 4, 3, 2]);
+    assert_eq!(xs, [1, 5, 4, 3, 2, 6]);
+}
+
+fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/conc_eval/slice/subslice.rs
+++ b/crux-mir/test/conc_eval/slice/subslice.rs
@@ -1,0 +1,37 @@
+#[cfg_attr(crux, crux::test)]
+fn crux_test() {
+    let mut xs: [u32; 6] = [1, 2, 3, 4, 5, 6];
+    let ys: &mut [u32] = &mut xs;
+
+    let [_, rest @ ..] = ys else { panic!() };
+    assert_eq!(*rest, [2, 3, 4, 5, 6]);
+
+    let [_, rest @ ..] = rest else { panic!() };
+    assert_eq!(*rest, [3, 4, 5, 6]);
+    
+    let [_, _, rest @ ..] = ys else { panic!() };
+    assert_eq!(*rest, [3, 4, 5, 6]);
+
+    let [first @ .., _] = ys else { panic!() };
+    assert_eq!(*first, [1, 2, 3, 4, 5]);
+
+    let [first @ .., _] = first else { panic!() };
+    assert_eq!(*first, [1, 2, 3, 4]);
+    
+    let [first @ .., _, _] = ys else { panic!() };
+    assert_eq!(*first, [1, 2, 3, 4]);
+
+    let [_, middle @ .., _] = ys else { panic!() };
+    assert_eq!(*middle, [2, 3, 4, 5]);
+
+    for i in middle.iter_mut() {
+        *i ^= 7;
+    }
+    assert_eq!(*middle, [5, 4, 3, 2]);
+    assert_eq!(ys, [1, 5, 4, 3, 2, 6]);
+    assert_eq!(xs, [1, 5, 4, 3, 2, 6]);
+}
+
+fn main() {
+    println!("{:?}", crux_test());
+}


### PR DESCRIPTION
See the included tests for examples of Rust syntax that results in these projections appearing in MIR. Although these projections are also valid on arrays - see e.g. the included xfail test, which Rust can comprehend but Crucible cannot - Crucible's representation of arrays hinders us from supporting them. See comments in code for details.