### PR TITLE
Save the names of the test function when running with coverage

### DIFF
--- a/crux-mir/src/Mir/Language.hs
+++ b/crux-mir/src/Mir/Language.hs
@@ -418,8 +418,11 @@ runTestsWithExtraOverrides initS bindExtra (cruxOpts, mirOpts) = do
             -- It's a bit redundant to emit the entire crate's translation
             -- metadata for each test, but we do it anyway.  This keeps us from
             -- overwriting the metadata when multiple tests are run with the
-            -- same `outDir`.
+            -- same `outDir`. 
             Aeson.encodeFile path (mir ^. rmTransInfo)
+
+            let testFile = Crux.outDir cruxOpts' </> "tests.json"
+            Aeson.encodeFile testFile (map idText testNames)
 
         res <- Crux.runSimulatorWithUserState initS cruxOpts' $ simCallbacks fnName
         when (not $ printResultOnly mirOpts) $ do


### PR DESCRIPTION
This fixes #1530:  when running with coverage we save the names of the tests as an additional piece of data.  We then
use the names of the tests to determine which functions to include in the coverage statistics.