### PR TITLE
`crucible-llvm`: Remove `LLVM_{Dbg,Debug}`

### DIFF
--- a/crucible-llvm-cli/src/Lang/Crucible/LLVM/CLI.hs
+++ b/crucible-llvm-cli/src/Lang/Crucible/LLVM/CLI.hs
@@ -101,7 +101,6 @@ withLlvmHooks k = do
                     , _llvmTypeCtx = tyCtx
                     , llvmGlobalAliases = Map.empty
                     , llvmFunctionAliases = Map.empty
-                    , llvmUnnamedMd = IntMap.empty
                     }
               let ?lc = tyCtx
               let ?memOpts = Mem.defaultMemOptions

--- a/crucible-llvm/CHANGELOG.md
+++ b/crucible-llvm/CHANGELOG.md
@@ -1,5 +1,8 @@
 # next
 
+* The `LLVM_Debug` data constructor for `LLVMStmt`, as well as the related
+  `LLVM_Dbg` data type, have been removed.
+
 # 0.8.0 -- 2025-11-09
 
 * `Lang.Crucible.LLVM.MemModel.{loadString,loadMaybeString,strLen}`

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Extension/Syntax.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Extension/Syntax.hs
@@ -230,43 +230,6 @@ data LLVMStmt (f :: CrucibleType -> Type) :: CrucibleType -> Type where
      !(f (LLVMPointerType wptr)) {- Second pointer -} ->
      LLVMStmt f (BVType wptr)
 
-  -- | Debug information
-  LLVM_Debug ::
-    !(LLVM_Dbg f c)              {- Debug variant -} ->
-    LLVMStmt f UnitType
-
--- | Debug statement variants - these have no semantic meaning
-data LLVM_Dbg f c where
-  -- | Annotates a value pointed to by a pointer with local-variable debug information
-  --
-  -- <https://llvm.org/docs/SourceLevelDebugging.html#llvm-dbg-addr>
-  LLVM_Dbg_Addr ::
-    HasPtrWidth wptr =>
-    !(f (LLVMPointerType wptr))  {- Pointer to local variable -} ->
-    L.DILocalVariable            {- Local variable information -} ->
-    L.DIExpression               {- Complex expression -} ->
-    LLVM_Dbg f (LLVMPointerType wptr)
-
-  -- | Annotates a value pointed to by a pointer with local-variable debug information
-  --
-  -- <https://llvm.org/docs/SourceLevelDebugging.html#llvm-dbg-declare>
-  LLVM_Dbg_Declare ::
-    HasPtrWidth wptr =>
-    !(f (LLVMPointerType wptr))  {- Pointer to local variable -} ->
-    L.DILocalVariable            {- Local variable information -} ->
-    L.DIExpression               {- Complex expression -} ->
-    LLVM_Dbg f (LLVMPointerType wptr)
-
-  -- | Annotates a value with local-variable debug information
-  --
-  -- <https://llvm.org/docs/SourceLevelDebugging.html#llvm-dbg-value>
-  LLVM_Dbg_Value ::
-    !(TypeRepr c)                {- Type of local variable -} ->
-    !(f c)                       {- Value of local variable -} ->
-    L.DILocalVariable            {- Local variable information -} ->
-    L.DIExpression               {- Complex expression -} ->
-    LLVM_Dbg f c
-
 $(return [])
 
 instance TypeApp LLVMExtensionExpr where
@@ -357,7 +320,6 @@ instance TypeApp LLVMStmt where
     LLVM_PtrLe{} -> knownRepr
     LLVM_PtrAddOffset w _ _ _ -> LLVMPointerRepr w
     LLVM_PtrSubtract w _ _ _ -> BVRepr w
-    LLVM_Debug{} -> knownRepr
 
 instance PrettyApp LLVMStmt where
   ppApp pp = \case
@@ -385,13 +347,6 @@ instance PrettyApp LLVMStmt where
        pretty "ptrAddOffset" <+> ppGlobalVar mvar <+> pp x <+> pp y
     LLVM_PtrSubtract _ mvar x y ->
        pretty "ptrSubtract" <+> ppGlobalVar mvar <+> pp x <+> pp y
-    LLVM_Debug dbg -> ppApp pp dbg
-
-instance PrettyApp LLVM_Dbg where
-  ppApp pp = \case
-    LLVM_Dbg_Addr    x _ _ -> pretty "dbg.addr"    <+> pp x
-    LLVM_Dbg_Declare x _ _ -> pretty "dbg.declare" <+> pp x
-    LLVM_Dbg_Value _ x _ _ -> pretty "dbg.value"   <+> pp x
 
 -- TODO: move to a Pretty instance
 ppGlobalVar :: GlobalVar Mem -> Doc ann
@@ -401,26 +356,6 @@ ppGlobalVar = viaShow
 ppAlignment :: Alignment -> Doc ann
 ppAlignment = viaShow
 
