### PR TITLE
Rename the "breakpoint" feature to "cut" or "cutpoint"

### DIFF
--- a/crucible-llvm/CHANGELOG.md
+++ b/crucible-llvm/CHANGELOG.md
@@ -1,5 +1,11 @@
 # next
 
+* **BREAKING:** Rename various bits associated with the "breakpoint"
+  feature in accordance with renaming the feature to "cutpoint".
+  In particular, `testBreakpointFunction` is now `testCutpointFunction`.
+  Also, the family of LLVM symbols recognized now begins with `__cutpoint__`
+  rather than `__breakpoint__`.
+
 * Remove `llvmOverride_declare :: Text.LLVM.AST.Declare` from `LLVMOverride`.
 
   * Add `Lang.Crucible.LLVM.Intrinsics.Declare` module.

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Constant.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Constant.hs
@@ -49,7 +49,7 @@ module Lang.Crucible.LLVM.Translation.Constant
 
     -- * Utility functions
   , showInstr
-  , testBreakpointFunction
+  , testCutpointFunction
   ) where
 
 import qualified Control.Exception as X
@@ -1200,5 +1200,5 @@ transConstantExpr expr = case expr of
  badExp :: String -> m a
  badExp msg = throwError $ unlines [msg, show expr]
 
-testBreakpointFunction :: String -> Bool
-testBreakpointFunction = isPrefixOf "__breakpoint__"
+testCutpointFunction :: String -> Bool
+testCutpointFunction = isPrefixOf "__cutpoint__"

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Instruction.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Instruction.hs
@@ -2024,7 +2024,7 @@ unaryArithOp op _ x =
          return $ App $ FloatNeg fi a
 
 -- | Generate a call to an LLVM function, without any special
---   handling for debug intrinsics or breakpoints.
+--   handling for debug intrinsics or cuts/cutpoints.
 callOrdinaryFunction ::
    Maybe L.Instr {- ^ The instruction causing this call -} ->
    Bool    {- ^ Is the function a tail call? -} ->
@@ -2064,7 +2064,7 @@ callOrdinaryFunction instr _tailCall fnTy _fn _args _assign_f =
 
 
 -- | Generate a call to an LLVM function, generating special support
--- for debugging intrinsics and breakpoint functions.
+-- for debugging intrinsics and cuts/cutpoint functions.
 callFunction :: forall s arch ret.
    (?transOpts :: TranslationOptions) =>
    L.Instr {- ^ Source instruction of the call -} ->
@@ -2098,11 +2098,11 @@ callFunction instr tailCall_ fnTy fn args assign_f
                  ] = return ()
 
      | L.ValSymbol (L.Symbol nm) <- fn
-     , testBreakpointFunction nm = do
+     , testCutpointFunction nm = do
         some_val_args <- mapM (\tv -> typedValueAsCrucibleValue tv) args
         case Ctx.fromList some_val_args of
           Some val_args -> do
-            addBreakpointStmt (Text.pack nm) val_args
+            addCutStmt (Text.pack nm) val_args
 
      | otherwise = callOrdinaryFunction (Just instr) tailCall_ fnTy fn args assign_f
 
@@ -2118,7 +2118,7 @@ typedValueAsCrucibleValue tv = case L.typedValue tv of
       Nothing -> reportError $ fromString $
         "Could not find identifier " ++ show i ++ "."
   v -> reportError $ fromString $
-    "Unsupported breakpoint parameter: " ++ show v ++ "."
+    "Unsupported cutpoint parameter: " ++ show v ++ "."
 
 
 

--- a/crucible-syntax/CHANGELOG.md
+++ b/crucible-syntax/CHANGELOG.md
@@ -1,5 +1,10 @@
 # next
 
+* **BREAKING:** Rename various bits associated with the "breakpoint"
+  feature in accordance with renaming the feature to "cutpoint".
+  In particular the concrete name "breakpoint" has been changed to
+  "cut", and the `Breakpoint_` atom has been changed to
+  `Cut_`.
 * Add `seq-reverse` syntax for reversing symbolic sequences.
 * The `Lang.Crucible.Syntax.Overrides` module has been removed from this library,
   as the overrides it provided (`proveObligations` and `crucible-print-assumption-state`)

--- a/crucible-syntax/src/Lang/Crucible/Syntax/Atoms.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Atoms.hs
@@ -79,7 +79,7 @@ data Keyword = Defun | DefBlock | DefGlobal | Declare | Extern
              | Assert_ | Assume_
              | SetRegister
              | Funcall
-             | Breakpoint_
+             | Cut_
              | BV | BVConcat_ | BVSelect_ | BVTrunc_
              | BVZext_ | BVSext_ | BVNonzero_ | BoolToBV_
              | BVCarry_ | BVSCarry_ | BVSBorrow_
@@ -125,7 +125,7 @@ keywords =
   , ("assert!", Assert_)
   , ("assume!", Assume_)
   , ("funcall", Funcall)
-  , ("breakpoint", Breakpoint_)
+  , ("cut", Cut_)
 
     -- types
   , ("Any" , AnyT)

--- a/crucible-syntax/src/Lang/Crucible/Syntax/Concrete.hs
+++ b/crucible-syntax/src/Lang/Crucible/Syntax/Concrete.hs
@@ -1549,11 +1549,11 @@ normStmt' =
         DropRef_    -> dropRef
         Assert_     -> assertion
         Assume_     -> assumption
