### PR TITLE
Fix documentation typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Notes on Freeze Files
 ---------------------
 
 We use the `cabal.GHC-*.config` files to constrain dependency versions in CI.
-We recommand using the following command for best results before building
+We recommend using the following command for best results before building
 locally:
 
 ```

--- a/crucible-llvm/CHANGELOG.md
+++ b/crucible-llvm/CHANGELOG.md
@@ -91,7 +91,7 @@
   * `Lang.Crucible.LLVM.Globals`: `populateGlobal`
   * `Lang.Crucible.LLVM.MemModel.Generic`: `writeMem` and `writeConstMem`
 * `Lang.Crucible.LLVM`: `registerModuleFn` has changed type to
-  accomodate lazy loading of Crucible IR.
+  accommodate lazy loading of Crucible IR.
 * `Lang.Crucible.LLVM.Translation` : The `ModuleTranslation` record is
   now opaque, the `cfgMap` is no longer exported and `globalInitMap`
   and `modTransNonce` have become lens-style getters instead of record

--- a/crucible-llvm/doc/limitations.md
+++ b/crucible-llvm/doc/limitations.md
@@ -104,7 +104,7 @@ somewhat inaccurately. LLVM's intended semantics for `freeze` state that
 if the argument is an `undef` or `poison` value, then `freeze` should return
 an arbitrary value; otherwise, it should return the argument unchanged. In
 `crucible-llvm`, however, a `freeze` instruction _always_ returns the argument
-unchanged. The issue is that `crucibe-llvm` currently does not have the ability
+unchanged. The issue is that `crucible-llvm` currently does not have the ability
 to reliably determine whether a given value is `undef` or `poison`.
 
 One can often get close to the intended LLVM semantics for `freeze` by enabling

--- a/crux-llvm/svcomp/README.md
+++ b/crux-llvm/svcomp/README.md
@@ -96,7 +96,7 @@ command:
 $ ./scripts/execute-runs/mkInstall.sh crux crux-path
 ```
 
-For whatever reason, the secon argument (ostensibly the path to extract to)
+For whatever reason, the second argument (ostensibly the path to extract to)
 doesn't seem to actually get used in practice, and the directory it will
 _actually_ be extracted to is the basename of the Crux `.zip` file itself.
 Navigate into this newly extracted directory and run the following:

--- a/crux-mir/Concurrency.md
+++ b/crux-mir/Concurrency.md
@@ -2,7 +2,7 @@
 
 Crux-mir has experimental support for multithreaded programs. 
 
-This document explains (1) how to use crux-mir to simualte multithreaded programs, (2)
+This document explains (1) how to use crux-mir to simulate multithreaded programs, (2)
 what is currently supported, and (3) how to extend support for additional primitives.
 
 ## Setting up and running crux-mir with concurrency support


### PR DESCRIPTION
Found and fixed using [`typos`]:

    git ls-files --exclude-standard '*.md' | \
      xargs --max-args 1 --max-procs=8 typos -w

[`typos`]: https://github.com/crate-ci/typos