### PR TITLE
crux-mir: use MirAggregate for structs

### DIFF
--- a/crucible-mir/src/Mir/Generator.hs
+++ b/crucible-mir/src/Mir/Generator.hs
@@ -677,6 +677,13 @@ mirRef_agElem_constOffset ::
 mirRef_agElem_constOffset off sz tpr ref =
   mirRef_agElem (R.App $ usizeLit $ fromIntegral off) sz tpr ref
 
+mirRef_agElem_unsized ::
+  R.Expr MIR s UsizeType ->
+  C.TypeRepr tp ->
+  R.Expr MIR s MirReferenceType ->
+  MirGenerator h s ret (R.Expr MIR s MirReferenceType)
+mirRef_agElem_unsized off tpr ref = G.extensionStmt $ MirRef_AgElem_Unsized off tpr ref
+
 mirRef_eq ::
   R.Expr MIR s MirReferenceType ->
   R.Expr MIR s MirReferenceType ->

--- a/crucible-mir/src/Mir/Generator.hs
+++ b/crucible-mir/src/Mir/Generator.hs
@@ -621,22 +621,6 @@ subfieldRef ::
   MirGenerator h s ret (R.Expr MIR s MirReferenceType)
 subfieldRef ctx ref idx = G.extensionStmt (MirSubfieldRef ctx ref idx)
 
--- | Extend the reference path encapsulated in the provided @Expr MIR s
--- MirReferenceType@ (i.e. @ref@), which should terminate in a struct, to
--- terminate at the @fieldNum@th field of that struct. If @expectedTy@ is
--- provided, then it will be asserted (via `subfieldMirRef_UntypedLeaf`) to
--- match the observed type of the field during simulation.
---
--- Essentially an untyped/dynamically-typed version of `subfieldRef` that infers
--- the appropriate struct context and field type when they aren't statically
--- known/knowable - e.g. for structs containing trait objects.
-subfieldRef_Untyped ::
-  R.Expr MIR s MirReferenceType ->
-  Int ->
-  Maybe (Some C.TypeRepr) ->
-  MirGenerator h s ret (R.Expr MIR s MirReferenceType)
-subfieldRef_Untyped ref fieldNum expectedTy = G.extensionStmt (MirSubfieldRef_Untyped ref fieldNum expectedTy)
-
 subvariantRef ::
   C.TypeRepr discrTp ->
   C.CtxRepr variantsCtx ->

--- a/crucible-mir/src/Mir/Generator.hs
+++ b/crucible-mir/src/Mir/Generator.hs
@@ -679,10 +679,9 @@ mirRef_agElem_constOffset off sz tpr ref =
 
 mirRef_agElem_unsized ::
   R.Expr MIR s UsizeType ->
-  C.TypeRepr tp ->
   R.Expr MIR s MirReferenceType ->
   MirGenerator h s ret (R.Expr MIR s MirReferenceType)
-mirRef_agElem_unsized off tpr ref = G.extensionStmt $ MirRef_AgElem_Unsized off tpr ref
+mirRef_agElem_unsized off ref = G.extensionStmt $ MirRef_AgElem_Unsized off ref
 
 mirRef_eq ::
   R.Expr MIR s MirReferenceType ->

--- a/crucible-mir/src/Mir/Intrinsics/MethodSpec.hs
+++ b/crucible-mir/src/Mir/Intrinsics/MethodSpec.hs
@@ -121,7 +121,10 @@ class MethodSpecBuilderImpl sym msb where
         msb ->
         OverrideSim (p sym) sym MIR rtp args ret (MethodSpec sym)
 
-data MethodSpecBuilder sym = forall msb. MethodSpecBuilderImpl sym msb => MethodSpecBuilder msb
+data MethodSpecBuilder sym = forall msb. MethodSpecBuilderImpl sym msb => MethodSpecBuilder {
+    msbData :: msb,
+    msbNonce :: Word64
+}
 
 type MethodSpecBuilderSymbol = "MethodSpecBuilder"
 type MethodSpecBuilderType = IntrinsicType MethodSpecBuilderSymbol EmptyCtx
@@ -138,6 +141,7 @@ type family MethodSpecBuilderFam (sym :: Type) (ctx :: Ctx CrucibleType) :: Type
 instance IsSymInterface sym => IntrinsicClass sym MethodSpecBuilderSymbol where
   type Intrinsic sym MethodSpecBuilderSymbol ctx = MethodSpecBuilderFam sym ctx
 
-  muxIntrinsic _sym _iTypes _nm Empty _ _ _ =
-    fail "can't mux MethodSpecBuilders"
+  muxIntrinsic _sym _iTypes _nm Empty _p msb1 msb2
+    | msbNonce msb1 == msbNonce msb2 = return msb1
+    | otherwise = fail "can't mux MethodSpecBuilders"
   muxIntrinsic _sym _tys nm ctx _ _ _ = typeError nm ctx

--- a/crucible-mir/src/Mir/Intrinsics/Reference.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Reference.hs
@@ -56,9 +56,7 @@ module Mir.Intrinsics.Reference
     dropMirRefLeaf,
     dropMirRefIO,
     subfieldMirRefLeaf,
-    subfieldMirRef_UntypedLeaf,
     subfieldMirRefIO,
-    subfieldMirRef_UntypedIO,
     subvariantMirRefLeaf,
     subvariantMirRefIO,
     subindexMirRefSim,
@@ -128,8 +126,6 @@ import Data.Parameterized.Context
     Index,
     adjustM,
     field,
-    intIndex,
-    size,
     (!),
     (::>),
     pattern Empty,
@@ -934,48 +930,6 @@ subfieldMirRefLeaf ctx ref idx =
     let tpr = ctx ! idx
     return $ MirReference tpr root (Field_RefPath ctx path idx)
 
--- | Mimic `subfieldMirRefLeaf`, but infer the appropriate `CtxRepr` and `Index`
--- at simulation time. If @expectedTy@ is provided, this will assert that it
--- matches the actual type of the field during simulation.
-subfieldMirRef_UntypedLeaf ::
-    MirReference sym ->
-    Int ->
-    Maybe (Some TypeRepr) ->
-    MuxLeafT sym IO (MirReference sym)
-subfieldMirRef_UntypedLeaf ref fieldNum expectedTy =
-  case ref of
-    MirReference_Integer _ ->
-      bail $ "attempted untyped subfield on the result of an integer-to-pointer cast"
-    MirReference structReprHopefully refRoot refPath ->
-      case structReprHopefully of
-        StructRepr structCtx ->
-          do
-            Some fieldIdx <-
-              case intIndex fieldNum (size structCtx) of
-                Just someIdx -> pure someIdx
-                Nothing ->
-                  bail $ unwords $
-                    [ "out-of-bounds field access:"
-                    , "field", show fieldNum, "of struct", show structCtx ]
-            let fieldRepr = structCtx ! fieldIdx
-            () <- case expectedTy of
-              Nothing -> pure ()
-              Just (Some expected) ->
-                case testEquality expected fieldRepr of
-                  Just Refl -> pure ()
-                  Nothing ->
-                    bail $ unwords $
-                      [ "expected field type", show expected
-                      , "did not match actual field type", show fieldRepr ]
-            let fieldPath = Field_RefPath structCtx refPath fieldIdx
-            pure $ MirReference fieldRepr refRoot fieldPath
-        notAStruct ->
-          bail $ unwords $
-            [ "untyped subfield requires a reference to a struct, but got a reference to"
-            , show notAStruct ]
-  where
-    bail msg = leafAbort $ GenericSimError $ msg
-
 subfieldMirRefIO ::
     IsSymBackend sym bak =>
     bak ->
@@ -986,17 +940,6 @@ subfieldMirRefIO ::
     IO (MirReferenceMux sym)
 subfieldMirRefIO bak iTypes ctx ref idx =
     modifyRefMuxMA bak iTypes (\ref' -> subfieldMirRefLeaf ctx ref' idx) ref
-
-subfieldMirRef_UntypedIO ::
-    IsSymBackend sym bak =>
-    bak ->
-    IntrinsicTypes sym ->
-    MirReferenceMux sym ->
-    Int ->
-    Maybe (Some TypeRepr) ->
-    IO (MirReferenceMux sym)
-subfieldMirRef_UntypedIO bak iTypes ref fieldNum expectedTy =
-    modifyRefMuxMA bak iTypes (\ref' -> subfieldMirRef_UntypedLeaf ref' fieldNum expectedTy) ref
 
 
 subvariantMirRefLeaf ::

--- a/crucible-mir/src/Mir/Intrinsics/Reference.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Reference.hs
@@ -1120,10 +1120,9 @@ mirRef_agElem_unsizedLeaf ::
     SymGlobalState sym ->
     IntrinsicTypes sym ->
     RegValue sym UsizeType ->
-    TypeRepr tp ->
     MirReference sym ->
     MuxLeafT sym IO (MirReference sym)
-mirRef_agElem_unsizedLeaf bak gs iTypes off tpr ref =
+mirRef_agElem_unsizedLeaf bak gs iTypes off ref =
   typedLeafOp "MirAggregate unsized element projection" MirAggregateRepr ref $ \root path -> do
     let ref' = MirReference MirAggregateRepr root path
     offConcrete <- case asBV off of
@@ -1131,11 +1130,10 @@ mirRef_agElem_unsizedLeaf bak gs iTypes off tpr ref =
       Nothing -> leafAbort $ GenericSimError $
         "mirRef_agElem_unsized: offset must be concrete, but got " ++ show (printSymExpr off)
     MirAggregate _ m <- readMirRefLeaf bak gs iTypes MirAggregateRepr ref'