-        Breakpoint_ -> breakpoint
+        Cut_        -> cut_
         _           -> void (extensionParser ?parserHooks)
 
   where
-    printStmt, printLnStmt, letStmt, setGlobal, setReg, setRef, dropRef, assertion, breakpoint :: m ()
+    printStmt, printLnStmt, letStmt, setGlobal, setReg, setRef, dropRef, assertion, cut_ :: m ()
     printStmt =
       do Posd loc e <- unary Print_ (located $ reading $ check (StringRepr UnicodeRepr))
          strAtom <- eval loc e
@@ -1643,13 +1643,13 @@ normStmt' =
          msg' <- eval mLoc msg
          tell [Posd loc $ Assume cond' msg']
 
-    breakpoint =
+    cut_ =
       do (Posd loc (nm, arg_list)) <-
-           located $ binary Breakpoint_
-             (string <&> BreakpointName)
+           located $ binary Cut_
+             (string <&> CutpointName)
              (rep ra_value)
          case toCtx arg_list of
-           Some args -> tell [Posd loc $ Breakpoint nm args]
+           Some args -> tell [Posd loc $ Cut nm args]
       where
         ra_value :: m (Some (Value s))
         ra_value = (reading synth) >>= \case

--- a/crucible-syntax/test-data/cuts.cbl
+++ b/crucible-syntax/test-data/cuts.cbl
@@ -7,12 +7,12 @@
     (set-register! $i 0)
     (jump header:))
   (defblock header:
-    (breakpoint "foo_header" (n $s $i))
+    (cut "foo_header" (n $s $i))
     (let i $i)
     (let c (< i n))
     (branch c body: end:))
   (defblock body:
-    (breakpoint "foo_body" (n $s $i i))
+    (cut "foo_body" (n $s $i i))
     (let s $s)
     (set-register! $s (+ s i))
     (set-register! $i (+ i 1))

--- a/crucible-syntax/test-data/cuts.out.good
+++ b/crucible-syntax/test-data/cuts.out.good
@@ -5,12 +5,12 @@
       (set-register! $i 0)
       (jump header:))
    (defblock header:
-      (breakpoint "foo_header" (n $s $i))
+      (cut "foo_header" (n $s $i))
       (let i $i)
       (let c (< i n))
       (branch c body: end:))
    (defblock body:
-      (breakpoint "foo_body" (n $s $i i))
+      (cut "foo_body" (n $s $i i))
       (let s $s)
       (set-register! $s (+ s i))
       (set-register! $i (+ i 1))

--- a/crucible/CHANGELOG.md
+++ b/crucible/CHANGELOG.md
@@ -1,5 +1,17 @@
 # next
 
+* **BREAKING:** Rename various bits associated with the "breakpoint"
+  feature in accordance with renaming the feature to "cut" or
+  "cutpoint".
+  Exported Haskell symbols renamed:
+  - `Lang.Crucible.Simulator.Breakpoint` -> `Lang.Crucible.Simulator.Cut`
+  - `BreakpointName` -> `CutpointName`
+  - `Breakpoint` -> `Cut`
+  - `addBreakpointStmt` -> `addCutStmt`
+  - `breakAndReturn` -> `cutAndReturn`
+  - `breakpointPostdomInfo` -> `cutpointPostdomInfo`
+  - `cfgBreakpoints` -> `cfgCutpoints`
+  - `setFrameBreakpointPostdomInfo` -> `setFrameCutpointPostdomInfo`
 * Add `reverseSymSequence` to `Lang.Crucible.Simulator.SymSequence`
 * **BREAKING:** Add `SequenceReverse` constructor to `App` in
   `Lang.Crucible.CFG.Expr` for reversing symbolic sequences.

--- a/crucible/crucible.cabal
+++ b/crucible/crucible.cabal
@@ -210,10 +210,10 @@ library
     Lang.Crucible.FunctionHandle
     Lang.Crucible.README
     Lang.Crucible.Simulator
-    Lang.Crucible.Simulator.Breakpoint
     Lang.Crucible.Simulator.BoundedExec
     Lang.Crucible.Simulator.BoundedRecursion
     Lang.Crucible.Simulator.CallFrame
+    Lang.Crucible.Simulator.Cut
     Lang.Crucible.Simulator.Evaluation
     Lang.Crucible.Simulator.EvalStmt
     Lang.Crucible.Simulator.ExecutionTree

--- a/crucible/src/Lang/Crucible/Analysis/Postdom.hs
+++ b/crucible/src/Lang/Crucible/Analysis/Postdom.hs
@@ -15,7 +15,7 @@
 {-# LANGUAGE TupleSections #-}
 module Lang.Crucible.Analysis.Postdom
   ( postdomInfo
-  , breakpointPostdomInfo
+  , cutpointPostdomInfo
   , validatePostdom
   ) where
 
@@ -49,12 +49,12 @@ inEdges b =
     Just l -> (\(Some n) -> toNode n `reverseEdge` b) <$> l
 
 inEdgeGraph :: BlockMap ext blocks ret -> [Some (BlockID blocks)] -> G.UGr
-inEdgeGraph m breakpointIds = G.mkGraph ((,()) <$> nodes) edges
+inEdgeGraph m cutpointIds = G.mkGraph ((,()) <$> nodes) edges
   where nodes = 0 : toListFC (toNode . blockID) m
         cfgEdges = foldMapFC inEdges m
-        breakpointEdges = map (\(Some bid) -> reverseEdge 0 (getBlock bid m))
-                              breakpointIds
-        edges = cfgEdges ++ breakpointEdges
+        cutpointEdges = map (\(Some bid) -> reverseEdge 0 (getBlock bid m))
+                              cutpointIds
+        edges = cfgEdges ++ cutpointEdges
 
 -- | Return subgraph of nodes reachable from given node.
 reachableSubgraph :: G.Node -> G.UGr -> G.UGr
@@ -76,8 +76,8 @@ postdomMap :: forall ext blocks ret
             . BlockMap ext blocks ret
            -> [Some (BlockID blocks)]
            -> Map (Some (BlockID blocks)) [Some (BlockID blocks)]
-postdomMap m breakpointIds = r
-  where g0 = inEdgeGraph m breakpointIds
+postdomMap m cutpointIds = r
+  where g0 = inEdgeGraph m cutpointIds
         g = reachableSubgraph 0 g0
 
         idMap = nodeToBlockIDMap m
@@ -98,8 +98,8 @@ postdomAssignment :: forall ext blocks ret
                    . BlockMap ext blocks ret
                   -> [Some (BlockID blocks)]
                   -> CFGPostdom blocks
-postdomAssignment m breakpointIds = fmapFC go m
-  where pd = postdomMap m breakpointIds
+postdomAssignment m cutpointIds = fmapFC go m
+  where pd = postdomMap m cutpointIds
         go :: Block ext blocks ret c -> Const [Some (BlockID blocks)] c
         go b = Const $ fromMaybe [] (Map.lookup (Some (blockID b)) pd)
 
@@ -107,9 +107,9 @@ postdomAssignment m breakpointIds = fmapFC go m
 postdomInfo :: CFG ext b i r -> CFGPostdom b
 postdomInfo g = postdomAssignment (cfgBlockMap g) []
 
-breakpointPostdomInfo :: CFG ext b i r -> [BreakpointName] -> CFGPostdom b
-breakpointPostdomInfo g breakpointNames = postdomAssignment (cfgBlockMap g) $
-  mapMaybe (\nm -> Bimap.lookup nm (cfgBreakpoints g)) breakpointNames
+cutpointPostdomInfo :: CFG ext b i r -> [CutpointName] -> CFGPostdom b
+cutpointPostdomInfo g cutpointNames = postdomAssignment (cfgBlockMap g) $
+  mapMaybe (\nm -> Bimap.lookup nm (cfgCutpoints g)) cutpointNames
 
 blockEndsWithError :: Block ext blocks ret args -> Bool
 blockEndsWithError b =

--- a/crucible/src/Lang/Crucible/Analysis/Reachable.hs
+++ b/crucible/src/Lang/Crucible/Analysis/Reachable.hs
@@ -119,11 +119,11 @@ reachableCFG g =
                  SomeCFG g'
         where oldToNew = mkOldMap newToOld
               new_map = remapBlockMap oldToNew newToOld
-              new_breakpoints = Bimap.mapR (mapSome $ remapBlockID oldToNew) (cfgBreakpoints g)
+              new_cutpoints = Bimap.mapR (mapSome $ remapBlockID oldToNew) (cfgCutpoints g)
               g' = CFG { cfgHandle = cfgHandle g
                        , cfgBlockMap = new_map
                        , cfgEntryBlockID = remapBlockID oldToNew entry_id
-                       , cfgBreakpoints = new_breakpoints
+                       , cfgCutpoints = new_cutpoints
                        }
   where old_map = cfgBlockMap g
         entry_id = cfgEntryBlockID g

--- a/crucible/src/Lang/Crucible/CFG/Common.hs
+++ b/crucible/src/Lang/Crucible/CFG/Common.hs
@@ -15,7 +15,7 @@ module Lang.Crucible.CFG.Common
   ( -- * Global variables
     GlobalVar(..)
   , freshGlobalVar
-  , BreakpointName(..)
+  , CutpointName(..)
   ) where
 
 import           Data.Text (Text)
@@ -65,8 +65,8 @@ freshGlobalVar halloc nm tp = do
          , globalType  = tp
          }
 
