### PR TITLE
`crucible-llvm`: Support vectorized `llvm.{umin,umax,smin,max}` intrinsics

### DIFF
--- a/crucible-llvm/CHANGELOG.md
+++ b/crucible-llvm/CHANGELOG.md
@@ -13,6 +13,8 @@
 * Fix a bug that would cause the simuator to compute incorrect results for the
   `llvm.is.fpclass` intrinsic. (Among other things, this is used to power the
   `isnan` function in Clang 17 or later.)
+* Support vectorized versions of the `llvm.u{min,max}` and `llvm.s{min,max}`
+  intrinsics.
 
 # 0.7.1 -- 2025-03-21
 


### PR DESCRIPTION
Doing so allows `crux-llvm`'s `T1177.c` test case to pass with LLVM 16 or later, as Clang 16+ is more likely to generate uses of these intrinsics in optimized code.

Fixes #1589.