### PR TITLE
Fix `uniquelyConcRegMap` blocking clause: use OR not AND

### DIFF
--- a/crucible-cli/CHANGELOG.md
+++ b/crucible-cli/CHANGELOG.md
@@ -5,6 +5,8 @@
   into the `crucible-cli` test suite's `Overrides` module. This prevents library
   consumers from having to compile test-specific code. The main CLI applications
   no longer register these overrides by default.
+* **BREAKING:** `setupOverridesHook` now takes a `FloatModeRepr fm` argument
+  (and constrains `fs ~ Flags fm`).
 
 # 0.2 -- 2025-11-09
 

--- a/crucible-cli/src/Lang/Crucible/CLI.hs
+++ b/crucible-cli/src/Lang/Crucible/CLI.hs
@@ -107,13 +107,13 @@ data SimulateProgramHooks ext = SimulateProgramHooks
     --
     -- Used by the LLVM frontend to set up the LLVM global memory variable.
   , setupOverridesHook ::
-      forall p solver sym bak t st fs.
+      forall p solver sym bak t st fm.
       ( IsSymBackend sym bak
-      , sym ~ ExprBuilder t st fs
-      , bak ~ CBO.OnlineBackend solver t st fs
+      , sym ~ ExprBuilder t st (Flags fm)
+      , bak ~ CBO.OnlineBackend solver t st (Flags fm)
       , WPO.OnlineSolver solver
       ) =>
-      bak -> HandleAllocator -> IO [(FnBinding p sym ext,Position)]
+      bak -> FloatModeRepr fm -> HandleAllocator -> IO [(FnBinding p sym ext,Position)]
     -- ^ Action to set up overrides before parsing a program.
   , resolveExternsHook ::
       forall sym t st fs. (IsSymInterface sym, sym ~ ExprBuilder t st fs) =>