-newtype BreakpointName = BreakpointName { breakpointNameText :: Text }
+newtype CutpointName = CutpointName { cutpointNameText :: Text }
   deriving (Eq, Ord, Show)
 
-instance Pretty BreakpointName where
-  pretty = pretty . breakpointNameText
+instance Pretty CutpointName where
+  pretty = pretty . cutpointNameText

--- a/crucible/src/Lang/Crucible/CFG/Core.hs
+++ b/crucible/src/Lang/Crucible/CFG/Core.hs
@@ -781,7 +781,7 @@ data CFG (ext :: Type)
    = CFG { cfgHandle :: FnHandle init ret
          , cfgBlockMap :: !(BlockMap ext blocks ret)
          , cfgEntryBlockID :: !(BlockID blocks init)
-         , cfgBreakpoints :: !(Bimap BreakpointName (Some (BlockID blocks)))
+         , cfgCutpoints :: !(Bimap CutpointName (Some (BlockID blocks)))
          }
 
 cfgArgTypes :: CFG ext blocks init ret -> CtxRepr init

--- a/crucible/src/Lang/Crucible/CFG/EarlyMergeLoops.hs
+++ b/crucible/src/Lang/Crucible/CFG/EarlyMergeLoops.hs
@@ -342,7 +342,7 @@ lowerValueWrites ng pvals st =
    Print {}       -> orig
    Assert {}      -> orig
    Assume {}      -> orig
