### PR TITLE
`crucible-mir`: Avoid catch-all patterns in `mux*` operations 

### DIFF
--- a/crucible-mir/src/Mir/Intrinsics.hs
+++ b/crucible-mir/src/Mir/Intrinsics.hs
@@ -504,7 +504,10 @@ muxRefRoot sym iTypes c root1 root2 = case (root1, root2) of
   (Const_RefRoot tpr v1, Const_RefRoot _tpr v2) -> do
     v' <- lift $ muxRegForType sym iTypes tpr c v1 v2
     return $ Const_RefRoot tpr v'
-  _ -> mzero
+
+  (RefCell_RefRoot {}, _) -> mzero
+  (GlobalVar_RefRoot {}, _) -> mzero
+  (Const_RefRoot {}, _) -> mzero
 
 muxRefPath ::
   IsSymInterface sym =>
@@ -543,7 +546,15 @@ muxRefPath sym c path1 path2 = case (path1,path2) of
          do off' <- lift $ bvIte sym c off1 off2
             p' <- muxRefPath sym c p1 p2
             return (AgElem_RefPath off' sz tpr p')
-  _ -> mzero
+
+  (Empty_RefPath {}, _) -> mzero
+  (Field_RefPath {}, _) -> mzero
+  (Variant_RefPath {}, _) -> mzero
+  (Index_RefPath {}, _) -> mzero
+  (Just_RefPath {}, _) -> mzero
+  (VectorAsMirVector_RefPath {}, _) -> mzero
+  (ArrayAsMirVector_RefPath {}, _) -> mzero
+  (AgElem_RefPath {}, _) -> mzero
 
 muxRef' :: forall sym.
   IsSymInterface sym =>


### PR DESCRIPTION
Using catch-all patterns here means that it is all too easy to forget to update this code when adding new data constructors for the types being muxed. This patch uses more explicit pattern matching to ensure that GHC's pattern-match coverage checker will explicitly warn if someone forgets to update these functions. I have set up the code to ensure that the number of patterns scales linearly with the number of data constructors (instead of matching every pairwise combination of data constructors, which would scale quadratically).

Refactoring only, no intended change in behavior.