### PR TITLE
`crucible-mir`: Properly support const generics

### DIFF
--- a/crucible-mir/CHANGELOG.md
+++ b/crucible-mir/CHANGELOG.md
@@ -1,7 +1,7 @@
 # next -- TBA
 
 This release supports [version
-3](https://github.com/GaloisInc/mir-json/blob/master/SCHEMA_CHANGELOG.md#3) of
+5](https://github.com/GaloisInc/mir-json/blob/master/SCHEMA_CHANGELOG.md#5) of
 `mir-json`'s schema.
 
 * Support simulating Rust code up to version 1.86.
@@ -40,6 +40,10 @@ This release supports [version
   `std::arch::asm!` macro). `crucible-mir` does not support _simulating_ inline
   assembly, but it can now translate code that uses it without crashing.
 * Implement basic support for creation and manipulation of union-type values.
+* `TyConst` now has a `ConstVal` field to indicate the value of the constant
+  used to instantiate a const generic parameter. This has no impact on the
+  semantics of `crucible-mir` itself, but this can be used by tools that want
+  to distinguish different instantiations of const generic functions.
 
 # 0.4 -- 2025-03-21
 

--- a/crucible-mir/src/Mir/JSON.hs
+++ b/crucible-mir/src/Mir/JSON.hs
@@ -74,7 +74,6 @@ instance FromJSON Substs where
 instance FromJSON Ty where
     parseJSON = withText "Ty" $ \v -> case v of
         "nonty::Lifetime" -> pure TyLifetime
-        "nonty::Const" -> pure TyConst
         _ -> pure $ TyInterned v
 
 newtype InlineTy = InlineTy { getInlineTy :: Ty }
@@ -104,6 +103,7 @@ instance FromJSON InlineTy where
       Just (String "Float") -> TyFloat <$> v .: "size"
       Just (String "Never") -> pure TyNever
       Just (String "Foreign") -> pure TyForeign
+      Just (String "Const") -> TyConst <$> v .: "constant"
       r -> fail $ "unsupported ty: " ++ show r
 
 instance FromJSON NamedTy where

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -101,8 +101,11 @@ data Ty =
       | TyNever
       | TyForeign       -- External types, of unknown size and alignment
 
+      | TyConst !ConstVal
+        -- ^ Represents constants in 'Substs'. This has no effect on the
+        -- semantics of @crucible-mir@, but it is used for looking up
+        -- instantiations of polymorphic functions or ADTs in SAW.
       | TyLifetime      -- Placeholder for representing lifetimes in `Substs`
-      | TyConst         -- Placeholder for representing constants in `Substs`
 
       -- | The erased concrete type of a trait object.  This is never emitted
       -- by mir-json.  It's used in vtable shims, to replace the type of the

--- a/crucible-mir/src/Mir/PP.hs
+++ b/crucible-mir/src/Mir/PP.hs
@@ -86,7 +86,11 @@ instance Pretty Ty where
     pretty (TyDowncast adt i)    = parens (pretty adt <+> pretty "as" <+> pretty i)
     pretty TyNever = pretty "never"
     pretty TyLifetime = pretty "lifetime"
-    pretty TyConst = pretty "const"
+    pretty (TyConst c) = braces (pretty c)
+      -- Using braces is redundant for constants like `2`, but it would be
+      -- somewhat annoying to implement the logic needed to check whether
+      -- braces are strictly required or not, so we err on the side of always
+      -- including braces.
     pretty TyForeign = pretty "foreign"
     pretty TyErased = pretty "erased"
     pretty (TyInterned s) = pretty s

--- a/crucible-mir/src/Mir/ParseTranslate.hs
+++ b/crucible-mir/src/Mir/ParseTranslate.hs
@@ -43,7 +43,7 @@ import Debug.Trace
 -- If you update the supported mir-json schema version below, make sure to also
 -- update the crux-mir README accordingly.
 supportedSchemaVersion :: Word64
-supportedSchemaVersion = 4
+supportedSchemaVersion = 5
 
 parseMIR :: (HasCallStack, ?debug::Int) =>
             FilePath

--- a/crux-mir/README.md
+++ b/crux-mir/README.md
@@ -49,7 +49,7 @@ Next, navigate to the `crucible/dependencies/mir-json` directory. Install
 [the `mir-json` README][mir-json-readme].
 
 Currently, `crux-mir` supports [version
-4](https://github.com/GaloisInc/mir-json/blob/master/SCHEMA_CHANGELOG.md#4) of
+5](https://github.com/GaloisInc/mir-json/blob/master/SCHEMA_CHANGELOG.md#5) of
 `mir-json`'s schema. Note that the schema versions produced by `mir-json` can
 change over time as dictated by internal requirements and upstream changes. To
 help smooth this over:

--- a/crux-mir/README.md
+++ b/crux-mir/README.md
@@ -158,7 +158,7 @@ To compile and test a single Rust program:
      │
   43 │     assert!(a == b);
      │             ^^^^^^
-  
+
   ✅ 100% example_1/ffs_fast[0]: 10/10
   ✅ 100% example_1/ffs_ref[0]: 4/4
   ✅  50% example_1/test_ffs_correct[0]: 1/2


### PR DESCRIPTION
This contains the `crucible-mir`-side changes needed to properly support const
generics, as detailed in https://github.com/GaloisInc/mir-json/issues/64.
Specifically, the `TyConst` data constructor now supports a `ConstVal` field
that describes the constant used to instantiate a const generic parameter. This
has no impact on the semantics of `crucible-mir` itself, but this `ConstVal`
can be used by downstream tools that wish to distinguish different
instantiations of const generic functions. (The primary use case is SAW's
`mir_find_adt` function.)

This bumps the `mir-json` submodule to bring in the changes from
https://github.com/GaloisInc/mir-json/pull/173. Because this requires a bump
to the MIR JSON schema version, corresponding changes to the version number
must also be made here.