-   Breakpoint {}  -> orig
+   Cut {}         -> orig
 
   where
     orig = pure (Seq.fromList [st])
@@ -380,7 +380,7 @@ lowerValueReads ng pvals st =
     Print {}       -> lowerAtomReads ng pvals atomsToLower st
     Assert {}      -> lowerAtomReads ng pvals atomsToLower st
     Assume {}      -> lowerAtomReads ng pvals atomsToLower st
-    Breakpoint {}  -> lowerAtomReads ng pvals atomsToLower st
+    Cut {}         -> lowerAtomReads ng pvals atomsToLower st
   where
     atomsToLower :: [Some (Atom s)]
     atomsToLower = Set.toList (foldStmtInputs addIfLowered (pos_val st) mempty)

--- a/crucible/src/Lang/Crucible/CFG/ExtractSubgraph.hs
+++ b/crucible/src/Lang/Crucible/CFG/ExtractSubgraph.hs
@@ -44,7 +44,7 @@ extractSubgraph :: (KnownCtx TypeRepr init, KnownRepr TypeRepr ret)
                 -> BlockID blocks init
                 -> HandleAllocator
                 -> IO (Maybe (SomeCFG ext init ret))
-extractSubgraph (CFG{cfgBlockMap = orig, cfgBreakpoints = breakpoints}) cuts bi halloc =
+extractSubgraph (CFG{cfgBlockMap = orig, cfgCutpoints = cutpoints}) cuts bi halloc =
   extractSubgraphFirst orig cuts MapF.empty zeroSize bi $
     \(SubgraphIntermediate finalMap finalInitMap _sz entryID cb) -> do
         hn <- mkHandle halloc startFunctionName
@@ -54,9 +54,9 @@ extractSubgraph (CFG{cfgBlockMap = orig, cfgBreakpoints = breakpoints}) cuts bi 
             { cfgBlockMap = bm
             , cfgEntryBlockID = entryID
             , cfgHandle = hn
-            , cfgBreakpoints = Bimap.fromList $ Map.toList $
+            , cfgCutpoints = Bimap.fromList $ Map.toList $
                 Map.mapMaybe (viewSome $ \bid -> Some <$> MapF.lookup bid finalMap) $
-                Bimap.toMap breakpoints
+                Bimap.toMap cutpoints
             }
 
 -- | Type for carrying intermediate results through subraph extraction

--- a/crucible/src/Lang/Crucible/CFG/Generator.hs
+++ b/crucible/src/Lang/Crucible/CFG/Generator.hs
@@ -60,7 +60,7 @@ module Lang.Crucible.CFG.Generator
   , assertExpr
   , assumeExpr
   , addPrintStmt
-  , addBreakpointStmt
+  , addCutStmt
   , extensionStmt
   , mkAtom
   , mkFresh
@@ -455,13 +455,13 @@ addPrintStmt e =
   do e_a <- mkAtom e
      addStmt (Print e_a)
 
--- | Add a breakpoint.
-addBreakpointStmt ::
+-- | Add a cutpoint.
+addCutStmt ::
   (Monad m, IsSyntaxExtension ext) =>
-  Text {- ^ breakpoint name -} ->
-  Assignment (Value s) args {- ^ breakpoint values -} ->
+  Text {- ^ cutpoint name -} ->
+  Assignment (Value s) args {- ^ cutpoint values -} ->
   Generator ext s t r m ()
-addBreakpointStmt nm args = addStmt $ Breakpoint (BreakpointName nm) args
+addCutStmt nm args = addStmt $ Cut (CutpointName nm) args
 
 -- | Add an assert statement.
 assertExpr ::

--- a/crucible/src/Lang/Crucible/CFG/Reg.hs
+++ b/crucible/src/Lang/Crucible/CFG/Reg.hs
@@ -586,7 +586,7 @@ data Stmt ext s
    | Assert !(Atom s BoolType) !(Atom s (StringType Unicode))
      -- | Assume the given expression.
    | Assume !(Atom s BoolType) !(Atom s (StringType Unicode))
-   | forall args . Breakpoint BreakpointName !(Assignment (Value s) args)
+   | forall args . Cut CutpointName !(Assignment (Value s) args)
 
 instance PrettyExt ext => Show (Stmt ext s) where
   show = show . pretty
@@ -602,7 +602,7 @@ instance PrettyExt ext => Pretty (Stmt ext s) where
       Print  v   -> "print"  <+> pretty v
       Assert c m -> "assert" <+> pretty c <+> pretty m
       Assume c m -> "assume" <+> pretty c <+> pretty m
-      Breakpoint nm args -> "breakpoint" <+> pretty nm <+> parens (commas (toListFC pretty args))
+      Cut nm args -> "cut" <+> pretty nm <+> parens (commas (toListFC pretty args))
 
 -- | Return local value assigned by this statement or @Nothing@ if this
 -- does not modify a register.
@@ -617,7 +617,7 @@ stmtAssignedValue s =
     Print{} -> Nothing
     Assert{} -> Nothing
     Assume{} -> Nothing
