### PR TITLE
ci: Use Dependabot for weekly bumps to pinned GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  # For why `cooldown`, see
+  # https://docs.zizmor.sh/audits/#dependabot-cooldown
+  cooldown:
+    default-days: 7

--- a/.github/workflows/crux-llvm-build.yml
+++ b/.github/workflows/crux-llvm-build.yml
@@ -233,7 +233,9 @@ jobs:
         # workflow, so it is safe to skip this step on forks. Note that it
         # isn't sufficient to test the pull request info because this job is
         # also scheduled. See notes in README.md.
-        if: github.event.pull_request.head.repo.fork == false && github.repository_owner == 'GaloisInc'
+        if: github.event.pull_request.head.repo.fork == false &&
+            github.repository_owner == 'GaloisInc' &&
+            github.actor != 'dependabot[bot]'
         env:
           SIGNING_PASSPHRASE: ${{ secrets.SIGNING_PASSPHRASE }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
@@ -241,7 +243,9 @@ jobs:
           .github/ci.sh sign "${NAME}.tar.gz"
 
       - uses: actions/upload-artifact@v4
-        if: github.event.pull_request.head.repo.fork == false && github.repository_owner == 'GaloisInc'
+        if: github.event.pull_request.head.repo.fork == false &&
+            github.repository_owner == 'GaloisInc' &&
+            github.actor != 'dependabot[bot]'
         with:
           path: crux-llvm-*.tar.gz*
           name: crux-llvm-${{ matrix.os }}-${{ runner.arch }}-${{ matrix.ghc }}

--- a/.github/workflows/crux-mir-build.yml
+++ b/.github/workflows/crux-mir-build.yml
@@ -214,7 +214,9 @@ jobs:
         # workflow, so it is safe to skip this step on forks. Note that it
         # isn't sufficient to test the pull request info because this job is
         # also scheduled. See notes in README.md.
-        if: github.event.pull_request.head.repo.fork == false && github.repository_owner == 'GaloisInc'
+        if: github.event.pull_request.head.repo.fork == false &&
+            github.repository_owner == 'GaloisInc' &&
+            github.actor != 'dependabot[bot]'
         env:
           SIGNING_PASSPHRASE: ${{ secrets.SIGNING_PASSPHRASE }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
@@ -222,7 +224,9 @@ jobs:
           .github/ci.sh sign "${NAME}.tar.gz"
 
       - uses: actions/upload-artifact@v4
-        if: github.event.pull_request.head.repo.fork == false && github.repository_owner == 'GaloisInc'
+        if: github.event.pull_request.head.repo.fork == false &&
+            github.repository_owner == 'GaloisInc' &&
+            github.actor != 'dependabot[bot]'
         with:
           path: crux-mir-*.tar.gz*
           name: crux-mir-${{ matrix.os }}-${{ runner.arch }}-${{ matrix.ghc }}


### PR DESCRIPTION
We have previously manually bumped the pinned versions of the actions used in our CI workflows. Let's automate this process using Dependabot! With this configuration, Dependabot will check for updates weekly, and open pull requests for each of them.

Benefits:

- Save maintainer time when updates are push-button
- See benefits from updated dependencies more quickly and reliably

Risks:

- Requires maintainers to review and merge more PRs
- May create noise for updates that aren't push-button and require some manual intervention

I think our experience using Dependabot on parameterized-utils and What4 justifies integrating it here. In both repos, we've had 3 PRs so far over a period of a few months, and each was merged quickly and without manual intervention.