### PR TITLE
ci: Check freeze files on Linux only

### DIFF
--- a/.github/workflows/crucible-go-build.yml
+++ b/.github/workflows/crucible-go-build.yml
@@ -40,8 +40,7 @@ jobs:
       # eight bytes: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00")
       cache-key-prefix: 1-go
       check: false
-      # https://github.com/GaloisInc/.github/issues/55
-      check-freeze: false
+      check-freeze: ${{ startsWith(matrix.os, 'ubuntu') }}
       ghc: ${{ matrix.ghc }}
       os: ${{ matrix.os }}
       pre-hook: |

--- a/.github/workflows/crucible-jvm-build.yml
+++ b/.github/workflows/crucible-jvm-build.yml
@@ -40,8 +40,7 @@ jobs:
       # eight bytes: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00")
       cache-key-prefix: 1-jvm
       check: false
-      # https://github.com/GaloisInc/.github/issues/55
-      check-freeze: false
+      check-freeze: ${{ startsWith(matrix.os, 'ubuntu') }}
       ghc: ${{ matrix.ghc }}
       os: ${{ matrix.os }}
       pre-hook: |

--- a/.github/workflows/crucible-wasm-build.yml
+++ b/.github/workflows/crucible-wasm-build.yml
@@ -40,8 +40,7 @@ jobs:
       # eight bytes: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00")
       cache-key-prefix: 1-wasm
       check: false
-      # https://github.com/GaloisInc/.github/issues/55
-      check-freeze: false
+      check-freeze: ${{ startsWith(matrix.os, 'ubuntu') }}
       ghc: ${{ matrix.ghc }}
       os: ${{ matrix.os }}
       pre-hook: |


### PR DESCRIPTION
As noticed on https://github.com/GaloisInc/.github/pull/59, the freeze files may be missing libraries that are required to build on Windows (e.g., Win32). The proper solution would be to check in freeze files for each platform. This would ensure deterministic builds on each platform. However, this would impose an undue maintenance burden, as not all developers have access to dev machines with each supported OS installed. So, only check the completeness of the freeze files on Linux.