-    Breakpoint{} -> Nothing
+    Cut{} -> Nothing
 
 -- | Fold all registers that are inputs tostmt.
 foldStmtInputs :: TraverseExt ext => (forall x . Value s x -> b -> b) -> Stmt ext s -> b -> b
@@ -631,7 +631,7 @@ foldStmtInputs f s b =
     Print  e     -> f (AtomValue e) b
     Assert c m   -> f (AtomValue c) (f (AtomValue m) b)
     Assume c m   -> f (AtomValue c) (f (AtomValue m) b)
-    Breakpoint _ args -> foldrFC' f b args
+    Cut _ args   -> foldrFC' f b args
 
 substStmt :: ( Applicative m, TraverseExt ext )
           => (forall (x :: CrucibleType). Nonce s x -> m (Nonce s' x))
@@ -647,7 +647,7 @@ substStmt f s =
     Print e -> Print <$> substAtom f e
     Assert c m -> Assert <$> substAtom f c <*> substAtom f m
     Assume c m -> Assume <$> substAtom f c <*> substAtom f m
-    Breakpoint nm args -> Breakpoint nm <$> traverseFC (substValue f) args
+    Cut nm args -> Cut nm <$> traverseFC (substValue f) args
 
 mapStmtAtom :: ( Applicative m, TraverseExt ext )
           => (forall (x :: CrucibleType). Atom s x -> m (Atom s x))
@@ -663,7 +663,7 @@ mapStmtAtom f s =
     Print e -> Print <$> f e
     Assert c m -> Assert <$> f c <*> f m
     Assume c m -> Assume <$> f c <*> f m
-    Breakpoint nm args -> Breakpoint nm <$> traverseFC (substValueAtom f) args
+    Cut nm args -> Cut nm <$> traverseFC (substValueAtom f) args
 
 substPosdStmt :: ( Applicative m, TraverseExt ext )
               => (forall (x :: CrucibleType). Nonce s x -> m (Nonce s' x))

--- a/crucible/src/Lang/Crucible/CFG/SSAConversion.hs
+++ b/crucible/src/Lang/Crucible/CFG/SSAConversion.hs
@@ -129,11 +129,11 @@ data BlockInput ext s blocks ret args
            , binputTerm       :: !(Posd (ExtendedTermStmt s blocks ret))
            }
 
--- The Breakpoint non-terminator statement becomes a jump during SSA conversion.
--- This datatype temporarily adds breakpoint as a terminator statement.
+-- The Cut non-terminator statement becomes a jump during SSA conversion.
+-- This datatype temporarily adds cut as a terminator statement.
 data ExtendedTermStmt s blocks ret where
   BaseTermStmt :: TermStmt s ret -> ExtendedTermStmt s blocks ret
-  BreakStmt :: JumpInfo s blocks -> ExtendedTermStmt s blocks ret
+  CutStmt :: JumpInfo s blocks -> ExtendedTermStmt s blocks ret
 
 type BlockInputAssignment ext s blocks ret
    = Assignment (BlockInput ext s blocks ret)
@@ -144,21 +144,21 @@ extBlockInputAssignment ::
 extBlockInput ::
   BlockInput ext s blocks ret args ->
   BlockInput ext s (blocks ::> tp) ret arg
-extBreakpoints ::
-  Bimap BreakpointName (Some (C.BlockID blocks)) ->
-  Bimap BreakpointName (Some (C.BlockID (blocks ::> tp)))
+extCutpoints ::
+  Bimap CutpointName (Some (C.BlockID blocks)) ->
+  Bimap CutpointName (Some (C.BlockID (blocks ::> tp)))
 #ifdef UNSAFE_OPS
 extBlockInputAssignment = unsafeCoerce
 
 extBlockInput = unsafeCoerce
 
-extBreakpoints = unsafeCoerce
+extCutpoints = unsafeCoerce
 #else
 extBlockInputAssignment = fmapFC extBlockInput
 
 extBlockInput bi = bi { binputID = C.extendBlockID (binputID bi) }
 
-extBreakpoints = Bimap.mapR (mapSome C.extendBlockID)
+extCutpoints = Bimap.mapR (mapSome C.extendBlockID)
 #endif
 
 ------------------------------------------------------------------------
@@ -295,11 +295,11 @@ extBlockInfo bi binput = do
   let blocks' = extBlockInputAssignment $ biBlocks bi
   let jump_info' = extJumpInfoMap $ biJumpInfo bi
   let switch_info' = extSwitchInfoMap $ biSwitchInfo bi
-  let breakpoints' = extBreakpoints $ biBreakpoints bi
+  let cutpoints' = extCutpoints $ biCutpoints bi
   BI { biBlocks = extend blocks' binput
      , biJumpInfo = jump_info'
      , biSwitchInfo = switch_info'
-     , biBreakpoints = breakpoints'
+     , biCutpoints = cutpoints'
      }
 
 ------------------------------------------------------------------------
@@ -393,7 +393,7 @@ data BlockInfo ext s ret blocks
    = BI { biBlocks      :: !(Assignment (BlockInput ext s blocks ret) blocks)
         , biJumpInfo    :: !(JumpInfoMap s blocks)
         , biSwitchInfo  :: !(SwitchInfoMap s blocks)
-        , biBreakpoints :: !(Bimap BreakpointName (Some (C.BlockID blocks)))
+        , biCutpoints :: !(Bimap CutpointName (Some (C.BlockID blocks)))
         }
 
 -- | This infers the information given a set of blocks.
@@ -403,7 +403,7 @@ inferBlockInfo blocks = seq input_map $ resolveBlocks bi0 blocks
         bi0 = BI { biBlocks = empty
                  , biJumpInfo = emptyJumpInfoMap
                  , biSwitchInfo = emptySwitchInfoMap
-                 , biBreakpoints = Bimap.empty
+                 , biCutpoints = Bimap.empty
                  }
         resolveBlocks ::
           BlockInfo ext s ret blocks ->
@@ -432,7 +432,7 @@ inferBlockInfo blocks = seq input_map $ resolveBlocks bi0 blocks
                   let bi' = extBlockInfo bi binput
                   let ji = JumpInfo block_id crepr ra
                   let bi'' = bi' { biJumpInfo = insertJumpInfo l ji (biJumpInfo bi') }
-                  splitLastBlockInputOnBreakpoints bi'' rest
+                  splitLastBlockInputOnCutpoints bi'' rest
                 LambdaID l -> do
                   let block_id = C.BlockID (nextIndex sz)
                   let lastArg = AtomValue (lambdaAtom l)
@@ -445,16 +445,16 @@ inferBlockInfo blocks = seq input_map $ resolveBlocks bi0 blocks
                   let bi' = extBlockInfo bi binput
                   let si = SwitchInfo block_id crepr ra
                   let bi'' = bi' { biSwitchInfo = insertSwitchInfo l si (biSwitchInfo bi') }
