### PR TITLE
Update how coverage is reported.

### DIFF
--- a/crux-mir/README.md
+++ b/crux-mir/README.md
@@ -161,14 +161,13 @@ To compile and test a single Rust program:
   
   ✅ 100% example_1/ffs_fast[0]: 10/10
   ✅ 100% example_1/ffs_ref[0]: 4/4
-  ✅  50% example_1/test_ffs_correct[0]: 1/2
+  🚧  50% example_1/test_ffs_correct[0]: 1/2
+  ❌  0% example_1/never_called_func[0]: 0/0
   ```
   In addition to warnings about uncovered paths, we generate statistics about
   the coverage for each function.   A green checkmark (✅) indicates that a
-  function was called during symbolic execution, while a red cross (❌) indicates
-  that a function was not visited at all.  For each function we also report
-  how many of the alternatives of all branches were visited, which is also
-  summarized as a percantage.
+  function was called during symbolic execution and *all* paths were covered, while a red cross (❌) indicates that a function was not visited at all. A construction sign (🚧) indicates a function that was called, but not all branches were covered.
+  For each function we also report how many of the alternatives of all branches were visited, which is also summarized as a percentage.
 
 * To limit the coverage only to the code in your crate, use `--filter` to point the tool to the file you want to analyze. Then you get a more condensed output, for example:
   ```

--- a/crux-mir/test/coverage/coverage.good
+++ b/crux-mir/test/coverage/coverage.good
@@ -4,4 +4,4 @@ warning: branch condition never has a value other than [1]
 11 │     } else if x == 1 {
    │               ^^^^^^
 
-✅  75% coverage/crux_test[0]: 3/4
+🚧  75% coverage/crux_test[0]: 3/4

--- a/crux-mir/test/coverage/coverage_cond.good
+++ b/crux-mir/test/coverage/coverage_cond.good
@@ -11,5 +11,5 @@ warning: branch condition never has value false
    │         ^^^^
 
 ✅ 100% coverage_cond/crux_test[0]: 0/0
-✅  50% coverage_cond/f[0]: 1/2
-✅  50% coverage_cond/g[0]: 1/2
+🚧  50% coverage_cond/f[0]: 1/2
+🚧  50% coverage_cond/g[0]: 1/2

--- a/crux-mir/test/coverage/coverage_loop.good
+++ b/crux-mir/test/coverage/coverage_loop.good
@@ -4,4 +4,4 @@ warning: branch condition never has value true
 12 │         } else if i > 99 {
    │                   ^^^^^^
 
-✅  87% coverage_loop/crux_test[0]: 7/8
+🚧  87% coverage_loop/crux_test[0]: 7/8

--- a/crux-mir/test/coverage/coverage_macro.good
+++ b/crux-mir/test/coverage/coverage_macro.good
@@ -8,4 +8,4 @@ warning: branch condition never has value false
    │     -------------------------- in this macro invocation
 
 ✅ 100% coverage_macro/crux_test[0]: 0/0
-✅  75% coverage_macro/f[0]: 3/4
+🚧  75% coverage_macro/f[0]: 3/4

--- a/crux-mir/test/coverage/coverage_match.good
+++ b/crux-mir/test/coverage/coverage_match.good
@@ -13,4 +13,4 @@ warning: branch condition never has value 20
 ❌   0% coverage_match/E[0]::A[0]::{constant#0}[0]: 0/0
 ❌   0% coverage_match/E[0]::B[0]::{constant#0}[0]: 0/0
 ❌   0% coverage_match/E[0]::C[0]::{constant#0}[0]: 0/0
-✅  71% coverage_match/crux_test[0]: 5/7
+🚧  71% coverage_match/crux_test[0]: 5/7

--- a/crux-mir/test/coverage/coverage_shortcircuit.good
+++ b/crux-mir/test/coverage/coverage_shortcircuit.good
@@ -4,4 +4,4 @@ warning: branch condition never has a value other than [0]
 9 │     if x == 0 || x == 1 {
   │        ^^^^^^
 
-✅  25% coverage_shortcircuit/crux_test[0]: 1/4
+🚧  25% coverage_shortcircuit/crux_test[0]: 1/4

--- a/crux-mir/test/coverage/coverage_try.good
+++ b/crux-mir/test/coverage/coverage_try.good
@@ -5,4 +5,4 @@ warning: branch condition never has value 1
    │                 ^^^^^^^^^^^^^^^^^^^^^
 
 ✅ 100% coverage_try/crux_test[0]: 0/0
-✅  75% coverage_try/f[0]: 3/4
+🚧  75% coverage_try/f[0]: 3/4


### PR DESCRIPTION
Incomplete coverage is marked with 🚧, for example:

🚧  75% ring/digest[0]::sha2[0]::rustcrypto_cryptol_test[0]::wrap_slice[0]: 3/4
✅ 100% ring/digest[0]::sha2[0]::rustcrypto_cryptol_test[0]::xxx[0]: 0/0
❌   0% ring/digest[0]::sha2[0]::rustcrypto_hs_test[0]::SIGMA_0_equiv[0]: 0/0