### PR TITLE
Add function handle symbol name to error message.

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
@@ -481,7 +481,7 @@ evalStmt bak = eval
              do p <- Partial.annotateME sym mop (BadFunctionPointer lookupErr) (falsePred sym)
                 loc <- getCurrentProgramLoc sym
                 let estr = "Failed to load function handle: "
-                           <> maybe  "<unidentified>" id gsym
+                           <> fromMaybe "<unidentified>" gsym
                 let err = SimError loc (AssertFailureSimError estr
                                         (show (ME.ppFuncLookupError lookupErr)))
                 addProofObligation bak (LabeledPred p err)

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
@@ -480,7 +480,10 @@ evalStmt bak = eval
            Left lookupErr -> lift $
              do p <- Partial.annotateME sym mop (BadFunctionPointer lookupErr) (falsePred sym)
                 loc <- getCurrentProgramLoc sym
-                let err = SimError loc (AssertFailureSimError "Failed to load function handle" (show (ME.ppFuncLookupError lookupErr)))
+                let estr = "Failed to load function handle: "
+                           <> maybe  "<unidentified>" id gsym
+                let err = SimError loc (AssertFailureSimError estr
+                                        (show (ME.ppFuncLookupError lookupErr)))
                 addProofObligation bak (LabeledPred p err)
                 abortExecBecause (AssertionFailure err)
 

--- a/crux-llvm/test-data/golden/golden/invoke-test.z3.good
+++ b/crux-llvm/test-data/golden/golden/invoke-test.z3.good
@@ -1,6 +1,6 @@
 [Crux] Found counterexample for verification goal
 [Crux]   internal: error: in _ZN3std2rt10lang_start17h4f32aa1279b9079fE
-[Crux]   Failed to load function handle
+[Crux]   Failed to load function handle: _ZN3std2rt19lang_start_internal17h3dc68cf5532522d7E
 [Crux]   Details:
 [Crux]     No implementation or override found for pointer
 [Crux]     The given pointer could not be resolved to a callable function


### PR DESCRIPTION
Shows the symbol name for the function that could not be found.

Addresses https://github.com/GaloisInc/saw-script/issues/2198