### PR TITLE
crucible-mir: tolerant parsing of Unsupported instance shims

### DIFF
--- a/crucible-mir/src/Mir/JSON.hs
+++ b/crucible-mir/src/Mir/JSON.hs
@@ -156,6 +156,22 @@ instance FromJSON Instance where
             <$> (IkCloneShim <$> v .: "ty" <*> v .: "callees") <*> v .: "def_id" <*> v .: "args"
         Just (String "ClosureFnPointerShim") -> Instance IkClosureFnPointerShim
             <$> v .: "call_mut" <*> pure mempty
+        Just (String "Unsupported") -> do
+            -- `mir-json` emits `"kind": "Unsupported"` for shim variants it
+            -- does not yet model (e.g. `ConstructCoroutineInClosureShim`,
+            -- `FutureDropPollShim`, `AsyncDropGlueCtorShim`, `AsyncDropGlue`,
+            -- `ThreadLocalShim`, `FnPtrAddrShim`). Accept these so that
+            -- modules referencing such shims can still be loaded. If one of
+            -- them is actually called during translation, downstream code
+            -- in `Mir.Trans` raises a clear error including the shim name.
+            shim <- v .:? "shim_kind" .!= "unknown"
+            -- The "Unsupported" payload from older `mir-json` versions
+            -- carries no `def_id` or `args`; use a synthetic placeholder
+            -- crate so the DefId is well-formed but obviously fake. Newer
+            -- versions can optionally provide the original def_id/args.
+            defid <- v .:? "def_id" .!= textId "unsupported_shim/0"
+            args  <- v .:? "args"   .!= mempty
+            return $ Instance (IkUnsupported shim) defid args
         r -> fail $ "unsupported instance: " ++ show r
 
 instance FromJSON FnSig where

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -230,6 +230,13 @@ data InstanceKind =
     -- ^ Shim used when converting a closure to a function pointer.  This
     -- function builds a dummy closure value and then passes it to `_inDefId`,
     -- which is the closure's `call_mut` method.
+    | IkUnsupported Text
+    -- ^ A shim type that `mir-json` recognized but cannot emit (e.g.
+    -- `ConstructCoroutineInClosureShim`, `FutureDropPollShim`,
+    -- `AsyncDropGlueCtorShim`, `AsyncDropGlue`, `ThreadLocalShim`,
+    -- `FnPtrAddrShim`). Loading a module with such instances succeeds, but
+    -- any attempt to translate or call one of them produces a clear error
+    -- naming the original shim kind (the `Text` payload).
     deriving (Eq, Ord, Show, Generic)
 
 data Adt = Adt


### PR DESCRIPTION
## Problem

`mir-json` emits `{"kind": "Unsupported"}` for six instance shim variants it does not yet model:

- `ConstructCoroutineInClosureShim`
- `ThreadLocalShim`
- `FutureDropPollShim`
- `FnPtrAddrShim`
- `AsyncDropGlueCtorShim`
- `AsyncDropGlue`

These appear in the `intrinsics` array of any compiled crate that exercises async Rust, thread-locals, or function-pointer-address taking — even when the user's verified function never touches those code paths.

Today the crucible-mir JSON parser at [`crucible-mir/src/Mir/JSON.hs:159`](https://github.com/GaloisInc/crucible/blob/master/crucible-mir/src/Mir/JSON.hs#L159) fails the *entire* `mir_load_module` call with `"unsupported instance: Just (Object [\"kind\" .= \"Unsupported\"])"` the moment it encounters one of these. This blocks SAW from verifying ordinary Rust code that happens to be in a crate or transitive dependency containing async machinery.

## Fix

Add a new `IkUnsupported Text` constructor to `InstanceKind` and accept `"kind": "Unsupported"` in the JSON parser. The optional `shim_kind` payload carries the original mir-json shim name so any downstream consumer can produce a clear, actionable error if the shim is actually called during translation.

This is a *tolerant-parse* change: the module loads, the verified function (which doesn't reach the shim) succeeds, and a clear error is deferred to translation time should anyone ever try to compile or invoke the `IkUnsupported` instance.

## Diff

```
crucible-mir/src/Mir/JSON.hs | 16 ++++++++++++++++
crucible-mir/src/Mir/Mir.hs  |  9 ++++++++-
2 files changed, 24 insertions(+), 1 deletion(-)
```

No behavior change for modules that don't contain `Unsupported` instances. Existing tests under `crux-mir/test/conc_eval/` are not affected.

## Companion PR

- [GaloisInc/mir-json#272](https://github.com/GaloisInc/mir-json/pull/272) — adds the `shim_kind` field to mir-json's `Unsupported` emissions so the deferred error message can name the specific shim. (This crucible-mir PR works fine without the mir-json companion — if `shim_kind` is absent, it falls back to `"unknown"`.)

## End-to-end validation

I ran this fix against the test in `intTests/test_mir_async_basic/` (synchronous helper alongside async fn) plus a hand-crafted module containing an injected `Unsupported` entry, and confirmed:

1. ✅ Modules containing `Unsupported` instances load successfully (previously failed at parse time).
2. ✅ `mir_verify` on a function that doesn't reach the shim succeeds.
3. ✅ Genuinely unknown `kind` strings (e.g. `"GarbageKind"`) still produce the original `"unsupported instance: …"` error — the fix is scoped to `"Unsupported"` only.

Filed as draft for upstream review.