### PR TITLE
ci: manually `cabal build` packages

### DIFF
--- a/.github/workflows/crux-llvm-build.yml
+++ b/.github/workflows/crux-llvm-build.yml
@@ -180,9 +180,6 @@ jobs:
         run: .github/ci.sh test crucible-llvm-cli
         if: runner.os == 'Linux'
 
-      - name: Test crucible-llvm-debug
-        run: .github/ci.sh test crucible-llvm-debug
-
       - name: Test crux-llvm
         run: .github/ci.sh test crux-llvm
         if: runner.os == 'Linux' || runner.os == 'macOS'

--- a/.github/workflows/crux-mir-build.yml
+++ b/.github/workflows/crux-mir-build.yml
@@ -165,7 +165,6 @@ jobs:
 
       - run: .github/ci.sh test crucible-mir-syntax
       - run: .github/ci.sh test crucible-mir-cli
-      - run: .github/ci.sh test crucible-mir-debug
       - run: .github/ci.sh test crux-mir
 
       - uses: actions/cache/save@v4

--- a/.github/workflows/crux-mir-build.yml
+++ b/.github/workflows/crux-mir-build.yml
@@ -146,7 +146,18 @@ jobs:
       - name: Generate source distributions
         run: cabal sdist crucible-syntax crucible-concurrency crucible-mir crux-mir
 
-      - run: cabal build exe:crux-mir
+      - run: >
+          cabal build
+          crucible
+          crucible-cli
+          crucible-concurrency
+          crucible-debug
+          crucible-mir
+          crucible-mir-cli
+          crucible-mir-debug
+          crucible-mir-syntax
+          crucible-syntax
+          crux-mir
 
       - name: Haddock
         # See Note [--disable-documentation] in `crucible-go-build.yml`.

--- a/crucible-mir-debug/src/Lang/Crucible/MIR/Debug.hs
+++ b/crucible-mir-debug/src/Lang/Crucible/MIR/Debug.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Lang.Crucible.MIR.Debug
   ( mirCommandExt
@@ -42,6 +43,15 @@ mirCommandExt =
   , Debug.extName = name
   , Debug.extRegex = regex
   }
+
+-- | There are currently no MIR-specific debugger responses, but we may add some
+-- in the future.
+data MIRResponse
+
+instance PP.Pretty MIRResponse where
+  pretty = \case
+
+type instance Debug.ResponseExt MIRCommand = MIRResponse
 
 mirExtImpl :: ExtImpl MIRCommand p sym ext t
 mirExtImpl =


### PR DESCRIPTION
It turns out `cabal test` will not build a package unless it contains a test suite - so if a package lacks a test suite and fails to build, CI would not catch such a failure. Unfortunately, this seems to have happened for `crucible-mir-debug` (introduced in https://github.com/GaloisInc/crucible/pull/1486). This addition ought to prevent this in the future.