### PR TITLE
Use the current name of a 'metadata-action' input.

### DIFF
--- a/.github/workflows/crux-llvm-build.yml
+++ b/.github/workflows/crux-llvm-build.yml
@@ -293,7 +293,7 @@ jobs:
         id: labels
         with:
           images: ${{ matrix.image }}
-          label-custom: |
+          labels: |
              org.opencontainers.image.source=https://github.com/${{ matrix.image-repo }}
 
       - uses: docker/login-action@v4

--- a/.github/workflows/crux-mir-build.yml
+++ b/.github/workflows/crux-mir-build.yml
@@ -282,7 +282,7 @@ jobs:
         id: labels
         with:
           images: ${{ matrix.image }}
-          label-custom: |
+          labels: |
              org.opencontainers.image.source=https://github.com/${{ matrix.image-repo }}
 
       - uses: docker/login-action@v4


### PR DESCRIPTION
The input was called `label-custom` in earlier versions of `metadata-action`. In the current version it is called `labels` and the older name is no longer recognized.