### PR TITLE
`crucible-mir`: Don't use `Any` to represent vtables in `DynRefType`

### DIFF
--- a/crucible-mir/CHANGELOG.md
+++ b/crucible-mir/CHANGELOG.md
@@ -11,6 +11,8 @@ This release supports [version
 * Extend the override for the `atomic_xchg` intrinsic to support storing
   pointer values in addition to integer values.
 * Support translating constant trait object values.
+* Change `DynRefType` and `DynRefRepr` to store the types of vtable fields
+  directly instead of erasing their types using Crucible's `Any` type.
 
 # 0.6 -- 2026-01-29
 

--- a/crucible-mir/src/Mir/Generator.hs
+++ b/crucible-mir/src/Mir/Generator.hs
@@ -12,6 +12,7 @@
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
@@ -133,11 +134,19 @@ data MirPlace s where
 --
 -- rustc also supports "unsized rvalues".  Currently we don't support them, but
 -- we may need to add `PtrMetadata` to `MirExp`s at some point as well.
-data PtrMetadata s =
-      NoMeta
-    | SliceMeta (R.Expr MIR s UsizeType) -- ^ The slice length
-    | DynMeta (R.Expr MIR s C.AnyType) -- ^ The trait object's vtable
-  deriving Show
+data PtrMetadata s where
+    NoMeta :: PtrMetadata s
+    SliceMeta ::
+      -- | The slice length
+      R.Expr MIR s UsizeType ->
+      PtrMetadata s
+    DynMeta ::
+      -- | The types of the trait object's vtable fields
+      C.CtxRepr vtableCtx ->
+      -- | The trait object's vtable
+      R.Expr MIR s (C.StructType vtableCtx) ->
+      PtrMetadata s
+deriving instance Show (PtrMetadata s)
 
 ---------------------------------------------------------------------------------
 

--- a/crucible-mir/src/Mir/Intrinsics.hs
+++ b/crucible-mir/src/Mir/Intrinsics.hs
@@ -1208,13 +1208,13 @@ type instance ExprExtension MIR = EmptyExprExtension
 type instance StmtExtension MIR = MirStmt
 
 -- | The 'MirReferenceType' is the data pointer - either an immutable or mutable
--- reference. The 'AnyType' is the vtable.
-type DynRefType = StructType (EmptyCtx ::> MirReferenceType ::> AnyType)
+-- reference. @vtableCtx@ consists of the types of the vtable fields.
+type DynRefType vtableCtx = StructType (EmptyCtx ::> MirReferenceType ::> StructType vtableCtx)
 
-dynRefDataIndex :: Index (EmptyCtx ::> MirReferenceType ::> AnyType) MirReferenceType
+dynRefDataIndex :: Index (EmptyCtx ::> MirReferenceType ::> StructType vtableCtx) MirReferenceType
 dynRefDataIndex = skipIndex baseIndex
 
-dynRefVtableIndex :: Index (EmptyCtx ::> MirReferenceType ::> AnyType) AnyType
+dynRefVtableIndex :: Index (EmptyCtx ::> MirReferenceType ::> StructType vtableCtx) (StructType vtableCtx)
 dynRefVtableIndex = lastIndex (incSize $ incSize zeroSize)
 
 


### PR DESCRIPTION
We now store the Crucible types of vtables directly, allowing us to avoid some simulation-time checks to unpack `Any` values when retrieving vtables.

While this is a backwards-incompatible change, it is one that appears unlikely to break much code in practice. (For instance, SAW continues to build with needing any modifications.)

Fixes #1747.