-                  splitLastBlockInputOnBreakpoints bi'' rest
-        splitLastBlockInputOnBreakpoints ::
+                  splitLastBlockInputOnCutpoints bi'' rest
+        splitLastBlockInputOnCutpoints ::
           BlockInfo ext s ret blocks ->
           [Block ext s ret] ->
           Some (BlockInfo ext s ret)
-        splitLastBlockInputOnBreakpoints bi rest
+        splitLastBlockInputOnCutpoints bi rest
           | first_binputs :> last_binput <- biBlocks bi
-          , (first_stmts, break_stmt Seq.:<| last_stmts) <-
-              Seq.breakl isBreakpoint (binputStmts last_binput)
-          , Breakpoint nm args <- pos_val break_stmt = do
+          , (first_stmts, cut_stmt Seq.:<| last_stmts) <-
+              Seq.breakl isCut (binputStmts last_binput)
+          , Cut nm args <- pos_val cut_stmt = do
             let block_id = C.BlockID $ nextIndex $ size $ biBlocks bi
 
             let first_binputs' = extBlockInputAssignment $ first_binputs
@@ -462,7 +462,7 @@ inferBlockInfo blocks = seq input_map $ resolveBlocks bi0 blocks
             let jump_info = JumpInfo block_id (fmapFC typeOfValue args) args
             let last_binput' = (extBlockInput last_binput)
                   { binputStmts = first_stmts
-                  , binputTerm = break_stmt { pos_val = BreakStmt jump_info }
+                  , binputTerm = cut_stmt { pos_val = CutStmt jump_info }
                   }
 
             let new_binput = (extBlockInput last_binput)
@@ -471,23 +471,23 @@ inferBlockInfo blocks = seq input_map $ resolveBlocks bi0 blocks
                   , binputStmts = last_stmts
                   }
 
-            let new_breakpoints = do
-                  let try_new_breakpoints = Bimap.tryInsert nm (Some block_id) $
-                        extBreakpoints $ biBreakpoints bi
-                  if Bimap.pairMember (nm, (Some block_id)) try_new_breakpoints
-                    then try_new_breakpoints
-                    else error $ "Duplicate breakpoint: " ++ show nm
+            let new_cutpoints = do
+                  let try_new_cutpoints = Bimap.tryInsert nm (Some block_id) $
+                        extCutpoints $ biCutpoints bi
+                  if Bimap.pairMember (nm, (Some block_id)) try_new_cutpoints
+                    then try_new_cutpoints
+                    else error $ "Duplicate cutpoint: " ++ show nm
             let bi' = BI
                   { biBlocks = first_binputs' :> last_binput' :> new_binput
                   , biJumpInfo = extJumpInfoMap $ biJumpInfo bi
                   , biSwitchInfo = extSwitchInfoMap $ biSwitchInfo bi
-                  , biBreakpoints = new_breakpoints
+                  , biCutpoints = new_cutpoints
                   }
-            splitLastBlockInputOnBreakpoints bi' rest
-        splitLastBlockInputOnBreakpoints bi rest = resolveBlocks bi rest
-        isBreakpoint :: Posd (Stmt ext s) -> Bool
-        isBreakpoint = \case
-          Posd _ Breakpoint{} -> True
+            splitLastBlockInputOnCutpoints bi' rest
+        splitLastBlockInputOnCutpoints bi rest = resolveBlocks bi rest
+        isCut :: Posd (Stmt ext s) -> Bool
+        isCut = \case
+          Posd _ Cut{} -> True
           _ -> False
 
 
@@ -695,7 +695,7 @@ resolveTermStmt bi reg_map bindings (BaseTermStmt t0) =
     ErrorStmt e -> C.ErrorStmt (resolveAtom reg_map e)
 
     Output l e -> C.Jump (resolveLambdaAsJump bi reg_map l (resolveAtom reg_map e))
