### PR TITLE
`crucible-mir`: Document why vtable types are erased

### DIFF
--- a/crucible-mir/src/Mir/Intrinsics.hs
+++ b/crucible-mir/src/Mir/Intrinsics.hs
@@ -1208,7 +1208,7 @@ type instance ExprExtension MIR = EmptyExprExtension
 type instance StmtExtension MIR = MirStmt
 
 -- | The 'MirReferenceType' is the data pointer - either an immutable or mutable
--- reference. The 'AnyType' is the vtable.
+-- reference. The 'AnyType' is the vtable. See @Note [Erase vtable types]@.
 type DynRefType = StructType (EmptyCtx ::> MirReferenceType ::> AnyType)
 
 dynRefDataIndex :: Index (EmptyCtx ::> MirReferenceType ::> AnyType) MirReferenceType
@@ -1217,6 +1217,38 @@ dynRefDataIndex = skipIndex baseIndex
 dynRefVtableIndex :: Index (EmptyCtx ::> MirReferenceType ::> AnyType) AnyType
 dynRefVtableIndex = lastIndex (incSize $ incSize zeroSize)
 
+{-
+Note [Erase vtable types]
+~~~~~~~~~~~~~~~~~~~~~~~~~
+DynRefType erases the type of a trait object's vtable using Crucible's Any
+type. Note that the vtable type is known statically, which makes the choice to
+use Any here somewhat unusual. The main reason why we need Any is because
+vtable types can potentially be recursive. For instance, consider the
+std::error::Error trait:
+
+  trait Error {
+      fn cause(&self) -> Option<&dyn Error>;
+  }
+
+Now suppose that we want to translate the type `&dyn Error` to Crucible. The
+vtable for a trait object of this type will have a field for the `cause`
+method, and this field's type will recursively mention `&dyn Error`. We have to
+be careful when translating this, because we might run this risk of infinitely
+recursing.
+
+Using the Any type is one way to break the recursion. Rather than translating
+all of a vtable's field types upfront, we instead just represent the entire
+vtable type as Any. Later, when making a virtual call, we check dynamically (at
+simulation time) that the Any's underlying type actually matches the expected
+vtable type, which allows us to unfold the vtable type definition once (and
+only once, to avoid infinitely recursing).
+
+An alternative approach would be to use Crucible's RecursiveType instead of
+Any. It is unclear if this is worth the effort, however, as we would have to
+invent a new symbol for each vtable type. Moreover, the amount of machinery
+needed to roll/unroll recursive types is similar to the machinery needed to
+pack/unpack Any types.
+-}
 
 data MirStmt :: (CrucibleType -> Type) -> CrucibleType -> Type where
   MirNewRef ::

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -1298,7 +1298,7 @@ mkTraitObject traitName' vtableName e = do
 
     return $ mkStructExp
         [ e
-        , packAny vtable
+        , packAny vtable -- See Note [Erase vtable types] in Mir.Intrinsics
         ]
 
     where
@@ -2901,6 +2901,8 @@ mkVirtCall col dynTraitName methIndex recvTy recvExpr argTys argExprs retTy = do
 
     let vtableStructTy' = C.StructRepr vtableTys
     okBlk <- G.newLambdaLabel' vtableStructTy'
+    -- See Note [Erase vtable types] in Mir.Intrinsics for why we need to
+    -- unpack an Any type here.
     vtable <- G.continueLambda okBlk $ do
         G.branchMaybe (R.App $ E.UnpackAny vtableStructTy' recvVtable) okBlk errBlk
 

--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -299,7 +299,8 @@ pattern DynRefCtx = Ctx.Empty Ctx.:> MirReferenceRepr Ctx.:> C.AnyRepr
 
 -- | The representation for a @&dyn Tr@/@&mut dyn Tr@. Both use the same
 -- representation: a pair of a data value (which is either @&Ty@ or @&mut Ty@)
--- and a vtable. The vtable is type-erased (`AnyRepr`). See `DynRefCtx`.
+-- and a vtable. The vtable is type-erased (`AnyRepr`); see @Note [Erase vtable
+-- types]@ in "Mir.Intrinsics". See also `DynRefCtx`.
 pattern DynRefRepr :: () => (tp ~ DynRefType) => C.TypeRepr tp
 pattern DynRefRepr = C.StructRepr DynRefCtx
 


### PR DESCRIPTION
Resolves #1747.