### PR TITLE
`crux-mir`: Correctly concretize nested references

### DIFF
--- a/crux-mir/CHANGELOG.md
+++ b/crux-mir/CHANGELOG.md
@@ -18,6 +18,8 @@ This release supports [version
   not yet supported.
 * Support custom dynamically-sized types, allowing for use of types like
   `Arc<dyn Fn>`, `Box<dyn Fn>`, et al.
+* Fix a bug where concretizing reference values or `Vec` values would cause the
+  simulator to crash when attempting to read from the concretized values.
 
 # 0.10 -- 2025-03-21
 

--- a/crux-mir/test/symb_eval/concretize/assert_refs.good
+++ b/crux-mir/test/symb_eval/concretize/assert_refs.good
@@ -1,0 +1,11 @@
+test assert_refs/<DISAMB>::crux_test[0]: FAILED
+
+failures:
+
+---- assert_refs/<DISAMB>::crux_test[0] counterexamples ----
+[Crux] Found counterexample for verification goal
+[Crux]   ./libs/crucible/lib.rs:48:13: 55:14 !test/symb_eval/concretize/assert_refs.rs:12:5: 12:67: error: in assert_refs/<DISAMB>::crux_test[0]
+[Crux]   MIR assertion at test/symb_eval/concretize/assert_refs.rs:12:5:
+[Crux]   	42 42 [42] [42]
+
+[Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/concretize/assert_refs.rs
+++ b/crux-mir/test/symb_eval/concretize/assert_refs.rs
@@ -1,0 +1,17 @@
+// A regression test for #1513. This test ensures that crux-mir can
+// successfully pass reference types (or types that use references under the
+// hood, like Vecs) to the crucible_assert! macro.
+
+extern crate crucible;
+use crucible::*;
+
+#[crux::test]
+fn crux_test() {
+    let x: u32 = 42;
+    let v: Vec<u32> = vec![x];
+    crucible_assert!(false, "{:?} {:?} {:?} {:?}", &x, &&x, v, &v);
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}


### PR DESCRIPTION
Previously, the implementation of `crucible::concretize` was incorrect for nested reference types (e.g., `&&u32`). This is because when concretizing the reference type, we must also recursively concretize the pointee value, but we failed to propagate global-state changes from the recursive call correctly. This leads to the global state missing `RefCell`s that it should have, as seen in the oddities in https://github.com/GaloisInc/crucible/issues/1513.

This fixes the issue by ensuring that we read from the newly updated global state properly immediately after the recursive call. This fixes https://github.com/GaloisInc/crucible/issues/1513.

While I was in town, I also noticed some blatant code duplication in the code that powers `crucible::concretize`, which I fixed in its own commit. As such, this PR also fixes #1516.