### PR TITLE
crucible-mir: add Pin/Arc/Mutex/RwLock transparent type patterns

### DIFF
--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -153,6 +153,26 @@ pattern CTyMethodSpec <- M.TyAdt _ $(M.explodedDefIdPat ["crucible", "method_spe
 pattern CTyMethodSpecBuilder :: M.Ty
 pattern CTyMethodSpecBuilder <- M.TyAdt _ $(M.explodedDefIdPat ["crucible", "method_spec", "raw", "MethodSpecBuilder"]) (M.Substs [])
 
+-- | Pin<T> is a transparent wrapper around T in MIR.  We erase it during
+-- type translation so that async poll functions using Pin<&mut Self> are
+-- treated identically to &mut Self.
+pattern CTyPin :: M.Ty -> M.Ty
+pattern CTyPin t <- M.TyAdt _ $(M.explodedDefIdPat ["core", "pin", "Pin"]) (M.Substs [t])
+
+-- | Arc<T> is modeled transparently as T for verification purposes.
+-- The reference counting is abstracted away.
+pattern CTyArc :: M.Ty -> M.Ty
+pattern CTyArc t <- M.TyAdt _ $(M.explodedDefIdPat ["alloc", "sync", "Arc"]) (M.Substs [t])
+
+-- | Mutex<T> is modeled transparently as T for verification purposes.
+-- The locking semantics are abstracted away.
+pattern CTyMutex :: M.Ty -> M.Ty
+pattern CTyMutex t <- M.TyAdt _ $(M.explodedDefIdPat ["std", "sync", "mutex", "Mutex"]) (M.Substs [t])
+
+-- | RwLock<T> is modeled transparently as T for verification purposes.
+-- The read/write locking semantics are abstracted away.
+pattern CTyRwLock :: M.Ty -> M.Ty
+pattern CTyRwLock t <- M.TyAdt _ $(M.explodedDefIdPat ["std", "sync", "rwlock", "RwLock"]) (M.Substs [t])
 
 -- These don't have custom representation, but are referenced in various
 -- places.
@@ -191,6 +211,12 @@ tyToRepr col t0 = case t0 of
         C.AsBaseType btr ->
             Right (Some (C.SymbolicArrayRepr (Ctx.Empty Ctx.:> C.BaseBVRepr (knownNat @SizeBits)) btr))
         C.NotBaseType -> Left "unsupported: crucible arrays of non-base type"
+  -- Pin<T> is a transparent wrapper; erase it to just T
+  CTyPin t -> tyToRepr col t
+  -- Arc<T>, Mutex<T>, RwLock<T> are modeled transparently for verification
+  CTyArc t -> tyToRepr col t
+  CTyMutex t -> tyToRepr col t
+  CTyRwLock t -> tyToRepr col t
   CTyAny -> Right (Some C.AnyRepr)
   CTyMethodSpec -> Right (Some MethodSpecRepr)
   CTyMethodSpecBuilder -> Right (Some MethodSpecBuilderRepr)


### PR DESCRIPTION
## Closing — patterns were unnecessary at best and wrong at worst

After further diagnosis I'm withdrawing this PR. Sharing the findings in case they're useful to others reaching for a similar shortcut.

### `CTyPin` is redundant

`Pin<Ptr>` has been `#[repr(transparent)]` in the bundled stdlib (`libs/core/src/pin.rs`) since 2023, and across every rustc version mir-json supports. mir-json's analyzer emits `repr_transparent: true` for it at [`src/analyz/ty_json.rs:1849`](https://github.com/GaloisInc/mir-json/blob/master/src/analyz/ty_json.rs#L1849), and crucible-mir's existing `reprTransparentFieldTy` mechanism at [`crucible-mir/src/Mir/TransTy.hs:646`](https://github.com/GaloisInc/crucible/blob/master/crucible-mir/src/Mir/TransTy.hs#L646) already strips Pin to its inner pointer during translation. The `CTyPin` pattern produced the identical result — it was solving a non-problem.

### `CTyArc` / `CTyMutex` / `CTyRwLock` are semantically wrong

These types are *not* `repr(transparent)` in the bundled stdlib:

- `Arc<T>` has three fields (`ptr: NonNull<ArcInner<T>>`, `phantom: PhantomData<ArcInner<T>>`, `alloc: A`)
- `Mutex<T>` has three fields (`inner: sys::Mutex`, `poison: poison::Flag`, `data: UnsafeCell<T>`)
- `RwLock<T>` has the same shape as `Mutex<T>`

Today, crucible-mir translates each through the standard `TyAdt → Struct` path against the bundled stdlib. The existing tests [`crux-mir/test/conc_eval/sync/arc.rs`](https://github.com/GaloisInc/crucible/blob/master/crux-mir/test/conc_eval/sync/arc.rs), `sync/mutex.rs`, `sync/rwlock.rs`, and `dyn/receiver_pin.rs` all pass against the real (non-transparent) struct translation. Adding these patterns would replace honest translation with an erasure that silently drops:

| Coverage that would be lost |
|---|
| `Arc::clone` refcount-overflow check (real `MAX_REFCOUNT` abort) |
| `Arc::drop` running the inner `T`'s destructor |
| `size_of::<Arc<T>>()` / transmute / FFI layout reasoning (16-byte `ArcInner` header would vanish) |
| Mutex `poison` flag — `clear_poison()` / `is_poisoned()` would become no-ops |

### Lesson: speculative "transparent wrapper" patterns are dangerous

The patterns were added speculatively, without a concrete failing case in the test suite. If a real failure exists for any of these types — most likely a method-body issue (e.g. an unsupported intrinsic inside `Arc::new` or atomic operation inside `Mutex::lock`) rather than a type-translation issue — the right fix is to address that specific failure, not to silently erase the type.

If anyone has hit a translation failure on `Arc`/`Mutex`/`RwLock`/`Pin` in real code, please point me at it — I'd like to fix it for real.

Closing.