### PR TITLE
crucible-llvm: GEP overflow check respects laxArith option

### DIFF
--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Instruction.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Instruction.hs
@@ -443,7 +443,7 @@ insertValue _ _ _ = fail "invalid insertValue instruction"
 
 
 evalGEP :: forall s arch ret wptr.
-  wptr ~ ArchWidth arch =>
+  (?transOpts :: TranslationOptions, wptr ~ ArchWidth arch) =>
   L.Instr ->
   GEPResult (LLVMExpr s arch) ->
   LLVMGenerator s arch ret (LLVMExpr s arch)
@@ -495,7 +495,7 @@ evalGEP instr (GEPResult _lanes finalMemType gep0) = finish =<< go gep0
 
 
 calcGEP_array :: forall wptr s arch ret.
-  wptr ~ ArchWidth arch =>
+  (?transOpts :: TranslationOptions, wptr ~ ArchWidth arch) =>
   MemType {- ^ Type of the array elements -} ->
   Expr LLVM s (LLVMPointerType wptr) {- ^ Base pointer -} ->
   LLVMExpr s arch {- ^ index value -} ->
@@ -526,8 +526,9 @@ calcGEP_array typ base idx =
      -- Perform the multiply
      mvar <- getMemVar
      off0 <- AtomExpr <$> (mkAtom $ app $ BVMul PtrWidth (app $ BVLit PtrWidth (BV.mkBV PtrWidth isz)) idx')
-     let off  =
-           if isz == 0
+     let noLaxArith = not (laxArith ?transOpts)
+         off  =
+           if isz == 0 || not noLaxArith
            then off0
            else
              let
@@ -549,7 +550,8 @@ calcGEP_array typ base idx =
                -- Multiplication overflow will result in a pointer which is not "in
                -- bounds" for the given allocation. We translate all GEP
                -- instructions as if they had the `inbounds` attribute set, so
-               -- the result would be a poison value.
+               -- the result would be a poison value. When laxArith is enabled
+               -- (via enable_lax_loads_and_stores), this check is skipped.
                poisonSideCondition mvar (BVRepr PtrWidth) poison off0 cond
 
      -- Perform the pointer offset arithmetic


### PR DESCRIPTION
When the user enables lax loads/stores (e.g. via SAW's `enable_lax_loads_and_stores`), arithmetic overflow checks during GEP index computation should be suppressed for consistency with the rest of the lax-arithmetic path. Currently the GEP path always emits an overflow assertion regardless of the option.

This patch threads the `laxArith` setting through `Translation/Instruction.hs` so the GEP overflow assertion is omitted when lax arithmetic is enabled.

1 file changed, +7/-5. Independent single-commit PR; no dependency on other patches in the series.