### PR TITLE
`crucible-mir`: `MirAggregate` representation for unions

### DIFF
--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -1615,14 +1615,6 @@ evalPlaceProj ty pl@(MirPlace tpr ref meta) (M.PField idx fieldTy) = do
             -- Since `findReprTransparentField` returned `Just`, we know that
             -- fields aside from `tIdx` must be zero-sized, and thus contain no
             -- actual data.  So we can return a dummy reference here.
-            --
-            -- Also, for enum types, `#[repr(transparent)]` is only allowed on
-            -- single-variant enums, so we know `tIdx` refers to a field of
-            -- variant 0 (as with structs).
-            fieldTy <- case adt ^? M.adtvariants . ix 0 . M.vfields . ix idx . M.fty of
-                Just x -> return x
-                Nothing -> mirFail $ "impossible: accessed out of range field " ++
-                    show idx ++ " of " ++ show adt ++ "?"
             MirExp tpr' e <- initialValue fieldTy >>= \x -> case x of
                 Just x -> return x
                 Nothing -> mirFail $ "failed to produce dummy value of type " ++ show fieldTy

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -1440,7 +1440,8 @@ union's fields. When interpreting this initialization:
   size of the union/`MirAggregate`.
 
 The type of a (subrange of a) `MirAggregate` is unspecified until it's written
-to, and fixed thereafter. This means that, once a union's `MirAggregate` is
+to, and fixed thereafter. This allows for unions to be default-initialized by an
+untyped `MirAggregate`. This also means that, once a union's `MirAggregate` is
 initialized with a field of a given type, we only support reading from the union
 via a field of the same type (which, in practice, generally means the same
 field). When reading from the union, we rely on the initialization behavior

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -1365,7 +1365,14 @@ evalRval rv@(M.RAdtAg (M.AdtAg adt agv ops ty optField)) = do
                 M.Struct -> buildStruct adt es
                 M.Enum _ -> buildEnum adt (fromInteger agv) es
                 M.Union -> do
-                    mirFail $ "evalRval: Union types are unsupported, for " ++ show (adt ^. adtname)
+                  fieldExpr <- case es of
+                    [e] -> pure e
+                    [] -> mirFail "evalRval: no union field initializer?"
+                    _ -> mirFail "evalRval: multiple union field initializers?"
+                  fieldIdx <- case optField of
+                    Just idx -> pure idx
+                    Nothing -> mirFail "evalRval: no union field initializer index?"
+                  buildUnion adt fieldIdx fieldExpr
       _ -> mirFail $ "evalRval: unsupported type for AdtAg: " ++ show ty
 evalRval (M.ThreadLocalRef did _) = staticPlace did >>= addrOfPlace
 
@@ -1374,6 +1381,64 @@ evalRval rv@(M.CopyForDeref lv) = evalLvalue lv
 
 evalRval rv@(M.ShallowInitBox op ty) = mirFail
     "evalRval: ShallowInitBox not supported"
+
+-- | Construct a `MirExp` representing a union, and initialize it with a
+-- particular field, specified by a field index and an expression. The
+-- expression's type must match the field's type in the provided `M.Adt`.
+buildUnion ::
+  M.Adt ->
+  -- | The index of the field being used to initialize the union
+  Int ->
+  MirExp s ->
+  MirGenerator h s ret (MirExp s)
+buildUnion unionAdt fieldIdx (MirExp fieldTpr fieldExpr) = do
+  unionFields <- case unionAdt ^. M.adtvariants of
+    [v] -> pure (v ^. M.vfields)
+    [] -> die "no variants?"
+    _ -> die "multiple variants?"
+
+  unionField <- case unionFields ^? ix fieldIdx of
+    Just field -> pure field
+    Nothing -> die $ "field index " <> show fieldIdx <> " out of range"
+
+  Some expectedFieldTpr <- tyToReprM (unionField ^. M.fty)
+  case testEquality expectedFieldTpr fieldTpr of
+    Just _ -> pure ()
+    Nothing -> die $
+      "expected field to have type " <> show expectedFieldTpr <>
+      ", but it was " <> show fieldTpr
+
+  emptyAg <- mirAggregate_uninit unionSize
+  fullAg <- mirAggregate_set fieldOffset fieldSize fieldTpr fieldExpr emptyAg
+  pure (MirExp MirAggregateRepr fullAg)
+  where
+    unionSize = fromIntegral (unionAdt ^. M.adtSize)
+
+    -- See Note [union representation]
+    fieldOffset = 0
+    fieldSize = unionSize
+
+    die :: String -> MirGenerator h s ret a
+    die s = mirFail ("buildUnion: "<>show (unionAdt ^. M.adtname)<>": "<>s)
+
+{- 
+Note [union representation]
+----------------------------------------
+
+Crucible represents Rust unions as `MirAggregate` values.
+
+A union's `MirAggregate` representation has the same size as the union itself,
+according to the `_adtSize` field of the `Mir.Mir.Adt` that describes it.
+
+A union is always initialized with a single expression representing one of the
+union's fields. When interpreting this initialization:
+- We declare that the given field appears at offset 0 in the `MirAggregate`,
+  even if the field would appear at a nonzero offset according to Rust's memory
+  model.
+- We declare that the given field spans the entire `MirAggregate` representing
+  the union, even if the field type's size on its own would be smaller than the
+  size of the union/`MirAggregate`.
+-}
 
 evalLvalue :: HasCallStack => M.Lvalue -> MirGenerator h s ret (MirExp s)
 evalLvalue lv = evalPlace lv >>= readPlace

