### PR TITLE
crucible-jvm: Optimize `ClassRefs` instance for list type.

### DIFF
--- a/crucible-jvm/src/Lang/Crucible/JVM/ClassRefs.hs
+++ b/crucible-jvm/src/Lang/Crucible/JVM/ClassRefs.hs
@@ -30,6 +30,10 @@ instance ClassRefs a => ClassRefs (Maybe a) where
 
 instance ClassRefs a => ClassRefs [a] where
   classRefs = Set.unions . map classRefs
+  -- NOTE: This is a performance-critical function that may be called
+  -- a large number of times.
+  -- Benchmarking shows that this version with 'Set.unions' consumes
+  -- less time and memory than a similar definition with 'foldMap'.
 
 --
 instance ClassRefs J.ClassName where


### PR DESCRIPTION
Benchmarking shows this change to cause a significant reduction in runtime and memory allocation for the `classRefs` function.

See galoisInc/saw-script#2975.