### PR TITLE
ci: Don't run Haskell builds and tests on documentation-only changes

### DIFF
--- a/.github/workflows/crucible-go-build.yml
+++ b/.github/workflows/crucible-go-build.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches: [master, "release-**"]
   pull_request:
+    # Don't run on documentation-only changes
+    paths-ignore: ["**.md"]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/crucible-jvm-build.yml
+++ b/.github/workflows/crucible-jvm-build.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches: [master, "release-**"]
   pull_request:
+    # Don't run on documentation-only changes
+    paths-ignore: ["**.md"]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/crucible-wasm-build.yml
+++ b/.github/workflows/crucible-wasm-build.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches: [master, "release-**"]
   pull_request:
+    # Don't run on documentation-only changes
+    paths-ignore: ["**.md"]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/crux-llvm-build.yml
+++ b/.github/workflows/crux-llvm-build.yml
@@ -5,6 +5,8 @@ on:
     tags: ["crux-v?[0-9]+.[0-9]+(.[0-9]+)?"]
     branches: [master, "release-**"]
   pull_request:
+    # Don't run on documentation-only changes
+    paths-ignore: ["**.md"]
   schedule:
     - cron: "0 10 * * *" # 10am UTC -> 2/3am PST
   workflow_dispatch:

--- a/.github/workflows/crux-mir-build.yml
+++ b/.github/workflows/crux-mir-build.yml
@@ -4,6 +4,8 @@ on:
     tags: ["crux-v?[0-9]+.[0-9]+(.[0-9]+)?"]
     branches: [master, "release-**"]
   pull_request:
+    # Don't run on documentation-only changes
+    paths-ignore: ["**.md"]
   schedule:
     - cron: "0 10 * * *" # 10am UTC -> 2/3am PST
   workflow_dispatch:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches: [master, "release-**"]
   pull_request:
+    # Don't run on documentation-only changes
+    paths-ignore: ["**.md"]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Let's save some time and electricity by avoiding these (fairly expensive) CI builds on docs-only changes.