### PR TITLE
`crucible-mir`: support constructing union values

### DIFF
--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -303,7 +303,7 @@ tyToReprM ty = do
     Right repr -> return repr
     Left err -> mirFail ("tyToRepr: " ++ err)
 
--- Checks whether a type can be default-initialized.  Any time this returns
+-- | Checks whether a type can be default-initialized.  Any time this returns
 -- `True`, `initialValue` must also return `Just`.  Non-initializable ADT
 -- fields are wrapped in `Maybe` to support field-by-field initialization.
 canInitialize :: M.Collection -> M.Ty -> Bool

--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -323,6 +323,9 @@ canInitialize col ty = case ty of
     M.TyClosure _ -> True
     M.TyAdt _ _ _
       | Just ty' <- tyAdtDef col ty >>= reprTransparentFieldTy col -> canInitialize col ty'
+      | Just adt <- tyAdtDef col ty
+      , M.Union <- adt ^. M.adtkind ->
+        False
       | otherwise -> True
     -- Others
     M.TyArray _ _ -> True

--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -236,7 +236,9 @@ tyToRepr col t0 = case t0 of
         -- signatures mentioning union types without crashing during MIR
         -- translation (e.g., in Mir.Trans.mkHandleMap).
         --
-        -- See #1429 for the larger issue of properly supporting union types.
+        -- See #1429 for the larger issue of properly supporting union types,
+        -- and see `Mir.Trans.evalRval` for a related hack to help "support"
+        -- unions.
         Right (Some C.AnyRepr)
   M.TyDowncast _adt _i   -> Right (Some C.AnyRepr)
 

--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -304,7 +304,7 @@ tyToReprM ty = do
     Left err -> mirFail ("tyToRepr: " ++ err)
 
 -- Checks whether a type can be default-initialized.  Any time this returns
--- `True`, `Trans.initialValue` must also return `Just`.  Non-initializable ADT
+-- `True`, `initialValue` must also return `Just`.  Non-initializable ADT
 -- fields are wrapped in `Maybe` to support field-by-field initialization.
 canInitialize :: M.Collection -> M.Ty -> Bool
 canInitialize col ty = case ty of

--- a/crux-mir/test/conc_eval/union/in_struct.rs
+++ b/crux-mir/test/conc_eval/union/in_struct.rs
@@ -1,0 +1,27 @@
+union U {
+    x: u8,
+    y: i8,
+}
+
+struct S {
+    u: U,
+}
+
+fn foo(b: bool) -> u8 {
+    if b {
+        let u = U { x: 42 };
+        let s = S { u };
+        unsafe { s.u.x }
+    } else {
+        43
+    }
+}
+
+#[cfg_attr(crux, crux::test)]
+pub fn bar() -> u8 {
+    foo(false)
+}
+
+pub fn main() {
+    println!("{}", bar());
+}

--- a/crux-mir/test/conc_eval/union/unused_local.rs
+++ b/crux-mir/test/conc_eval/union/unused_local.rs
@@ -1,0 +1,22 @@
+union U {
+    x: u8,
+    y: i8,
+}
+
+fn foo(b: bool) -> u8 {
+    if b {
+        let u = U { x: 42 };
+        unsafe { u.x }
+    } else {
+        43
+    }
+}
+
+#[cfg_attr(crux, crux::test)]
+pub fn bar() -> u8 {
+    foo(false)
+}
+
+pub fn main() {
+    println!("{}", bar());
+}

--- a/crux-mir/test/conc_eval/union/unused_static.rs
+++ b/crux-mir/test/conc_eval/union/unused_static.rs
@@ -1,0 +1,26 @@
+union U {
+    x: u8,
+    y: i8,
+}
+
+pub static FOO: U = U { x: 42 };
+
+fn foo(b: bool) -> u8 {
+    if b {
+        // Note that it doesn't suffice to merely have a `static` union value
+        // declaration; if no function refers to the value, dead-code
+        // elimination seems to get rid of it.
+        unsafe { FOO.x }
+    } else {
+        43
+    }
+}
+
+#[cfg_attr(crux, crux::test)]
+pub fn bar() -> u8 {
+    foo(false)
+}
+
+pub fn main() {
+    println!("{}", bar());
+}


### PR DESCRIPTION
These changes follow up on #1473 by allowing construction of union-type values, while still leaving meaningful manipulation of those values unsupported. The aim is to postpone more union-related errors past translation time, to allow Crucible to consume code that mentions, but does not use, unions. See the included tests for examples of code Crucible can now consume.