-resolveTermStmt _ reg_map _ (BreakStmt (JumpInfo next_id types inputs)) = do
+resolveTermStmt _ reg_map _ (CutStmt (JumpInfo next_id types inputs)) = do
   let args = fmapFC (resolveReg reg_map) inputs
   C.Jump $ C.JumpTarget next_id types args
 
@@ -915,14 +915,14 @@ resolveStmts nm bi sz reg_map bindings appMap (Posd p s0:rest) t = do
                            (resolveAtom reg_map m))
                  (resolveStmts nm bi sz reg_map bindings appMap rest t)
 
-    -- breakpoint statements are eliminated during the inferBlockInfo phase
-    Breakpoint{} -> error $
-      "Unexpected breakpoint at position " ++ show p ++ ": " ++ show (Pretty.pretty s0)
+    -- cut statements are eliminated during the inferBlockInfo phase
+    Cut{} -> error $
+      "Unexpected cut at position " ++ show p ++ ": " ++ show (Pretty.pretty s0)
 
 data SomeBlockMap ext ret where
   SomeBlockMap ::
     Ctx.Index blocks tp ->
-    Bimap BreakpointName (Some (C.BlockID blocks)) ->
+    Bimap CutpointName (Some (C.BlockID blocks)) ->
     C.BlockMap ext blocks ret ->
     SomeBlockMap ext ret
 
@@ -952,7 +952,7 @@ resolveBlockMap nm entry blocks = do
       case lookupJumpInfo entry (biJumpInfo bi) of
         Nothing -> panic "resolveBlockMap" ["Missing initial block."]
         Just (JumpInfo (C.BlockID idx) _ _) ->
-          SomeBlockMap idx (biBreakpoints bi) $
+          SomeBlockMap idx (biCutpoints bi) $
             fmapFC (resolveBlock bi) (biBlocks bi)
 
 ------------------------------------------------------------------------
@@ -970,7 +970,7 @@ toSSA g = do
   let entry = cfgEntryLabel g
   let blocks = cfgBlocks g
   case resolveBlockMap (handleName h) entry blocks of
-    SomeBlockMap idx breakpoints block_map -> do
+    SomeBlockMap idx cutpoints block_map -> do
           let b = block_map ! idx
           case C.blockInputs b `testEquality` initTypes of
             Nothing -> error $
@@ -981,6 +981,6 @@ toSSA g = do
               let g' = C.CFG { C.cfgHandle = h
                              , C.cfgBlockMap = block_map
                              , C.cfgEntryBlockID = C.BlockID idx
-                             , C.cfgBreakpoints = breakpoints
+                             , C.cfgCutpoints = cutpoints
                              }
               reachableCFG g'

--- a/crucible/src/Lang/Crucible/Simulator/CallFrame.hs
+++ b/crucible/src/Lang/Crucible/Simulator/CallFrame.hs
@@ -38,7 +38,7 @@ module Lang.Crucible.Simulator.CallFrame
   , framePostdom
   , frameProgramLoc
   , setFrameBlock
-  , setFrameBreakpointPostdomInfo
+  , setFrameCutpointPostdomInfo
   , extendFrame
   , updateFrame
   , mergeCallFrame
@@ -198,13 +198,13 @@ setFrameBlock bid@(BlockID block_id) args f = f'
                  , _framePostdom = mkFramePostdom pds
                  }
 
-setFrameBreakpointPostdomInfo ::
-  [BreakpointName] ->
+setFrameCutpointPostdomInfo ::
+  [CutpointName] ->
   CallFrame sym ext blocks ret ctx ->
   CallFrame sym ext blocks ret ctx
-setFrameBreakpointPostdomInfo breakpoints f = case f of
+setFrameCutpointPostdomInfo cutpoints f = case f of
   CallFrame{ _frameCFG = g, _frameBlockID = Some (BlockID block_id) } -> do
-    let pdInfo = breakpointPostdomInfo g breakpoints
+    let pdInfo = cutpointPostdomInfo g cutpoints
     f { _framePostdomMap = pdInfo
       , _framePostdom  = mkFramePostdom (getConst $ pdInfo Ctx.! block_id)
       }

--- a/crucible/src/Lang/Crucible/Simulator/Cut.hs
+++ b/crucible/src/Lang/Crucible/Simulator/Cut.hs
@@ -1,20 +1,20 @@
 -----------------------------------------------------------------------
 -- |
--- Module           : Lang.Crucible.Simulator.Breakpoint
--- Description      : Support for symbolic execution breakpoints
+-- Module           : Lang.Crucible.Simulator.Cut
+-- Description      : Support for symbolic execution cuts
 -- Copyright        : (c) Galois, Inc 2019
 -- License          : BSD3
 -- Maintainer       : Andrei Stefanescu <andrei@galois.com>
 -- Stability        : provisional
 --
 -- This module provides execution features for changing the state on
