### PR TITLE
Unconditionally succeed when loading 0-sized values

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Common.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Common.hs
@@ -511,6 +511,8 @@ valueLoad ::
   ValueView {- ^ view of stored value -} ->
   ValueCtor (ValueLoad Addr)
 valueLoad lo ltp so v
+  -- The non-zero test ensures that 0-byte loads are always overlapping
+  -- with the most recent store so that they're not spuriously rejected.
   | le <= so && nonZeroLoad = ValueCtorVar (OldMemory lo ltp) -- Load ends before store
   | se <= lo && nonZeroLoad = ValueCtorVar (OldMemory lo ltp) -- Store ends before load
     -- Load is before store.

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Common.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Common.hs
@@ -511,8 +511,8 @@ valueLoad ::
   ValueView {- ^ view of stored value -} ->
   ValueCtor (ValueLoad Addr)
 valueLoad lo ltp so v
-  | le <= so = ValueCtorVar (OldMemory lo ltp) -- Load ends before store
-  | se <= lo = ValueCtorVar (OldMemory lo ltp) -- Store ends before load
+  | le <= so && nonZeroLoad = ValueCtorVar (OldMemory lo ltp) -- Load ends before store
+  | se <= lo && nonZeroLoad = ValueCtorVar (OldMemory lo ltp) -- Store ends before load
     -- Load is before store.
   | lo < so  = splitTypeValue ltp (so - lo) (\o tp -> valueLoad (lo+o) tp so v)
     -- Load ends after store ends.
@@ -534,6 +534,7 @@ valueLoad lo ltp so v
  where stp = fromMaybe (error ("Coerce value given bad view " ++ show v)) (viewType v)
        le = typeEnd lo ltp
        se = so + storageTypeSize stp
+       nonZeroLoad = le - lo > 0
 
 -- | @LinearLoadStoreOffsetDiff stride delta@ represents the fact that
 --   the difference between the load offset and the store offset is

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Generic.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Generic.hs
@@ -696,6 +696,21 @@ readMemInvalidate sym w end mop (LLVMPointer blk off) tp d msg sz readPrev =
       | otherwise
       = liftIO (Partial.partErr sym mop $ Invalidated msg)
 
+-- | Construct a value of a type that has no in-memory representation at all
+buildEmptyVal :: StorageType -> Maybe (LLVMVal sym)
+buildEmptyVal t =
+  case storageTypeF t of
+    Struct fields   -> LLVMValStruct <$> traverse emptyStorageField fields
+    Array n eltTy
+      | n == 0      -> Just (LLVMValArray eltTy V.empty)
+      | otherwise   -> LLVMValArray eltTy . V.replicate (fromIntegral n) <$> buildEmptyVal eltTy
+    X86_FP80        -> Nothing
+    Float           -> Nothing
+    Double          -> Nothing
+    Bitvector {}    -> Nothing -- Bitvectors can't be empty; they have a non-zero size invariant
+  where
+    emptyStorageField field = (,) field <$> buildEmptyVal (field ^. fieldVal)
+
 -- | Read a value from memory.
 readMem :: forall sym w.
   ( 1 <= w, IsSymInterface sym, HasLLVMAnn sym
@@ -708,6 +723,12 @@ readMem :: forall sym w.
   Alignment ->
   Mem sym ->
   IO (PartLLVMVal sym)
+readMem sym _ _ _ tp _ _
+  -- no actual memory read happens when reading a value with
+  -- no memory representation. This check comes up in
+  -- particular when evaluating llvm_points_to statements
+  -- in SAW script.
+  | Just v <- buildEmptyVal tp = pure (Partial.totalLLVMVal sym v)
 readMem sym w gsym l tp alignment m = do
   sz         <- bvLit sym w (bytesToBV w (typeEnd 0 tp))
   p1         <- isAllocated sym w alignment l (Just sz) m

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Generic.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Generic.hs
@@ -91,6 +91,7 @@ import           Data.Text (Text)
 import           Numeric.Natural
 import           Prettyprinter
 import           Lang.Crucible.Panic (panic)
+import qualified Data.Vector as V
 
 import           Data.BitVector.Sized (BV)
 import qualified Data.BitVector.Sized as BV

--- a/crux-llvm/test-data/golden/T1549.ll
+++ b/crux-llvm/test-data/golden/T1549.ll
@@ -1,0 +1,18 @@
+%struct.S = type { i32, i32, [0 x i8] }
+
+define i32 @main() {
+  ; Allocate a ptr large enough to hold a %struct.S value.
+  %sp = alloca %struct.S
+
+  ; Write a %struct.S value to the pointer whose fields are all zeroes.
+  store %struct.S { i32 0, i32 0, [0 x i8] [] }, ptr %sp
+
+  ; Write 0 to the second field of the struct (at offset 1).
+  %sp2 = getelementptr inbounds %struct.S, ptr %sp, i32 0, i32 1
+  store i32 0, ptr %sp2, align 4
+
+  ; Load a %struct.S value from the pointer after the write above.
+  %x = load %struct.S, ptr %sp, align 4
+
+  ret i32 0
+}

--- a/crux-llvm/test-data/golden/T1549.pre-clang15.z3.good
+++ b/crux-llvm/test-data/golden/T1549.pre-clang15.z3.good
@@ -1,0 +1,4 @@
+SKIP_TEST
+
+This test case requires the use of opaque pointers, which are most easily
+usable with LLVM 15 or later.

--- a/crux-llvm/test-data/golden/T1549.z3.good
+++ b/crux-llvm/test-data/golden/T1549.z3.good
@@ -1,0 +1,1 @@
+[Crux] Overall status: Valid.


### PR DESCRIPTION
These values have no representation in memory and thus do not need to depend on what's in memory at all.