### PR TITLE
`crucible-llvm`: Fix the semantics of the `llvm.is.fpclass` override

### DIFF
--- a/crucible-llvm/CHANGELOG.md
+++ b/crucible-llvm/CHANGELOG.md
@@ -10,6 +10,9 @@
   `loadBytes`.
 * Support simulating LLVM bitcode files whose data layout strings specify
   function pointer alignment.
+* Fix a bug that would cause the simuator to compute incorrect results for the
+  `llvm.is.fpclass` intrinsic. (Among other things, this is used to power the
+  `isnan` function in Clang 17 or later.)
 
 # 0.7.1 -- 2025-03-21
 

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/LLVM.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Intrinsics/LLVM.hs
@@ -1933,8 +1933,8 @@ callIsFpclass ::
 callIsFpclass regOp@(regValue -> op) (regValue -> test) = do
   sym <- getSymInterface
   let w1 = knownNat @1
-  bv1 <- liftIO $ bvZero sym w1
-  bv0 <- liftIO $ bvOne sym w1
+  bv1 <- liftIO $ bvOne sym w1
+  bv0 <- liftIO $ bvZero sym w1
 
   let negative bit = liftIO $ do
         isNeg <- iFloatIsNeg @_ @fi sym op


### PR DESCRIPTION
Fix a couple of subtle typos (introduced in https://github.com/GaloisInc/crucible/commit/6eca1935b6e7d1b56934ec3d03d2c9f5091f2760) that causes the definitions of 1-bit zero and one to be swapped, resulting in the semantics for the `llvm.is.fpclass` intrinsic to be utterly wrong. This allows the `llvm.is.fpclass` test case to succeed on Clang 17 or later:

```
$ PATH=~/Software/clang+llvm-17.0.2/bin:$PATH cabal -v0 run crux-llvm-test -- -p llvm.is.fpclass
<snip>
crux-llvm
  clang 17.0.2
    llvm.is.fpclass.ll
      solver=z3
        loop-merging=loop
          clang-range=recent-clang
            z3 4.8.14
              llvm.is.fpclass
                llvm.is.fpclass crux run:    OK (0.14s)
                llvm.is.fpclass crux output: OK
        loop-merging=loopmerge
          clang-range=recent-clang
            z3 4.8.14
              llvm.is.fpclass
                llvm.is.fpclass crux run:    OK (0.15s)
                llvm.is.fpclass crux output: OK

All 4 tests passed (0.29s)
```

Fixes #1586.