### PR TITLE
CI: Add `rme`/`rme-what4` as Docker dependencies

### DIFF
--- a/.github/cabal.project.crux-llvm
+++ b/.github/cabal.project.crux-llvm
@@ -10,4 +10,6 @@ packages:
 optional-packages:
   dependencies/llvm-pretty/
   dependencies/llvm-pretty-bc-parser/
+  dependencies/rme/rme/
+  dependencies/rme/rme-what4/
   dependencies/what4/what4/

--- a/.github/cabal.project.crux-mir
+++ b/.github/cabal.project.crux-mir
@@ -8,4 +8,6 @@ packages:
   crux-mir/
 
 optional-packages:
+  dependencies/rme/rme/
+  dependencies/rme/rme-what4/
   dependencies/what4/what4/


### PR DESCRIPTION
This is a follow-up to #1507 that ensures that the Docker builds for the `crux-{llvm,mir}` images properly pick up the newly added `rme`/`rme-what4` packages as a submodule dependency.

This should fix the nightly CI failures seen [here](https://github.com/GaloisInc/crucible/actions/runs/17292511148/job/49082975920).