--- breakpoints.
+-- cutpoints.
 -----------------------------------------------------------------------
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
-module Lang.Crucible.Simulator.Breakpoint
-  ( breakAndReturn
+module Lang.Crucible.Simulator.Cut
+  ( cutAndReturn
   ) where
 
 import           Control.Lens
@@ -39,26 +39,26 @@ import qualified Lang.Crucible.Simulator.OverrideSim as C
 import qualified Lang.Crucible.Simulator.RegValue as C
 import qualified What4.FunctionName as W
 
--- | This execution feature registers an override for a breakpoint.
---   The override summarizes the execution from the breakpoint
+-- | This execution feature registers an override for a cutpoint.
+--   The override summarizes the execution from the cutpoint
 --   to the return from the function (similar to a tail call).
 --   This feature requires a map from each function handle
---   to the list of breakpoints in the respective function with this
+--   to the list of cutpoints in the respective function with this
 --   execution feature.
-breakAndReturn ::
+cutAndReturn ::
   (C.IsSymInterface sym, C.IsSyntaxExtension ext) =>
   C.CFG ext blocks init ret ->
-  C.BreakpointName ->
+  C.CutpointName ->
   Ctx.Assignment C.TypeRepr args ->
   C.TypeRepr ret ->
   C.OverrideSim p sym ext rtp args ret (C.RegValue sym ret) ->
-  HashMap C.SomeHandle [C.BreakpointName] ->
+  HashMap C.SomeHandle [C.CutpointName] ->
   IO (C.ExecutionFeature p sym ext rtp)
-breakAndReturn C.CFG{..} breakpoint_name arg_types ret_type override all_breakpoints =
-  case Bimap.lookup breakpoint_name cfgBreakpoints of
-    Just (Some breakpoint_block_id)
-      | breakpoint_block <- C.getBlock breakpoint_block_id cfgBlockMap
-      , Just Refl <- testEquality (C.blockInputs breakpoint_block) arg_types ->
+cutAndReturn C.CFG{..} cutpoint_name arg_types ret_type override all_cutpoints =
+  case Bimap.lookup cutpoint_name cfgCutpoints of
+    Just (Some cutpoint_block_id)
+      | cutpoint_block <- C.getBlock cutpoint_block_id cfgBlockMap
+      , Just Refl <- testEquality (C.blockInputs cutpoint_block) arg_types ->
         return $ C.ExecutionFeature $ \case
           C.RunningState (C.RunPostBranchMerge block_id) state
             | frame <- state ^. C.stateCrucibleFrame
@@ -66,11 +66,11 @@ breakAndReturn C.CFG{..} breakpoint_name arg_types ret_type override all_breakpo
             , Just Refl <- testEquality
                 (fmapFC C.blockInputs cfgBlockMap)
                 (fmapFC C.blockInputs $ C.frameBlockMap frame)
-            , Just Refl <- testEquality breakpoint_block_id block_id
+            , Just Refl <- testEquality cutpoint_block_id block_id
             , Just Refl <- testEquality ret_type (C.frameReturnType frame) -> do
               let override_frame = C.OF $ C.OverrideFrame
                     { _override = W.functionNameFromText $
-                        C.breakpointNameText breakpoint_name
+                        C.cutpointNameText cutpoint_name
                     , _overrideHandle = C.frameHandle frame
                     , _overrideRegMap = state ^.
                         C.stateCrucibleFrame . C.frameRegs
@@ -80,11 +80,11 @@ breakAndReturn C.CFG{..} breakpoint_name arg_types ret_type override all_breakpo
                   C.pushCallFrame C.TailReturnToCrucible override_frame
               return $ C.ExecutionFeatureNewState result_state
           C.CallState return_handler (C.CrucibleCall block_id frame) state
-            | Just breakpoints <- HashMap.lookup
+            | Just cutpoints <- HashMap.lookup
                 (C.frameHandle frame)
-                all_breakpoints -> do
-              let result_frame = C.setFrameBreakpointPostdomInfo
-                    breakpoints
+                all_cutpoints -> do
+              let result_frame = C.setFrameCutpointPostdomInfo
+                    cutpoints
                     frame
               result_state <- runReaderT
                 (C.performFunctionCall
@@ -93,11 +93,11 @@ breakAndReturn C.CFG{..} breakpoint_name arg_types ret_type override all_breakpo
                 state
               return $ C.ExecutionFeatureNewState result_state
           C.TailCallState value_from_value (C.CrucibleCall block_id frame) state
-            | Just breakpoints <- HashMap.lookup
+            | Just cutpoints <- HashMap.lookup
                 (C.frameHandle frame)
-                all_breakpoints -> do
-              let result_frame = C.setFrameBreakpointPostdomInfo
-                    breakpoints
+                all_cutpoints -> do
+              let result_frame = C.setFrameCutpointPostdomInfo
+                    cutpoints
                     frame
               result_state <- runReaderT
                 (C.performTailCall
@@ -106,4 +106,4 @@ breakAndReturn C.CFG{..} breakpoint_name arg_types ret_type override all_breakpo
                 state
               return $ C.ExecutionFeatureNewState result_state
           _ -> return C.ExecutionFeatureNoChange
-    _ -> fail $ "unexpected breakpoint: " ++ show breakpoint_name
+    _ -> fail $ "unexpected cutpoint: " ++ show cutpoint_name


### PR DESCRIPTION
This includes changing the symbols it reacts to from `__breakpoint__` to `__cutpoint__`. Otherwise, NFCI.

The conclusion after some discussion is that "breakpoint" isn't a good name for what this does, and "cut" is better.

There's a slight overlap with some prolog-type cut logic in crucible-syntax, but that also beats the large overlap with the debugger's breakpoints.

I think I have found all the matching uses of "break" and not assimilated any unrelated ones (there are a few references to the string operation in here, for example) but please crosscheck. Also I'm not particularly familiar with this code so if I've done something horrible please speak up.