### PR TITLE
`crucible-mir`: Check schema version even when parsing succeeds

### DIFF
--- a/crucible-mir/src/Mir/ParseTranslate.hs
+++ b/crucible-mir/src/Mir/ParseTranslate.hs
@@ -34,7 +34,7 @@ import Prettyprinter (Pretty(..))
 import qualified Lang.Crucible.FunctionHandle as C
 
 
-import Mir.Mir (Collection(..), namedTys, tiTy, tiNeedsDrop, tiLayout)
+import Mir.Mir (Collection(..), namedTys, tiTy, tiNeedsDrop, tiLayout, version)
 import Mir.JSON ()
 import Mir.GenericOps (uninternTys)
 import Mir.Pass(rewriteCollection)
@@ -62,6 +62,7 @@ parseMIR path f = do
       case J.eitherDecode @Collection f of
         Left msg -> fallback msg
         Right col -> pure col
+    checkSchemaVersion (col ^. version)
     when (?debug > 5) $ do
       traceM "--------------------------------------------------------------"
       traceM $ "Loaded module: " ++ path


### PR DESCRIPTION
It is possible for a MIR JSON file to parse even if the schema version doesn't match what is expected, as noticed in https://github.com/GaloisInc/saw-script/pull/2852#issuecomment-3603837138. This ensures that the schema version is checked regardless of whether parsing succeeds or not.