@@ -133,7 +133,7 @@ data SimulateProgramHooks ext = SimulateProgramHooks
 defaultSimulateProgramHooks :: SimulateProgramHooks ext
 defaultSimulateProgramHooks = SimulateProgramHooks
   { setupHook = \_sym _ha fds -> liftIO (assertNoForwardDecs fds)
-  , setupOverridesHook = \_sym _ha -> pure []
+  , setupOverridesHook = \_bak _fm _ha -> pure []
   , resolveExternsHook = \_sym externs gst ->
     do assertNoExterns externs
        pure gst
@@ -219,6 +219,7 @@ simulateProgramWithExtension mkExt fn theInput outh profh opts hooks dbg dbgCmds
               hooks
               @(Personality ext (ExprBuilder t EmptyExprBuilderState (Flags FloatIEEE)))
               bak
+              FloatIEEERepr
               ha
             dbgOv <-
               FnBinding

--- a/crucible-cli/test-data/simulate/unique-conc.cbl
+++ b/crucible-cli/test-data/simulate/unique-conc.cbl
@@ -1,0 +1,14 @@
+;; Test unique concretization
+
+(defun @main () Unit
+  (start start:
+    (let x (fresh Integer))
+    (let y (fresh Integer))
+    ;; Constrain x to be uniquely 42
+    (assume! (equal? x (the Integer 42)) "x is 42")
+    ;; y is unconstrained -- multiple values are possible
+    (funcall @uniquely-conc-ints x y)
+    ;; Now constrain y too
+    (assume! (equal? y (the Integer 7)) "y is 7")
+    (funcall @uniquely-conc-ints x y)
+    (return ())))

--- a/crucible-cli/test-data/simulate/unique-conc.out.good
+++ b/crucible-cli/test-data/simulate/unique-conc.out.good
@@ -1,0 +1,6 @@
+==== Begin Simulation ====
+uniquelyConcRegMap: MultipleModels
+uniquelyConcRegMap: unique
+
+==== Finish Simulation ====
+==== No proof obligations ====

--- a/crucible-cli/test/Overrides.hs
+++ b/crucible-cli/test/Overrides.hs
@@ -64,15 +64,16 @@ mkOverrideBinding ha name override = do
 -- | Set up all test overrides
 setupOverrides ::
   ( IsSymBackend sym bak
-  , sym ~ ExprBuilder scope st fs
+  , sym ~ ExprBuilder scope st (Flags fm)
   , SymExpr sym ~ Expr scope
-  , bak ~ CBO.OnlineBackend solver scope st fs
+  , bak ~ CBO.OnlineBackend solver scope st (Flags fm)
   , WPO.OnlineSolver solver
   ) =>
   bak ->
+  FloatModeRepr fm ->
   HandleAllocator ->
   IO [(FnBinding p sym ext, Position)]
-setupOverrides bak ha =
+setupOverrides bak fm ha =
   do let sym = backendGetSym bak
      sequence
        [ mkOverrideBinding ha "symbolicBranchTest" symbolicBranchTest
@@ -83,6 +84,7 @@ setupOverrides bak ha =
        , mkOverrideBinding ha "crucible-print-assumption-state" (printAssumptionState (Just sym))
        , mkOverrideBinding ha "prove-offline" (proveOffline (Just sym))
        , mkOverrideBinding ha "prove-online" (proveOnline bak (Just sym))
+       , mkOverrideBinding ha "uniquely-conc-ints" (uniquelyConcInts bak fm)
        ]
 
 
@@ -292,3 +294,34 @@ proveOnline bak _proxy =
       let prover = CB.onlineProver sym sp
       let strat = CB.ProofStrategy prover CB.keepGoing
       CB.proveCurrentObligations bak strat proveChecker
+
+-- | Test unique concretization of two integers via 'uniquelyConcRegMap'.
+--
+-- Calls the real 'uniquelyConcRegMap' on a two-entry RegMap. The bug
+-- (now fixed) was that the blocking clause used AND instead of OR,
+-- causing a map to be reported as uniquely concretized whenever any
+-- single entry was unique.
+--
+-- Prints a message, so must be observed on the programs stdout (which the test
+-- suite does).
+uniquelyConcInts ::
+  ( IsSymBackend sym bak
+  , sym ~ ExprBuilder scope st (Flags fm)
+  , SymExpr sym ~ Expr scope
+  , bak ~ CBO.OnlineBackend solver scope st (Flags fm)
+  , WPO.OnlineSolver solver
+  ) =>
+  bak ->
+  FloatModeRepr fm ->
+  OverrideSim p sym ext r
+    (EmptyCtx ::> IntegerType ::> IntegerType) UnitType (RegValue sym UnitType)
+uniquelyConcInts bak fm = do
+  h <- printHandle <$> getContext
+  args <- getOverrideArgs
+  let x = reg @0 args
+  let y = reg @1 args
+  let rm = RegMap (Empty :> RegEntry IntegerRepr x :> RegEntry IntegerRepr y)
+  result <- liftIO $ Conc.uniquelyConcRegMap bak fm MapF.empty MapF.empty rm
+  liftIO $ case result of
+    Left e  -> hPutStrLn h ("uniquelyConcRegMap: " ++ show e)
+    Right _ -> hPutStrLn h "uniquelyConcRegMap: unique"

--- a/crucible-cli/test/Test.hs
+++ b/crucible-cli/test/Test.hs
@@ -75,7 +75,7 @@ testSimulator inFile outFile =
      IO.withFile outFile IO.WriteMode $ \outh -> do
        let hooks =
              defaultSimulateProgramHooks
-               { setupOverridesHook = Overrides.setupOverrides
+               { setupOverridesHook = \bak fm ha -> Overrides.setupOverrides bak fm ha
                }
        simulateProgram inFile contents outh Nothing testOptions hooks False []
 

--- a/crucible/CHANGELOG.md
+++ b/crucible/CHANGELOG.md
@@ -1,5 +1,9 @@
 # next
 
+* Fix `uniquelyConcRegMap` blocking clause: use disjunction (OR) instead of
+  conjunction (AND). The old code would falsely report a `RegMap` as uniquely
+  concretized whenever any single component was unique, even if other components
+  had multiple possible values.
 * **BREAKING:** Rename various bits associated with the "breakpoint"
   feature in accordance with renaming the feature to "cut" or
   "cutpoint".

--- a/crucible/src/Lang/Crucible/Concretize.hs
+++ b/crucible/src/Lang/Crucible/Concretize.hs
@@ -667,10 +667,11 @@ uniquelyConcRegMap bak fm iFns sFns m = do
                 pure (Const p)
           let RM.RegMap mAssign = m
           preds <- Ctx.zipWithM notEq concM mAssign
+          -- not (modelA_1 == modelB_1) \/ ... \/ not (modelA_n == modelB_n)
           p <-
             foldlMFC
-              (\p (Const p') -> W4I.andPred sym p p')
-              (W4I.truePred sym)
+              (\p (Const p') -> W4I.orPred sym p p')
+              (W4I.falsePred sym)
               preds
 
           frm <- CB.pushAssumptionFrame bak


### PR DESCRIPTION
The blocking clause in `uniquelyConcRegMap` used conjunction (AND) to combine per-entry "not equal" predicates. This meant if any single RegMap entry was uniquely determined, the conjunction was UNSAT, falsely reporting the entire map as unique. Use disjunction (OR) instead so that uniqueness is only reported when all entries are uniquely determined.

Adds a `FloatModeRepr` arg to the overrides hook for this.