### PR TITLE
Label the Crux Docker images to appear in the Crux repository.

### DIFF
--- a/.github/workflows/crux-llvm-build.yml
+++ b/.github/workflows/crux-llvm-build.yml
@@ -268,6 +268,7 @@ jobs:
         include:
           - file: .github/Dockerfile-crux-llvm
             image: ghcr.io/galoisinc/crux-llvm
+            image-repo: GaloisInc/crux
             cache: ghcr.io/galoisinc/cache-crux-llvm
     steps:
       - uses: actions/checkout@v6
@@ -292,6 +293,8 @@ jobs:
         id: labels
         with:
           images: ${{ matrix.image }}
+          label-custom: |
+             org.opencontainers.image.source=https://github.com/${{ matrix.image-repo }}
 
       - uses: docker/login-action@v4
         with:

--- a/.github/workflows/crux-mir-build.yml
+++ b/.github/workflows/crux-mir-build.yml
@@ -245,6 +245,7 @@ jobs:
         include:
           - file: .github/Dockerfile-crux-mir
             image: ghcr.io/galoisinc/crux-mir
+            image-repo: GaloisInc/crux
             cache: ghcr.io/galoisinc/cache-crux-mir
     steps:
       - uses: actions/checkout@v6
@@ -281,6 +282,8 @@ jobs:
         id: labels
         with:
           images: ${{ matrix.image }}
+          label-custom: |
+             org.opencontainers.image.source=https://github.com/${{ matrix.image-repo }}
 
       - uses: docker/login-action@v4
         with:


### PR DESCRIPTION
This should list future versions of the `crux-llvm` and `crux-mir` Docker images in the new Crux repository instead of this one.