### PR TITLE
`crucible-mir`: Make operand pretty-printing behave more like `rustc`

### DIFF
--- a/crucible-mir/src/Mir/PP.hs
+++ b/crucible-mir/src/Mir/PP.hs
@@ -211,7 +211,7 @@ instance Pretty Lvalue where
       parens (pretty lv <+> pretty "as subtype" <+> pretty ty)
 
 instance Pretty Rvalue where
-    pretty (Use a) = pretty_fn1 "use" a
+    pretty (Use a) = pretty a
     pretty (Repeat a b) = brackets (pretty a <> semi <> pretty b)
     pretty (Ref Shared b _c) = pretty "&" <> pretty b
     pretty (Ref Unique b _c) = pretty "&unique" <+> pretty b
@@ -261,9 +261,9 @@ instance Pretty TerminatorKind where
 
 instance Pretty Operand where
     pretty (OpConstant c) = pretty c
-    pretty (Move c) = pretty c
-    pretty (Copy c) = pretty c
-    pretty (Temp c) = pretty c
+    pretty (Move c) = pretty_fn1 "move" c
+    pretty (Copy c) = pretty_fn1 "copy" c
+    pretty (Temp c) = pretty_fn1 "temp" c
 
 instance Pretty Constant where
     pretty (Constant a b) =
@@ -284,9 +284,9 @@ instance Pretty Constant where
         (TyFnDef defId, ConstZST) ->
           pr_id defId
         (_, ConstZST) ->
-          pretty "<ZST:" <+> pretty a <> pretty ">"
+          pretty_fn1 "const" "<ZST:" <+> pretty a <> pretty ">"
         _ ->
-          pretty b
+          pretty_fn1 "const" b
 
 instance Pretty NullOp where
     pretty SizeOf = pretty "sizeof"


### PR DESCRIPTION
Instead of printing all operand uses with a catch-all `"use"` label, we now distinguish between moves, copies, constants, and temporary values. This takes direct inspiration from how `rustc`'s own MIR pretty-printer works.

For instance, after these changes the following Rust code:

```rs
pub fn f(x: u8) -> u8 {
    x
}

pub fn g(x: String) -> String {
    x
}

pub fn main() {
    f(1);
    g(String::from("hello"));
}
```

Will pretty-print like so using `crux-mir --print-mir`:

```rs
fn test/ea07f402::f[0](_1 : u8) -> u8 {
   let mut _0 : u8;
   bb0: {
      _0 = copy(_1);
      return;
   }
}
fn test/ea07f402::g[0](_1 : $lang/0::String[0]<>) -> $lang/0::String[0]<> {
   let mut _0 : $lang/0::String[0]<>;
   bb0: {
      _0 = move(_1);
      return;
   }
}
fn test/ea07f402::main[0]() -> () {
   let mut _0 : ();
   let const _1 : u8;
   let const _2 : $lang/0::String[0]<>;
   let mut _3 : $lang/0::String[0]<>;
   bb0: {
      call(test/ea07f402::f[0](const(1)), (_1, bb1))
   }
   bb1: {
      call( alloc/9e7d739c::string[0]::{impl#43}[0]::from[0]::_instbb64d9ba9587f048[0]( const(&test/ea07f402::{{alloc}}[0]) )
      , (_3, bb2) )
   }
   bb2: {
      call(test/ea07f402::g[0](move(_3)), (_2, bb3))
   }
   bb3: {
      drop _2 -> bb4 (Just core/4cac97e0::ptr[0]::drop_in_place[0]::_drop5795d5dd1fa6877b[0]);
   }
   bb4: {
      return;
   }
}
```

Resolves #1825.