### PR TITLE
CI: Fix the tag matching patterns

### DIFF
--- a/.github/workflows/crux-llvm-build.yml
+++ b/.github/workflows/crux-llvm-build.yml
@@ -2,7 +2,9 @@ name: crux-llvm
 
 on:
   push:
-    tags: ["crux-v?[0-9]+.[0-9]+(.[0-9]+)?"]
+    tags:
+      - "crux-v?[0-9]+.[0-9]+"
+      - "crux-v?[0-9]+.[0-9]+.[0-9]+"
     branches: [master, "release-**"]
   pull_request:
     # Don't run on documentation-only changes

--- a/.github/workflows/crux-mir-build.yml
+++ b/.github/workflows/crux-mir-build.yml
@@ -1,7 +1,9 @@
 name: crux-mir
 on:
   push:
-    tags: ["crux-v?[0-9]+.[0-9]+(.[0-9]+)?"]
+    tags:
+      - "crux-v?[0-9]+.[0-9]+"
+      - "crux-v?[0-9]+.[0-9]+.[0-9]+"
     branches: [master, "release-**"]
   pull_request:
     # Don't run on documentation-only changes


### PR DESCRIPTION
They aren't regexps and don't support parenthesized subgroups.

Closes #1348.
Compare https://github.com/GaloisInc/saw-script/pull/2267.