### PR TITLE
Include the host architecture in the name of the uploaded artifacts

### DIFF
--- a/.github/workflows/crux-llvm-build.yml
+++ b/.github/workflows/crux-llvm-build.yml
@@ -244,7 +244,7 @@ jobs:
         if: github.event.pull_request.head.repo.fork == false && github.repository_owner == 'GaloisInc'
         with:
           path: crux-llvm-*.tar.gz*
-          name: crux-llvm-${{ matrix.os }}-${{ matrix.ghc }}
+          name: crux-llvm-${{ matrix.os }}-${{ runner.arch }}-${{ matrix.ghc }}
 
 
   build-push-image:

--- a/.github/workflows/crux-mir-build.yml
+++ b/.github/workflows/crux-mir-build.yml
@@ -225,7 +225,7 @@ jobs:
         if: github.event.pull_request.head.repo.fork == false && github.repository_owner == 'GaloisInc'
         with:
           path: crux-mir-*.tar.gz*
-          name: crux-mir-${{ matrix.os }}-${{ matrix.ghc }}
+          name: crux-mir-${{ matrix.os }}-${{ runner.arch }}-${{ matrix.ghc }}
 
   build-push-image:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
In line with the naming in the `saw-script` and `mir-json` repositories