--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -228,16 +228,7 @@ tyToRepr col t0 = case t0 of
         SomeRustEnumRepr _ ctx <- enumVariants col adt
         Right (Some (RustEnumRepr discrTp ctx))
       M.Union ->
-        -- This is a hack. crucible-mir doesn't _actually_ support union types,
-        -- and if you try simulating a code that performs an operation on a
-        -- union-typed value, then it will fail at simulation time.
-        -- Nevertheless, we intentionally choose to use Any as a placeholder
-        -- type instead of failing so that crucible-mir can translate type
-        -- signatures mentioning union types without crashing during MIR
-        -- translation (e.g., in Mir.Trans.mkHandleMap).
-        --
-        -- See #1429 for the larger issue of properly supporting union types.
-        Right (Some C.AnyRepr)
+        Right (Some MirAggregateRepr)
   M.TyDowncast _adt _i   -> Right (Some C.AnyRepr)
 
   M.TyFloat _ -> Right (Some C.RealValRepr)

--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -1481,7 +1481,12 @@ initialValue (M.TyAdt nm _ _) = do
                 Just (discr, var) -> do
                     fldExps <- mapM initField (var^.M.vfields)
                     Just <$> buildEnum' adt discr fldExps
-        M.Union -> return Nothing
+        M.Union ->
+            -- Unions are default-initialized to an untyped `MirAggregate` of an
+            -- appropriate size, like tuples. See Note [union representation] in
+            -- `Mir.Trans`.
+            let unionSize = fromIntegral (adt ^. M.adtSize)
+            in Just . MirExp MirAggregateRepr <$> mirAggregate_uninit unionSize
 
 
 

--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -292,7 +292,7 @@ tyToReprM ty = do
     Right repr -> return repr
     Left err -> mirFail ("tyToRepr: " ++ err)
 
--- Checks whether a type can be default-initialized.  Any time this returns
+-- | Checks whether a type can be default-initialized.  Any time this returns
 -- `True`, `initialValue` must also return `Just`.  Non-initializable ADT
 -- fields are wrapped in `Maybe` to support field-by-field initialization.
 canInitialize :: M.Collection -> M.Ty -> Bool

--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -293,7 +293,7 @@ tyToReprM ty = do
     Left err -> mirFail ("tyToRepr: " ++ err)
 
 -- Checks whether a type can be default-initialized.  Any time this returns
--- `True`, `Trans.initialValue` must also return `Just`.  Non-initializable ADT
+-- `True`, `initialValue` must also return `Just`.  Non-initializable ADT
 -- fields are wrapped in `Maybe` to support field-by-field initialization.
 canInitialize :: M.Collection -> M.Ty -> Bool
 canInitialize col ty = case ty of

--- a/crux-mir/test/conc_eval/union/in_struct.rs
+++ b/crux-mir/test/conc_eval/union/in_struct.rs
@@ -1,0 +1,27 @@
+union U {
+    x: u16,
+    y: [u8; 2],
+}
+
+struct S {
+    u: U,
+}
+
+fn foo(b: bool) -> u16 {
+    if b {
+        let u = U { x: 42 };
+        let s = S { u };
+        unsafe { s.u.x }
+    } else {
+        43
+    }
+}
+
+#[cfg_attr(crux, crux::test)]
+pub fn bar() -> u16 {
+    foo(false)
+}
+
+pub fn main() {
+    println!("{}", bar());
+}

