### PR TITLE
`crux-mir`: Always print error messages upon `mir-json` compilation failures

### DIFF
--- a/crux-mir/src/Mir/Generate.hs
+++ b/crux-mir/src/Mir/Generate.hs
@@ -35,6 +35,9 @@ import Mir.Mir
 import Mir.ParseTranslate (parseMIR)
 import Mir.PP()
 
+import qualified Crux.Config.Common as Crux (CruxOptions(..), OutputOptions(..))
+import qualified Crux.Config.Load as Crux (ColorOptions(..))
+
 import Debug.Trace
 
 
@@ -60,11 +63,18 @@ mirJsonOutFile rustFile = rustFile -<.> "mir"
 getRlibsDir :: (?defaultRlibsDir :: FilePath) => IO FilePath
 getRlibsDir = maybe ?defaultRlibsDir id <$> lookupEnv "CRUX_RUST_LIBRARY_PATH"
 
-compileMirJson :: (?defaultRlibsDir :: FilePath) => Bool -> FilePath -> IO ()
-compileMirJson keepRlib rustFile = do
+compileMirJson :: (?defaultRlibsDir :: FilePath) => Crux.CruxOptions -> Bool -> FilePath -> IO ()
+compileMirJson cruxOpts keepRlib rustFile = do
     let outFile = rustFile -<.> "bin"
 
     rlibsDir <- getRlibsDir
+    -- rustc produces colorful error messages, so preserve the colors whenever
+    -- possible when printing the error messages back out to the user.
+    let colorOpts
+          | Crux.noColorsErr $ Crux.colorOptions $ Crux.outputOptions cruxOpts
+          = []
+          | otherwise
+          = ["--color=always"]
     -- TODO: don't hardcode -L library path
     let cp =
           Proc.proc "mir-json" $
@@ -74,18 +84,15 @@ compileMirJson keepRlib rustFile = do
                 , lib ++ "=" ++ rlibsDir </> "lib" ++ lib <.> "rlib"
                 ]
               | lib <- libDependencies ] ++
+            colorOpts ++
             [ "--cfg", "crux", "--cfg", "crux_top_level"
             , "-Z", "ub-checks=false"
             , "-o", outFile]
-    (ec, sout, serr) <- Proc.readCreateProcessWithExitCode cp ""
+    (ec, _sout, serr) <- Proc.readCreateProcessWithExitCode cp ""
     case ec of
-        ExitFailure cd -> fail $ unlines $
-            [ "Error " ++ show cd ++ " while running mir-json on " ++ rustFile
-            , "*** Standard out:"
-            ] ++
-            [ "   " ++ l | l <- lines sout ] ++
-            [ "*** Standard error:" ] ++
-            [ "   " ++ l | l <- lines serr ]
+        ExitFailure cd -> do
+            hPutStrLn stderr serr
+            fail $ "Error " ++ show cd ++ " while running mir-json on " ++ rustFile
         ExitSuccess    -> return ()
 
     when (not keepRlib) $ do
@@ -93,10 +100,10 @@ compileMirJson keepRlib rustFile = do
             True  -> removeFile outFile
             False -> return ()
 
-maybeCompileMirJson :: (?defaultRlibsDir :: FilePath) => Bool -> FilePath -> IO ()
-maybeCompileMirJson keepRlib rustFile = do
+maybeCompileMirJson :: (?defaultRlibsDir :: FilePath) => Crux.CruxOptions -> Bool -> FilePath -> IO ()
+maybeCompileMirJson cruxOpts keepRlib rustFile = do
     build <- needsRebuild (mirJsonOutFile rustFile) [rustFile]
-    when build $ compileMirJson keepRlib rustFile
+    when build $ compileMirJson cruxOpts keepRlib rustFile
 
 
 linkJson :: [FilePath] -> IO B.ByteString
@@ -168,15 +175,16 @@ libDependencies =
 -- last .mir file was created, this function does nothing
 -- This function uses 'failIO' if any error occurs
 generateMIR :: (HasCallStack, ?debug::Int, ?defaultRlibsDir :: FilePath) =>
-               FilePath          -- ^ location of input file
+               Crux.CruxOptions
+            -> FilePath          -- ^ location of input file
             -> Bool              -- ^ `True` to keep the generated .rlib
             -> IO Collection
-generateMIR inputFile keepRlib
+generateMIR cruxOpts inputFile keepRlib
   | ext == ".rs" = do
     when (?debug > 2) $
         traceM $ "Generating " ++ stem <.> "mir"
     let rustFile = inputFile
-    maybeCompileMirJson keepRlib rustFile
+    maybeCompileMirJson cruxOpts keepRlib rustFile
     rlibsDir <- getRlibsDir
     let libJsonPaths = [rlibsDir </> "lib" ++ lib <.> "mir" | lib <- libDependencies]
     b <- maybeLinkJson (mirJsonOutFile rustFile : libJsonPaths) (linkOutFile rustFile)

--- a/crux-mir/src/Mir/Language.hs
+++ b/crux-mir/src/Mir/Language.hs
@@ -255,7 +255,7 @@ runTestsWithExtraOverrides initS bindExtra (cruxOpts, mirOpts) = do
                 ifs -> error $ "expected exactly 1 input file, but got " ++ show (length ifs) ++ " files"
 
     -- Load the MIR collection
-    col <- generateMIR filename False
+    col <- generateMIR cruxOpts filename False
 
     when (onlyPP mirOpts) $ do
       -- TODO: make this exit more gracefully somehow


### PR DESCRIPTION
Previously, compiler errors would only be shown if the user explicitly opted into them using `--sim-verbose=3` or higher. This is a fairly counterintuitive default setting, as it means that users who run `crux-mir` on a malformed Rust file (a fairly common occurrence) will have to scratch their heads until they realize why `crux-mir` isn't showing them what went wrong.

This patch changes `crux-mir` to unconditionally show compiler error messages when compilation fails, regardless of the `--sim-verbose` level. I have adopted a convention for formatting the standard output/standard error of `mir-json` that is very similar to what `crux-llvm` uses when it unsucessfully compiles something using a `clang` subprocess.

Fixes #1084.