### PR TITLE
`crux-mir`: Add `--test-skip-filter` flag

### DIFF
--- a/crux-mir/CHANGELOG.md
+++ b/crux-mir/CHANGELOG.md
@@ -20,6 +20,9 @@ This release supports [version
   `Arc<dyn Fn>`, `Box<dyn Fn>`, et al.
 * Fix a bug where concretizing reference values or `Vec` values would cause the
   simulator to crash when attempting to read from the concretized values.
+* Add a `--test-skip-filter <string>` flag, which only runs tests whose names
+  do not contain `<string>`. This acts as a `crux-mir` analog to `cargo test`'s
+  `--skip` flag.
 
 # 0.10 -- 2025-03-21
 

--- a/crux-mir/src/Mir/Language.hs
+++ b/crux-mir/src/Mir/Language.hs
@@ -647,7 +647,7 @@ showRegEntry col mty (C.RegEntry tp rv) =
                                 adt ^? adtvariants . ix i
                         case variantFields' col var of
                             Left err -> return (Left ("Type not supported: " ++ err))
-                            Right (C.Some fctx) -> do 
+                            Right (C.Some fctx) -> do
                                 Refl <- failIfNotEqual tpr (C.StructRepr $ fieldCtxType fctx)
                                             ("when printing enum type " ++ show name)
                                 return $ Right (var, readFields fctx fields)


### PR DESCRIPTION
`--test-skip-filter` is a `crux-mir` analog to the `--skip` flag in `cargo test`. With `--test-skip-filter`, you can do things like this:

```
$ cargo crux-test --lib -- -s z3 --test-skip-filter will_fail
<snip>
     Running unittests src/lib.rs (target/aarch64-apple-darwin/debug/deps/example_3-facd64e17d6c5340)
test example_3/8a336145::crux_test[0]::verify_success[0]: [Crux] Attempting to prove verification conditions.
ok

[Crux-MIR] ---- FINAL RESULTS ----
[Crux] Goal status:
[Crux]   Total: 1
[Crux]   Proved: 1
[Crux]   Disproved: 0
[Crux]   Incomplete: 0
[Crux]   Unknown: 0
[Crux] Overall status: Valid.
```

Fixes https://github.com/GaloisInc/crucible/issues/1512.