### PR TITLE
Require exports lists in `crucible`

### DIFF
--- a/cabal.project.ci
+++ b/cabal.project.ci
@@ -1,3 +1,7 @@
+-- See Note [Export lists] in crucible.cabal
+package crucible
+  ghc-options: -Werror=missing-export-lists
+
 -- See Note [Asserts] in crucible-llvm
 package crucible-llvm
   ghc-options: -fno-ignore-asserts

--- a/crucible/crucible.cabal
+++ b/crucible/crucible.cabal
@@ -34,6 +34,25 @@ flag unsafe-operations
   Default: True
 
 common bldflags
+  -- Note [Export lists]
+  -- -------------------
+  --
+  -- We don't allow modules without export lists.
+  --
+  -- From the GHC docs:
+  --
+  --     Declaring an explicit export list [...] enables GHC dead code analysis,
+  --     prevents accidental export of names and can ease optimizations like
+  --     inlining.
+  --
+  -- It also makes it easier to organize the Haddocks using section headers, and
+  -- allows for internal/hidden definitions and constructors.
+  --
+  -- We can't use -Werror=missing-export-lists here because it interferes with
+  -- ghcid. However, we enable it in CI, see ../cabal.project.ci.
+  ghc-options:
+    -Wmissing-export-lists
+
   ghc-options: -Wall
                -Werror=incomplete-patterns
                -Werror=missing-methods

--- a/crucible/src/Lang/Crucible/README.hs
+++ b/crucible/src/Lang/Crucible/README.hs
@@ -1,6 +1,7 @@
 {- | This module is only for documentation purposes, and provides a high
 level overview of Crucible aimed at developers. -}
 {-# OPTIONS_GHC -Wno-unused-imports #-}
+{-# OPTIONS_GHC -Wno-missing-export-lists #-}
 module Lang.Crucible.README where
 
 import What4.Interface


### PR DESCRIPTION
See the `Note` for motivation. Based on #1738, as `ForwardDataflow` was the only module actually missing an export list.