### PR TITLE
crux-mir: store size/align in vtable

### DIFF
--- a/crucible-mir/src/Mir/JSON.hs
+++ b/crucible-mir/src/Mir/JSON.hs
@@ -468,7 +468,7 @@ instance FromJSON VtableItem where
 
 instance FromJSON Vtable where
     parseJSON = withObject "Vtable" $ \v ->
-        Vtable <$> v .: "name" <*> v .: "items"
+        Vtable <$> v .: "name" <*> v .: "items" <*> v .: "size" <*> v .: "align"
 
 instance FromJSON CastKind where
     parseJSON = withObject "CastKind" $ \v ->

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -582,6 +582,8 @@ data VtableItem = VtableItem
 data Vtable = Vtable
     { _vtName :: VtableName
     , _vtItems :: [VtableItem]
+    , _vtSize :: Word
+    , _vtAlign :: Word
     }
     deriving (Show, Eq, Ord, Generic)
 

--- a/crucible-mir/src/Mir/PP.hs
+++ b/crucible-mir/src/Mir/PP.hs
@@ -335,10 +335,12 @@ instance Pretty VtableItem where
       ]
 
 instance Pretty Vtable where
-  pretty (Vtable name items) =
+  pretty (Vtable name items size align_) =
     vcat [pretty "vtable" <+> pretty name <+> lbrace ,
-          indent 3 (vcat (map pretty items)),
+          indent 3 (vcat (sizeItem : alignItem : map pretty items)),
           rbrace]
+    where sizeItem = pretty "size =" <+> pretty size <> semi
+          alignItem = pretty "align =" <+> pretty align_ <> semi
 
 instance Pretty CastKind where
     pretty = viaShow

--- a/crucible-mir/src/Mir/ParseTranslate.hs
+++ b/crucible-mir/src/Mir/ParseTranslate.hs
@@ -48,7 +48,7 @@ import Debug.Trace
 -- If you update the supported mir-json schema version below, make sure to also
 -- update the crux-mir README accordingly.
 supportedSchemaVersion :: Word64
-supportedSchemaVersion = 10
+supportedSchemaVersion = 11
 
 -- | Parse a MIR JSON file to a 'Collection'. If parsing fails, attempt to give
 -- a more informative error message if the MIR JSON schema version is

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -1306,16 +1306,16 @@ mkTraitObject traitName' vtableName e = do
         Just x -> return x
         Nothing -> error $ "missing vtable definition for " ++ show vtableName
 
-    let info =
-            [ MirExp UsizeRepr $ R.App $ usizeLit $ fromIntegral $ vtable ^. vtSize
-            , MirExp UsizeRepr $ R.App $ usizeLit $ fromIntegral $ vtable ^. vtAlign
-            ]
-
     let mkEntry :: MirHandle -> MirExp s
         mkEntry (MirHandle _ _ fh) =
             MirExp (C.FunctionHandleRepr (FH.handleArgTypes fh) (FH.handleReturnType fh))
                 (R.App $ E.HandleLit fh)
