### PR TITLE
`crucible`: Prefer `withStateBackend` over `withBackend`

### DIFF
--- a/crucible/src/Lang/Crucible/Simulator/BoundedExec.hs
+++ b/crucible/src/Lang/Crucible/Simulator/BoundedExec.hs
@@ -254,7 +254,6 @@ boundedExecFeature getLoopBounds generateSideConditions =
    IO (ExecutionFeatureResult p sym ext rtp)
  onTransition gvRef tgt_id res st = stateSolverProof st $
   do let sym = st ^. stateSymInterface
-     let simCtx = st ^. stateContext
      (globals', overLimit) <- checkBackedge gvRef (st ^. stateCrucibleFrame.frameBlockID) tgt_id (st ^. stateGlobals)
      let st' = st & stateGlobals .~ globals'
      case overLimit of
@@ -262,7 +261,7 @@ boundedExecFeature getLoopBounds generateSideConditions =
          do let msg = "reached maximum number of loop iterations (" ++ show n ++ ")"
             let loc = st ^. stateCrucibleFrame.to frameProgramLoc
             let err = SimError loc (ResourceExhausted msg)
-            when generateSideConditions $ withBackend simCtx $ \bak ->
+            when generateSideConditions $ withStateBackend st $ \bak ->
               addProofObligation bak (LabeledPred (falsePred sym) err)
             return (ExecutionFeatureNewState (AbortState (AssertionFailure err) st'))
        Nothing -> return (ExecutionFeatureModifiedState (ControlTransferState res st'))

--- a/crucible/src/Lang/Crucible/Simulator/BoundedRecursion.hs
+++ b/crucible/src/Lang/Crucible/Simulator/BoundedRecursion.hs
@@ -110,7 +110,6 @@ boundedRecursionFeature getRecursionBound generateSideConditions =
    IO (ExecutionFeatureResult p sym ext rtp)
  pushFrame gvRef rebuildStack h mkSt st = stateSolverProof st $
      do let sym = st ^. stateSymInterface
-        let simCtx = st ^. stateContext
         currGv <- readIORef gvRef
         let err = panic "pushFrame" ["Uninitialized global!"]
         let gv = fromMaybe err currGv
@@ -125,7 +124,7 @@ boundedRecursionFeature getRecursionBound generateSideConditions =
                 loc <- getCurrentProgramLoc sym
                 let msg = ("reached maximum number of recursive calls to function " ++ show h ++ " (" ++ show b ++ ")")
                 let simerr = SimError loc (ResourceExhausted msg)
-                when generateSideConditions $ withBackend simCtx $ \bak ->
+                when generateSideConditions $ withStateBackend st $ \bak ->
                   addProofObligation bak (LabeledPred (falsePred sym) simerr)
                 return (ExecutionFeatureNewState (AbortState (AssertionFailure simerr) st))
               _ -> do

--- a/crucible/src/Lang/Crucible/Simulator/PathSatisfiability.hs
+++ b/crucible/src/Lang/Crucible/Simulator/PathSatisfiability.hs
@@ -88,7 +88,7 @@ pathSatisfiabilityFeature sym considerSatisfiability =
           considerSatisfiability ploc p >>= \case
                IndeterminateBranchResult ->
                  return ExecutionFeatureNoChange
-               NoBranch chosen_branch -> withBackend (st ^. stateContext) $ \bak ->
+               NoBranch chosen_branch -> withStateBackend st $ \bak ->
                  do p' <- if chosen_branch then return p else notPred sym p
                     let frm = if chosen_branch then tp else fp
                     addAssumption bak (BranchCondition loc (pausedLoc frm) p')

--- a/crucible/src/Lang/Crucible/Simulator/PathSplitting.hs
+++ b/crucible/src/Lang/Crucible/Simulator/PathSplitting.hs
@@ -97,8 +97,7 @@ restoreWorkItem ::
   IO (ExecState p sym ext rtp)
 restoreWorkItem (WorkItem branchPred loc frm st assumes) =
   do let sym = st ^. stateSymInterface
-     let simCtx = st ^. stateContext
-     withBackend simCtx $ \bak ->
+     withStateBackend st $ \bak ->
       do setCurrentProgramLoc sym loc
          restoreAssumptionState bak assumes
          addAssumption bak (BranchCondition loc (pausedLoc frm) branchPred)
@@ -117,7 +116,7 @@ pathSplittingFeature ::
   ExecutionFeature p sym ext rtp
 pathSplittingFeature wl = ExecutionFeature $ \case
   SymbolicBranchState p trueFrame falseFrame _bt st ->
-    withBackend (st ^. stateContext) $ \bak ->
+    withStateBackend st $ \bak ->
     do let sym = st ^. stateSymInterface
        pnot <- notPred sym p
        assumes <- saveAssumptionState bak

--- a/crucible/src/Lang/Crucible/Simulator/PositionTracking.hs
+++ b/crucible/src/Lang/Crucible/Simulator/PositionTracking.hs
@@ -44,8 +44,7 @@ positionTrackingFeature _sym = return $ GenericExecutionFeature onStep
      IO (ExecutionFeatureResult p sym ext rtp)
    onStep exst@(RunningState (RunBlockStart _bid) st) =
      do let loc = st ^. (stateCrucibleFrame.to frameProgramLoc)
-        let simCtx = st ^. stateContext
-        liftIO $ withBackend simCtx $ \bak ->
+        liftIO $ withStateBackend st $ \bak ->
           addAssumptions bak (singleEvent (LocationReachedEvent loc))
         return (ExecutionFeatureModifiedState exst)
 

--- a/crucible/src/Lang/Crucible/Simulator/RecordAndReplay.hs
+++ b/crucible/src/Lang/Crucible/Simulator/RecordAndReplay.hs
@@ -338,7 +338,7 @@ replayFeature stop =
             | stop -> badPath
             | otherwise -> pure C.ExecutionFeatureNoChange
           W4P.PE valid (expectedLoc, rest) ->
-            C.withBackend (st ^. C.stateContext) $ \bak -> do
+            C.withStateBackend st $ \bak -> do
               let msg = "Trace must be valid"
               CB.assert bak valid (C.AssertFailureSimError msg "")
 

--- a/crux-mir/test/symb_eval/any/downcast_fail.good
+++ b/crux-mir/test/symb_eval/any/downcast_fail.good
@@ -7,6 +7,8 @@ failures:
 [Crux] Found counterexample for verification goal
 [Crux]   test/symb_eval/any/downcast_fail.rs:10:14: 10:33: error: in downcast_fail/<DISAMB>::crux_test[0]
 [Crux]   failed to downcast Any as BVRepr 32
+[Crux]   Context:
+[Crux]     test/symb_eval/any/downcast_fail.rs:10:14: 10:33: downcast_fail/<DISAMB>::crux_test[0]
 
 [Crux-MIR] ---- FINAL RESULTS ----
 [Crux] Goal status:

--- a/crux-mir/test/symb_eval/bytes/put_overflow.good
+++ b/crux-mir/test/symb_eval/bytes/put_overflow.good
@@ -7,6 +7,9 @@ failures:
 [Crux] Found counterexample for verification goal
 [Crux]   ./libs/core/src/panic.rs:62:9: 62:73 !./libs/bytes.rs:201:9: 202:49: error: in bytes/<DISAMB>::{impl#4}[0]::put_slice[0]
 [Crux]   panicking::panic_fmt, called from bytes/<DISAMB>::{impl#4}[0]::put_slice[0]
+[Crux]   Context:
+[Crux]     ./libs/core/src/panic.rs:62:9: 62:73 !./libs/bytes.rs:201:9: 202:49: bytes/<DISAMB>::{impl#4}[0]::put_slice[0]
+[Crux]     test/symb_eval/bytes/put_overflow.rs:9:5: 9:69: put_overflow/<DISAMB>::f[0]
 
 [Crux-MIR] ---- FINAL RESULTS ----
 [Crux] Goal status:

--- a/crux-mir/test/symb_eval/crux/early_fail.good
+++ b/crux-mir/test/symb_eval/crux/early_fail.good
@@ -9,6 +9,8 @@ failures:
 [Crux] Found counterexample for verification goal
 [Crux]   ./libs/core/src/panic.rs:62:9: 62:73 !test/symb_eval/crux/early_fail.rs:11:5: 11:20: error: in early_fail/<DISAMB>::fail1[0]
 [Crux]   panicking::panic_fmt, called from early_fail/<DISAMB>::fail1[0]
+[Crux]   Context:
+[Crux]     ./libs/core/src/panic.rs:62:9: 62:73 !test/symb_eval/crux/early_fail.rs:11:5: 11:20: early_fail/<DISAMB>::fail1[0]
 
 ---- early_fail/<DISAMB>::fail2[0] counterexamples ----
 [Crux] Found counterexample for verification goal

--- a/crux-mir/test/symb_eval/crux/multi.good
+++ b/crux-mir/test/symb_eval/crux/multi.good
@@ -22,6 +22,8 @@ failures:
 [Crux] Found counterexample for verification goal
 [Crux]   ./libs/core/src/panic.rs:62:9: 62:73 !test/symb_eval/crux/multi.rs:15:9: 15:22: error: in multi/<DISAMB>::fail2[0]
 [Crux]   panicking::panic_fmt, called from multi/<DISAMB>::fail2[0]
+[Crux]   Context:
+[Crux]     ./libs/core/src/panic.rs:62:9: 62:73 !test/symb_eval/crux/multi.rs:15:9: 15:22: multi/<DISAMB>::fail2[0]
 
 ---- multi/<DISAMB>::fail3[0] counterexamples ----
 [Crux] Found counterexample for verification goal


### PR DESCRIPTION
This replaces uses of `withBackend` in `crucible` with `withStateBackend`, which uses a `SimState` to keep track of stack traces. A nice result of this change is that `crucible-mir` now produces stack traces on errors that arise from uses of `mirFail`, as can be seen in the changes to the `crux-mir` golden output in this commit.

Fixes https://github.com/GaloisInc/crucible/issues/1752.