### PR TITLE
`crucible-mir`: Add basic scaffolding for inline assembly

### DIFF
--- a/crucible-mir/CHANGELOG.md
+++ b/crucible-mir/CHANGELOG.md
@@ -36,6 +36,9 @@ This release supports [version
 * Implement the `size_of` and `(min_)align_of` nullary ops and intrinsics
   correctly using the layout information.
 * Support translating `Subslice` projections on slices.
+* Add basic scaffolding for representing inline assembly (e.g., using the
+  `std::arch::asm!` macro). `crucible-mir` does not support _simulating_ inline
+  assembly, but it can now translate code that uses it without crashing.
 
 # 0.4 -- 2025-03-21
 

--- a/crucible-mir/src/Mir/JSON.hs
+++ b/crucible-mir/src/Mir/JSON.hs
@@ -378,6 +378,7 @@ instance FromJSON TerminatorKind where
         Just (String "Drop") -> Drop <$> v .: "location" <*> v .: "target" <*> v .: "drop_fn"
         Just (String "Call") ->  Call <$> v .: "func" <*> v .: "args" <*> v .: "destination"
         Just (String "Assert") -> Assert <$> v .: "cond" <*> v .: "expected" <*> v .: "msg" <*> v .: "target"
+        Just (String "InlineAsm") -> pure InlineAsm
         k -> fail $ "unsupported terminator kind" ++ show k
 
 instance FromJSON Operand where

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -459,6 +459,11 @@ data TerminatorKind =
                  _aexpected :: Bool,
                  _amsg      :: AssertMessage,
                  _atarget   :: BasicBlockInfo }
+      | InlineAsm
+        -- ^ @crucible-mir@ does not support simulating inline assembly, but we
+        -- nevertheless include this as a 'TerminatorKind' so that we can
+        -- successfully translate code that mentions it. Provided that that
+        -- code is never simulated, this should work out.
       deriving (Show,Eq, Ord, Generic)
 
 data Operand =

--- a/crucible-mir/src/Mir/PP.hs
+++ b/crucible-mir/src/Mir/PP.hs
@@ -243,6 +243,7 @@ instance Pretty TerminatorKind where
     pretty (Assert op expect _msg target1) =
       pretty "assert" <+> pretty op <+> pretty "==" <+> pretty expect
                     <+> arrow <+> pretty target1
+    pretty InlineAsm = pretty "inlineasm;"
 
 
 

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -2098,6 +2098,8 @@ transTerminatorKind M.Abort _tpos tr =
 transTerminatorKind M.Unreachable _tpos tr = do
     recordUnreachable
     G.reportError (S.litExpr "Unreachable!!!!!")
+transTerminatorKind M.InlineAsm _tpos _tr =
+    mirFail "Inline assembly not supported"
 
 
 --- translation of toplevel glue ---

--- a/crux-mir/test/conc_eval/stdlib/asm.rs
+++ b/crux-mir/test/conc_eval/stdlib/asm.rs
@@ -1,0 +1,23 @@
+// A regression test for #1520. While crucible-mir doesn't support simulating
+// inline assembly (via the asm! macro), it should at least be able to
+// translate it without crashing. This test case ensures that this happens.
+
+use std::arch::asm;
+
+fn f(x: bool) -> u32 {
+    if x {
+        unsafe { asm!(""); }
+        1
+    } else {
+        0
+    }
+}
+
+#[cfg_attr(crux, crux::test)]
+pub fn crux_test() -> u32 {
+    f(false)
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}


### PR DESCRIPTION
`crucible-mir` does not support _simulating_ inline assembly, but it can now translate code that uses it without crashing.

Fixes https://github.com/GaloisInc/crucible/issues/1520.