-instance TestEqualityFC LLVM_Dbg where
-  testEqualityFC testSubterm = $(U.structuralTypeEquality [t|LLVM_Dbg|]
-    [(U.DataArg 0 `U.TypeApp` U.AnyType, [|testSubterm|])
-    ,(U.ConType [t|TypeRepr|] `U.TypeApp` U.AnyType, [|testEquality|])
-    ])
-
-instance OrdFC LLVM_Dbg where
-  compareFC compareSubterm = $(U.structuralTypeOrd [t|LLVM_Dbg|]
-    [(U.DataArg 0 `U.TypeApp` U.AnyType, [|compareSubterm|])
-    ,(U.ConType [t|TypeRepr|] `U.TypeApp` U.AnyType, [|compareF|])
-    ])
-
-instance FoldableFC LLVM_Dbg where
-  foldMapFC = foldMapFCDefault
-instance FunctorFC LLVM_Dbg where
-  fmapFC = fmapFCDefault
-
-instance TraversableFC LLVM_Dbg where
-  traverseFC = $(U.structuralTraversal [t|LLVM_Dbg|] [])
-
 instance TestEqualityFC LLVMStmt where
   testEqualityFC testSubterm =
     $(U.structuralTypeEquality [t|LLVMStmt|]
@@ -429,7 +364,6 @@ instance TestEqualityFC LLVMStmt where
        ,(U.ConType [t|GlobalVar|] `U.TypeApp` U.AnyType, [|testEquality|])
        ,(U.ConType [t|CtxRepr|] `U.TypeApp` U.AnyType, [|testEquality|])
        ,(U.ConType [t|TypeRepr|] `U.TypeApp` U.AnyType, [|testEquality|])
-       ,(U.ConType [t|LLVM_Dbg|] `U.TypeApp` U.DataArg 0 `U.TypeApp` U.AnyType, [|testEqualityFC testSubterm|])
        ])
 
 instance OrdFC LLVMStmt where
@@ -440,7 +374,6 @@ instance OrdFC LLVMStmt where
        ,(U.ConType [t|GlobalVar|] `U.TypeApp` U.AnyType, [|compareF|])
        ,(U.ConType [t|CtxRepr|] `U.TypeApp` U.AnyType, [|compareF|])
        ,(U.ConType [t|TypeRepr|] `U.TypeApp` U.AnyType, [|compareF|])
-       ,(U.ConType [t|LLVM_Dbg|] `U.TypeApp` U.DataArg 0 `U.TypeApp` U.AnyType, [|compareFC compareSubterm|])
        ])
 
 instance FunctorFC LLVMStmt where
@@ -451,6 +384,4 @@ instance FoldableFC LLVMStmt where
 
 instance TraversableFC LLVMStmt where
   traverseFC =
-    $(U.structuralTraversal [t|LLVMStmt|]
-      [(U.ConType [t|LLVM_Dbg|] `U.TypeApp` U.DataArg 0 `U.TypeApp` U.AnyType, [|traverseFC|])
-      ])
+    $(U.structuralTraversal [t|LLVMStmt|] [])

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
@@ -533,8 +533,6 @@ evalStmt bak = eval
     do mem <- getMem mvar
        liftIO $ doPtrSubtract bak mem x y
 
-  eval LLVM_Debug{} = pure ()
-
 
 mkMemVar :: Text
          -> HandleAllocator

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Monad.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Monad.hs
@@ -53,8 +53,6 @@ import Control.Monad (unless)
 import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.State.Strict (MonadState(..))
 import Data.IORef (IORef, modifyIORef)
-import Data.IntMap.Strict (IntMap)
-import qualified Data.IntMap.Strict as IntMap
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Set (Set)
@@ -97,9 +95,6 @@ data LLVMContext arch
      -- | For each function symbol, compute the set of
      --   aliases to that symbol
    , llvmFunctionAliases :: Map L.Symbol (Set L.GlobalAlias)
-     -- | Map the index of each piece of unnamed LLVM metadata to its value.
-     -- This information is used to resolve the arguments to debug intrinsics.
-   , llvmUnnamedMd :: IntMap L.ValMd
    }
 
 llvmTypeCtx :: Simple Lens (LLVMContext arch) TypeContext
@@ -113,8 +108,6 @@ mkLLVMContext mvar m = do
   unless (null errs) $
     malformedLLVMModule "Failed to construct LLVM type context" errs
   let dl = llvmDataLayout typeCtx
-  let unnamedMd =
-        IntMap.fromList [(L.umIndex um, L.umValues um) | um <- L.modUnnamedMd m]
 
   case mkNatRepr (ptrBitwidth dl) of
     Some (wptr :: NatRepr wptr) | Just LeqProof <- testLeq (knownNat @16) wptr ->
@@ -130,7 +123,6 @@ mkLLVMContext mvar m = do
                      , _llvmTypeCtx = typeCtx
                      , llvmGlobalAliases = mempty   -- these are computed later
                      , llvmFunctionAliases = mempty -- these are computed later
-                     , llvmUnnamedMd = unnamedMd
                      }
            return (Some ctx)
     _ ->

--- a/crux-llvm/test-data/golden/shrink.z3.good
+++ b/crux-llvm/test-data/golden/shrink.z3.good
@@ -1,2 +1,1 @@
-[Crux] Translation warning at shrink.c:0:0 in @addflt: dbg intrinsic def/use violation for: %sub2.neg
 [Crux] Overall status: Valid.


### PR DESCRIPTION
These existed solely for the benefit of Heapster, which has now been removed from SAW. It proves non-trivial to maintain this code, so let's remove it.

Fixes #1610.