### PR TITLE
`crucible-mir`: Enable `UndecidableInstances` in more places for GHC 9.4 support

### DIFF
--- a/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
@@ -14,6 +14,9 @@
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE ViewPatterns #-}
 
+-- See: https://ghc.haskell.org/trac/ghc/ticket/11581
+{-# LANGUAGE UndecidableInstances #-}
+
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- TODO(#1786): refine exports

--- a/crucible-mir/src/Mir/Intrinsics/MethodSpec.hs
+++ b/crucible-mir/src/Mir/Intrinsics/MethodSpec.hs
@@ -11,6 +11,9 @@
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE ViewPatterns #-}
 
+-- See: https://ghc.haskell.org/trac/ghc/ticket/11581
+{-# LANGUAGE UndecidableInstances #-}
+
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- TODO(#1786): refine exports, if necessary

--- a/crucible-mir/src/Mir/Intrinsics/Reference.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Reference.hs
@@ -12,6 +12,9 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE ViewPatterns #-}
 
+-- See: https://ghc.haskell.org/trac/ghc/ticket/11581
+{-# LANGUAGE UndecidableInstances #-}
+
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- TODO(#1786): refine exports


### PR DESCRIPTION
GHC 9.6 or later do not require `UndecidableInstances` to build `crucible-mir` after https://github.com/GaloisInc/crucible/pull/1784, but GHC 9.4 does require it. This wasn't caught in `crucible`'s CI (which only tests GHC 9.6 through 9.10), but since SAW's CI still requires supporting GHC 9.4, this was caught when attempting to bump the `crucible` submodule in SAW. (See https://github.com/GaloisInc/saw-script/pull/3119#issuecomment-4114120763).

For backwards compatibility with GHC 9.4, this enables `UndecidableInstances` in the places that need them.