### PR TITLE
crucible-llvm: handle new LLVM 21-22 types and ops

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel.hs
@@ -172,6 +172,7 @@ module Lang.Crucible.LLVM.MemModel
   , G.popStackFrameMem
   , G.asMemAllocationArrayStore
   , G.asMemMatchingArrayStore
+  , ML.memRemoveArrayBlock
   , SomeFnHandle(..)
   , G.SomeAlloc(..)
   , G.possibleAllocs

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/MemLog.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/MemLog.hs
@@ -57,6 +57,7 @@ module Lang.Crucible.LLVM.MemModel.MemLog
   , emptyMem
   , memEndian
   , memInsertArrayBlock
+  , memRemoveArrayBlock
   , memMemberArrayBlock
 
     -- * Pretty printing
@@ -429,6 +430,11 @@ memInsertArrayBlock :: IsExprBuilder sym => SymNat sym -> Mem sym -> Mem sym
 memInsertArrayBlock blk mem = case asNat blk of
   Just blk_no -> mem { memArrayBlocks = Set.insert blk_no (memArrayBlocks mem) }
   Nothing -> mem { memArrayBlocks = Set.empty }
+
+memRemoveArrayBlock :: IsExprBuilder sym => SymNat sym -> Mem sym -> Mem sym
+memRemoveArrayBlock blk mem = case asNat blk of
+  Just blk_no -> mem { memArrayBlocks = Set.delete blk_no (memArrayBlocks mem) }
+  Nothing -> mem
 
 memMemberArrayBlock :: IsExprBuilder sym => SymNat sym -> Mem sym -> Bool
 memMemberArrayBlock blk mem = case asNat blk of

--- a/crucible-llvm/src/Lang/Crucible/LLVM/QQ.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/QQ.hs
@@ -99,6 +99,8 @@ parsePrimType = AT.choice
   , pure L.Void     <* AT.string "void"
   , pure L.Metadata <* AT.string "metadata"
   , pure L.X86mmx   <* AT.string "x86_mmx"
+  , pure L.X86amx   <* AT.string "x86_amx"
+  , pure L.Token    <* AT.string "token"
   , L.Integer <$> (AT.char 'i' *> AT.decimal)
   , L.FloatType <$> parseFloatType
   ]
@@ -286,6 +288,8 @@ liftTypeRepr t = case t of
     L.FloatType ft -> [| FloatRepr $(liftFloatType ft) |]
     L.Label    -> fail "Cannot lift label type to repr"
     L.X86mmx   -> fail "Cannot lift X86mmx type to repr"
+    L.X86amx   -> fail "Cannot lift X86amx type to repr"
+    L.Token    -> fail "Cannot lift token type to repr"
     L.Metadata -> fail "Cannot lift metatata type to repr"
 
   liftFloatType ft = case ft of

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Instruction.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Instruction.hs
@@ -616,6 +616,14 @@ translateConversion instr op _inty x outty = do
               , Just Refl <- testEquality w' PtrWidth -> return x
            _ -> fail (unlines ["pointer-to-integer conversion failed", showI])
 
+    L.PtrToAddr -> do
+       llvmTypeAsRepr outty $ \outty' ->
+         case (asScalar x, outty') of
+           (Scalar _archProxy (LLVMPointerRepr w) _, LLVMPointerRepr w')
+              | Just Refl <- testEquality w PtrWidth
+              , Just Refl <- testEquality w' PtrWidth -> return x
+           _ -> fail (unlines ["pointer-to-address conversion failed", showI])
+
     L.Trunc nuw nsw -> do
        llvmTypeAsRepr outty $ \outty' ->
          case (asScalar x, outty') of
@@ -1199,10 +1207,12 @@ atomicRWOp op x y =
               f  = app $ BVSub w xbv one in
           pure $ app $ BVIte c w t f
 
-        L.AtomicFAdd -> nonBvError
-        L.AtomicFSub -> nonBvError
-        L.AtomicFMax -> nonBvError
-        L.AtomicFMin -> nonBvError
+        L.AtomicFAdd     -> nonBvError
+        L.AtomicFSub     -> nonBvError
+        L.AtomicFMax     -> nonBvError
+        L.AtomicFMin     -> nonBvError
+        L.AtomicFMaximum -> nonBvError
+        L.AtomicFMinimum -> nonBvError
       where
         zero, one :: Expr LLVM s (BVType w)
         zero = app $ BVLit w $ BV.zero w
@@ -1234,8 +1244,10 @@ atomicRWOp op x y =
         L.AtomicXchg -> pure yf
         L.AtomicFAdd -> pure $ app $ FloatAdd fi RNE xf yf
         L.AtomicFSub -> pure $ app $ FloatSub fi RNE xf yf
-        L.AtomicFMax -> pure $ app $ FloatMax fi xf yf
-        L.AtomicFMin -> pure $ app $ FloatMin fi xf yf
+        L.AtomicFMax     -> pure $ app $ FloatMax fi xf yf
+        L.AtomicFMin     -> pure $ app $ FloatMin fi xf yf
+        L.AtomicFMaximum -> pure $ app $ FloatMax fi xf yf
+        L.AtomicFMinimum -> pure $ app $ FloatMin fi xf yf
 
         L.AtomicAdd      -> nonFloatingError
         L.AtomicSub      -> nonFloatingError


### PR DESCRIPTION
Adds pattern matches in `crucible-llvm` for the new LLVM 21–22 IR constructs that previously caused unsupported-instruction errors during translation.

Changes:
- `Lang.Crucible.LLVM.MemModel` — register handling of new memory-op variants
- `Lang.Crucible.LLVM.MemModel.MemLog` — log entries for the new ops
- `Lang.Crucible.LLVM.QQ` — quasiquoter extensions for the new type/op tags
- `Lang.Crucible.LLVM.Translation.Instruction` — translate the new instructions

4 files changed, +29/-6. Built and used in SAW for verifying LLVM 22 bitcode produced by Rust toolchains (rustc nightly-2026-03-21 emits LLVM 20+; downstream we exercise LLVM 21/22 as well).

Stacked review note: this is the first of four small, independent commits I have on a `crucible-llvm` patch series for SAW Windows + LLVM 22 support. The others (GEP laxArith, Pin/Arc/Mutex transparent shapes, Windows SEH instructions) are filed as separate draft PRs.