### PR TITLE
llvm: Remove use of `Data.Dynamic` in memory model

### DIFF
--- a/crucible-llvm/CHANGELOG.md
+++ b/crucible-llvm/CHANGELOG.md
@@ -34,6 +34,8 @@
 * Remove the `Eq LLVMConst` instance. This instance was inherently unreliable
   because it cannot easily compute a simple `True`-or-`False` answer in the
   presence of `undef` or `poison` values.
+* Replace `Data.Dynamic.Dynamic` with `SomeFnHandle` in
+  `MemModel.{doInstallHandle,doLookupHandle}`.
 
 # 0.8.0 -- 2025-11-09
 

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Errors/MemoryError.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Errors/MemoryError.hs
@@ -38,7 +38,6 @@ import           Prelude hiding (pred)
 
 import           Data.Text (Text)
 import qualified Text.LLVM.AST as L
-import           Type.Reflection (SomeTypeRep(SomeTypeRep))
 import           Prettyprinter
 
 import           What4.Interface
@@ -100,7 +99,6 @@ data FuncLookupError
   = SymbolicPointer
   | RawBitvector
   | NoOverride
-  | Uncallable SomeTypeRep
   deriving (Eq, Ord)
 
 ppFuncLookupError :: FuncLookupError -> Doc ann
@@ -109,10 +107,6 @@ ppFuncLookupError =
     SymbolicPointer -> "Cannot resolve a symbolic pointer to a function handle"
     RawBitvector -> "Cannot treat raw bitvector as function pointer"
     NoOverride -> "No implementation or override found for pointer"
-    Uncallable (SomeTypeRep typeRep) ->
-      vsep [ "Data associated with the pointer found, but was not a callable function:"
-           , hang 2 (viaShow typeRep)
-           ]
 
 type MemErrContext sym w = MemoryOp sym w
 


### PR DESCRIPTION
Make the code simpler to read and easier to use. Remove a seemingly unreachable error case in the memory model.