-    vtableExp@(MirExp vtableTy _) <- return $ mkStructExp $ info ++ map mkEntry handles
+    let vtParts = VtableParts
+            { vtpMethods = map mkEntry handles
+            , vtpSize = R.App $ usizeLit $ fromIntegral $ vtable ^. vtSize
+            , vtpAlign = R.App $ usizeLit $ fromIntegral $ vtable ^. vtAlign
+            }
+    vtableExp@(MirExp vtableTy _) <- return $ mkStructExp $ vtablePartsToEntries vtParts
 
     -- Check that the vtable we constructed has the appropriate type for the
     -- trait.  A mismatch would cause runtime errors at calls to trait methods.

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -2731,11 +2731,6 @@ splitMethodArgs args argsSize =
     (R.AtomExpr arg0, fmapFC R.AtomExpr args')
 
 
-type (x :: k) :<: (xs :: Ctx.Ctx k) = Ctx.SingleCtx x Ctx.<+> xs
-
-(<:) :: forall f tp ctx. f tp -> Ctx.Assignment f ctx -> Ctx.Assignment f (tp :<: ctx)
-x <: xs = Ctx.singleton x Ctx.<++> xs
-
 data AssignUncons (f :: k -> Type) :: Ctx.Ctx k -> Type where
   AssignUncons :: f x -> Ctx.Assignment f y -> AssignUncons f (Ctx.SingleCtx x Ctx.<+> y)
 
@@ -2752,16 +2747,6 @@ assignUncons (xs Ctx.:> x) =
   case assignUncons xs of
     Right (AssignUncons y ys) -> Right $ AssignUncons y (ys Ctx.:> x)
     Left Refl -> Right $ AssignUncons x Ctx.Empty
-
-data AsFunctionHandleRepr :: C.CrucibleType -> Type where
-  AsFunctionHandleRepr ::
-    C.CtxRepr args ->
-    C.TypeRepr ret ->
-    AsFunctionHandleRepr (C.FunctionHandleType args ret)
-
-asFunctionHandleRepr :: C.TypeRepr tp -> Maybe (AsFunctionHandleRepr tp)
-asFunctionHandleRepr (C.FunctionHandleRepr args ret) = Just $ AsFunctionHandleRepr args ret
-asFunctionHandleRepr _ = Nothing
 
 unappendAssignment :: forall k f (xs :: Ctx.Ctx k) (ys :: Ctx.Ctx k).
     Ctx.Size ys ->
@@ -2960,8 +2945,7 @@ dispatchFromDyn dynTraitName recvTy recvExp die = do
 -- function.
 mkVirtCall
   :: HasCallStack
-  => M.Collection
-  -> M.TraitName
+  => M.TraitName
   -> Integer -- ^ The method index
   -> M.Ty -- ^ The MIR type of the method receiver
   -> C.TypeRepr recvTy -- ^ The Crucible type of the method receiver
@@ -2972,65 +2956,11 @@ mkVirtCall
   -> MirGenerator h s ret
     ( R.Expr MIR s (C.FunctionHandleType (C.AnyType :<: argTys) retTy)
     , Ctx.Assignment (R.Expr MIR s) (C.AnyType :<: argTys))
-mkVirtCall col dynTraitName methIndex recvTy recvTpr recvExpr argTprs argExprs retTpr = do
-    -- Unpack vtable type
-    dynTrait <- case col ^. M.traits . at dynTraitName of
-      Just x -> return x
-      Nothing -> die ["undefined trait " ++ show dynTraitName]
-    Some vtableStructTpr <- case traitVtableType col dynTrait of
-      Left err -> die ["traitVtableType: " ++ err]
-      Right x -> return x
-    Some vtableTprs <- case vtableStructTpr of
-      C.StructRepr ctx -> return $ Some ctx
-      _ -> die ["vtable type is not a struct"]
-
-    let vtableIdxInt = numVtableInfoSlots + fromInteger methIndex
-    Some vtableIdx <- case Ctx.intIndex vtableIdxInt (Ctx.size vtableTprs) of
-      Just x -> return x
-      Nothing -> die ["method index out of range for vtable:",
-        "method =", show methIndex, "; size =", show (Ctx.size vtableTprs)]
-
-    -- Check that the vtable entry has the correct signature.
-    AsFunctionHandleRepr vtsArgTprs vtsRetTpr <-
-      case asFunctionHandleRepr (vtableTprs Ctx.! vtableIdx) of
-        Just x -> return x
-        _ -> die ["vtable entry is not a function"]
-    AssignUncons vtsRecvTpr vtsArgTprs' <- case assignUncons vtsArgTprs of
-      Right x -> return x
-      Left _ -> die ["vtable shim has no arguments"]
-
-    Refl <- case testEquality vtsRecvTpr C.AnyRepr of
-      Just x -> return x
-      Nothing -> die ["vtable shim receiver is not Any"]
-    Refl <- case testEquality vtsArgTprs' argTprs of
-      Just x -> return x
-      Nothing -> die ["vtable shim arguments don't match method; vtable shim =",
-        show vtsArgTprs', "; method =", show argTprs]
-    Refl <- case testEquality vtsRetTpr retTpr of
-      Just x -> return x
-      Nothing -> die ["vtable shim return type doesn't match method; vtable shim =",
-        show vtsRetTpr, "; method =", show retTpr]
-
+mkVirtCall dynTraitName methIndex recvTy recvTpr recvExpr argTprs argExprs retTpr = do
     (MirExp recvTpr' recvExpr', recvVtable) <-
       dispatchFromDyn dynTraitName recvTy (MirExp recvTpr recvExpr) die
 
-    -- Downcast the vtable to its proper struct type
-    errBlk <- G.newLabel
-    G.defineBlock errBlk $ do
-        G.reportError $ R.App $ E.StringLit $ fromString $
-            unwords ["bad vtable downcast:", show dynTraitName,
-                "to", show vtableTprs]
-
-    let vtableStructTpr' = C.StructRepr vtableTprs
-    okBlk <- G.newLambdaLabel' vtableStructTpr'
-    -- See Note [Erase vtable types] in Mir.Intrinsics.Dyn for why we need to
-    -- unpack an Any type here.
-    vtable <- G.continueLambda okBlk $ do
-        G.branchMaybe (R.App $ E.UnpackAny vtableStructTpr' recvVtable) okBlk errBlk
-
-    -- Extract the function handle from the vtable
-    let vtsFH = R.App $ E.GetStruct vtable vtableIdx
-            (C.FunctionHandleRepr (C.AnyRepr <: argTprs) vtsRetTpr)
+    vtsFH <- getVtableMethod dynTraitName (fromInteger methIndex) argTprs retTpr recvVtable
 
     pure (vtsFH, (R.App (E.PackAny recvTpr' recvExpr') <: argExprs))
 
@@ -3045,8 +2975,7 @@ mkVirtCall col dynTraitName methIndex recvTy recvTpr recvExpr argTprs argExprs r
 -- then tail-call that function on those arguments.
 doVirtTailCall
   :: HasCallStack
-  => M.Collection
-  -> M.TraitName
+  => M.TraitName
   -> Integer -- ^ The method index
   -> M.Ty -- ^ The MIR type of the method receiver
   -> C.TypeRepr recvTy -- ^ The Crucible type of the method receiver
@@ -3055,8 +2984,8 @@ doVirtTailCall
   -> Ctx.Assignment (R.Expr MIR s) argTys -- ^ The arguments (excluding the receiver)
   -> C.TypeRepr retTy -- ^ The return type
   -> MirGenerator h s retTy a
-doVirtTailCall col dynTraitName methodIndex recvTy recvTpr recvExpr argTprs argExprs retTpr = do
-  (fnHandle, args) <- mkVirtCall col dynTraitName methodIndex
+doVirtTailCall dynTraitName methodIndex recvTy recvTpr recvExpr argTprs argExprs retTpr = do
+  (fnHandle, args) <- mkVirtCall dynTraitName methodIndex
     recvTy recvTpr recvExpr argTprs argExprs retTpr
   G.tailCall fnHandle args
 
@@ -3074,8 +3003,7 @@ doVirtTailCall col dynTraitName methodIndex recvTy recvTpr recvExpr argTprs argE
 -- > G.Generator MIR s t retTpr    (ST h) (R.Expr MIR s retTpr)
 doVirtCall
   :: HasCallStack
-  => M.Collection
-  -> M.TraitName
+  => M.TraitName
   -> Integer -- ^ The method index
   -> M.Ty -- ^ The MIR type of the method receiver
   -> C.TypeRepr recvTy -- ^ The Crucible type of the method receiver
@@ -3084,8 +3012,8 @@ doVirtCall
   -> Ctx.Assignment (R.Expr MIR s) argTys -- ^ The arguments (excluding the receiver)
   -> C.TypeRepr retTy -- ^ The return type
   -> MirGenerator h s anyRetTy (R.Expr MIR s retTy)
-doVirtCall col dynTraitName methodIndex recvTy recvTpr recvExpr argTprs argExprs retTpr = do
-  (fnHandle, args) <- mkVirtCall col dynTraitName methodIndex
+doVirtCall dynTraitName methodIndex recvTy recvTpr recvExpr argTprs argExprs retTpr = do
+  (fnHandle, args) <- mkVirtCall dynTraitName methodIndex
     recvTy recvTpr recvExpr argTprs argExprs retTpr
   G.call fnHandle args
 
@@ -3131,7 +3059,6 @@ transVirtCall colState intrName' methName dynTraitName methIndex
         label <- G.newLabel
         G.defineBlock label $
           doVirtTailCall
-            (colState ^. collection)
             dynTraitName
             methIndex
             recvTy

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -2555,7 +2555,7 @@ mkVtableMap :: (HasCallStack) => Collection -> FH.HandleAllocator -> IO VtableMa
 mkVtableMap col halloc = mapM mkVtable (col ^. vtables)
   where
     mkVtable :: M.Vtable -> IO [MirHandle]
-    mkVtable (M.Vtable name items) = mapM (mkHandle name) items
+    mkVtable (M.Vtable name items _size _align) = mapM (mkHandle name) items
 
     mkHandle :: M.DefId -> M.VtableItem -> IO MirHandle
     mkHandle vtableName (VtableItem fnName _)
@@ -2580,7 +2580,7 @@ transVtable :: forall h. (HasCallStack, ?debug::Int, ?customOps::CustomOpMap, ?a
   => CollectionState
   -> M.Vtable
   -> ST h [(Text, Core.AnyCFG MIR)]
-transVtable colState (M.Vtable name items)
+transVtable colState (M.Vtable name items _size _align)
   | Just handles <- Map.lookup name (colState ^. vtableMap) =
     zipWithM (transVtableShim colState name) items handles
   | otherwise = error $ unwords ["no vtableMap entry for", show name]

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -1301,17 +1301,26 @@ mkTraitObject traitName' vtableName e = do
     handles <- Maybe.fromMaybe (error $ "missing vtable handles for " ++ show vtableName) <$>
         use (cs . vtableMap . at vtableName)
 
+    col <- use $ cs . collection
+    vtable <- case col ^. vtables . at vtableName of
+        Just x -> return x
+        Nothing -> error $ "missing vtable definition for " ++ show vtableName
+
+    let info =
+            [ MirExp UsizeRepr $ R.App $ usizeLit $ fromIntegral $ vtable ^. vtSize
+            , MirExp UsizeRepr $ R.App $ usizeLit $ fromIntegral $ vtable ^. vtAlign
+            ]
+
     let mkEntry :: MirHandle -> MirExp s
         mkEntry (MirHandle _ _ fh) =
             MirExp (C.FunctionHandleRepr (FH.handleArgTypes fh) (FH.handleReturnType fh))
                 (R.App $ E.HandleLit fh)
-    vtable@(MirExp vtableTy _) <- return $ mkStructExp $ map mkEntry handles
+    vtableExp@(MirExp vtableTy _) <- return $ mkStructExp $ info ++ map mkEntry handles
 
     -- Check that the vtable we constructed has the appropriate type for the
     -- trait.  A mismatch would cause runtime errors at calls to trait methods.
     trait <- Maybe.fromMaybe (error $ "unknown trait " ++ show traitName') <$>
         use (cs . collection . M.traits . at traitName')
-    col <- use $ cs . collection
     Some vtableTy' <- case traitVtableType col trait of
                         Left err -> error ("mkTraitObject: " ++ err)
                         Right x -> return x
@@ -1323,7 +1332,7 @@ mkTraitObject traitName' vtableName e = do
 
     return $ mkStructExp
         [ e
-        , packAny vtable -- See Note [Erase vtable types] in Mir.Intrinsics.Dyn
+        , packAny vtableExp -- See Note [Erase vtable types] in Mir.Intrinsics.Dyn
         ]
 
     where
@@ -2975,7 +2984,8 @@ mkVirtCall col dynTraitName methIndex recvTy recvTpr recvExpr argTprs argExprs r
       C.StructRepr ctx -> return $ Some ctx
       _ -> die ["vtable type is not a struct"]
 
-    Some vtableIdx <- case Ctx.intIndex (fromInteger methIndex) (Ctx.size vtableTprs) of
+    let vtableIdxInt = numVtableInfoSlots + fromInteger methIndex
+    Some vtableIdx <- case Ctx.intIndex vtableIdxInt (Ctx.size vtableTprs) of
       Just x -> return x
       Nothing -> die ["method index out of range for vtable:",
         "method =", show methIndex, "; size =", show (Ctx.size vtableTprs)]

--- a/crucible-mir/src/Mir/TransCustom.hs
+++ b/crucible-mir/src/Mir/TransCustom.hs
@@ -2533,20 +2533,22 @@ callOnceVirtShimDef methodIdx = CustomMirOp $ \ops ->
       Some vtableCtx <- case vtableStructTpr of
         C.StructRepr ctx -> return $ Some ctx
         _ -> mirFail $ "callOnceVirtShimDef: vtable type is not a struct"
-      Some vtableMethodIdx <- case Ctx.intIndex (fromInteger methodIdx) (Ctx.size vtableCtx) of
+      let methodSlotIdx = numVtableInfoSlots + fromInteger methodIdx
+      Some vtableMethodSlotIdx <- case Ctx.intIndex methodSlotIdx (Ctx.size vtableCtx) of
         Just x -> return x
         Nothing -> mirFail $ "callOnceVirtShimDef: method index out of range for vtable: "
-          ++ "method = " ++ show methodIdx ++ "; size = " ++ show (Ctx.size vtableCtx)
-      let vtableMethodTpr = vtableCtx Ctx.! vtableMethodIdx
+          ++ "method = " ++ show methodIdx ++ "; slot = " ++ show methodSlotIdx
+          ++ "; size = " ++ show (Ctx.size vtableCtx)
+      let vtableMethodTpr = vtableCtx Ctx.! vtableMethodSlotIdx
       Some retTpr <- case vtableMethodTpr of
         C.FunctionHandleRepr _ retTpr -> return $ Some retTpr
-        tpr -> mirFail $ "callOnceVirtShimDef: expected method " ++ show methodIdx
+        tpr -> mirFail $ "callOnceVirtShimDef: expected method " ++ show methodSlotIdx
           ++ " of " ++ show dynTraitName ++ " to have FunctionHandleRepr, but got " ++ show tpr
 
       MirExp retTpr <$> doVirtCall
         col
         dynTraitName
-        methodIdx
+        methodIdx   -- method index, not vtable slot index
         (TyRawPtr recvTy Immut)
         recvTpr
         recv

--- a/crucible-mir/src/Mir/TransCustom.hs
+++ b/crucible-mir/src/Mir/TransCustom.hs
@@ -1239,7 +1239,7 @@ size_of_val = (["core", "intrinsics", "size_of_val"], \substs -> case substs of
             -- support computing the size of trait objects that aren't embedded
             -- in a custom DST. TODO(#1614): Lift this restriction.
             DynRefRepr -> case ty of
-                TyDynamic dynTraitName -> getVtableUsize dynTraitName 0 e
+                TyDynamic dynTraitName -> getVtableUsize dynTraitName vtableSizeSlotIdx e
                 TyAdt {} -> unsupportedCustomDst ty
                 _ -> panic "size_of_val"
                        ["Unexpected DynRefRepr type", show (PP.pretty ty)]
@@ -1306,7 +1306,7 @@ align_of_val = (["core", "intrinsics", "align_of_val"], \substs -> case substs o
             -- support computing the alignment of trait objects that aren't
             -- embedded in a custom DST. TODO(#1614): Lift this restriction.
             DynRefRepr -> case ty of
-                TyDynamic dynTraitName -> getVtableUsize dynTraitName 1 e
+                TyDynamic dynTraitName -> getVtableUsize dynTraitName vtableAlignSlotIdx e
                 TyAdt {} -> unsupportedCustomDst ty
                 _ -> panic "align_of_val"
                        ["Unexpected DynRefRepr type", show (PP.pretty ty)]

--- a/crucible-mir/src/Mir/TransCustom.hs
+++ b/crucible-mir/src/Mir/TransCustom.hs
@@ -720,7 +720,6 @@ drop_in_place_dyn =
 
                 callExpr <-
                     doVirtCall
-                        col
                         traitName'
                         dropMethodIndex
                         selfTy
@@ -1213,43 +1212,11 @@ size_of = (["core", "intrinsics", "size_of"], \substs -> case substs of
     )
 
 -- | Read a @usize@ value from slot @idx@ of a vtable.
-getVtableUsize :: TraitName -> Int -> R.Expr MIR s C.AnyType -> MirGenerator h s ret (MirExp s)
-getVtableUsize dynTraitName idx vtable = do
-  col <- use $ cs . collection
-
-  -- Unpack vtable type
-  dynTrait <- case col ^. traits . at dynTraitName of
-    Just x -> return x
-    Nothing -> die ["undefined trait " ++ show dynTraitName]
-  Some vtableStructTpr <- case traitVtableType col dynTrait of
-    Left err -> die ["traitVtableType: " ++ err]
-    Right x -> return x
-  Some vtableTprs <- case vtableStructTpr of
-    C.StructRepr ctx -> return $ Some ctx
-    _ -> die ["vtable type is not a struct"]
-
-  let vtableIdxInt = idx
-  Some vtableIdx <- case Ctx.intIndex vtableIdxInt (Ctx.size vtableTprs) of
-    Just x -> return x
-    Nothing -> die ["slot index out of range for vtable:",
-      "idx =", show idx, "; size =", show (Ctx.size vtableTprs)]
-
-  let slotTpr = vtableTprs Ctx.! vtableIdx
-  Refl <- testEqualityOrFail slotTpr UsizeRepr $
-    "expected trait " ++ show dynTraitName ++ " vtable slot " ++ show idx
-      ++ " to contain a `usize`, but got " ++ show slotTpr
-
-  let vtableStructTpr' = C.StructRepr vtableTprs
-  vtableDowncast <- G.fromJustExpr (R.App $ E.UnpackAny vtableStructTpr' vtable)
-      (R.App $ E.StringLit $ fromString $ "bad vtable type for " ++ show dynTraitName)
-
-  let usize = R.App $ E.GetStruct vtableDowncast vtableIdx UsizeRepr
-  return $ MirExp UsizeRepr usize
-
-  where
-    die :: HasCallStack => [String] -> a
-    die words' = error $ unwords $
-      ["failed to get usize from slot", show idx, "of trait", show dynTraitName] ++ words'
+getVtableUsize :: TraitName -> Int -> R.Expr MIR s DynRefType -> MirGenerator h s ret (MirExp s)
+getVtableUsize dynTraitName idx dynRef = do
+  let vtable = S.getStruct dynRefVtableIndex dynRef
+  usizeExp <- getVtableSlot dynTraitName idx UsizeRepr vtable
+  return $ MirExp UsizeRepr usizeExp
 
 size_of_val :: (ExplodedDefId, CustomRHS)
 size_of_val = (["core", "intrinsics", "size_of_val"], \substs -> case substs of
@@ -1273,9 +1240,7 @@ size_of_val = (["core", "intrinsics", "size_of_val"], \substs -> case substs of
             -- do here is make an effort to give a descriptive error message.
             -- TODO(#1614): Support trait objects and custom DSTs here.
             DynRefRepr -> case ty of
-                TyDynamic dynTraitName -> do
-                    let vtable = S.getStruct dynRefVtableIndex e
-                    getVtableUsize dynTraitName 0 vtable
+                TyDynamic dynTraitName -> getVtableUsize dynTraitName 0 e
                 TyAdt {} -> unsupportedCustomDst ty
                 _ -> panic "size_of_val"
                        ["Unexpected DynRefRepr type", show (PP.pretty ty)]
@@ -1343,9 +1308,7 @@ align_of_val = (["core", "intrinsics", "align_of_val"], \substs -> case substs o
             -- do here is make an effort to give a descriptive error message.
             -- TODO(#1614): Support trait objects and custom DSTs here.
             DynRefRepr -> case ty of
-                TyDynamic dynTraitName -> do
-                    let vtable = S.getStruct dynRefVtableIndex e
-                    getVtableUsize dynTraitName 1 vtable
+                TyDynamic dynTraitName -> getVtableUsize dynTraitName 1 e
                 TyAdt {} -> unsupportedCustomDst ty
                 _ -> panic "align_of_val"
                        ["Unexpected DynRefRepr type", show (PP.pretty ty)]
@@ -2575,7 +2538,6 @@ callOnceVirtShimDef methodIdx = CustomMirOp $ \ops ->
           ++ " of " ++ show dynTraitName ++ " to have FunctionHandleRepr, but got " ++ show tpr
 
       MirExp retTpr <$> doVirtCall
-        col
         dynTraitName
         methodIdx   -- method index, not vtable slot index
         (TyRawPtr recvTy Immut)

--- a/crucible-mir/src/Mir/TransCustom.hs
+++ b/crucible-mir/src/Mir/TransCustom.hs
@@ -1235,10 +1235,9 @@ size_of_val = (["core", "intrinsics", "size_of_val"], \substs -> case substs of
                        ["Unexpected MirSliceRepr type", show (PP.pretty ty)]
 
             -- Trait objects (e.g., `&dyn Debug` and custom DSTs whose last
-            -- field contains a trait object) are unsized. This override
-            -- currently does not support any kind of trait object, so all we
-            -- do here is make an effort to give a descriptive error message.
-            -- TODO(#1614): Support trait objects and custom DSTs here.
+            -- field contains a trait object) are unsized.  We currently
+            -- support computing the size of trait objects that aren't embedded
+            -- in a custom DST. TODO(#1614): Lift this restriction.
             DynRefRepr -> case ty of
                 TyDynamic dynTraitName -> getVtableUsize dynTraitName 0 e
                 TyAdt {} -> unsupportedCustomDst ty
@@ -1303,10 +1302,9 @@ align_of_val = (["core", "intrinsics", "align_of_val"], \substs -> case substs o
                        ["Unexpected MirSliceRepr type", show (PP.pretty ty)]
 
             -- Trait objects (e.g., `&dyn Debug` and custom DSTs whose last
-            -- field contains a trait object) are unsized. This override
-            -- currently does not support any kind of trait object, so all we
-            -- do here is make an effort to give a descriptive error message.
-            -- TODO(#1614): Support trait objects and custom DSTs here.
+            -- field contains a trait object) are unsized.  We currently
+            -- support computing the alignment of trait objects that aren't
+            -- embedded in a custom DST. TODO(#1614): Lift this restriction.
             DynRefRepr -> case ty of
                 TyDynamic dynTraitName -> getVtableUsize dynTraitName 1 e
                 TyAdt {} -> unsupportedCustomDst ty

--- a/crucible-mir/src/Mir/TransCustom.hs
+++ b/crucible-mir/src/Mir/TransCustom.hs
@@ -2515,26 +2515,12 @@ callOnceVirtShimDef methodIdx = CustomMirOp $ \ops ->
         in itraverseFC (\idx tpr -> go argTupleTy argTupleExp idx tpr) argCtx
 
       -- Look up `methodIdx` return type.
-      -- This unfortunately duplicates some of the logic from `mkVirtCall`.
-      dynTrait <- case col ^. traits . at dynTraitName of
-        Just x -> return x
-        Nothing -> mirFail $ "callOnceVirtShimDef: undefined trait " ++ show dynTraitName
-      Some vtableStructTpr <- case traitVtableType col dynTrait of
-        Left err -> mirFail $ "callOnceVirtShimDef: traitVtableType: " ++ err
-        Right x -> return x
-      Some vtableCtx <- case vtableStructTpr of
-        C.StructRepr ctx -> return $ Some ctx
-        _ -> mirFail $ "callOnceVirtShimDef: vtable type is not a struct"
-      let methodSlotIdx = numVtableInfoSlots + fromInteger methodIdx
-      Some vtableMethodSlotIdx <- case Ctx.intIndex methodSlotIdx (Ctx.size vtableCtx) of
-        Just x -> return x
-        Nothing -> mirFail $ "callOnceVirtShimDef: method index out of range for vtable: "
-          ++ "method = " ++ show methodIdx ++ "; slot = " ++ show methodSlotIdx
-          ++ "; size = " ++ show (Ctx.size vtableCtx)
-      let vtableMethodTpr = vtableCtx Ctx.! vtableMethodSlotIdx
+      Some (VtableInfo vtableCtx vtableSlotIdx) <-
+        vtableMethodInfo' dynTraitName (fromInteger methodIdx)
+      let vtableMethodTpr = vtableCtx Ctx.! vtableSlotIdx
       Some retTpr <- case vtableMethodTpr of
         C.FunctionHandleRepr _ retTpr -> return $ Some retTpr
-        tpr -> mirFail $ "callOnceVirtShimDef: expected method " ++ show methodSlotIdx
+        tpr -> mirFail $ "callOnceVirtShimDef: expected method " ++ show methodIdx
           ++ " of " ++ show dynTraitName ++ " to have FunctionHandleRepr, but got " ++ show tpr
 
       MirExp retTpr <$> doVirtCall

--- a/crucible-mir/src/Mir/TransCustom.hs
+++ b/crucible-mir/src/Mir/TransCustom.hs
@@ -1212,6 +1212,45 @@ size_of = (["core", "intrinsics", "size_of"], \substs -> case substs of
     _ -> Nothing
     )
 
+-- | Read a @usize@ value from slot @idx@ of a vtable.
+getVtableUsize :: TraitName -> Int -> R.Expr MIR s C.AnyType -> MirGenerator h s ret (MirExp s)
+getVtableUsize dynTraitName idx vtable = do
+  col <- use $ cs . collection
+
+  -- Unpack vtable type
+  dynTrait <- case col ^. traits . at dynTraitName of
+    Just x -> return x
+    Nothing -> die ["undefined trait " ++ show dynTraitName]
+  Some vtableStructTpr <- case traitVtableType col dynTrait of
+    Left err -> die ["traitVtableType: " ++ err]
+    Right x -> return x
+  Some vtableTprs <- case vtableStructTpr of
+    C.StructRepr ctx -> return $ Some ctx
+    _ -> die ["vtable type is not a struct"]
+
+  let vtableIdxInt = idx
+  Some vtableIdx <- case Ctx.intIndex vtableIdxInt (Ctx.size vtableTprs) of
+    Just x -> return x
+    Nothing -> die ["slot index out of range for vtable:",
+      "idx =", show idx, "; size =", show (Ctx.size vtableTprs)]
+
+  let slotTpr = vtableTprs Ctx.! vtableIdx
+  Refl <- testEqualityOrFail slotTpr UsizeRepr $
+    "expected trait " ++ show dynTraitName ++ " vtable slot " ++ show idx
+      ++ " to contain a `usize`, but got " ++ show slotTpr
+
+  let vtableStructTpr' = C.StructRepr vtableTprs
+  vtableDowncast <- G.fromJustExpr (R.App $ E.UnpackAny vtableStructTpr' vtable)
+      (R.App $ E.StringLit $ fromString $ "bad vtable type for " ++ show dynTraitName)
+
+  let usize = R.App $ E.GetStruct vtableDowncast vtableIdx UsizeRepr
+  return $ MirExp UsizeRepr usize
+
+  where
+    die :: HasCallStack => [String] -> a
+    die words' = error $ unwords $
+      ["failed to get usize from slot", show idx, "of trait", show dynTraitName] ++ words'
+
 size_of_val :: (ExplodedDefId, CustomRHS)
 size_of_val = (["core", "intrinsics", "size_of_val"], \substs -> case substs of
     Substs [_] -> Just $ CustomOp $ \opTys ops -> case (opTys, ops) of
@@ -1234,7 +1273,9 @@ size_of_val = (["core", "intrinsics", "size_of_val"], \substs -> case substs of
             -- do here is make an effort to give a descriptive error message.
             -- TODO(#1614): Support trait objects and custom DSTs here.
             DynRefRepr -> case ty of
-                TyDynamic {} -> unsupportedTraitObject ty
+                TyDynamic dynTraitName -> do
+                    let vtable = S.getStruct dynRefVtableIndex e
+                    getVtableUsize dynTraitName 0 vtable
                 TyAdt {} -> unsupportedCustomDst ty
                 _ -> panic "size_of_val"
                        ["Unexpected DynRefRepr type", show (PP.pretty ty)]
@@ -1260,13 +1301,6 @@ size_of_val = (["core", "intrinsics", "size_of_val"], \substs -> case substs of
         sz <- getLayoutFieldAsExpr "size_of_val" laySize ty
         pure $ MirExp UsizeRepr $ R.App $ usizeMul len sz
 
-    unsupportedTraitObject :: Ty -> MirGenerator h s ret a
-    unsupportedTraitObject ty =
-        mirFail $ unlines
-            [ "size_of_val does not currently support trait objects"
-            , "In the type " ++ show (PP.pretty ty)
-            ]
-
     unsupportedCustomDst :: Ty -> MirGenerator h s ret a
     unsupportedCustomDst ty =
         mirFail $ unlines
@@ -1285,7 +1319,7 @@ align_of_val :: (ExplodedDefId, CustomRHS)
 align_of_val = (["core", "intrinsics", "align_of_val"], \substs -> case substs of
     Substs [_] -> Just $ CustomOp $ \opTys ops -> case (opTys, ops) of
         -- We first check whether the underlying type is sized or not.
-        ([TyRawPtr ty _], [MirExp tpr _]) -> case tpr of
+        ([TyRawPtr ty _], [MirExp tpr e]) -> case tpr of
             -- Slices (e.g., `&[u8]`, `&str`, and custom DSTs whose last field
             -- contains a slice) are unsized. We currently support computing
             -- the alignment of slice values that aren't embedded in a custom
@@ -1309,7 +1343,9 @@ align_of_val = (["core", "intrinsics", "align_of_val"], \substs -> case substs o
             -- do here is make an effort to give a descriptive error message.
             -- TODO(#1614): Support trait objects and custom DSTs here.
             DynRefRepr -> case ty of
-                TyDynamic {} -> unsupportedTraitObject ty
+                TyDynamic dynTraitName -> do
+                    let vtable = S.getStruct dynRefVtableIndex e
+                    getVtableUsize dynTraitName 1 vtable
                 TyAdt {} -> unsupportedCustomDst ty
                 _ -> panic "align_of_val"
                        ["Unexpected DynRefRepr type", show (PP.pretty ty)]
@@ -1325,13 +1361,6 @@ align_of_val = (["core", "intrinsics", "align_of_val"], \substs -> case substs o
     _ -> Nothing
     )
   where
-    unsupportedTraitObject :: Ty -> MirGenerator h s ret a
-    unsupportedTraitObject ty =
-        mirFail $ unlines
-            [ "align_of_val does not currently support trait objects"
-            , "In the type " ++ show (PP.pretty ty)
-            ]
-
     unsupportedCustomDst :: Ty -> MirGenerator h s ret a
     unsupportedCustomDst ty =
         mirFail $ unlines

--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -1911,6 +1911,10 @@ vtableInfoTys =
 numVtableInfoSlots :: Int
 numVtableInfoSlots = length vtableInfoTys
 
+-- | Convert a method index to a slot index.
+vtableMethodSlotIdx :: Int -> Int
+vtableMethodSlotIdx methodIdx = numVtableInfoSlots + methodIdx
+
 -- TODO: make mir-json emit trait vtable layouts for all dyns observed in the
 -- crate, then use that info to greatly simplify this function
 traitVtableType :: (HasCallStack) =>
@@ -1940,6 +1944,16 @@ data VtableInfo tp = forall ctx. VtableInfo
 
 vtableInfo :: M.TraitName -> Int -> C.TypeRepr tp -> MirGenerator h s ret (VtableInfo tp)
 vtableInfo dynTraitName slotIdx slotTpr = do
+  Some vt@(VtableInfo ctx idx) <- vtableInfo' dynTraitName slotIdx
+  let tpr = ctx Ctx.! idx
+  Refl <- testEqualityOrFail tpr slotTpr $
+    dieMsg $ "expected slot to contain " ++ show slotTpr ++ ", but got " ++ show tpr
+  return vt
+  where
+    dieMsg s = "vtableInfo: trait" ++ show dynTraitName ++ ", slot " ++ show slotIdx ++ ": " ++ s
+
+vtableInfo' :: M.TraitName -> Int -> MirGenerator h s ret (Some VtableInfo)
+vtableInfo' dynTraitName slotIdx = do
   col <- use $ cs . collection
 
   dynTrait <- case col ^. M.traits . at dynTraitName of
@@ -1956,17 +1970,17 @@ vtableInfo dynTraitName slotIdx slotTpr = do
     Just x -> return x
     Nothing -> die "slot index out of range for trait"
 
-  let tpr = vtableTprs Ctx.! slotIdx'
-  Refl <- testEqualityOrFail tpr slotTpr $
-    dieMsg $ "expected slot to contain " ++ show slotTpr ++ ", but got " ++ show tpr
-
-  return $ VtableInfo vtableTprs slotIdx'
+  return $ Some (VtableInfo vtableTprs slotIdx')
 
   where
     die :: String -> MirGenerator h s ret a
     die s = mirFail $ dieMsg s
 
     dieMsg s = "vtableInfo': trait" ++ show dynTraitName ++ ", slot " ++ show slotIdx ++ ": " ++ s
+
+vtableMethodInfo' :: M.TraitName -> Int -> MirGenerator h s ret (Some VtableInfo)
+vtableMethodInfo' dynTraitName methodIdx = do
+  vtableInfo' dynTraitName (vtableMethodSlotIdx methodIdx)
 
 -- | Read a value from a vtable slot.
 getVtableSlot ::
@@ -1994,7 +2008,7 @@ getVtableMethod ::
   R.Expr MIR s C.AnyType ->
   MirGenerator h s ret (R.Expr MIR s (C.FunctionHandleType (C.AnyType :<: argTps) retTp))
 getVtableMethod dynTraitName methodIdx argTprs retTpr vtableExp = do
-  let slotIdx = numVtableInfoSlots + methodIdx
+  let slotIdx = vtableMethodSlotIdx methodIdx
   let slotTpr = C.FunctionHandleRepr (C.AnyRepr <: argTprs) retTpr
   getVtableSlot dynTraitName slotIdx slotTpr vtableExp
 

--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -1899,6 +1899,18 @@ getLayoutFieldAsMirExp opName layoutFieldLens ty =
 
 -- Vtable handling
 
+-- | Non-method fields present at the start of every vtable.
+vtableInfoTys :: [M.Ty]
+vtableInfoTys =
+    -- Size of the erased type
+    [ M.TyUint M.USize
+    -- Alignment of the erased type
+    , M.TyUint M.USize
+    ]
+
+numVtableInfoSlots :: Int
+numVtableInfoSlots = length vtableInfoTys
+
 -- TODO: make mir-json emit trait vtable layouts for all dyns observed in the
 -- crate, then use that info to greatly simplify this function
 traitVtableType :: (HasCallStack) =>
@@ -1910,7 +1922,7 @@ traitVtableType col trait = vtableTy
     methodSigs = map (\(M.TraitMethod _name sig) -> sig) (trait ^. M.traitItems)
     shimSigs = map convertShimSig methodSigs
 
-    vtableTy = tyListToCtx col (map M.TyFnPtr shimSigs) $ \ctx ->
+    vtableTy = tyListToCtx col (vtableInfoTys ++ map M.TyFnPtr shimSigs) $ \ctx ->
         Right (Some (C.StructRepr ctx))
 
 eraseSigReceiver :: M.FnSig -> M.FnSig

--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -1897,7 +1897,21 @@ getLayoutFieldAsMirExp opName layoutFieldLens ty =
   MirExp UsizeRepr <$> getLayoutFieldAsExpr opName layoutFieldLens ty
 
 
--- Vtable handling
+-- Vtable layout helpers
+
+-- | Collection of pieces that go into constructing a vtable.  We use this to
+-- avoid hardcoding indices or orderings in various places throughout the code.
+data VtableParts s = VtableParts
+  { vtpMethods :: [MirExp s]
+  , vtpSize :: R.Expr MIR s UsizeType
+  , vtpAlign :: R.Expr MIR s UsizeType
+  }
+
+vtablePartsToEntries :: VtableParts s -> [MirExp s]
+vtablePartsToEntries vtp =
+  MirExp UsizeRepr (vtpSize vtp) :
+  MirExp UsizeRepr (vtpAlign vtp) :
+  vtpMethods vtp
 
 -- | Non-method fields present at the start of every vtable.
 vtableInfoTys :: [M.Ty]
@@ -1911,9 +1925,18 @@ vtableInfoTys =
 numVtableInfoSlots :: Int
 numVtableInfoSlots = length vtableInfoTys
 
+vtableSizeSlotIdx :: Int
+vtableSizeSlotIdx = 0
+
+vtableAlignSlotIdx :: Int
+vtableAlignSlotIdx = 1
+
 -- | Convert a method index to a slot index.
 vtableMethodSlotIdx :: Int -> Int
 vtableMethodSlotIdx methodIdx = numVtableInfoSlots + methodIdx
+
+
+-- Vtable construction and use
 
 -- TODO: make mir-json emit trait vtable layouts for all dyns observed in the
 -- crate, then use that info to greatly simplify this function

--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -1930,6 +1930,80 @@ eraseSigReceiver sig = sig & M.fsarg_tys %~ \xs -> case xs of
     [] -> error $ unwords ["dynamic trait method has no receiver", show sig]
     (_ : tys) -> M.TyErased : tys
 
+-- | Info about a specific slot in a trait vtable.  @tp@ is the type of the
+-- slot.
+data VtableInfo tp = forall ctx. VtableInfo
+  -- | The fields of the vtable's `StructType`.
+  (C.CtxRepr ctx)
+  -- | The `Ctx.Index` of the requested slot of the vtable.
+  (Ctx.Index ctx tp)
+
+vtableInfo :: M.TraitName -> Int -> C.TypeRepr tp -> MirGenerator h s ret (VtableInfo tp)
+vtableInfo dynTraitName slotIdx slotTpr = do
+  col <- use $ cs . collection
+
+  dynTrait <- case col ^. M.traits . at dynTraitName of
+    Just x -> return x
+    Nothing -> die "undefined trait"
+  Some vtableStructTpr <- case traitVtableType col dynTrait of
+    Left err -> die $ "traitVtableType: " ++ err
+    Right x -> return x
+  Some vtableTprs <- case vtableStructTpr of
+    C.StructRepr ctx -> return $ Some ctx
+    _ -> die "vtable type is not a struct"
+
+  Some slotIdx' <- case Ctx.intIndex slotIdx (Ctx.size vtableTprs) of
+    Just x -> return x
+    Nothing -> die "slot index out of range for trait"
+
+  let tpr = vtableTprs Ctx.! slotIdx'
+  Refl <- testEqualityOrFail tpr slotTpr $
+    dieMsg $ "expected slot to contain " ++ show slotTpr ++ ", but got " ++ show tpr
+
+  return $ VtableInfo vtableTprs slotIdx'
+
+  where
+    die :: String -> MirGenerator h s ret a
+    die s = mirFail $ dieMsg s
+
+    dieMsg s = "vtableInfo': trait" ++ show dynTraitName ++ ", slot " ++ show slotIdx ++ ": " ++ s
+
+-- | Read a value from a vtable slot.
+getVtableSlot ::
+  M.TraitName ->
+  Int ->
+  C.TypeRepr tp ->
+  R.Expr MIR s C.AnyType ->
+  MirGenerator h s ret (R.Expr MIR s tp)
+getVtableSlot dynTraitName slotIdx slotTpr vtableExp = do
+  VtableInfo vtableCtx slotIdx' <- vtableInfo dynTraitName slotIdx slotTpr
+
+  let vtableStructTpr = C.StructRepr vtableCtx
+  vtableDowncast <- G.fromJustExpr (R.App $ E.UnpackAny vtableStructTpr vtableExp)
+    (R.App $ E.StringLit $ fromString $ "bad vtable type for " ++ show dynTraitName)
+
+  return $ R.App $ E.GetStruct vtableDowncast slotIdx' slotTpr
+
+-- | Retrieve a method `C.FunctionHandleType` from a vtable.  Note the index is
+-- a method index, not a slot index.
+getVtableMethod ::
+  M.TraitName ->
+  Int ->
+  C.CtxRepr argTps ->
+  C.TypeRepr retTp ->
+  R.Expr MIR s C.AnyType ->
+  MirGenerator h s ret (R.Expr MIR s (C.FunctionHandleType (C.AnyType :<: argTps) retTp))
+getVtableMethod dynTraitName methodIdx argTprs retTpr vtableExp = do
+  let slotIdx = numVtableInfoSlots + methodIdx
+  let slotTpr = C.FunctionHandleRepr (C.AnyRepr <: argTprs) retTpr
+  getVtableSlot dynTraitName slotIdx slotTpr vtableExp
+
+type (x :: k) :<: (xs :: Ctx.Ctx k) = Ctx.SingleCtx x Ctx.<+> xs
+
+(<:) :: forall f tp ctx. f tp -> Ctx.Assignment f ctx -> Ctx.Assignment f (tp :<: ctx)
+x <: xs = Ctx.singleton x Ctx.<++> xs
+
+
 ---- "Allocation"
 --
 --

--- a/crux-mir/CHANGELOG.md
+++ b/crux-mir/CHANGELOG.md
@@ -1,7 +1,7 @@
 # next
 
 This release supports [version
-10](https://github.com/GaloisInc/mir-json/blob/master/SCHEMA_CHANGELOG.md#10) of
+11](https://github.com/GaloisInc/mir-json/blob/master/SCHEMA_CHANGELOG.md#11) of
 `mir-json`'s schema.
 
 # 0.12 -- 2026-01-29

--- a/crux-mir/README.md
+++ b/crux-mir/README.md
@@ -49,7 +49,7 @@ Next, navigate to the `crucible/dependencies/mir-json` directory. Install
 [the `mir-json` README][mir-json-readme].
 
 Currently, `crux-mir` supports [version
-10](https://github.com/GaloisInc/mir-json/blob/master/SCHEMA_CHANGELOG.md#10) of
+11](https://github.com/GaloisInc/mir-json/blob/master/SCHEMA_CHANGELOG.md#11) of
 `mir-json`'s schema. Note that the schema versions produced by `mir-json` can
 change over time as dictated by internal requirements and upstream changes. To
 help smooth this over:

--- a/crux-mir/test/conc_eval/mem/align_of_val.rs
+++ b/crux-mir/test/conc_eval/mem/align_of_val.rs
@@ -1,4 +1,4 @@
-// use std::fmt::Debug;
+use std::fmt::Debug;
 
 // pub struct C<T: ?Sized> {
 //     pub x: u32,
@@ -19,10 +19,11 @@ fn crux_test() {
     assert_eq!(1, align_of_val::<str>(&"r"));
     assert_eq!(1, align_of_val::<str>(&"ro"));
 
-    // TODO(#1614): The following are not currently supported:
-
     // Trait objects
-    // assert_eq!(1, align_of_val::<dyn Debug>(&()));
+    assert_eq!(1, align_of_val::<dyn Debug>(&()));
+    assert_eq!(4, align_of_val::<dyn Debug>(&123_i32));
+
+    // TODO(#1614): The following are not currently supported:
 
     // Custom DSTs with a slice as the last field
     // let sized: C<[u8; 8]> = C {

--- a/crux-mir/test/conc_eval/mem/size_of_val.rs
+++ b/crux-mir/test/conc_eval/mem/size_of_val.rs
@@ -1,4 +1,4 @@
-// use std::fmt::Debug;
+use std::fmt::Debug;
 
 // pub struct C<T: ?Sized> {
 //     pub x: u32,
@@ -21,10 +21,11 @@ fn crux_test() {
     assert_eq!(4, size_of_val::<str>(&"roș")); // Note that ș occupies two bytes, not one!
     assert_eq!(5, size_of_val::<str>(&"roșu"));
 
-    // TODO(#1614): The following are not currently supported:
-
     // Trait objects
-    // crucible_assert!(0 == size_of_val::<dyn Debug>(x));
+    assert_eq!(0, size_of_val::<dyn Debug>(&()));
+    assert_eq!(4, size_of_val::<dyn Debug>(&123_i32));
+
+    // TODO(#1614): The following are not currently supported:
 
     // Custom DSTs with a slice as the last field
     // let sized: C<[u8; 8]> = C {


### PR DESCRIPTION
Currently, vtables in crux-mir store only the method `FunctionHandle`s.  In rustc the vtable contains a bit more information, notably including the size and alignment of the erased type.  This is used for two major purposes:

1. Size and align are used to implement `size_of_val` and `align_of_val` on `&dyn Trait`.
2. Align is used to compute the offset of the last field of custom DSTs with `dyn Trait` tails.  `CustomDST<dyn Trait>` must have the same layout in memory as `CustomDST<ErasedType>`, so the offset / padding of the final `dyn Trait` field depends on the alignment of `ErasedType`.

This branch adds the size and align fields to the vtable and uses them to implement the (non-custom DST) `dyn Trait` case of `size_of_val` and `align_of_val`.  The offset computation for custom DSTs will be part of the future migration of structs to use `MirAggregateRepr`.

Fixes the non-custom case of #1614