### PR TITLE
ci: capture more `crux-mir` output for `symb_eval` golden tests

### DIFF
--- a/crux-mir/test/Test.hs
+++ b/crux-mir/test/Test.hs
@@ -74,7 +74,7 @@ runCrux rustFile outHandle mode =
     -- The timeout is temporarily increased even further due to a performance
     -- regression (#627).  This keeps CI from breaking while we investigate.
     -- TODO: revert the timeout to 180 once performance is fixed
-    let quiet = True
+    let quiet = False
     let outOpts = (Crux.outputOptions defaultCruxOptions)
                     { Crux.simVerbose = 0
                     , Crux.quietMode = quiet

--- a/crux-mir/test/symb_eval/alloc/out_of_bounds.good
+++ b/crux-mir/test/symb_eval/alloc/out_of_bounds.good
@@ -1,4 +1,5 @@
-test out_of_bounds/<DISAMB>::crux_test[0]: FAILED
+test out_of_bounds/<DISAMB>::crux_test[0]: [Crux] Attempting to prove verification conditions.
+FAILED
 
 failures:
 
@@ -10,4 +11,11 @@ failures:
 [Crux]   test/symb_eval/alloc/out_of_bounds.rs:12:9: 12:24: error: in out_of_bounds/<DISAMB>::crux_test[0]
 [Crux]   attempted to read empty mux tree
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 2
+[Crux]   Proved: 0
+[Crux]   Disproved: 2
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/alloc/uninit_read.good
+++ b/crux-mir/test/symb_eval/alloc/uninit_read.good
@@ -1,4 +1,5 @@
-test uninit_read/<DISAMB>::crux_test[0]: FAILED
+test uninit_read/<DISAMB>::crux_test[0]: [Crux] Attempting to prove verification conditions.
+FAILED
 
 failures:
 
@@ -10,4 +11,11 @@ failures:
 [Crux]   test/symb_eval/alloc/uninit_read.rs:9:9: 9:23: error: in uninit_read/<DISAMB>::crux_test[0]
 [Crux]   attempted to read empty mux tree
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 2
+[Crux]   Proved: 0
+[Crux]   Disproved: 2
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/alloc/valid_read.good
+++ b/crux-mir/test/symb_eval/alloc/valid_read.good
@@ -1,3 +1,5 @@
 test valid_read/<DISAMB>::crux_test[0]: returned 45, ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/alloc/zero_length.good
+++ b/crux-mir/test/symb_eval/alloc/zero_length.good
@@ -1,3 +1,5 @@
 test zero_length/<DISAMB>::crux_test[0]: ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/any/conditional.good
+++ b/crux-mir/test/symb_eval/any/conditional.good
@@ -1,3 +1,5 @@
 test conditional/<DISAMB>::crux_test[0]: ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/any/downcast.good
+++ b/crux-mir/test/symb_eval/any/downcast.good
@@ -1,3 +1,5 @@
 test downcast/<DISAMB>::crux_test[0]: returned 1, ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/any/downcast_fail.good
+++ b/crux-mir/test/symb_eval/any/downcast_fail.good
@@ -1,4 +1,5 @@
-test downcast_fail/<DISAMB>::crux_test[0]: FAILED
+test downcast_fail/<DISAMB>::crux_test[0]: [Crux] Attempting to prove verification conditions.
+FAILED
 
 failures:
 
@@ -7,4 +8,11 @@ failures:
 [Crux]   test/symb_eval/any/downcast_fail.rs:10:14: 10:33: error: in downcast_fail/<DISAMB>::crux_test[0]
 [Crux]   failed to downcast Any as BVRepr 32
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 1
+[Crux]   Proved: 0
+[Crux]   Disproved: 1
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/array/basic.good
+++ b/crux-mir/test/symb_eval/array/basic.good
@@ -1,3 +1,5 @@
 test basic/<DISAMB>::crux_test[0]: returned 3, ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/array/mux_slice.good
+++ b/crux-mir/test/symb_eval/array/mux_slice.good
@@ -1,3 +1,11 @@
-test mux_slice/<DISAMB>::crux_test[0]: returned Symbolic BV, ok
+test mux_slice/<DISAMB>::crux_test[0]: returned Symbolic BV, [Crux] Attempting to prove verification conditions.
+ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 1
+[Crux]   Proved: 1
+[Crux]   Disproved: 0
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/array/slice.good
+++ b/crux-mir/test/symb_eval/array/slice.good
@@ -1,3 +1,5 @@
 test slice/<DISAMB>::crux_test[0]: returned 5, ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/array/slice_mut.good
+++ b/crux-mir/test/symb_eval/array/slice_mut.good
@@ -1,3 +1,5 @@
 test slice_mut/<DISAMB>::crux_test[0]: returned 5, ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/array/symbolic.good
+++ b/crux-mir/test/symb_eval/array/symbolic.good
@@ -1,3 +1,11 @@
-test symbolic/<DISAMB>::crux_test[0]: ok
+test symbolic/<DISAMB>::crux_test[0]: [Crux] Attempting to prove verification conditions.
+ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 4
+[Crux]   Proved: 4
+[Crux]   Disproved: 0
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/bitvector/arith.good
+++ b/crux-mir/test/symb_eval/bitvector/arith.good
@@ -1,3 +1,11 @@
-test arith/<DISAMB>::crux_test[0]: ok
+test arith/<DISAMB>::crux_test[0]: [Crux] Attempting to prove verification conditions.
+ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 11
+[Crux]   Proved: 11
+[Crux]   Disproved: 0
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/bitvector/cmp.good
+++ b/crux-mir/test/symb_eval/bitvector/cmp.good
@@ -1,3 +1,11 @@
-test cmp/<DISAMB>::crux_test[0]: ok
+test cmp/<DISAMB>::crux_test[0]: [Crux] Attempting to prove verification conditions.
+ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 2
+[Crux]   Proved: 2
+[Crux]   Disproved: 0
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/bitvector/from_to.good
+++ b/crux-mir/test/symb_eval/bitvector/from_to.good
@@ -1,3 +1,5 @@
 test from_to/<DISAMB>::crux_test[0]: ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/bitvector/leading_zeros.good
+++ b/crux-mir/test/symb_eval/bitvector/leading_zeros.good
@@ -1,3 +1,11 @@
-test leading_zeros/<DISAMB>::crux_test[0]: ok
+test leading_zeros/<DISAMB>::crux_test[0]: [Crux] Attempting to prove verification conditions.
+ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 2
+[Crux]   Proved: 2
+[Crux]   Disproved: 0
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/bitvector/literals.good
+++ b/crux-mir/test/symb_eval/bitvector/literals.good
@@ -1,3 +1,5 @@
 test literals/<DISAMB>::crux_test[0]: ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/bitvector/overflowing_sub.good
+++ b/crux-mir/test/symb_eval/bitvector/overflowing_sub.good
@@ -1,3 +1,11 @@
-test overflowing_sub/<DISAMB>::crux_test[0]: ok
+test overflowing_sub/<DISAMB>::crux_test[0]: [Crux] Attempting to prove verification conditions.
+ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 2
+[Crux]   Proved: 2
+[Crux]   Disproved: 0
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/bitvector/symbolic.good
+++ b/crux-mir/test/symb_eval/bitvector/symbolic.good
@@ -1,3 +1,11 @@
-test symbolic/<DISAMB>::crux_test[0]: ok
+test symbolic/<DISAMB>::crux_test[0]: [Crux] Attempting to prove verification conditions.
+ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 1
+[Crux]   Proved: 1
+[Crux]   Disproved: 0
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/byteorder/read.good
+++ b/crux-mir/test/symb_eval/byteorder/read.good
@@ -1,3 +1,5 @@
 test read/<DISAMB>::crux_test[0]: returned 0, ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/byteorder/write.good
+++ b/crux-mir/test/symb_eval/byteorder/write.good
@@ -1,3 +1,5 @@
 test write/<DISAMB>::crux_test[0]: returned 0, ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/bytes/extend_bytes.good
+++ b/crux-mir/test/symb_eval/bytes/extend_bytes.good
@@ -1,3 +1,5 @@
 test extend_bytes/<DISAMB>::f[0]: ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/bytes/new.good
+++ b/crux-mir/test/symb_eval/bytes/new.good
@@ -1,3 +1,5 @@
 test new/<DISAMB>::f[0]: ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/bytes/put.good
+++ b/crux-mir/test/symb_eval/bytes/put.good
@@ -1,3 +1,5 @@
 test put/<DISAMB>::f[0]: ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/bytes/put_overflow.good
+++ b/crux-mir/test/symb_eval/bytes/put_overflow.good
@@ -1,4 +1,5 @@
-test put_overflow/<DISAMB>::f[0]: FAILED
+test put_overflow/<DISAMB>::f[0]: [Crux] Attempting to prove verification conditions.
+FAILED
 
 failures:
 
@@ -7,4 +8,11 @@ failures:
 [Crux]   ./libs/core/src/panic.rs:107:9: 107:73 !./libs/bytes.rs:201:9: 202:49: error: in bytes/<DISAMB>::{impl#4}[0]::put_slice[0]
 [Crux]   panicking::panic_fmt, called from bytes/<DISAMB>::{impl#4}[0]::put_slice[0]
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 1
+[Crux]   Proved: 0
+[Crux]   Disproved: 1
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/bytes/split_off.good
+++ b/crux-mir/test/symb_eval/bytes/split_off.good
@@ -1,3 +1,5 @@
 test split_off/<DISAMB>::f[0]: ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/bytes/split_to.good
+++ b/crux-mir/test/symb_eval/bytes/split_to.good
@@ -1,3 +1,5 @@
 test split_to/<DISAMB>::f[0]: ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/bytes/sym_len.good
+++ b/crux-mir/test/symb_eval/bytes/sym_len.good
@@ -1,3 +1,11 @@
-test sym_len/<DISAMB>::f[0]: ok
+test sym_len/<DISAMB>::f[0]: [Crux] Attempting to prove verification conditions.
+ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 30
+[Crux]   Proved: 30
+[Crux]   Disproved: 0
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/concretize/array.good
+++ b/crux-mir/test/symb_eval/concretize/array.good
@@ -1,3 +1,11 @@
-test array/<DISAMB>::crux_test[0]: returned (1, 2, 3), ok
+test array/<DISAMB>::crux_test[0]: returned (1, 2, 3), [Crux] Attempting to prove verification conditions.
+ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 2
+[Crux]   Proved: 2
+[Crux]   Disproved: 0
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/concretize/assert.good
+++ b/crux-mir/test/symb_eval/concretize/assert.good
@@ -1,4 +1,5 @@
-test assert/<DISAMB>::crux_test[0]: returned 1, FAILED
+test assert/<DISAMB>::crux_test[0]: returned 1, [Crux] Attempting to prove verification conditions.
+FAILED
 
 failures:
 
@@ -8,4 +9,11 @@ failures:
 [Crux]   MIR assertion at test/symb_eval/concretize/assert.rs:10:5:
 [Crux]   	100 + 157 == 1
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 1
+[Crux]   Proved: 0
+[Crux]   Disproved: 1
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/concretize/assert_ok.good
+++ b/crux-mir/test/symb_eval/concretize/assert_ok.good
@@ -1,3 +1,11 @@
-test assert_ok/<DISAMB>::crux_test[0]: returned 1, ok
+test assert_ok/<DISAMB>::crux_test[0]: returned 1, [Crux] Attempting to prove verification conditions.
+ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 187
+[Crux]   Proved: 187
+[Crux]   Disproved: 0
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/concretize/assert_refs.good
+++ b/crux-mir/test/symb_eval/concretize/assert_refs.good
@@ -1,4 +1,5 @@
-test assert_refs/<DISAMB>::crux_test[0]: FAILED
+test assert_refs/<DISAMB>::crux_test[0]: [Crux] Attempting to prove verification conditions.
+FAILED
 
 failures:
 
@@ -8,4 +9,11 @@ failures:
 [Crux]   MIR assertion at test/symb_eval/concretize/assert_refs.rs:12:5:
 [Crux]   	42 42 [42] [42]
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 1
+[Crux]   Proved: 0
+[Crux]   Disproved: 1
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/concretize/conc.good
+++ b/crux-mir/test/symb_eval/concretize/conc.good
@@ -1,3 +1,11 @@
-test conc/<DISAMB>::crux_test[0]: returned (1, 0), ok
+test conc/<DISAMB>::crux_test[0]: returned (1, 0), [Crux] Attempting to prove verification conditions.
+ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 1
+[Crux]   Proved: 1
+[Crux]   Disproved: 0
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/concretize/no_conc.good
+++ b/crux-mir/test/symb_eval/concretize/no_conc.good
@@ -1,3 +1,11 @@
-test no_conc/<DISAMB>::crux_test[0]: returned (Symbolic BV, Symbolic BV), ok
+test no_conc/<DISAMB>::crux_test[0]: returned (Symbolic BV, Symbolic BV), [Crux] Attempting to prove verification conditions.
+ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 3
+[Crux]   Proved: 3
+[Crux]   Disproved: 0
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/concretize/static_ref.good
+++ b/crux-mir/test/symb_eval/concretize/static_ref.good
@@ -1,3 +1,5 @@
 test static_ref/<DISAMB>::f[0]: returned 0, ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/crux/early_fail.good
+++ b/crux-mir/test/symb_eval/crux/early_fail.good
@@ -1,5 +1,7 @@
-test early_fail/<DISAMB>::fail1[0]: FAILED
-test early_fail/<DISAMB>::fail2[0]: FAILED
+test early_fail/<DISAMB>::fail1[0]: [Crux] Attempting to prove verification conditions.
+FAILED
+test early_fail/<DISAMB>::fail2[0]: [Crux] Attempting to prove verification conditions.
+FAILED
 
 failures:
 
@@ -14,4 +16,11 @@ failures:
 [Crux]   MIR assertion at test/symb_eval/crux/early_fail.rs:17:5:
 [Crux]   	x == 0
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 2
+[Crux]   Proved: 0
+[Crux]   Disproved: 2
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/crux/fail_return.good
+++ b/crux-mir/test/symb_eval/crux/fail_return.good
@@ -1,5 +1,7 @@
-test fail_return/<DISAMB>::fail1[0]: returned Symbolic BV, FAILED
-test fail_return/<DISAMB>::fail2[0]: returned 123, FAILED
+test fail_return/<DISAMB>::fail1[0]: returned Symbolic BV, [Crux] Attempting to prove verification conditions.
+FAILED
+test fail_return/<DISAMB>::fail2[0]: returned 123, [Crux] Attempting to prove verification conditions.
+FAILED
 
 failures:
 
@@ -21,4 +23,11 @@ failures:
 [Crux]   MIR assertion at test/symb_eval/crux/fail_return.rs:15:5:
 [Crux]   	x + 1 > x
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 4
+[Crux]   Proved: 0
+[Crux]   Disproved: 4
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/crux/mixed_fail.good
+++ b/crux-mir/test/symb_eval/crux/mixed_fail.good
@@ -1,7 +1,11 @@
-test mixed_fail/<DISAMB>::fail1[0]: FAILED
-test mixed_fail/<DISAMB>::fail2[0]: FAILED
-test mixed_fail/<DISAMB>::pass1[0]: ok
-test mixed_fail/<DISAMB>::pass2[0]: ok
+test mixed_fail/<DISAMB>::fail1[0]: [Crux] Attempting to prove verification conditions.
+FAILED
+test mixed_fail/<DISAMB>::fail2[0]: [Crux] Attempting to prove verification conditions.
+FAILED
+test mixed_fail/<DISAMB>::pass1[0]: [Crux] Attempting to prove verification conditions.
+ok
+test mixed_fail/<DISAMB>::pass2[0]: [Crux] Attempting to prove verification conditions.
+ok
 
 failures:
 
@@ -23,4 +27,11 @@ failures:
 [Crux]   MIR assertion at test/symb_eval/crux/mixed_fail.rs:14:5:
 [Crux]   	x + 2 > x
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 6
+[Crux]   Proved: 2
+[Crux]   Disproved: 4
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/crux/multi.good
+++ b/crux-mir/test/symb_eval/crux/multi.good
@@ -1,6 +1,9 @@
-test multi/<DISAMB>::fail1[0]: FAILED
-test multi/<DISAMB>::fail2[0]: FAILED
-test multi/<DISAMB>::fail3[0]: FAILED
+test multi/<DISAMB>::fail1[0]: [Crux] Attempting to prove verification conditions.
+FAILED
+test multi/<DISAMB>::fail2[0]: [Crux] Attempting to prove verification conditions.
+FAILED
+test multi/<DISAMB>::fail3[0]: [Crux] Attempting to prove verification conditions.
+FAILED
 
 failures:
 
@@ -24,4 +27,11 @@ failures:
 [Crux]   MIR assertion at test/symb_eval/crux/multi.rs:20:5:
 [Crux]   	x == 0
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 4
+[Crux]   Proved: 0
+[Crux]   Disproved: 4
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/crypto/bytes.good
+++ b/crux-mir/test/symb_eval/crypto/bytes.good
@@ -1,4 +1,5 @@
-test bytes/<DISAMB>::f[0]: FAILED
+test bytes/<DISAMB>::f[0]: [Crux] Attempting to prove verification conditions.
+FAILED
 
 failures:
 
@@ -24,4 +25,11 @@ failures:
 [Crux]   MIR assertion at test/symb_eval/crypto/bytes.rs:85:7:
 [Crux]   	a[i] == b[i]
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 5
+[Crux]   Proved: 0
+[Crux]   Disproved: 5
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/crypto/bytes2.good
+++ b/crux-mir/test/symb_eval/crypto/bytes2.good
@@ -1,3 +1,11 @@
-test bytes2/<DISAMB>::f[0]: ok
+test bytes2/<DISAMB>::f[0]: [Crux] Attempting to prove verification conditions.
+ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 11
+[Crux]   Proved: 11
+[Crux]   Disproved: 0
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/crypto/double.good
+++ b/crux-mir/test/symb_eval/crypto/double.good
@@ -1,3 +1,11 @@
-test double/<DISAMB>::f[0]: ok
+test double/<DISAMB>::f[0]: [Crux] Attempting to prove verification conditions.
+ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 1
+[Crux]   Proved: 1
+[Crux]   Disproved: 0
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/crypto/ffs.good
+++ b/crux-mir/test/symb_eval/crypto/ffs.good
@@ -1,3 +1,11 @@
-test ffs/<DISAMB>::f[0]: ok
+test ffs/<DISAMB>::f[0]: [Crux] Attempting to prove verification conditions.
+ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 2
+[Crux]   Proved: 2
+[Crux]   Disproved: 0
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/debug/dump_rv.good
+++ b/crux-mir/test/symb_eval/debug/dump_rv.good
@@ -8,4 +8,6 @@ f = let -- test/symb_eval/debug/dump_rv.rs:30:19: 30:40
  in arrayMap [BV 2::[64]] 0x2a:[8] [BV 3::[64]] 0x1b:[8] v15
 ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/debug/dump_what4.good
+++ b/crux-mir/test/symb_eval/debug/dump_what4.good
@@ -1,6 +1,14 @@
 test dump_what4/<DISAMB>::test[0]: a = 0x7b:[32]
 b = bvSum cx@1:bv 0x1:[32]
 c = eq 0x0:[32] cx@1:bv
+[Crux] Attempting to prove verification conditions.
 ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 1
+[Crux]   Proved: 1
+[Crux]   Disproved: 0
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/debug/print_str.good
+++ b/crux-mir/test/symb_eval/debug/print_str.good
@@ -3,4 +3,6 @@ foo
 bar
 ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/enum/mux.good
+++ b/crux-mir/test/symb_eval/enum/mux.good
@@ -1,3 +1,11 @@
-test mux/<DISAMB>::test[0]: ok
+test mux/<DISAMB>::test[0]: [Crux] Attempting to prove verification conditions.
+ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 3
+[Crux]   Proved: 3
+[Crux]   Disproved: 0
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/fnptr/mux.good
+++ b/crux-mir/test/symb_eval/fnptr/mux.good
@@ -1,3 +1,5 @@
 test mux/<DISAMB>::crux_test[0]: returned 2, ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/io/vec_cursor_read.good
+++ b/crux-mir/test/symb_eval/io/vec_cursor_read.good
@@ -1,3 +1,5 @@
 test vec_cursor_read/<DISAMB>::f[0]: ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/io/vec_write.good
+++ b/crux-mir/test/symb_eval/io/vec_write.good
@@ -1,3 +1,5 @@
 test vec_write/<DISAMB>::f[0]: ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/macros/derive_symbolic.good
+++ b/crux-mir/test/symb_eval/macros/derive_symbolic.good
@@ -1,4 +1,6 @@
 test derive_symbolic/<DISAMB>::empty[0]: ok
 test derive_symbolic/<DISAMB>::nonempty[0]: ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/mux/array.good
+++ b/crux-mir/test/symb_eval/mux/array.good
@@ -1,3 +1,11 @@
-test array/<DISAMB>::crux_test[0]: returned Symbolic BV, ok
+test array/<DISAMB>::crux_test[0]: returned Symbolic BV, [Crux] Attempting to prove verification conditions.
+ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 6
+[Crux]   Proved: 6
+[Crux]   Disproved: 0
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/mux/array_mut.good
+++ b/crux-mir/test/symb_eval/mux/array_mut.good
@@ -1,3 +1,11 @@
-test array_mut/<DISAMB>::crux_test[0]: returned Symbolic BV, ok
+test array_mut/<DISAMB>::crux_test[0]: returned Symbolic BV, [Crux] Attempting to prove verification conditions.
+ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 2
+[Crux]   Proved: 2
+[Crux]   Disproved: 0
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/num/checked_add.good
+++ b/crux-mir/test/symb_eval/num/checked_add.good
@@ -1,4 +1,5 @@
-test checked_add/<DISAMB>::crux_test[0]: returned 44, FAILED
+test checked_add/<DISAMB>::crux_test[0]: returned 44, [Crux] Attempting to prove verification conditions.
+FAILED
 
 failures:
 
@@ -7,4 +8,11 @@ failures:
 [Crux]   test/symb_eval/num/checked_add.rs:6:5: 6:12: error: in checked_add/<DISAMB>::crux_test[0]
 [Crux]   attempt to compute `const 100_u8 + move _1`, which would overflow
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 1
+[Crux]   Proved: 0
+[Crux]   Disproved: 1
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/num/checked_div.good
+++ b/crux-mir/test/symb_eval/num/checked_div.good
@@ -1,4 +1,5 @@
-test checked_div/<DISAMB>::crux_test[0]: returned 65, FAILED
+test checked_div/<DISAMB>::crux_test[0]: returned 65, [Crux] Attempting to prove verification conditions.
+FAILED
 
 failures:
 
@@ -13,4 +14,11 @@ failures:
 [Crux]   test/symb_eval/num/checked_div.rs:8:5: 8:10: error: in checked_div/<DISAMB>::div_unsigned[0]
 [Crux]   attempt to divide `copy _1` by zero
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 3
+[Crux]   Proved: 0
+[Crux]   Disproved: 3
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/num/checked_mul.good
+++ b/crux-mir/test/symb_eval/num/checked_mul.good
@@ -1,4 +1,5 @@
-test checked_mul/<DISAMB>::crux_test[0]: returned 44, FAILED
+test checked_mul/<DISAMB>::crux_test[0]: returned 44, [Crux] Attempting to prove verification conditions.
+FAILED
 
 failures:
 
@@ -7,4 +8,11 @@ failures:
 [Crux]   test/symb_eval/num/checked_mul.rs:6:5: 6:12: error: in checked_mul/<DISAMB>::crux_test[0]
 [Crux]   attempt to compute `const 100_u8 * move _1`, which would overflow
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 1
+[Crux]   Proved: 0
+[Crux]   Disproved: 1
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/num/checked_mul_signed.good
+++ b/crux-mir/test/symb_eval/num/checked_mul_signed.good
@@ -1,4 +1,5 @@
-test checked_mul_signed/<DISAMB>::crux_test[0]: returned 44, FAILED
+test checked_mul_signed/<DISAMB>::crux_test[0]: returned 44, [Crux] Attempting to prove verification conditions.
+FAILED
 
 failures:
 
@@ -7,4 +8,11 @@ failures:
 [Crux]   test/symb_eval/num/checked_mul_signed.rs:6:5: 6:13: error: in checked_mul_signed/<DISAMB>::crux_test[0]
 [Crux]   attempt to compute `const -100_i8 * move _1`, which would overflow
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 1
+[Crux]   Proved: 0
+[Crux]   Disproved: 1
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/num/checked_shift.good
+++ b/crux-mir/test/symb_eval/num/checked_shift.good
@@ -1,4 +1,5 @@
-test checked_shift/<DISAMB>::crux_test[0]: returned 0, FAILED
+test checked_shift/<DISAMB>::crux_test[0]: returned 0, [Crux] Attempting to prove verification conditions.
+FAILED
 
 failures:
 
@@ -7,4 +8,11 @@ failures:
 [Crux]   test/symb_eval/num/checked_shift.rs:6:5: 6:15: error: in checked_shift/<DISAMB>::crux_test[0]
 [Crux]   attempt to shift left by `const 64_i64`, which would overflow
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 1
+[Crux]   Proved: 0
+[Crux]   Disproved: 1
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/num/unchecked_arith.good
+++ b/crux-mir/test/symb_eval/num/unchecked_arith.good
@@ -1,8 +1,13 @@
-test unchecked_arith/<DISAMB>::add_test[0]: returned 44, FAILED
-test unchecked_arith/<DISAMB>::mul_test[0]: returned 32, FAILED
-test unchecked_arith/<DISAMB>::shl_test[0]: returned 0, FAILED
-test unchecked_arith/<DISAMB>::shr_test[0]: returned 0, FAILED
-test unchecked_arith/<DISAMB>::sub_test[0]: returned 156, FAILED
+test unchecked_arith/<DISAMB>::add_test[0]: returned 44, [Crux] Attempting to prove verification conditions.
+FAILED
+test unchecked_arith/<DISAMB>::mul_test[0]: returned 32, [Crux] Attempting to prove verification conditions.
+FAILED
+test unchecked_arith/<DISAMB>::shl_test[0]: returned 0, [Crux] Attempting to prove verification conditions.
+FAILED
+test unchecked_arith/<DISAMB>::shr_test[0]: returned 0, [Crux] Attempting to prove verification conditions.
+FAILED
+test unchecked_arith/<DISAMB>::sub_test[0]: returned 156, [Crux] Attempting to prove verification conditions.
+FAILED
 
 failures:
 
@@ -31,4 +36,11 @@ failures:
 [Crux]   ./libs/core/src/num/uint_macros.rs:762:17: 762:53 !./libs/core/src/num/mod.rs:436:5: 454:6: error: in core/<DISAMB>::num[0]::{impl#6}[0]::unchecked_sub[0]
 [Crux]   Binary operation (-) would overflow
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 5
+[Crux]   Proved: 0
+[Crux]   Disproved: 5
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/overrides/bad_symb1.good
+++ b/crux-mir/test/symb_eval/overrides/bad_symb1.good
@@ -1,4 +1,5 @@
-test bad_symb1/<DISAMB>::crux_test[0]: FAILED
+test bad_symb1/<DISAMB>::crux_test[0]: [Crux] Attempting to prove verification conditions.
+FAILED
 
 failures:
 
@@ -7,4 +8,11 @@ failures:
 [Crux]   ./libs/crucible/symbolic.rs:28:50: 28:61 !./libs/crucible/symbolic.rs:34:1: 40:2: error: in crucible/<DISAMB>::symbolic[0]::{impl#3}[0]::symbolic[0]
 [Crux]   symbolic variable name must be a concrete string
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 1
+[Crux]   Proved: 0
+[Crux]   Disproved: 1
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/overrides/bad_symb2.good
+++ b/crux-mir/test/symb_eval/overrides/bad_symb2.good
@@ -1,4 +1,5 @@
-test bad_symb2/<DISAMB>::crux_test[0]: FAILED
+test bad_symb2/<DISAMB>::crux_test[0]: [Crux] Attempting to prove verification conditions.
+FAILED
 
 failures:
 
@@ -7,4 +8,11 @@ failures:
 [Crux]   ./libs/crucible/symbolic.rs:28:50: 28:61 !./libs/crucible/symbolic.rs:34:1: 40:2: error: in crucible/<DISAMB>::symbolic[0]::{impl#3}[0]::symbolic[0]
 [Crux]   invalid symbolic variable name "\NUL:., /": Identifier must start with a letter.
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 1
+[Crux]   Proved: 0
+[Crux]   Disproved: 1
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/overrides/override1.good
+++ b/crux-mir/test/symb_eval/overrides/override1.good
@@ -1,4 +1,6 @@
 test override1/<DISAMB>::f[0]: Hello, I'm an override
 returned 2, ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/overrides/override2.good
+++ b/crux-mir/test/symb_eval/overrides/override2.good
@@ -1,4 +1,5 @@
-test override2/<DISAMB>::f[0]: FAILED
+test override2/<DISAMB>::f[0]: [Crux] Attempting to prove verification conditions.
+FAILED
 
 failures:
 
@@ -8,4 +9,11 @@ failures:
 [Crux]   MIR assertion at test/symb_eval/overrides/override2.rs:9:5:
 [Crux]   	foo.wrapping_add(1) == foo
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 1
+[Crux]   Proved: 0
+[Crux]   Disproved: 1
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/overrides/override3.good
+++ b/crux-mir/test/symb_eval/overrides/override3.good
@@ -1,3 +1,11 @@
-test override3/<DISAMB>::f[0]: ok
+test override3/<DISAMB>::f[0]: [Crux] Attempting to prove verification conditions.
+ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 1
+[Crux]   Proved: 1
+[Crux]   Disproved: 0
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/overrides/override4.good
+++ b/crux-mir/test/symb_eval/overrides/override4.good
@@ -1,3 +1,11 @@
-test override4/<DISAMB>::f[0]: ok
+test override4/<DISAMB>::f[0]: [Crux] Attempting to prove verification conditions.
+ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 2
+[Crux]   Proved: 2
+[Crux]   Disproved: 0
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/overrides/override5.good
+++ b/crux-mir/test/symb_eval/overrides/override5.good
@@ -1,4 +1,5 @@
-test override5/<DISAMB>::f[0]: FAILED
+test override5/<DISAMB>::f[0]: [Crux] Attempting to prove verification conditions.
+FAILED
 
 failures:
 
@@ -8,4 +9,11 @@ failures:
 [Crux]   MIR assertion at test/symb_eval/overrides/override5.rs:10:5:
 [Crux]   	foo.wrapping_add(1) != 0
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 1
+[Crux]   Proved: 0
+[Crux]   Disproved: 1
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/overrides/override_rust.good
+++ b/crux-mir/test/symb_eval/overrides/override_rust.good
@@ -1,3 +1,5 @@
 test override_rust/<DISAMB>::crux_test[0]: ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/refs/mux_init_imm.good
+++ b/crux-mir/test/symb_eval/refs/mux_init_imm.good
@@ -1,3 +1,5 @@
 test mux_init_imm/<DISAMB>::crux_test[0]: returned Symbolic BV, ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/refs/mux_init_mut.good
+++ b/crux-mir/test/symb_eval/refs/mux_init_mut.good
@@ -1,3 +1,5 @@
 test mux_init_mut/<DISAMB>::crux_test[0]: returned Symbolic BV, ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/scalar/test1.good
+++ b/crux-mir/test/symb_eval/scalar/test1.good
@@ -1,3 +1,11 @@
-test test1/<DISAMB>::f[0]: ok
+test test1/<DISAMB>::f[0]: [Crux] Attempting to prove verification conditions.
+ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 84
+[Crux]   Proved: 84
+[Crux]   Disproved: 0
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/sym_bytes/construct.good
+++ b/crux-mir/test/symb_eval/sym_bytes/construct.good
@@ -1,4 +1,5 @@
-test construct/<DISAMB>::crux_test[0]: returned Symbolic BV, FAILED
+test construct/<DISAMB>::crux_test[0]: returned Symbolic BV, [Crux] Attempting to prove verification conditions.
+FAILED
 
 failures:
 
@@ -8,4 +9,11 @@ failures:
 [Crux]   MIR assertion at test/symb_eval/sym_bytes/construct.rs:13:5:
 [Crux]   	sym2[0] == 0
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 1
+[Crux]   Proved: 0
+[Crux]   Disproved: 1
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/sym_bytes/deserialize.good
+++ b/crux-mir/test/symb_eval/sym_bytes/deserialize.good
@@ -1,4 +1,5 @@
-test deserialize/<DISAMB>::crux_test[0]: returned Symbolic BV, FAILED
+test deserialize/<DISAMB>::crux_test[0]: returned Symbolic BV, [Crux] Attempting to prove verification conditions.
+FAILED
 
 failures:
 
@@ -7,4 +8,11 @@ failures:
 [Crux]   test/symb_eval/sym_bytes/deserialize.rs:19:21: 19:44: error: in deserialize/<DISAMB>::deserialize[0]
 [Crux]   attempt to compute `copy _45 + move _60`, which would overflow
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 3
+[Crux]   Proved: 2
+[Crux]   Disproved: 1
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/union/init_cond.good
+++ b/crux-mir/test/symb_eval/union/init_cond.good
@@ -1,4 +1,5 @@
-test init_cond/<DISAMB>::foo[0]: returned 4660, FAILED
+test init_cond/<DISAMB>::foo[0]: returned 4660, [Crux] Attempting to prove verification conditions.
+FAILED
 
 failures:
 
@@ -7,4 +8,11 @@ failures:
 [Crux]   test/symb_eval/union/init_cond.rs:14:13: 18:6: error: in init_cond/<DISAMB>::foo[0]
 [Crux]   bad MirAggregate merge: offset 0: type mismatch: IntrinsicRepr MirAggregate [] != BVRepr 16
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 1
+[Crux]   Proved: 0
+[Crux]   Disproved: 1
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/vec/clone.good
+++ b/crux-mir/test/symb_eval/vec/clone.good
@@ -1,3 +1,5 @@
 test clone/<DISAMB>::f[0]: ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/vec/into_iter.good
+++ b/crux-mir/test/symb_eval/vec/into_iter.good
@@ -1,3 +1,5 @@
 test into_iter/<DISAMB>::f[0]: ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/vec/macro.good
+++ b/crux-mir/test/symb_eval/vec/macro.good
@@ -1,3 +1,5 @@
 test macro/<DISAMB>::f[0]: ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/vec/sort_by_key.good
+++ b/crux-mir/test/symb_eval/vec/sort_by_key.good
@@ -1,3 +1,5 @@
 test sort_by_key/<DISAMB>::f[0]: ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/vector/as_mut_slice.good
+++ b/crux-mir/test/symb_eval/vector/as_mut_slice.good
@@ -1,3 +1,5 @@
 test as_mut_slice/<DISAMB>::f[0]: ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/vector/as_slice.good
+++ b/crux-mir/test/symb_eval/vector/as_slice.good
@@ -1,3 +1,5 @@
 test as_slice/<DISAMB>::f[0]: ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/vector/concat.good
+++ b/crux-mir/test/symb_eval/vector/concat.good
@@ -1,3 +1,5 @@
 test concat/<DISAMB>::f[0]: ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/vector/copy_from_slice.good
+++ b/crux-mir/test/symb_eval/vector/copy_from_slice.good
@@ -1,3 +1,5 @@
 test copy_from_slice/<DISAMB>::f[0]: ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/vector/mut.good
+++ b/crux-mir/test/symb_eval/vector/mut.good
@@ -1,3 +1,5 @@
 test mut/<DISAMB>::f[0]: ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/vector/new.good
+++ b/crux-mir/test/symb_eval/vector/new.good
@@ -1,3 +1,5 @@
 test new/<DISAMB>::f[0]: ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/vector/pop.good
+++ b/crux-mir/test/symb_eval/vector/pop.good
@@ -1,3 +1,5 @@
 test pop/<DISAMB>::f[0]: ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/vector/push.good
+++ b/crux-mir/test/symb_eval/vector/push.good
@@ -1,3 +1,5 @@
 test push/<DISAMB>::f[0]: ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/vector/replicate.good
+++ b/crux-mir/test/symb_eval/vector/replicate.good
@@ -1,3 +1,5 @@
 test replicate/<DISAMB>::f[0]: ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/vector/split_at.good
+++ b/crux-mir/test/symb_eval/vector/split_at.good
@@ -1,3 +1,5 @@
 test split_at/<DISAMB>::f[0]: ok
 
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.


### PR DESCRIPTION
Including, most notably, how many goals (if any) were generated and proved/disproved in the course of verification. This could have helped avoid e.g. the performance regression addressed in #1625.