### PR TITLE
Deprecate `BitSet` module

### DIFF
--- a/crucible/src/Lang/Crucible/Utils/BitSet.hs
+++ b/crucible/src/Lang/Crucible/Utils/BitSet.hs
@@ -12,6 +12,7 @@
 -- built on top of GHC-native Integers.
 ------------------------------------------------------------------------
 module Lang.Crucible.Utils.BitSet
+{-# DEPRECATED "This module is deprecated" #-}
 ( BitSet
 , getBits
 , empty


### PR DESCRIPTION
This module does not appear to be consumed by any downstream code, except the ancient `mss`:

https://github.com/search?q=owner%3AGaloisInc+%2FUtils%5C.BitSet%2F&type=code

It's also not really clear why it should be part of Crucible; the data-structure it provides is not fundamentally related to symbolic execution. We can save a bit of compile time and artifact sizes by removing it someday.