-    MirAggregateEntry sz _ _ <- case IntMap.lookup offConcrete m of
-      Just entry -> return entry
-      Nothing -> leafAbort $ GenericSimError $
-        "mirRef_agElem_unsized: no entry at offset " ++ show offConcrete
-    return $ MirReference tpr root (AgElem_RefPath off sz tpr path)
+    (sz, Some entryTpr) <- case IntMap.lookup offConcrete m of
+      Just (MirAggregateEntry sz entryTpr _) -> return (sz, Some entryTpr)
+      Nothing -> return (0, Some MirAggregateRepr)
+    return $ MirReference entryTpr root (AgElem_RefPath off sz entryTpr path)
 
 mirRef_agElem_unsizedIO ::
     IsSymBackend sym bak =>
@@ -1143,11 +1141,10 @@ mirRef_agElem_unsizedIO ::
     SymGlobalState sym ->
     IntrinsicTypes sym ->
     RegValue sym UsizeType ->
-    TypeRepr tp ->
     MirReferenceMux sym ->
     IO (MirReferenceMux sym)
-mirRef_agElem_unsizedIO bak gs iTypes off tpr ref =
-    modifyRefMuxMA bak iTypes (mirRef_agElem_unsizedLeaf bak gs iTypes off tpr) ref
+mirRef_agElem_unsizedIO bak gs iTypes off ref =
+    modifyRefMuxMA bak iTypes (mirRef_agElem_unsizedLeaf bak gs iTypes off) ref
 
 
 refRootEq ::

--- a/crucible-mir/src/Mir/Intrinsics/Reference.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Reference.hs
@@ -1069,12 +1069,11 @@ mirRef_agElem_unsizedLeaf ::
     MuxLeafT sym IO (MirReference sym)
 mirRef_agElem_unsizedLeaf bak gs iTypes off ref =
   typedLeafOp "MirAggregate unsized element projection" MirAggregateRepr ref $ \root path -> do
-    let ref' = MirReference MirAggregateRepr root path
     offConcrete <- case asBV off of
       Just bv -> return $ fromIntegral $ BV.asUnsigned bv
       Nothing -> leafAbort $ GenericSimError $
         "mirRef_agElem_unsized: offset must be concrete, but got " ++ show (printSymExpr off)
-    MirAggregate _ m <- readMirRefLeaf bak gs iTypes MirAggregateRepr ref'
+    MirAggregate _ m <- readMirRefLeaf bak gs iTypes MirAggregateRepr ref
     (sz, Some entryTpr) <- case IntMap.lookup offConcrete m of
       Just (MirAggregateEntry sz entryTpr _) -> return (sz, Some entryTpr)
       Nothing -> return (0, Some MirAggregateRepr)

--- a/crucible-mir/src/Mir/Intrinsics/Reference.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Reference.hs
@@ -68,6 +68,8 @@ module Mir.Intrinsics.Reference
     subjustMirRefIO,
     mirRef_agElemLeaf,
     mirRef_agElemIO,
+    mirRef_agElem_unsizedLeaf,
+    mirRef_agElem_unsizedIO,
     refRootEq,
     refPathEq,
     mirRef_eqLeaf,
@@ -116,6 +118,7 @@ import Lens.Micro ((^.), (.~))
 
 import Data.BitVector.Sized qualified as BV
 import Data.Function ((&))