--- a/crux-mir/test/conc_eval/union/init.rs
+++ b/crux-mir/test/conc_eval/union/init.rs
@@ -1,0 +1,15 @@
+union U {
+    x: u16,
+    y: [u8; 2],
+}
+
+#[cfg_attr(crux, crux::test)]
+fn foo() -> u16 {
+    let x: u16 = 0x1234;
+    let u: U = U { x };
+    x
+}
+
+fn main() {
+    println!("{}", foo());
+}

--- a/crux-mir/test/conc_eval/union/init_cond.rs
+++ b/crux-mir/test/conc_eval/union/init_cond.rs
@@ -1,0 +1,23 @@
+// FAIL: attempt to mux differently-initialized unions
+
+use crucible::symbolic::Symbolic as _;
+
+union U {
+    x: u16,
+    y: [u8; 2],
+}
+
+#[cfg_attr(crux, crux::test)]
+fn foo() -> u16 {
+    let x: u16 = 0x1234;
+    let u = if bool::symbolic("cond") {
+        U { x }
+    } else {
+        U { y: x.to_ne_bytes() }
+    };
+    x
+}
+
+fn main() {
+    println!("{}", foo());
+}

--- a/crux-mir/test/conc_eval/union/read_other.rs
+++ b/crux-mir/test/conc_eval/union/read_other.rs
@@ -1,0 +1,20 @@
+// FAIL: reading a non-active union field
+
+union U {
+    x: u16,
+    y: [u8; 2],
+}
+
+#[cfg_attr(crux, crux::test)]
+fn foo() -> [u8; 2] {
+    let x: u16 = 0x1234;
+    let u: U = U { x };
+
+    let y = unsafe { u.y };
+    assert_eq!(y, x.to_ne_bytes());
+    y
+}
+
+fn main() {
+    println!("{:?}", foo());
+}

--- a/crux-mir/test/conc_eval/union/read_same.rs
+++ b/crux-mir/test/conc_eval/union/read_same.rs
@@ -1,0 +1,18 @@
+union U {
+    x: u16,
+    y: [u8; 2],
+}
+
+#[cfg_attr(crux, crux::test)]
+fn foo() -> u16 {
+    let x: u16 = 0x1234;
+    let u: U = U { x };
+
+    let x1 = unsafe { u.x };
+    assert_eq!(x, x1);
+    x1
+}
+
+fn main() {
+    println!("{}", foo());
+}

--- a/crux-mir/test/conc_eval/union/write_other.rs
+++ b/crux-mir/test/conc_eval/union/write_other.rs
@@ -1,0 +1,22 @@
+// FAIL: writing a non-active union field
+
+union U {
+    x: u16,
+    y: [u8; 2],
+}
+
+#[cfg_attr(crux, crux::test)]
+fn foo() -> u16 {
+    let mut u: U = U { x: 0xffff };
+    let x: u16 = 0x1234;
+    let y: [u8; 2] = x.to_ne_bytes();
+
+    u.y = y;
+    let x1 = unsafe { u.x };
+    assert_eq!(x, x1);
+    x1
+}
+
+fn main() {
+    println!("{}", foo());
+}

--- a/crux-mir/test/conc_eval/union/write_same.rs
+++ b/crux-mir/test/conc_eval/union/write_same.rs
@@ -1,0 +1,19 @@
+union U {
+    x: u16,
+    y: [u8; 2],
+}
+
+#[cfg_attr(crux, crux::test)]
+fn foo() -> u16 {
+    let mut u: U = U { x: 0xffff };
+    let x: u16 = 0x1234;
+
+    u.x = x;
+    let x1 = unsafe { u.x };
+    assert_eq!(x, x1);
+    x1
+}
+
+fn main() {
+    println!("{}", foo());
+}


### PR DESCRIPTION
These changes give union-type values a `MirAggregate` representation in Crucible, leveraging work discussed in #1498 and #1499 and implemented in part in #1503.

This means Crucible can now comprehend code involving union introduction. It can also, to a limited extent, comprehend code involving union elimination - only so long as the union is interpreted according to the type of the value originally used to initialize it. That is, it does not generally support the use of unions as a way to reinterpret blocks of memory, à la `std::mem::transmute`. I've included some xfail tests attesting to this.

This supersedes #1538, as it implements a more durable approach to handling unions.

Whether or not this fixes #1429 is up for some debate. I would suggest we close that issue, since this meaningfully addresses the overall problem, and open a new one for the specific task of supporting memory reinterpretation.