### PR TITLE
`crucible-mir`: Translate constant raw slice pointers properly

### DIFF
--- a/crucible-mir/CHANGELOG.md
+++ b/crucible-mir/CHANGELOG.md
@@ -1,5 +1,11 @@
 # next
 
+This release supports [version
+8](https://github.com/GaloisInc/mir-json/blob/master/SCHEMA_CHANGELOG.md#8) of
+`mir-json`'s schema.
+
+* Fix a translation error when translating constant slice raw pointers.
+
 # 0.6 -- 2026-01-29
 
 This release supports [version

--- a/crux-mir/test/conc_eval/slice/raw_ptr.rs
+++ b/crux-mir/test/conc_eval/slice/raw_ptr.rs
@@ -1,0 +1,20 @@
+// A regression test for #1733. This tests the constant translation machinery
+// on slice raw pointers (namely, the Y1 and Y2 constants).
+
+const X1: &[u8] = &[1, 2];
+const Y1: *const [u8] = X1 as _;
+
+const X2: &str = &"hello";
+const Y2: *const str = X2 as _;
+
+#[cfg_attr(crux, crux::test)]
+pub fn crux_test() -> (usize, usize) {
+    let y1_len = Y1.len();
+    let y2_u8: *const u8 = Y2 as _;
+    let y2_u8_slice: &[u8] = unsafe { std::slice::from_raw_parts(y2_u8, X2.len()) };
+    (Y1.len(), y2_u8_slice.len())
+}
+
+fn main() {
+    println!("{:?}", crux_test());
+}


### PR DESCRIPTION
`transConstVal` had cases for translating constant slice _references_, but it lacked corresponding cases for slice _raw pointers_. This commit adds the latter.

Fixes https://github.com/GaloisInc/crucible/issues/1733.