### PR TITLE
Bump what4 solvers snapshot

### DIFF
--- a/.github/Dockerfile-crux-llvm
+++ b/.github/Dockerfile-crux-llvm
@@ -69,7 +69,7 @@ RUN case ${TARGETPLATFORM} in \
       --silent \
       --tlsv1.2 \
       --output solvers.zip \
-      "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20251112/ubuntu-22.04-${WHAT4_SOLVERS_ARCH}-bin.zip"
+      "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20260119/ubuntu-22.04-${WHAT4_SOLVERS_ARCH}-bin.zip"
 RUN unzip solvers.zip && rm solvers.zip && chmod +x *
 
 WORKDIR /crux-llvm

--- a/.github/Dockerfile-crux-mir
+++ b/.github/Dockerfile-crux-mir
@@ -74,7 +74,7 @@ RUN case ${TARGETPLATFORM} in \
       --silent \
       --tlsv1.2 \
       --output solvers.zip \
-      "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20251112/ubuntu-22.04-${WHAT4_SOLVERS_ARCH}-bin.zip"
+      "https://github.com/GaloisInc/what4-solvers/releases/download/snapshot-20260119/ubuntu-22.04-${WHAT4_SOLVERS_ARCH}-bin.zip"
 RUN unzip solvers.zip && rm solvers.zip && chmod +x *
 
 WORKDIR /crux-mir

--- a/.github/workflows/crucible-go-build.yml
+++ b/.github/workflows/crucible-go-build.yml
@@ -49,7 +49,7 @@ jobs:
         cp "cabal.GHC-${{ matrix.ghc }}.config" cabal.project.freeze
       pre-test-hook: |
         env \
-          SOLVER_PKG_VERSION="snapshot-20251112" \
+          SOLVER_PKG_VERSION="snapshot-20260119" \
           BUILD_TARGET_OS="${{ matrix.os }}" \
           BUILD_TARGET_ARCH="${RUNNER_ARCH}" \
           "${GITHUB_WORKSPACE}/.github/ci.sh" \

--- a/.github/workflows/crucible-jvm-build.yml
+++ b/.github/workflows/crucible-jvm-build.yml
@@ -49,7 +49,7 @@ jobs:
         cp "cabal.GHC-${{ matrix.ghc }}.config" cabal.project.freeze
       pre-test-hook: |
         env \
-          SOLVER_PKG_VERSION="snapshot-20251112" \
+          SOLVER_PKG_VERSION="snapshot-20260119" \
           BUILD_TARGET_OS="${{ matrix.os }}" \
           BUILD_TARGET_ARCH="${RUNNER_ARCH}" \
           "${GITHUB_WORKSPACE}/.github/ci.sh" \

--- a/.github/workflows/crucible-wasm-build.yml
+++ b/.github/workflows/crucible-wasm-build.yml
@@ -49,7 +49,7 @@ jobs:
         cp "cabal.GHC-${{ matrix.ghc }}.config" cabal.project.freeze
       pre-test-hook: |
         env \
-          SOLVER_PKG_VERSION="snapshot-20251112" \
+          SOLVER_PKG_VERSION="snapshot-20260119" \
           BUILD_TARGET_OS="${{ matrix.os }}" \
           BUILD_TARGET_ARCH="${RUNNER_ARCH}" \
           "${GITHUB_WORKSPACE}/.github/ci.sh" \

--- a/.github/workflows/crux-llvm-build.yml
+++ b/.github/workflows/crux-llvm-build.yml
@@ -117,7 +117,7 @@ jobs:
 
       - run: .github/ci.sh install_system_deps
         env:
-          SOLVER_PKG_VERSION: "snapshot-20251112"
+          SOLVER_PKG_VERSION: "snapshot-20260119"
           BUILD_TARGET_OS: ${{ matrix.os }}
           BUILD_TARGET_ARCH: ${{ runner.arch }}
 

--- a/.github/workflows/crux-mir-build.yml
+++ b/.github/workflows/crux-mir-build.yml
@@ -132,7 +132,7 @@ jobs:
 
       - run: .github/ci.sh install_system_deps
         env:
-          SOLVER_PKG_VERSION: "snapshot-20251112"
+          SOLVER_PKG_VERSION: "snapshot-20260119"
           BUILD_TARGET_OS: ${{ matrix.os }}
           BUILD_TARGET_ARCH: ${{ runner.arch }}
 


### PR DESCRIPTION
Needed in order to cleanly build `saw` & friends for UBI9 in https://github.com/GaloisInc/saw-suite/pull/13

The solvers are unchanged, only added UBI9 binaries.

Supports https://github.com/GaloisInc/saw-script/pull/2980