### PR TITLE
debug: Export `Inputs`, `Outputs`

### DIFF
--- a/crucible-debug/src/Lang/Crucible/Debug.hs
+++ b/crucible-debug/src/Lang/Crucible/Debug.hs
@@ -17,9 +17,11 @@ module Lang.Crucible.Debug
   ( debugger
   , bareDebuggerExt
   , bareDebugger
+  , Inps.Inputs(..)
   , Inps.defaultDebuggerInputs
   , Inps.prepend
   , Outps.prettyOut
+  , Outps.Outputs(..)
   , Outps.defaultDebuggerOutputs
   , Arg.Arg(..)
   , AType.ArgTypeRepr(..)

--- a/crucible-debug/src/Lang/Crucible/Debug/Inputs.hs
+++ b/crucible-debug/src/Lang/Crucible/Debug/Inputs.hs
@@ -11,8 +11,7 @@ Maintainer       : Langston Barrett <langston@galois.com>
 {-# LANGUAGE TypeApplications #-}
 
 module Lang.Crucible.Debug.Inputs
-  ( Inputs
-  , recv
+  ( Inputs(..)
   , fail
   , parseInputs
   , parseInputsWithRetry

--- a/crucible-debug/src/Lang/Crucible/Debug/Outputs.hs
+++ b/crucible-debug/src/Lang/Crucible/Debug/Outputs.hs
@@ -8,8 +8,7 @@ Maintainer       : Langston Barrett <langston@galois.com>
 {-# LANGUAGE OverloadedStrings #-}
 
 module Lang.Crucible.Debug.Outputs
-  ( Outputs
-  , send
+  ( Outputs(..)
   , lift
   , accumulate
   , hPutStrLn


### PR DESCRIPTION
To make it easier to embed the debugger in other programs.