+import Data.IntMap qualified as IntMap
 import Data.Kind (Type)
 import Data.Parameterized.Context
   ( Ctx,
@@ -209,6 +212,7 @@ import Mir.FancyMuxTree
   )
 import Mir.Intrinsics.Aggregate
   ( MirAggregate (..),
+    MirAggregateEntry (..),
     MirAggregateType,
     adjustMirAggregateWithSymOffset,
     mirAggregate_concat,
@@ -1109,6 +1113,41 @@ mirRef_agElemIO ::
     IO (MirReferenceMux sym)
 mirRef_agElemIO bak iTypes off sz tpr ref =
     modifyRefMuxMA bak iTypes (mirRef_agElemLeaf off sz tpr) ref
+
+mirRef_agElem_unsizedLeaf ::
+    IsSymBackend sym bak =>
+    bak ->
+    SymGlobalState sym ->
+    IntrinsicTypes sym ->
+    RegValue sym UsizeType ->
+    TypeRepr tp ->
+    MirReference sym ->
+    MuxLeafT sym IO (MirReference sym)
+mirRef_agElem_unsizedLeaf bak gs iTypes off tpr ref =
+  typedLeafOp "MirAggregate unsized element projection" MirAggregateRepr ref $ \root path -> do
+    let ref' = MirReference MirAggregateRepr root path
+    offConcrete <- case asBV off of
+      Just bv -> return $ fromIntegral $ BV.asUnsigned bv
+      Nothing -> leafAbort $ GenericSimError $
+        "mirRef_agElem_unsized: offset must be concrete, but got " ++ show (printSymExpr off)
+    MirAggregate _ m <- readMirRefLeaf bak gs iTypes MirAggregateRepr ref'
+    MirAggregateEntry sz _ _ <- case IntMap.lookup offConcrete m of
+      Just entry -> return entry
+      Nothing -> leafAbort $ GenericSimError $
+        "mirRef_agElem_unsized: no entry at offset " ++ show offConcrete
+    return $ MirReference tpr root (AgElem_RefPath off sz tpr path)
+
+mirRef_agElem_unsizedIO ::
+    IsSymBackend sym bak =>
+    bak ->
+    SymGlobalState sym ->
+    IntrinsicTypes sym ->
+    RegValue sym UsizeType ->
+    TypeRepr tp ->
+    MirReferenceMux sym ->
+    IO (MirReferenceMux sym)
+mirRef_agElem_unsizedIO bak gs iTypes off tpr ref =
+    modifyRefMuxMA bak iTypes (mirRef_agElem_unsizedLeaf bak gs iTypes off tpr) ref
 
 
 refRootEq ::

--- a/crucible-mir/src/Mir/Intrinsics/Reference.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Reference.hs
@@ -93,6 +93,8 @@ module Mir.Intrinsics.Reference
     mirRef_peelIndexMA,
     mirRef_peelFieldLeaf,
     mirRef_peelFieldMA,
+    mirRef_peelAgElemLeaf,
+    mirRef_peelAgElemMA,
     mirRef_peelJustLeaf,
     mirRef_peelJustMA,
     mirRef_indexAndLenLeaf,
@@ -1751,6 +1753,59 @@ mirRef_peelFieldMA ::
 mirRef_peelFieldMA bak iTypes fieldReprs idx (MirReferenceMux ref) =
     let sym = backendGetSym bak in
     readFancyMuxTree' bak (mirRef_peelFieldLeaf sym fieldReprs idx)
+        (muxRegForType sym iTypes MirReferenceRepr) ref
+
+
+-- | Peel off an outermost 'AgElem_RefPath'. Given a pointer to a field of an
+-- aggregate, this produces a pointer to the containing struct.
+--
+-- This function takes in the expected offset and size of the field within the
+-- aggregate. If the 'AgElem_RefPath' is actually for a different offset or
+-- size, it will raise an error.
+--
+-- If the outermost path segment isn't 'AgElem_RefPath', this operation raises
+-- an error.
+mirRef_peelAgElemLeaf ::
+    (IsSymBackend sym bak, MonadAssert sym bak m) =>
+    bak ->
+    Word {-^ The expected offset -} ->
+    Word {-^ The expected size -} ->
+    MirReference sym {-^ The field pointer -} ->
+    MuxLeafT sym m (MirReferenceMux sym)
+mirRef_peelAgElemLeaf bak off sz (MirReference _tpr root path) = do
+    let sym = backendGetSym bak
+    case path of
+      AgElem_RefPath off' sz' _ path'
+        | sz' == sz -> do
+          offEq <- liftIO $ bvEq sym off' =<< wordLit sym off
+          leafAssert bak offEq $ Unsupported callStack $
+            "peelAgElem offset mismatch; expected " ++ show off
+              ++ ", but got " ++ show (printSymExpr off')
+          return $ MirReferenceMux $
+            toFancyMuxTree sym $ MirReference MirAggregateRepr root path'
+
+        | otherwise ->
+          leafAbort $ Unsupported callStack $
+            "peelAgElem size mismatch; expected " ++ show sz
+              ++ ", but got " ++ show sz'
+      _ ->
+        leafAbort $ Unsupported callStack $
+          "peelAgElem not implemented for this RefPath kind"
+mirRef_peelAgElemLeaf _ _ _ _ =
+    leafAbort $ Unsupported callStack $
+      "cannot perform peelAgElem on invalid pointer"
+
+mirRef_peelAgElemMA ::
+    MonadAssert sym bak m =>
+    bak ->
+    IntrinsicTypes sym ->
+    Word {-^ The expected offset -} ->
+    Word {-^ The expected size -} ->
+    MirReferenceMux sym ->
+    m (MirReferenceMux sym)
+mirRef_peelAgElemMA bak iTypes off sz (MirReferenceMux ref) =
+    let sym = backendGetSym bak in
+    readFancyMuxTree' bak (mirRef_peelAgElemLeaf bak off sz)
         (muxRegForType sym iTypes MirReferenceRepr) ref
 
 

--- a/crucible-mir/src/Mir/Intrinsics/Syntax.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Syntax.hs
@@ -216,7 +216,6 @@ data MirStmt :: (CrucibleType -> Type) -> CrucibleType -> Type where
      MirStmt f MirReferenceType
   MirRef_AgElem_Unsized ::
      !(f UsizeType) ->
-     !(TypeRepr tp) ->
      !(f MirReferenceType) ->
      MirStmt f MirReferenceType
   MirRef_Eq ::
@@ -413,7 +412,7 @@ instance TypeApp MirStmt where
     MirSubindexRef _ _ _ _ -> MirReferenceRepr
     MirSubjustRef _ _ -> MirReferenceRepr
     MirRef_AgElem _ _ _ _ -> MirReferenceRepr
-    MirRef_AgElem_Unsized _ _ _ -> MirReferenceRepr
+    MirRef_AgElem_Unsized _ _ -> MirReferenceRepr
     MirRef_Eq _ _ -> BoolRepr
     MirRef_Offset _ _ _ -> MirReferenceRepr
     MirRef_OffsetWrap _ _ _ -> MirReferenceRepr
@@ -451,7 +450,7 @@ instance PrettyApp MirStmt where
     MirSubindexRef _ x idx sz -> "subindexRef" <+> pp x <+> pp idx <+> viaShow sz
     MirSubjustRef _ x -> "subjustRef" <+> pp x
     MirRef_AgElem off _ _ ref -> "mirRef_agElem" <+> pp off <+> pp ref
-    MirRef_AgElem_Unsized off _ ref -> "mirRef_agElem_unsized" <+> pp off <+> pp ref
+    MirRef_AgElem_Unsized off ref -> "mirRef_agElem_unsized" <+> pp off <+> pp ref
     MirRef_Eq x y -> "mirRef_eq" <+> pp x <+> pp y
     MirRef_Offset p o s -> "mirRef_offset" <+> pp p <+> pp o <+> viaShow s
     MirRef_OffsetWrap p o s -> "mirRef_offsetWrap" <+> pp p <+> pp o <+> viaShow s
@@ -522,8 +521,8 @@ execMirStmt stmt s = withStateBackend s $ \bak ->
          readOnly s $ subjustMirRefIO bak iTypes tpr ref
        MirRef_AgElem (regValue -> off) sz tpr (regValue -> ref) ->
          readOnly s $ mirRef_agElemIO bak iTypes off sz tpr ref
-       MirRef_AgElem_Unsized (regValue -> off) tpr (regValue -> ref) ->
-         readOnly s $ mirRef_agElem_unsizedIO bak gs iTypes off tpr ref
+       MirRef_AgElem_Unsized (regValue -> off) (regValue -> ref) ->
+         readOnly s $ mirRef_agElem_unsizedIO bak gs iTypes off ref
        MirRef_Eq (regValue -> r1) (regValue -> r2) ->
          readOnly s $ mirRef_eqIO bak r1 r2
        MirRef_Offset (regValue -> ref) (regValue -> off) elemSize ->

--- a/crucible-mir/src/Mir/Intrinsics/Syntax.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Syntax.hs
@@ -119,6 +119,7 @@ import Mir.Intrinsics.Reference
     MirReferenceType,
     dropMirRefIO,
     mirRef_agElemIO,
+    mirRef_agElem_unsizedIO,
     mirRef_aggregateAsChunksIO,
     mirRef_eqIO,
     mirRef_offsetMA,
@@ -210,6 +211,11 @@ data MirStmt :: (CrucibleType -> Type) -> CrucibleType -> Type where
   MirRef_AgElem ::
      !(f UsizeType) ->
      !Word ->
+     !(TypeRepr tp) ->
+     !(f MirReferenceType) ->
+     MirStmt f MirReferenceType
+  MirRef_AgElem_Unsized ::
+     !(f UsizeType) ->
      !(TypeRepr tp) ->
      !(f MirReferenceType) ->
      MirStmt f MirReferenceType
@@ -407,6 +413,7 @@ instance TypeApp MirStmt where
     MirSubindexRef _ _ _ _ -> MirReferenceRepr
     MirSubjustRef _ _ -> MirReferenceRepr
     MirRef_AgElem _ _ _ _ -> MirReferenceRepr
+    MirRef_AgElem_Unsized _ _ _ -> MirReferenceRepr
     MirRef_Eq _ _ -> BoolRepr
     MirRef_Offset _ _ _ -> MirReferenceRepr
     MirRef_OffsetWrap _ _ _ -> MirReferenceRepr
@@ -444,6 +451,7 @@ instance PrettyApp MirStmt where
     MirSubindexRef _ x idx sz -> "subindexRef" <+> pp x <+> pp idx <+> viaShow sz
     MirSubjustRef _ x -> "subjustRef" <+> pp x
     MirRef_AgElem off _ _ ref -> "mirRef_agElem" <+> pp off <+> pp ref
+    MirRef_AgElem_Unsized off _ ref -> "mirRef_agElem_unsized" <+> pp off <+> pp ref
     MirRef_Eq x y -> "mirRef_eq" <+> pp x <+> pp y
     MirRef_Offset p o s -> "mirRef_offset" <+> pp p <+> pp o <+> viaShow s
     MirRef_OffsetWrap p o s -> "mirRef_offsetWrap" <+> pp p <+> pp o <+> viaShow s
@@ -514,6 +522,8 @@ execMirStmt stmt s = withStateBackend s $ \bak ->
          readOnly s $ subjustMirRefIO bak iTypes tpr ref
        MirRef_AgElem (regValue -> off) sz tpr (regValue -> ref) ->
          readOnly s $ mirRef_agElemIO bak iTypes off sz tpr ref
+       MirRef_AgElem_Unsized (regValue -> off) tpr (regValue -> ref) ->
+         readOnly s $ mirRef_agElem_unsizedIO bak gs iTypes off tpr ref
        MirRef_Eq (regValue -> r1) (regValue -> r2) ->
          readOnly s $ mirRef_eqIO bak r1 r2
        MirRef_Offset (regValue -> ref) (regValue -> off) elemSize ->

--- a/crucible-mir/src/Mir/Intrinsics/Syntax.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Syntax.hs
@@ -202,6 +202,11 @@ data MirStmt :: (CrucibleType -> Type) -> CrucibleType -> Type where
      !(TypeRepr tp) ->
      !(f MirReferenceType) ->
      MirStmt f MirReferenceType
+  -- | Like `MirRef_AgElem`, but the size and `TypeRepr` are inferred by
+  -- inspecting the aggregate.  This reads from memory instead of simply
+  -- adjusting the `MirReferencePath`, so it's best avoided if possible.
+  --
+  -- TODO: remove this once `MirRef_AgOffset` is implemented
   MirRef_AgElem_Unsized ::
      !(f UsizeType) ->
      !(f MirReferenceType) ->

--- a/crucible-mir/src/Mir/Intrinsics/Syntax.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Syntax.hs
@@ -37,7 +37,6 @@ import Data.Parameterized.Context
     pattern (:>),
   )
 import Data.Parameterized.NatRepr (NatRepr)
-import Data.Parameterized.Some (Some)
 import Data.Parameterized.TH.GADT qualified as U
 import Data.Parameterized.TraversableFC
   ( FoldableFC (..),
@@ -129,7 +128,6 @@ import Mir.Intrinsics.Reference
     newMirRefIO,
     readMirRefMA,
     subfieldMirRefIO,
-    subfieldMirRef_UntypedIO,
     subindexMirRefIO,
     subjustMirRefIO,
     subvariantMirRefIO,
@@ -180,16 +178,6 @@ data MirStmt :: (CrucibleType -> Type) -> CrucibleType -> Type where
      !(CtxRepr ctx) ->
      !(f MirReferenceType) ->
      !(Index ctx tp) ->
-     MirStmt f MirReferenceType
-  -- | Like `MirSubfieldRef`, but for fields with statically-unknown types, such
-  -- as trait objects. The `Int` is the index of the field, and the `TypeRepr`
-  -- is an optional type hint, if the expected type happens to be known and
-  -- representable. If provided, it will be dynamically checked at simulation
-  -- time.
-  MirSubfieldRef_Untyped ::
-     !(f MirReferenceType) ->
-     !Int ->
-     !(Maybe (Some TypeRepr)) ->
      MirStmt f MirReferenceType
   MirSubvariantRef ::
      !(TypeRepr discrTp) ->
@@ -407,7 +395,6 @@ instance TypeApp MirStmt where
     MirWriteRef _ _ _ -> UnitRepr
     MirDropRef _    -> UnitRepr
     MirSubfieldRef _ _ _ -> MirReferenceRepr
-    MirSubfieldRef_Untyped _ _ _ -> MirReferenceRepr
     MirSubvariantRef _ _ _ _ -> MirReferenceRepr
     MirSubindexRef _ _ _ _ -> MirReferenceRepr
     MirSubjustRef _ _ -> MirReferenceRepr
@@ -445,7 +432,6 @@ instance PrettyApp MirStmt where
     MirWriteRef _ x y -> "writeMirRef" <+> pp x <+> "<-" <+> pp y
     MirDropRef x    -> "dropMirRef" <+> pp x
     MirSubfieldRef _ x idx -> "subfieldRef" <+> pp x <+> viaShow idx
-    MirSubfieldRef_Untyped x fieldNum expectedTy -> "subfieldRef_Untyped" <+> pp x <+> viaShow fieldNum <+> viaShow expectedTy
     MirSubvariantRef _ _ x idx -> "subvariantRef" <+> pp x <+> viaShow idx
     MirSubindexRef _ x idx sz -> "subindexRef" <+> pp x <+> pp idx <+> viaShow sz
     MirSubjustRef _ x -> "subjustRef" <+> pp x
@@ -511,8 +497,6 @@ execMirStmt stmt s = withStateBackend s $ \bak ->
          writeOnly s $ dropMirRefIO bak gs ref
        MirSubfieldRef ctx0 (regValue -> ref) idx ->
          readOnly s $ subfieldMirRefIO bak iTypes ctx0 ref idx
-       MirSubfieldRef_Untyped (regValue -> ref) idx expectedTy ->
-         readOnly s $ subfieldMirRef_UntypedIO bak iTypes ref idx expectedTy
        MirSubvariantRef tp0 ctx0 (regValue -> ref) idx ->
          readOnly s $ subvariantMirRefIO bak iTypes tp0 ctx0 ref idx
        MirSubindexRef tpr (regValue -> ref) (regValue -> idx) elemSize ->

--- a/crucible-mir/src/Mir/PP.hs
+++ b/crucible-mir/src/Mir/PP.hs
@@ -341,6 +341,12 @@ instance Pretty Vtable where
     where sizeItem = pretty "size =" <+> pretty size <> semi
           alignItem = pretty "align =" <+> pretty align_ <> semi
 
+instance Pretty Layout where
+  pretty (Layout align_ size fieldOffsets) =
+    vcat [pretty "size =" <+> pretty size,
+          pretty "align =" <+> pretty align_,
+          pretty "fields =" <+> viaShow fieldOffsets]
+
 instance Pretty CastKind where
     pretty = viaShow
 
@@ -448,6 +454,9 @@ instance Pretty Collection where
           map pretty (Map.elems (col ^. traits)) ++
           [pretty "VTABLEs"] ++
           map pretty (Map.elems (col ^. vtables)) ++
+          [pretty "LAYOUTs"] ++
+          concat [[pretty name, indent 3 (pretty layout)]
+            | (name, layout) <- Map.toList (col ^. layouts)] ++
           [pretty "INTRINSICSs"] ++
           map pretty (Map.elems (col ^. intrinsics)) ++
           [pretty "STATICS"] ++

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -309,7 +309,7 @@ transConstSliceRef ty defid len = do
 -- Translate a constant (non-empty) tuple or constant closure value.
 transConstTuple :: M.Ty -> [ConstVal] -> MirGenerator h s ret (MirExp s)
 transConstTuple tupleTy vals = do
-    tys <- tupleLikeFieldTysM tupleTy
+    tys <- map snd <$> tyFieldsM tupleTy
     exps <- forM (zip tys vals) $ \(ty, val) -> do
         Some tpr <- tyToReprM ty
         transConstVal ty (Some tpr) val

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -1208,7 +1208,8 @@ evalCast' ck ty1 e ty2  = do
         when (numFields' /= numFields) $ mirFail $
             "coerceUnsized on incompatible types (mismatched fields): " ++ show (an1, an2)
         vals' <- forM (zip3 [0..] (v1 ^. vfields) (v2 ^. vfields)) $ \(i, f1, f2) -> do
-            val <- getStructField adt1 i expr
+            let adtTy = M.TyAdt (adt1 ^. M.adtname) (adt1 ^. M.adtOrigDefId) (adt1 ^. M.adtOrigSubsts)
+            val <- getStructField adtTy i expr
             -- Only compute a cast if the types are syntactically unequal.
             if (f1 ^. fty) == (f2 ^. fty)
               then pure val
@@ -1667,7 +1668,7 @@ evalPlaceProj ty pl@(MirPlace tpr ref meta) (M.PField idx fieldTy) = do
     M.TyAdt nm _ _ -> do
         adt <- findAdt nm
         case adt ^. adtkind of
-            Struct -> structFieldRef adt idx ref meta
+            Struct -> structFieldRef ty idx ref meta
             Enum _ -> mirFail $ "tried to access field of non-downcast " ++ show ty
             Union -> unionFieldRef adt idx ref
 
@@ -2897,7 +2898,7 @@ dispatchFromDyn dynTraitName recvTy recvExp die = do
     go :: M.Ty -> MirExp s -> WriterT [R.Expr MIR s C.AnyType] (MirGenerator h s ret) (MirExp s)
     go ty@(M.TyRawPtr pointeeTy _) mirExp = goPtr ty pointeeTy mirExp
     go ty@(M.TyRef pointeeTy _) mirExp = goPtr ty pointeeTy mirExp
-    go (M.TyAdt aname _ _) mirExp = do
+    go ty@(M.TyAdt aname _ _) mirExp = do
       adt <- lift $ findAdt aname
       col <- use $ cs . collection
       case adt ^. adtkind of
@@ -2910,7 +2911,7 @@ dispatchFromDyn dynTraitName recvTy recvExp die = do
             Nothing -> do
               let v = Maybe.fromJust $ adt ^? adtvariants . ix 0
               fieldExps' <- forM (zip [0..] (v ^. vfields)) $ \(i, f) -> do
-                fieldExp <- lift $ getStructField adt i mirExp
+                fieldExp <- lift $ getStructField ty i mirExp
                 go (f ^. fty) fieldExp
               -- It's safe to use `buildStructAdjusted` here because the only
               -- adjustment is `*const dyn Trait` to `*const T` or similar, and

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -2913,11 +2913,7 @@ dispatchFromDyn dynTraitName recvTy recvExp die = do
               fieldExps' <- forM (zip [0..] (v ^. vfields)) $ \(i, f) -> do
                 fieldExp <- lift $ getStructField ty i mirExp
                 go (f ^. fty) fieldExp
-              -- It's safe to use `buildStructAdjusted` here because the only
-              -- adjustment is `*const dyn Trait` to `*const T` or similar, and
-              -- `M.TyRef`/`M.TyRawPtr` all use the same `FieldKind`s
-              -- regardless of pointee type.
-              lift $ buildStructAdjusted adt fieldExps'
+              lift $ buildStruct adt fieldExps'
         _ -> return mirExp
     -- rustc only recurses into struct types to find the coerced field.  All
     -- other types are ignored.

--- a/crucible-mir/src/Mir/TransCustom.hs
+++ b/crucible-mir/src/Mir/TransCustom.hs
@@ -2354,7 +2354,7 @@ cloneShimDef ty _parts = CustomOp $ \_ _ -> mirFail $ "cloneShimDef not implemen
 -- | Create an 'IkCloneShim' implementation for a tuple or closure type.
 cloneShimTuple :: Ty -> [M.DefId] -> CustomOp
 cloneShimTuple tupleTy parts = CustomMirOp $ \ops -> do
-    tys <- tupleLikeFieldTysM tupleTy
+    tys <- map snd <$> tyFieldsM tupleTy
     when (length tys /= length parts) $ mirFail "cloneShimTuple: expected tys and parts to match"
     -- The clone shim expects exactly one operand, with a reference type that
     -- looks something `&(A, B, C)`. First, we dereference the argument to

--- a/crucible-mir/src/Mir/TransCustom.hs
+++ b/crucible-mir/src/Mir/TransCustom.hs
@@ -638,17 +638,22 @@ ptr_read_impl what substs =
   case substs of
     Substs [ty] -> Just $ CustomOp $ \_ ops -> case ops of
         [MirExp MirReferenceRepr ptr] -> do
+            sz <- tySizeM ty
             Some tpr <- tyToReprM ty
-            MirExp tpr <$> readMirRef tpr ptr
+            case (sz, tpr) of
+                (0, MirAggregateRepr) -> MirExp tpr <$> mirAggregate_zst
+                _ -> MirExp tpr <$> readMirRef tpr ptr
         _ -> mirFail $ "bad arguments for " ++ what ++ ": " ++ show ops
     _ -> Nothing
 
 ptr_write_impl :: String -> CustomRHS
 ptr_write_impl what substs =
   case substs of
-    Substs [_] -> Just $ CustomOp $ \_ ops -> case ops of
+    Substs [ty] -> Just $ CustomOp $ \_ ops -> case ops of
         [MirExp MirReferenceRepr ptr, MirExp tpr val] -> do
-            writeMirRef tpr ptr val
+            sz <- tySizeM ty
+            when (sz /= 0) $ do
+                writeMirRef tpr ptr val
             MirExp MirAggregateRepr <$> mirAggregate_zst
         _ -> mirFail $ "bad arguments for " ++ what ++ ": " ++ show ops
     _ -> Nothing
@@ -657,11 +662,13 @@ ptr_swap :: (ExplodedDefId, CustomRHS)
 ptr_swap = ( ["core", "ptr", "swap"], \substs -> case substs of
     Substs [ty] -> Just $ CustomOp $ \_ ops -> case ops of
         [MirExp MirReferenceRepr ptr1, MirExp MirReferenceRepr ptr2] -> do
-            Some tpr <- tyToReprM ty
-            x1 <- readMirRef tpr ptr1
-            x2 <- readMirRef tpr ptr2
-            writeMirRef tpr ptr1 x2
-            writeMirRef tpr ptr2 x1
+            sz <- tySizeM ty
+            when (sz /= 0) $ do
+                Some tpr <- tyToReprM ty
+                x1 <- readMirRef tpr ptr1
+                x2 <- readMirRef tpr ptr2
+                writeMirRef tpr ptr1 x2
+                writeMirRef tpr ptr2 x1
             MirExp MirAggregateRepr <$> mirAggregate_zst
         _ -> mirFail $ "bad arguments for ptr::swap: " ++ show ops
     _ -> Nothing)

--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -27,7 +27,7 @@ module Mir.TransTy where
 
 import Control.Monad
 import qualified Data.BitVector.Sized as BV
-import Data.List (findIndices)
+import Data.List (findIndices, intercalate)
 import Data.Foldable.WithIndex (ifind)
 import qualified Data.Map.Strict as Map
 import           Data.Function ((&))
@@ -877,13 +877,19 @@ construct MIR must be very careful to ensure that the type of that MIR is
 present.
 -}
 
+-- | Build an aggregate of type @agTy@ containing @xs@ as its field values.
+-- The order of @xs@ must match the field order produced by @tyFieldsM agTy@.
+-- If any entry in @xs@ is `Nothing`, that field will be left uninitialized in
+-- the output aggregate.
 buildAggregateMaybeM :: M.Ty -> [Maybe (MirExp s)] -> MirGenerator h s ret (MirExp s)
 buildAggregateMaybeM agTy xs = do
     layout <- tyLayoutM agTy
     offsetsAndTys <- tyFieldsM agTy
     when (length offsetsAndTys /= length xs) $
-        mirFail $ "buildTupleMaybeM: length mismatch:\n  offsetsAndTys = " ++ show offsetsAndTys
-            ++ "\n  xs = " ++ show xs
+        mirFail $ intercalate "\n"
+          [ "buildAggregateMaybeM: length mismatch:"
+          , "  offsetsAndTys = " ++ show offsetsAndTys
+          , "  xs = " ++ show xs ]
     ag0 <- mirAggregate_uninit_constSize (fromIntegral $ layout ^. M.laySize)
     ag1 <- foldM
         (\ag ((off, ty), mExp) -> do
@@ -1192,7 +1198,12 @@ tyFields col ty = do
                     Just adt ->
                         case adt ^. M.adtkind of
                             M.Struct -> map (\f -> f ^. M.fty) $ M.onlyVariant adt ^. M.vfields
-                            ak -> panic "tyFields" ["bad adt kind", show ak, "for type", show ty]
+                            -- Enums don't have field offsets (all unions,
+                            -- including single-variant ones, use VariantRepr).
+                            -- For unions, all field offsets are zero, but so
+                            -- far we haven't needed this function for unions.
+                            ak -> panic "tyFields"
+                              ["unsupported adt kind", show ak, "for type", show ty]
                     Nothing -> panic "tyFields" ["missing adt def for type", show ty]
             _ -> panic "tyFields" ["tyFields: unsupported type:", show ty]
     when (length tys /= length offsets) $
@@ -1219,10 +1230,12 @@ getStructField structTy i (MirExp structTpr e0) = do
   fields <- tyFieldsM structTy
   (off, ty) <- case fields ^? ix i of
     Just x -> return x
-    Nothing -> mirFail $ "tupleFieldRef: field index " ++ show i ++
-      " is out of range for tuple " ++ show structTy
-  -- Assume `NoMeta`.  Calling `getStructField` requires holding a struct by
-  -- value, which is only possible if the struct is sized.
+    Nothing -> mirFail $ "structFieldRef: field index " ++ show i ++
+      " is out of range for struct " ++ show structTy
+  -- This is similar to the `NoMeta` case of `structFieldRef`.  We can assume
+  -- that `structTy` is sized (and thus uses `NoMeta`) because calling
+  -- `getStructField` requires holding a struct by value, which is only
+  -- possible if the struct is sized.
   Some valTpr <- tyToReprM ty
   sz <- tySizeM ty
   case (sz, valTpr) of
@@ -1607,8 +1620,8 @@ structFieldRef structTy i ref meta = do
   fields <- tyFieldsM structTy
   (off, ty) <- case fields ^? ix i of
     Just x -> return x
-    Nothing -> mirFail $ "tupleFieldRef: field index " ++ show i ++
-      " is out of range for tuple " ++ show structTy
+    Nothing -> mirFail $ "structFieldRef: field index " ++ show i ++
+      " is out of range for struct " ++ show structTy
   let isLast = i + 1 == length fields
   case meta of
     DynMeta vtable | isLast -> do
@@ -1635,6 +1648,10 @@ structFieldRef structTy i ref meta = do
         _ -> return Nothing
 
       let offExp = R.App $ usizeLit $ fromIntegral off
+      -- No need for `padToAlign` here.  The correct alignment for the slice is
+      -- statically known based on its element type, and the layout emitted by
+      -- mir-json already includes the necessary padding for that alignment.
+      --
       -- Can't use typed/sized `mirRef_agElem` here because it requires the
       -- size to be a translation-time constant.
       ref' <- mirRef_agElem_unsized offExp ref

--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -979,14 +979,6 @@ writeStructField :: C.CtxRepr ctx -> Ctx.Index ctx tp ->
 writeStructField ctx idx e e' =
     return $ R.App $ E.SetStruct ctx e idx e'
 
-adjustStructField :: C.CtxRepr ctx -> Ctx.Index ctx tp ->
-    (R.Expr MIR s tp -> MirGenerator h s ret (R.Expr MIR s tp)) ->
-    R.Expr MIR s (C.StructType ctx) -> MirGenerator h s ret (R.Expr MIR s (C.StructType ctx))
-adjustStructField ctx idx f e = do
-    x <- readStructField ctx idx e
-    y <- f x
-    writeStructField ctx idx e y
-
 
 readJust' :: R.Expr MIR s (C.MaybeType tp) -> String ->
     MirGenerator h s ret (R.Expr MIR s tp)
@@ -1274,56 +1266,6 @@ getStructField adt i (MirExp structTpr e0) = structInfo adt i >>= \case
   where
     errFieldUninit = "field " ++ show i ++ " of " ++ show (adt ^. M.adtname) ++
         " read while uninitialized"
-
-setStructField :: M.Adt -> Int ->
-    MirExp s -> MirExp s -> MirGenerator h s ret (MirExp s)
-setStructField adt i (MirExp structTpr structExp) (MirExp fldTpr fldExp) = structInfo adt i >>= \case
-  SizedStruct ctx idx fld -> do
-    Refl <- expectStructOrFail ctx structTpr
-    Refl <- testEqualityOrFail fldTpr (fieldDataType fld) (errFieldType fld)
-    fldExp' <- buildFieldData fld fldExp
-    MirExp structTpr <$> writeStructField ctx idx structExp fldExp'
-  SizedField _fieldRepr ->
-    mirFail "setStructField: sized fields of unsized structs not yet supported"
-  UnsizedNonSliceField ->
-    mirFail "setStructField: unsized fields of unsized structs not yet supported"
-  UnsizedSliceField _elemSize _innerRepr ->
-    mirFail "setStructField: unsized fields of unsized structs not yet supported"
-  where
-    errFieldType :: FieldKind tp tp' -> String
-    errFieldType fld = "expected field value for " ++ show (adt ^. M.adtname, i) ++
-        " to have type " ++ show (fieldDataType fld) ++ ", but got " ++ show fldTpr
-
--- Run `f`, checking that its return type is the same as its argument.  Fails
--- if `f` returns a different type.
-checkSameType :: String ->
-    (MirExp s -> MirGenerator h s ret (MirExp s)) ->
-    R.Expr MIR s tp -> MirGenerator h s ret (R.Expr MIR s tp)
-checkSameType desc f e = do
-    let tpr = R.exprType e
-    MirExp tpr' _e' <- f (MirExp tpr e)
-    Refl <- testEqualityOrFail tpr tpr' $ "checkSameType: bad result type: expected " ++
-        show tpr ++ ", but got " ++ show tpr' ++ " (in " ++ show desc ++ ")"
-    return e
-
-mapStructField :: M.Adt -> Int ->
-    (MirExp s -> MirGenerator h s ret (MirExp s)) ->
-    MirExp s -> MirGenerator h s ret (MirExp s)
-mapStructField adt i f (MirExp structTpr e) = structInfo adt i >>= \case
-  SizedStruct ctx idx fld -> do
-    Refl <- expectStructOrFail ctx structTpr
-    let f' =
-            adjustStructField ctx idx $
-            adjustFieldData fld $
-            checkSameType ("mapStructField " ++ show i ++ " of " ++ show (adt ^. M.adtname)) $
-            f
-    MirExp structTpr <$> f' e
-  SizedField _fieldRepr ->
-    mirFail "mapStructField: sized fields of unsized structs not yet supported"
-  UnsizedNonSliceField ->
-    mirFail "mapStructField: unsized fields of unsized structs not yet supported"
-  UnsizedSliceField _elemSize _innerRepr ->
-    mirFail "mapStructField: unsized fields of unsized structs not yet supported"
 
 
 data EnumInfo = forall discrTp ctx ctx' tp tp'. EnumInfo

--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -1410,23 +1410,6 @@ buildStruct :: HasCallStack => M.Adt -> [MirExp s] ->
 buildStruct adt es =
     buildStruct' adt (map Just es)
 
--- | Like `buildStruct`, but only the `FieldKind`s of the ADT are used; its
--- actual field types are ignored in favor of the types of the provided
--- `MirExp`s.
---
--- Warning: this makes it easy to create a value whose `C.TypeRepr` doesn't
--- match its `M.Ty`!  This can be hard to debug since the error may show up far
--- downstream of the bad `buildStructAdjusted` call.  Don't use this unless
--- you're really sure that the `FieldKind`s will match up with the `M.Ty`s of
--- the exprs.  In almost all cases, it's better to use the non-adjusted
--- version.
---
--- TODO: now identical to buildStruct; remove
-buildStructAdjusted :: HasCallStack => M.Adt -> [MirExp s] ->
-    MirGenerator h s ret (MirExp s)
-buildStructAdjusted adt es = do
-    buildStruct adt es
-
 
 buildEnum' :: HasCallStack => M.Adt -> Int -> [Maybe (MirExp s)] ->
     MirGenerator h s ret (MirExp s)

--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -851,21 +851,6 @@ buildArrayLit elemTy exps = do
         ag0 (zip [0, elemSize ..] exps)
     return $ MirExp MirAggregateRepr ag1
 
--- | Get the fields of a tuple-like type.
-tupleLikeFieldTys :: M.Ty -> Maybe [M.Ty]
-tupleLikeFieldTys ty =
-    case ty of
-        M.TyTuple tys -> Just tys
-        M.TyClosure tys -> Just tys
-        M.TyCoroutineClosure tys -> Just tys
-        _ -> Nothing
-
-tupleLikeFieldTysM :: M.Ty -> MirGenerator h s ret [M.Ty]
-tupleLikeFieldTysM ty =
-    case tupleLikeFieldTys ty of
-        Just x -> return x
-        Nothing -> mirFail $ "tupleLikeFieldTysM: expected tuple-like type, but got " ++ show ty
-
 {-
 Note [present]
 --------------
@@ -903,19 +888,14 @@ buildTupleM tupleTy xs = buildTupleMaybeM tupleTy (map Just xs)
 -- [present].
 buildTupleMaybeM :: M.Ty -> [Maybe (MirExp s)] -> MirGenerator h s ret (MirExp s)
 buildTupleMaybeM tupleTy xs = do
-    fieldTys <- tupleLikeFieldTysM tupleTy
     layout <- tyLayoutM tupleTy
-    let fieldOffsets = case layout ^. M.layFieldOffsets of
-            Just x -> x
-            -- Should be impossible; all struct-like types should have field info.
-            Nothing -> panic "buildTupleMaybeM"
-                ["missing field_offsets in layout for", show tupleTy]
-    when (length fieldTys /= length fieldOffsets || length fieldTys /= length xs) $
-        mirFail $ "buildTupleMaybeM: length mismatch:\n  fieldTys = " ++ show fieldTys
-            ++ "\n  fieldOffsets = " ++ show fieldOffsets ++ "\n  xs = " ++ show xs
+    offsetsAndTys <- tyFieldsM tupleTy
+    when (length offsetsAndTys /= length xs) $
+        mirFail $ "buildTupleMaybeM: length mismatch:\n  offsetsAndTys = " ++ show offsetsAndTys
+            ++ "\n  xs = " ++ show xs
     ag0 <- mirAggregate_uninit_constSize (fromIntegral $ layout ^. M.laySize)
     ag1 <- foldM
-        (\ag (ty, off, mExp) -> do
+        (\ag ((off, ty), mExp) -> do
             sz <- tySizeM ty
             case mExp of
                 Just (MirExp tpr rv)
@@ -924,10 +904,10 @@ buildTupleMaybeM tupleTy xs = do
                   -- never be accessed.  A ZST field can have the same offset
                   -- as another field; omitting the ZST field prevents one from
                   -- overwriting the other.
-                  | sz /= 0 -> mirAggregate_set (fromIntegral off) sz tpr rv ag
+                  | sz /= 0 -> mirAggregate_set off sz tpr rv ag
                   | otherwise -> return ag
                 Nothing -> return ag)
-        ag0 (zip3 fieldTys fieldOffsets xs)
+        ag0 (zip offsetsAndTys xs)
     return $ MirExp MirAggregateRepr ag1
 
 getTupleElem :: HasCallStack => M.Ty -> MirExp s -> Int -> MirGenerator h s ret (MirExp s)

--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -45,7 +45,6 @@ import GHC.Stack
 import qualified Data.Parameterized.Context as Ctx
 import Data.Parameterized.Classes
 import Data.Parameterized.NatRepr
-import Data.Parameterized.Pair
 import Data.Parameterized.Some
 
 
@@ -64,15 +63,16 @@ import qualified Mir.Mir as M
 
 import           Mir.Generator
     ( MirExp(..), MirPlace(..), PtrMetadata(..), MirGenerator, mirFail
-    , subfieldRef, subfieldRef_Untyped, subvariantRef, subjustRef, subindexRef
-    , mirRef_agElem_constOffset, mirAggregate_uninit_constSize
+    , subfieldRef, subvariantRef, subjustRef
+    , mirRef_agElem_constOffset, mirRef_agElem_unsized
+    , mirAggregate_uninit_constSize
     , mirAggregate_zst, mirAggregate_get, mirAggregate_set
     , cs, collection, discrMap, findAdt, arrayZeroed )
 import           Mir.Intrinsics
     ( MIR, pattern MirSliceRepr, pattern MirReferenceRepr, MirReferenceType
     , pattern MirAggregateRepr
     , SizeBits, pattern UsizeRepr, UsizeType, pattern IsizeRepr
-    , isizeLit
+    , isizeLit, usizeAdd, usizeSub, usizeAnd
     , RustEnumType, pattern RustEnumRepr, SomeRustEnumRepr(..)
     , mkRustEnum, rustEnumVariant, rustEnumDiscriminant
     , pattern MethodSpecRepr, pattern MethodSpecBuilderRepr
@@ -239,9 +239,7 @@ tyToRepr col t0 = case t0 of
     case adt ^. M.adtkind of
       _ | Just ty <- reprTransparentFieldTy col adt ->
           tyToRepr col ty
-      M.Struct -> do
-        Some fctx <- variantFields' col (M.onlyVariant adt)
-        Right (Some (C.StructRepr (fieldCtxType fctx)))
+      M.Struct -> Right (Some MirAggregateRepr)
       M.Enum discrTy -> do
         Some discrTp <- tyToRepr col discrTy
         SomeRustEnumRepr _ ctx <- enumVariants col adt
@@ -663,6 +661,11 @@ findLastField col adtName = do
     [] -> Nothing
     fields -> Just (last fields)
 
+findLastFieldM :: M.AdtName -> MirGenerator h s ret (Maybe M.Field)
+findLastFieldM adtName = do
+  col <- use $ cs . collection
+  return $ findLastField col adtName
+
 -- | A version of `findLastField` that, when it encounters an ADT-type last
 -- field, will recursively find that ADT's last field.
 findLastFieldRec :: M.Collection -> M.AdtName -> Maybe M.Field
@@ -874,22 +877,10 @@ construct MIR must be very careful to ensure that the type of that MIR is
 present.
 -}
 
--- | Build a tuple of type @tupleTy@, using @xs@ to initialize the fields.
---
--- @tupleTy@ must be present in the `M.Collection`, as decribed in Note
--- [present].
-buildTupleM :: M.Ty -> [MirExp s] -> MirGenerator h s ret (MirExp s)
-buildTupleM tupleTy xs = buildTupleMaybeM tupleTy (map Just xs)
-
--- | Build a tuple of type @tupleTy@, using @xs@ to initialize the fields.  If
--- an entry in @xs@ is `Nothing`, that field will be left uninitialized.
---
--- @tupleTy@ must be present in the `M.Collection`, as decribed in Note
--- [present].
-buildTupleMaybeM :: M.Ty -> [Maybe (MirExp s)] -> MirGenerator h s ret (MirExp s)
-buildTupleMaybeM tupleTy xs = do
-    layout <- tyLayoutM tupleTy
-    offsetsAndTys <- tyFieldsM tupleTy
+buildAggregateMaybeM :: M.Ty -> [Maybe (MirExp s)] -> MirGenerator h s ret (MirExp s)
+buildAggregateMaybeM agTy xs = do
+    layout <- tyLayoutM agTy
+    offsetsAndTys <- tyFieldsM agTy
     when (length offsetsAndTys /= length xs) $
         mirFail $ "buildTupleMaybeM: length mismatch:\n  offsetsAndTys = " ++ show offsetsAndTys
             ++ "\n  xs = " ++ show xs
@@ -909,6 +900,22 @@ buildTupleMaybeM tupleTy xs = do
                 Nothing -> return ag)
         ag0 (zip offsetsAndTys xs)
     return $ MirExp MirAggregateRepr ag1
+
+-- | Build a tuple of type @tupleTy@, using @xs@ to initialize the fields.
+--
+-- @tupleTy@ must be present in the `M.Collection`, as decribed in Note
+-- [present].
+buildTupleM :: M.Ty -> [MirExp s] -> MirGenerator h s ret (MirExp s)
+buildTupleM tupleTy xs = buildTupleMaybeM tupleTy (map Just xs)
+
+-- | Build a tuple of type @tupleTy@, using @xs@ to initialize the fields.  If
+-- an entry in @xs@ is `Nothing`, that field will be left uninitialized.
+--
+-- @tupleTy@ must be present in the `M.Collection`, as decribed in Note
+-- [present].
+buildTupleMaybeM :: M.Ty -> [Maybe (MirExp s)] -> MirGenerator h s ret (MirExp s)
+buildTupleMaybeM tupleTy xs = do
+    buildAggregateMaybeM tupleTy xs
 
 getTupleElem :: HasCallStack => M.Ty -> MirExp s -> Int -> MirGenerator h s ret (MirExp s)
 getTupleElem tupleTy tupleExp i = do
@@ -1148,6 +1155,7 @@ tySizeM ty = do
             ((_, loc):_) -> prettySrcLoc loc
        in mirFail $ "tySizeM (called at " <> caller <> "): unsized type: " <> show ty
 
+
 -- | Get a type's `M.Layout`.  Returns `Nothing` if the type is not present in
 -- the `M.Collection` (as described in Note [present]).
 tyLayout :: M.Collection -> M.Ty -> Maybe M.Layout
@@ -1179,7 +1187,13 @@ tyFields col ty = do
             M.TyTuple x -> x
             M.TyClosure x -> x
             M.TyCoroutineClosure x -> x
-            M.TyAdt {} -> panic "tyFields" ["TODO: tyFields struct case"]  -- For now, we only call this on tuples
+            M.TyAdt adtName _ _ ->
+                case col ^. M.adts . at adtName of
+                    Just adt ->
+                        case adt ^. M.adtkind of
+                            M.Struct -> map (\f -> f ^. M.fty) $ M.onlyVariant adt ^. M.vfields
+                            ak -> panic "tyFields" ["bad adt kind", show ak, "for type", show ty]
+                    Nothing -> panic "tyFields" ["missing adt def for type", show ty]
             _ -> panic "tyFields" ["tyFields: unsupported type:", show ty]
     when (length tys /= length offsets) $
         panic "tyFields" ["field count vs offset count mismatch",
@@ -1196,76 +1210,24 @@ tyFieldsM ty = do
         Just x -> pure x
         Nothing -> mirFail $ "tyFieldsM: layout not found for type: " <> show ty
 
-structInfo :: M.Adt -> Int -> MirGenerator h s ret StructInfo
-structInfo adt i = do
-    when (adt ^. M.adtkind /= M.Struct) $ mirFail $
-        "expected struct, but got adt " ++ show (adt ^. M.adtname)
 
-    let var = M.onlyVariant adt
-    fldTy <- case var ^? M.vfields . ix i of
-        Just fld -> return $ fld ^. M.fty
-        Nothing -> mirFail errFieldIndex
-
-    col <- use $ cs . collection
-    case adtSizedness col adt of
-      Sized _ -> do
-        Some ctx <- variantFieldsM var
-        Some idx <- case Ctx.intIndex i (Ctx.size ctx) of
-            Just x -> return x
-            Nothing -> mirFail errFieldIndex
-        let tpr' = ctx Ctx.! idx
-        Some tpr <- tyToReprM fldTy
-
-        kind <- checkFieldKind (not $ canInitialize col fldTy) tpr tpr' $
-            "field " ++ show i ++ " of struct " ++ show (adt ^. M.adtname)
-
-        return $ SizedStruct ctx idx kind
-
-      -- We want to avoid attempting to compute the `CtxRepr` for this struct,
-      -- which may involve computing the `TypeRepr` of its unsized field, which
-      -- does (for `TyDynamic`) or should (for `TyStr` and `TySlice`) cause an
-      -- error.
-      Unsized -> case tySizedness col fldTy of
-        Sized _ -> do
-          Some (FieldRepr fieldKind) <- case tyToFieldRepr col fldTy of
-            Left err -> mirFail ("structInfo: " ++ err)
-            Right x -> return x
-          pure $ SizedField fieldKind
-        Unsized
-          | i /= length (var ^. M.vfields) - 1 ->
-            mirFail "encountered unsized field in non-last position"
-          | otherwise ->
-            case fldTy of
-              M.TySlice innerTy -> do
-                Some innerRepr <- tyToReprM innerTy
-                innerSize <- tySizeM innerTy
-                pure $ UnsizedSliceField innerSize innerRepr
-              M.TyStr -> do
-                Some innerRepr <- tyToReprM (M.TyUint M.B8)
-                let innerSize = 1  -- because the element type is u8
-                pure $ UnsizedSliceField innerSize innerRepr
-              _ -> pure UnsizedNonSliceField
-
-  where
-    errFieldIndex = "field index " ++ show i ++ " is out of range for struct " ++
-        show (adt ^. M.adtname)
-
-getStructField :: M.Adt -> Int -> MirExp s -> MirGenerator h s ret (MirExp s)
-getStructField adt i (MirExp structTpr e0) = structInfo adt i >>= \case
-  SizedStruct ctx idx fld -> do
-    Refl <- expectStructOrFail ctx structTpr
-    e1 <- readStructField ctx idx e0
-    e2 <- readFieldData' fld errFieldUninit e1
-    return $ MirExp (fieldDataType fld) e2
-  SizedField _fieldRepr ->
-    mirFail "getStructField: sized fields of unsized structs not yet supported"
-  UnsizedNonSliceField ->
-    mirFail "getStructField: unsized fields of unsized structs not yet supported"
-  UnsizedSliceField _elemSize _innerRepr ->
-    mirFail "getStructField: unsized fields of unsized structs not yet supported"
-  where
-    errFieldUninit = "field " ++ show i ++ " of " ++ show (adt ^. M.adtname) ++
-        " read while uninitialized"
+getStructField :: M.Ty -> Int -> MirExp s -> MirGenerator h s ret (MirExp s)
+getStructField structTy i (MirExp structTpr e0) = do
+  let tpr' = MirAggregateRepr
+  Refl <- testEqualityOrFail structTpr tpr' $ "bad representation " ++ show structTpr ++
+    " for struct type " ++ show structTy ++ ": expected " ++ show tpr'
+  fields <- tyFieldsM structTy
+  (off, ty) <- case fields ^? ix i of
+    Just x -> return x
+    Nothing -> mirFail $ "tupleFieldRef: field index " ++ show i ++
+      " is out of range for tuple " ++ show structTy
+  -- Assume `NoMeta`.  Calling `getStructField` requires holding a struct by
+  -- value, which is only possible if the struct is sized.
+  Some valTpr <- tyToReprM ty
+  sz <- tySizeM ty
+  case (sz, valTpr) of
+    (0, MirAggregateRepr) -> MirExp valTpr <$> mirAggregate_zst
+    _ -> MirExp valTpr <$> mirAggregate_get off sz valTpr e0
 
 
 data EnumInfo = forall discrTp ctx ctx' tp tp'. EnumInfo
@@ -1435,41 +1397,13 @@ buildStructAssign ctx0 es0 = go ctx0 $ reverse es0
         Nothing -> Left $ "type mismatch: expected " ++ show tpr ++ " but got " ++
             show (R.exprType e) ++ " in field " ++ show (length rest) ++ ": " ++ show (ctx0, es0)
 
--- | Like `buildStructAssign`, but only the `FieldKind`s of the `FieldCtxRepr`
--- are used; the actual types are ignored in favor of the types of the
--- `R.Expr`s.
-buildStructAssignAdjusted :: HasCallStack => FieldCtxRepr ctx -> [Some (R.Expr MIR s)] ->
-    Either String (Pair FieldCtxRepr (Ctx.Assignment (R.Expr MIR s)))
-buildStructAssignAdjusted ctx0 es0 = do
-  Some ctx0' <- adjust ctx0 $ reverse es0
-  asn <- buildStructAssign ctx0' (map Just es0)
-  return $ Pair ctx0' asn
-  where
-    adjust :: forall ctx s. FieldCtxRepr ctx -> [Some (R.Expr MIR s)] ->
-      Either String (Some FieldCtxRepr)
-    adjust Ctx.Empty [] = return $ Some Ctx.empty
-    adjust _ [] = Left "adjust: not enough expressions"
-    adjust Ctx.Empty _ = Left "adjust: too many expressions"
-    adjust (ctx Ctx.:> fr) (Some e : es) = do
-      let tpr = R.exprType e
-      Some fr' <- case fr of
-        FieldRepr (FkInit _) -> return $ Some $ FieldRepr (FkInit tpr)
-        FieldRepr (FkMaybe _) -> return $ Some $ FieldRepr (FkMaybe tpr)
-      Some ctx' <- adjust ctx es
-      return $ Some (ctx' Ctx.:> fr')
-
 buildStruct' :: HasCallStack => M.Adt -> [Maybe (MirExp s)] ->
     MirGenerator h s ret (MirExp s)
-buildStruct' adt es = do
+buildStruct' adt xs = do
     when (adt ^. M.adtkind /= M.Struct) $ mirFail $
         "expected struct, but got adt " ++ show (adt ^. M.adtname)
-    let var = M.onlyVariant adt
-    Some fctx <- variantFieldsM' var
-    asn <- case buildStructAssign fctx $ map (fmap (\(MirExp _ e) -> Some e)) es of
-        Left err -> mirFail $ "error building struct " ++ show (var ^. M.vname) ++ ": " ++ err
-        Right x -> return x
-    let ctx = fieldCtxType fctx
-    pure $ MirExp (C.StructRepr ctx) $ R.App $ E.MkStruct ctx asn
+    let adtTy = M.TyAdt (adt ^. M.adtname) (adt ^. M.adtOrigDefId) (adt ^. M.adtOrigSubsts)
+    buildAggregateMaybeM adtTy xs
 
 buildStruct :: HasCallStack => M.Adt -> [MirExp s] ->
     MirGenerator h s ret (MirExp s)
@@ -1486,19 +1420,12 @@ buildStruct adt es =
 -- you're really sure that the `FieldKind`s will match up with the `M.Ty`s of
 -- the exprs.  In almost all cases, it's better to use the non-adjusted
 -- version.
+--
+-- TODO: now identical to buildStruct; remove
 buildStructAdjusted :: HasCallStack => M.Adt -> [MirExp s] ->
     MirGenerator h s ret (MirExp s)
 buildStructAdjusted adt es = do
-    when (adt ^. M.adtkind /= M.Struct) $ mirFail $
-        "expected struct, but got adt " ++ show (adt ^. M.adtname)
-    let var = M.onlyVariant adt
-    Some fctx <- variantFieldsM' var
-    Pair fctx' asn <- case buildStructAssignAdjusted fctx $ map (\(MirExp _ e) -> Some e) es of
-        Left err -> mirFail $
-          "error building adjusted struct " ++ show (var ^. M.vname) ++ ": " ++ err
-        Right x -> return x
-    let ctx' = fieldCtxType fctx'
-    pure $ MirExp (C.StructRepr ctx') $ R.App $ E.MkStruct ctx' asn
+    buildStruct adt es
 
 
 buildEnum' :: HasCallStack => M.Adt -> Int -> [Maybe (MirExp s)] ->
@@ -1680,41 +1607,74 @@ fieldDataRef ::
 fieldDataRef (FkInit _tpr) ref = return ref
 fieldDataRef (FkMaybe tpr) ref = subjustRef tpr ref
 
+-- | Round up @sz@ to the next multiple of @align@.
+padToAlign :: R.Expr MIR s UsizeType -> R.Expr MIR s UsizeType -> R.Expr MIR s UsizeType
+padToAlign sz align =
+  let alignMinus1 = R.App $ usizeSub align (R.App $ usizeLit 1)
+      szPlusAlignMinus1 = R.App $ usizeAdd sz alignMinus1
+      alignMask = R.App $ E.BVNot (knownNat @SizeBits) alignMinus1
+  in R.App $ usizeAnd szPlusAlignMinus1 alignMask
+
 structFieldRef ::
-    M.Adt -> Int ->
+    M.Ty -> Int ->
     R.Expr MIR s MirReferenceType ->
     PtrMetadata s ->
     MirGenerator h s ret (MirPlace s)
-structFieldRef adt i ref0 meta = structInfo adt i >>= \case
-  SizedStruct ctx idx fld -> do
-    ref1 <- subfieldRef ctx ref0 idx
-    ref2 <- fieldDataRef fld ref1
-    return $ MirPlace (fieldDataType fld) ref2 NoMeta
-  SizedField fieldKind -> do
-    let fieldRepr = fieldDataType fieldKind
-    fieldRef <- subfieldRef_Untyped ref0 i (Just (Some fieldRepr))
-    dataRef <- fieldDataRef fieldKind fieldRef
-    return $ MirPlace fieldRepr dataRef NoMeta
+structFieldRef structTy i ref meta = do
+  fields <- tyFieldsM structTy
+  (off, ty) <- case fields ^? ix i of
+    Just x -> return x
+    Nothing -> mirFail $ "tupleFieldRef: field index " ++ show i ++
+      " is out of range for tuple " ++ show structTy
+  let isLast = i + 1 == length fields
+  case meta of
+    DynMeta vtable | isLast -> do
+      dynTraitName <- findUnsizedTailM structTy >>= \case
+        Just (M.TyDynamic trait) -> return trait
+        tailTy -> panic "structFieldRef"
+          ["expected struct with DynMeta to have TyDynamic tail, but got",
+            show tailTy, "for struct", show structTy]
+      alignExp <- getVtableSlot dynTraitName vtableAlignSlotIdx UsizeRepr vtable
+      let offExp = R.App $ usizeLit $ fromIntegral off
+      let offExp' = padToAlign offExp alignExp
+      ref' <- mirRef_agElem_unsized offExp' ref
+      return $ MirPlace C.AnyRepr ref' meta
 
-  -- Note the unconditional absence of (a caller of) `subjustRef` in the unsized
-  -- cases below. When casting from a sized struct to an unsized struct, we
-  -- currently assert that the last field of the sized struct is initializable,
-  -- so that we know no `subjustRef` is necessary. This is an artificial
-  -- restriction, but it lets us get away without knowing the concrete type of
-  -- the inhabitant of that field, which is unknown at translation time.
-  UnsizedNonSliceField -> do
-    fieldRef <- subfieldRef_Untyped ref0 i Nothing
-    return $ MirPlace C.AnyRepr fieldRef meta
-  UnsizedSliceField innerSize innerRepr -> do
-    fieldRef <- subfieldRef_Untyped ref0 i Nothing
-    elemRef <- subindexRef innerRepr fieldRef (R.App $ usizeLit 0) innerSize
-    case meta of
-      NoMeta ->
-        mirFail "expected slice metadata for slice field access, but found no metadata"
-      DynMeta _vtable ->
-        mirFail "expected slice metadata for slice field access, but found vtable"
-      SliceMeta _len ->
-        return $ MirPlace innerRepr elemRef meta
+    SliceMeta _len | isLast -> do
+      let adtName = case structTy of
+            M.TyAdt name _ _ -> name
+            _ -> panic "structFieldRef" ["expected struct type, but got", show structTy]
+      -- This is `Just elemTy` if the last field of `structTy` is a slice or
+      -- str, or `Nothing` if it's another struct DST.
+      optElemTy <- findLastFieldM adtName >>= \case
+        Just f | M.TySlice elemTy <- f ^. M.fty -> return $ Just elemTy
+        Just f | M.TyStr <- f ^. M.fty -> return $ Just $ M.TyUint M.B8
+        _ -> return Nothing
+
+      let offExp = R.App $ usizeLit $ fromIntegral off
+      -- Can't use typed/sized `mirRef_agElem` here because it requires the
+      -- size to be a translation-time constant.
+      ref' <- mirRef_agElem_unsized offExp ref
+
+      case optElemTy of
+        Just elemTy -> do
+          -- Output is a slice reference.  Project into the first element of
+          -- the array.
+          Some elemTpr <- tyToReprM elemTy
+          elemSz <- tySizeM elemTy
+          ref'' <- mirRef_agElem_constOffset 0 elemSz elemTpr ref'
+          return $ MirPlace elemTpr ref'' meta
+        Nothing -> do
+          -- Output is a reference to a nested custom DST.  No additional
+          -- projection is needed.
+          return $ MirPlace MirAggregateRepr ref' meta
+
+    _ -> do
+      Some valTpr <- tyToReprM ty
+      sz <- tySizeM ty
+      ref' <- mirRef_agElem_constOffset off sz valTpr ref
+      return $ MirPlace valTpr ref' NoMeta
+
 
 enumFieldRef ::
     M.Adt -> Int -> Int ->

--- a/crux-mir/src/Mir/Language.hs
+++ b/crux-mir/src/Mir/Language.hs
@@ -594,24 +594,16 @@ showRegEntry col mty entry@(C.RegEntry tp rv) =
               | otherwise =
                 showZSTValue fTy
         fieldStrs <- zipWithM showField [0..] fieldTys
-        showVariant' variant fieldStrs
+        showVariant variant fieldStrs
 
       | Just adt <- findAdt' col name -> do
         optParts <- case adt ^. adtkind of
             Struct -> do
                 let var = onlyVariant adt
-                C.Some fctx <- case variantFields' col var of
-                    Left err -> fail ("Type not supported: " ++ err)
-                    Right x -> return x
-                let ctx = fieldCtxType fctx
-                let expectedStructTpr = C.StructRepr ctx
-                Refl <-
-                  case testEquality expectedStructTpr tp of
-                    Just r -> pure r
-                    Nothing -> fail $
-                      "expected struct to have type " ++ show expectedStructTpr ++
-                      ", but got " ++ show tp
-                return $ Right (var, readFields fctx rv)
+                Refl <- failIfNotEqual tp MirAggregateRepr
+                            ("when printing struct type " ++ show mty)
+                strs <- showAgFields mty ("struct type " ++ show mty) rv
+                return $ Right (var, strs)
             Enum _ -> do
              case enumVariants col adt of
                Left err -> fail ("Type not supported: " ++ err)
@@ -636,12 +628,13 @@ showRegEntry col mty entry@(C.RegEntry tp rv) =
                             Right (C.Some fctx) -> do
                                 Refl <- failIfNotEqual tpr (C.StructRepr $ fieldCtxType fctx)
                                             ("when printing enum type " ++ show name)
-                                return $ Right (var, readFields fctx fields)
+                                strs <- showFields var fctx fields
+                                return $ Right (var, strs)
                     Nothing -> return $ Left "Symbolic enum"
             Union -> return $ Left "union printing is not yet implemented"
         case optParts of
             Left err -> return err
-            Right (variant, fields) -> showVariant variant fields
+            Right (variant, fieldStrs) -> showVariant variant fieldStrs
 
     (TyRef ty Immut, _) -> showRegEntry col ty (C.RegEntry tp rv)
 
@@ -675,6 +668,36 @@ showRegEntry col mty entry@(C.RegEntry tp rv) =
     readField (FieldRepr (FkMaybe tpr)) (W4.Err _) =
         error $ "readField: W4.Err for type " ++ show tpr
 
+    showFields :: Variant -> FieldCtxRepr ctx -> Ctx.Assignment (C.RegValue' sym) ctx ->
+        C.OverrideSim p sym MIR rtp args ret [String]
+    showFields variant fctx vs = do
+      let fields = readFields fctx vs
+      fieldStrs <-
+        zipWithM
+          (\fieldTy (C.Some fieldEntry) -> showRegEntry col fieldTy fieldEntry)
+          (variant ^.. vfields . each . fty)
+          fields
+      return fieldStrs
+
+    showAgFields :: Ty -> String -> MirAggregate sym ->
+        C.OverrideSim p sym MIR rtp args ret [String]
+    showAgFields agTy tyDesc ag = do
+      let MirAggregate _ m = ag
+      fields <- case tyFields col agTy of
+        Just x -> return x
+        Nothing -> fail $ "missing fields for " ++ tyDesc
+      strs <- forM fields $ \(off, ty) -> do
+        case col ^? layouts . ix ty . _Just . laySize of
+          Just 0 -> showZSTValue ty
+          Just _ -> do
+            case IntMap.lookup (fromIntegral off) m of
+              Just (MirAggregateEntry _ elemTpr elemRvPart) ->
+                goMaybe ty elemTpr elemRvPart
+              Nothing -> return "<uninit>"
+          Nothing -> fail $ "impossible: got field offsets for " ++ tyDesc
+            ++ ", but no layout for element " ++ show ty ++ "?"
+      return strs
+
     goMaybe ::
       Ty ->
       C.TypeRepr tp ->
@@ -689,23 +712,10 @@ showRegEntry col mty entry@(C.RegEntry tp rv) =
 
     showVariant ::
       Variant ->
-      -- | Field values, matching the order in the provided `Variant`
-      [C.Some (C.RegEntry sym)] ->
-      C.OverrideSim p sym MIR rtp args ret String
-    showVariant variant fields = do
-      fieldStrs <-
-        zipWithM
-          (\fieldTy (C.Some fieldEntry) -> showRegEntry col fieldTy fieldEntry)
-          (variant ^.. vfields . each . fty)
-          fields
-      showVariant' variant fieldStrs
-
-    showVariant' ::
-      Variant ->
       -- | Serialized field values, matching the order in the provided `Variant`
       [String] ->
       C.OverrideSim p sym MIR rtp args ret String
-    showVariant' variant fieldStrs = do
+    showVariant variant fieldStrs = do
       let varName = Text.unpack $ cleanVariantName (variant ^. vname)
       case variant ^. vctorkind of
         Just FnKind ->
@@ -736,7 +746,7 @@ showRegEntry col mty entry@(C.RegEntry tp rv) =
               let variant = onlyVariant adt
               let fieldTys = variant ^.. vfields . each . fty
               fieldStrs <- mapM showZSTValue fieldTys
-              showVariant' variant fieldStrs
+              showVariant variant fieldStrs
           | otherwise ->
               fail $ "showZSTValue: unknown ADT"
         _ ->

--- a/crux-mir/test/symb_eval/debug/dump_rv.good
+++ b/crux-mir/test/symb_eval/debug/dump_rv.good
@@ -1,6 +1,6 @@
 test dump_rv/<DISAMB>::test[0]: a = {0..4 -> 0x7b:[32], 4..8 -> 0x1c8:[32], size 8}
 b = {0..4 -> cxy@7:bv, 4..8 -> cxy@8:bv, size 8}
-c = {cxy@7:bv, cxy@8:bv}
+c = {0..4 -> cxy@7:bv, 4..8 -> cxy@8:bv, size 8}
 d = {0..1 -> 0x0:[8], 1..2 -> 0x1:[8], size 2}
 e = {0..1 -> 0x0:[8], 1..2 -> 0x1:[8], 2..3 -> 0x2a:[8], 3..4 -> 0x1b:[8], size 5}
 f = let -- test/symb_eval/debug/dump_rv.rs:30:19: 30:40


### PR DESCRIPTION
Migrates structs from `StructRepr` to `MirAggregateRepr`.  This includes handling for all of the unsized / custom DST cases.

This includes a new `mirRef_agElem_unsized` intrinsic, which is like `mirRef_agElem` but dynamically detects the size and `TypeRepr` to use for the `AgElem_RefPath`.  This is used for accessing the last field of a custom DST, similar to the old `subfieldRef_untyped` intrinsic.  We need this because the normal `mirRef_agElem` intrinsic requires the field size to be known at translation time, which is not possible when working with custom DSTs.  Once `mirRef_agOffset` is implemented (as part of aggregate flattening), we can modify the custom DST cases to use that instead.

This requires corresponding saw-script changes, which I haven't started on yet, before it can be merged.