### PR TITLE
`crucible-llvm`: Add variants of `llvm.stack{save,restore}` overrides for `p0` address space

### DIFF
--- a/crucible-llvm-cli/test-data/llvm.stacksave-stackrestore.cbl
+++ b/crucible-llvm-cli/test-data/llvm.stacksave-stackrestore.cbl
@@ -1,0 +1,8 @@
+(declare @llvm.stacksave.p0 () Pointer)
+(declare @llvm.stackrestore.p0 ((x Pointer)) Unit)
+
+(defun @main () Unit
+  (start start:
+    (let ptr (funcall @llvm.stacksave.p0))
+    (funcall @llvm.stackrestore.p0 ptr)
+    (return ())))

--- a/crucible-llvm-cli/test-data/llvm.stacksave-stackrestore.out.good
+++ b/crucible-llvm-cli/test-data/llvm.stacksave-stackrestore.out.good
@@ -1,0 +1,4 @@
+==== Begin Simulation ====
+
+==== Finish Simulation ====
+==== No proof obligations ====


### PR DESCRIPTION
In LLVM 18 or later, the `llvm.stack{save,restore}` instrinsics take suffixes like `p0` to indicate the address space of the pointers involved. This takes the existing, simplistic overrides for `llvm.stack{save,restore}` and copies them to so that we also support `llvm.stack{save,restore}.p0`, allowing us to support code that uses address space 0. (See
https://github.com/GaloisInc/crucible/issues/130 for the task of making these overrides more properly implement the intended semantics of the corresponding LLVM intrinsics.)

Towards https://github.com/GaloisInc/saw-script/issues/2730.