### PR TITLE
`crucible-mir`: Remove unnecessary `-fno-warn-orphans` pragmas

### DIFF
--- a/crucible-mir/src/Mir/DefId.hs
+++ b/crucible-mir/src/Mir/DefId.hs
@@ -3,9 +3,6 @@
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE DeriveGeneric, DeriveAnyClass, DefaultSignatures #-}
 
-{-# OPTIONS_GHC -fno-warn-orphans #-}
-
-
 module Mir.DefId
 ( DefId
 , didCrate

--- a/crucible-mir/src/Mir/FancyMuxTree.hs
+++ b/crucible-mir/src/Mir/FancyMuxTree.hs
@@ -31,8 +31,6 @@
 -- See: https://ghc.haskell.org/trac/ghc/ticket/11581
 {-# LANGUAGE UndecidableInstances #-}
 
-{-# OPTIONS_GHC -fno-warn-orphans #-}
-
 module Mir.FancyMuxTree
   {-
 ( -- * Internal implementation types


### PR DESCRIPTION
We should warn about orphan instances except in special circumstances. These modules were bypassing this by enabling `-fno-warn-orphans` via `OPTIONS_GHC` pragmas, despite the fact that neither module actually defines any orphan instances. Let's remove these pragmas so that we are warned going forward.