### PR TITLE
Fix `execResultGlobals` on `PartialRes`

### DIFF
--- a/crucible/CHANGELOG.md
+++ b/crucible/CHANGELOG.md
@@ -24,6 +24,8 @@
   traces in `SimError` and `IsSymBackend`
 * Fix `onlineProve` to properly negate goals before checking satisfiability
 * Avoid sending trivially-true goals to the solver in `Backend.Prove`.
+* Fix bug in `execResultGlobals` that caused it to erroneously always return the
+  non-aborted branch of a `FinishedResult ... (PartialRes ...)`.
 
 # 0.9 -- 2026-01-29
 

--- a/crucible/src/Lang/Crucible/Simulator/ExecutionTree.hs
+++ b/crucible/src/Lang/Crucible/Simulator/ExecutionTree.hs
@@ -480,7 +480,7 @@ execStateSimState = \case
 
 abortedGlobals ::
   Monad f =>
-  -- | How to handle 'AbortedBranch'.
+  -- | How to handle branches (e.g., 'AbortedBranch', 'PartialRes').
   --
   -- Common options include concretizing the 'Pred' or returning a partial
   -- result (e.g., 'Nothing').
@@ -499,7 +499,7 @@ abortedGlobals handleBranch =
 -- | Extract the 'SymGlobalState' from an 'ExecResult'.
 execResultGlobals ::
   Monad f =>
-  -- | How to handle 'AbortedBranch'.
+  -- | How to handle branches (e.g., 'AbortedBranch', 'PartialRes').
   --
   -- Common options include concretizing the 'Pred' or returning a partial
   -- result (e.g., 'Nothing').
@@ -508,7 +508,13 @@ execResultGlobals ::
   f (SymGlobalState sym)
 execResultGlobals handleBranch =
   \case
-    FinishedResult _ctx partial -> pure (partial ^. partialValue . gpGlobals)
+    FinishedResult simCtx partial ->
+      case partial of
+        TotalRes gp -> pure (gp ^. gpGlobals)
+        PartialRes loc p gp aborted -> do
+          let l = gp ^. gpGlobals
+          r <- abortedGlobals (handleBranch simCtx) aborted
+          handleBranch simCtx loc p l r
     TimeoutResult st -> execStateGlobals handleBranch st
     AbortedResult simCtx aborted ->
       abortedGlobals (handleBranch simCtx) aborted
@@ -516,7 +522,7 @@ execResultGlobals handleBranch =
 -- | Extract the 'SymGlobalState' from an 'ExecState'.
 execStateGlobals ::
   Monad f =>
-  -- | How to handle 'AbortedBranch'.
+  -- | How to handle branches (e.g., 'AbortedBranch', 'PartialRes').
   --
   -- Common options include concretizing the 'Pred' or returning a partial
   -- result (e.g., 'Nothing').


### PR DESCRIPTION
It previously ignored the possible branch inside `FinishedResult`, always returning the globals from the non-aborted side.