### PR TITLE
crucible-mir: remove allocation-agnostic indexing

### DIFF
--- a/crucible-mir/CHANGELOG.md
+++ b/crucible-mir/CHANGELOG.md
@@ -29,6 +29,10 @@ This release supports [version
   `Mir.Intrinsics`. These are only used by SAW at the moment.
 * Remove `Mir.FancyMuxTree.runMuxLeafIO'`, which does not seem to be used
   anywhere.
+* Remove allocation-agnostic indexing intrinsic (`Mir.Generator.subindexRef`,
+  `Mir.Intrinsics.Reference.subindexMirRef{IO,Leaf,Sim}`), and migrate existing
+  uses to allocation-specific intrinsics for aggregates, sybmolic arrays, and
+  vectors (`Mir.Generator.{mirRef_agElem,mirRef_arrayIndex,mirRef_vecIndex}`).
 
 # 0.6 -- 2026-01-29
 

--- a/crucible-mir/src/Mir/Generator.hs
+++ b/crucible-mir/src/Mir/Generator.hs
@@ -629,15 +629,6 @@ subvariantRef ::
   MirGenerator h s ret (R.Expr MIR s MirReferenceType)
 subvariantRef tp ctx ref idx = G.extensionStmt (MirSubvariantRef tp ctx ref idx)
 
-subindexRef ::
-  C.TypeRepr tp ->
-  R.Expr MIR s MirReferenceType ->
-  R.Expr MIR s UsizeType ->
-  -- | Size of the element, in bytes
-  Word ->
-  MirGenerator h s ret (R.Expr MIR s MirReferenceType)
-subindexRef tp ref idx elemSize = G.extensionStmt (MirSubindexRef tp ref idx elemSize)
-
 subjustRef ::
   C.TypeRepr tp ->
   R.Expr MIR s MirReferenceType ->

--- a/crucible-mir/src/Mir/Generator.hs
+++ b/crucible-mir/src/Mir/Generator.hs
@@ -667,6 +667,14 @@ mirRef_agElem_unsized ::
   MirGenerator h s ret (R.Expr MIR s MirReferenceType)
 mirRef_agElem_unsized off ref = G.extensionStmt $ MirRef_AgElem_Unsized off ref
 
+-- | Index into a symbolic @crucible::array::Array<T>@ (_not_ a @[T; N]@)
+mirRef_arrayIndex ::
+  R.Expr MIR s UsizeType ->
+  C.TypeRepr tp ->
+  R.Expr MIR s MirReferenceType ->
+  MirGenerator h s ret (R.Expr MIR s MirReferenceType)
+mirRef_arrayIndex idx elemTpr ref = G.extensionStmt $ MirRef_ArrayIndex idx elemTpr ref
+
 -- | Index into a @crucible::vector::Vector@ (_not_ a @std::vec::Vec@)
 mirRef_vecIndex ::
   R.Expr MIR s UsizeType ->

--- a/crucible-mir/src/Mir/Generator.hs
+++ b/crucible-mir/src/Mir/Generator.hs
@@ -667,6 +667,14 @@ mirRef_agElem_unsized ::
   MirGenerator h s ret (R.Expr MIR s MirReferenceType)
 mirRef_agElem_unsized off ref = G.extensionStmt $ MirRef_AgElem_Unsized off ref
 
+-- | Index into a @crucible::vector::Vector@ (_not_ a @std::vec::Vec@)
+mirRef_vecIndex ::
+  R.Expr MIR s UsizeType ->
+  C.TypeRepr tp ->
+  R.Expr MIR s MirReferenceType ->
+  MirGenerator h s ret (R.Expr MIR s MirReferenceType)
+mirRef_vecIndex idx elemTpr ref = G.extensionStmt $ MirRef_VecIndex idx elemTpr ref
+
 mirRef_eq ::
   R.Expr MIR s MirReferenceType ->
   R.Expr MIR s MirReferenceType ->

--- a/crucible-mir/src/Mir/Intrinsics/Reference.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Reference.hs
@@ -68,6 +68,8 @@ module Mir.Intrinsics.Reference
     mirRef_agElemIO,
     mirRef_agElem_unsizedLeaf,
     mirRef_agElem_unsizedIO,
+    mirRef_arrayIndexLeaf,
+    mirRef_arrayIndexIO,
     mirRef_vecIndexLeaf,
     mirRef_vecIndexIO,
     refRootEq,
@@ -1037,6 +1039,30 @@ subjustMirRefIO ::
     IO (MirReferenceMux sym)
 subjustMirRefIO bak iTypes tpr ref =
     modifyRefMuxMA bak iTypes (subjustMirRefLeaf tpr) ref
+
+
+mirRef_arrayIndexLeaf ::
+    RegValue sym UsizeType ->
+    TypeRepr tp ->
+    MirReference sym ->
+    MuxLeafT sym IO (MirReference sym)
+mirRef_arrayIndexLeaf idx elemTpr ref = case asBaseType elemTpr of
+  AsBaseType baseTpr ->
+    typedLeafOp "Crucible Array index" (UsizeArrayRepr baseTpr) ref $ \root path -> do
+      return $ MirReference elemTpr root (ArrayIndex_RefPath baseTpr path idx)
+  _ -> leafAbort $ GenericSimError $
+    "Crucible Array-indexing operates on arrays of a Crucible base type, but saw one of " <> show elemTpr
+
+mirRef_arrayIndexIO ::
+    IsSymBackend sym bak =>
+    bak ->
+    IntrinsicTypes sym ->
+    RegValue sym UsizeType ->
+    TypeRepr tp ->
+    MirReferenceMux sym ->
+    IO (MirReferenceMux sym)
+mirRef_arrayIndexIO bak iTypes idx elemTpr ref =
+  modifyRefMuxMA bak iTypes (mirRef_arrayIndexLeaf idx elemTpr) ref
 
 
 mirRef_vecIndexLeaf ::

--- a/crucible-mir/src/Mir/Intrinsics/Reference.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Reference.hs
@@ -68,6 +68,8 @@ module Mir.Intrinsics.Reference
     mirRef_agElemIO,
     mirRef_agElem_unsizedLeaf,
     mirRef_agElem_unsizedIO,
+    mirRef_vecIndexLeaf,
+    mirRef_vecIndexIO,
     refRootEq,
     refPathEq,
     mirRef_eqLeaf,
@@ -1035,6 +1037,27 @@ subjustMirRefIO ::
     IO (MirReferenceMux sym)
 subjustMirRefIO bak iTypes tpr ref =
     modifyRefMuxMA bak iTypes (subjustMirRefLeaf tpr) ref
+
+
+mirRef_vecIndexLeaf ::
+    RegValue sym UsizeType ->
+    TypeRepr tp ->
+    MirReference sym ->
+    MuxLeafT sym IO (MirReference sym)
+mirRef_vecIndexLeaf idx elemTpr ref =
+  typedLeafOp "Crucible Vector index" (VectorRepr elemTpr) ref $ \root path -> do
+    return $ MirReference elemTpr root (VectorIndex_RefPath elemTpr path idx)
+
+mirRef_vecIndexIO ::
+    IsSymBackend sym bak =>
+    bak ->
+    IntrinsicTypes sym ->
+    RegValue sym UsizeType ->
+    TypeRepr tp ->
+    MirReferenceMux sym ->
+    IO (MirReferenceMux sym)
+mirRef_vecIndexIO bak iTypes idx elemTpr ref =
+  modifyRefMuxMA bak iTypes (mirRef_vecIndexLeaf idx elemTpr) ref
 
 
 mirRef_agElemLeaf ::

--- a/crucible-mir/src/Mir/Intrinsics/Reference.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Reference.hs
@@ -59,9 +59,6 @@ module Mir.Intrinsics.Reference
     subfieldMirRefIO,
     subvariantMirRefLeaf,
     subvariantMirRefIO,
-    subindexMirRefSim,
-    subindexMirRefIO,
-    subindexMirRefLeaf,
     subjustMirRefLeaf,
     subjustMirRefIO,
     mirRef_agElemLeaf,
@@ -968,58 +965,6 @@ subvariantMirRefIO ::
     IO (MirReferenceMux sym)
 subvariantMirRefIO bak iTypes tp ctx ref idx =
     modifyRefMuxMA bak iTypes (\ref' -> subvariantMirRefLeaf tp ctx ref' idx) ref
-
-
-subindexMirRefSim ::
-    IsSymInterface sym =>
-    sym ->
-    TypeRepr tp ->
-    MirReferenceMux sym ->
-    RegValue sym UsizeType ->
-    -- | Size of the element, in bytes
-    Word ->
-    OverrideSim m sym ext rtp args ret (MirReferenceMux sym)
-subindexMirRefSim sym tpr ref idx elemSize = do
-    modifyRefMuxSim (\ref' -> subindexMirRefLeaf sym tpr ref' idx elemSize) ref
-
-subindexMirRefIO ::
-    IsSymBackend sym bak =>
-    bak ->
-    IntrinsicTypes sym ->
-    TypeRepr tp ->
-    MirReferenceMux sym ->
-    RegValue sym UsizeType ->
-    -- | Size of the element, in bytes
-    Word ->
-    IO (MirReferenceMux sym)
-subindexMirRefIO bak iTypes tpr ref x elemSize =
-    modifyRefMuxMA bak iTypes (\ref' -> subindexMirRefLeaf (backendGetSym bak) tpr ref' x elemSize) ref
-
-subindexMirRefLeaf ::
-    IsSymInterface sym =>
-    sym ->
-    TypeRepr tp ->
-    MirReference sym ->
-    RegValue sym UsizeType ->
-    -- | Size of the element, in bytes
-    Word ->
-    MuxLeafT sym IO (MirReference sym)
-subindexMirRefLeaf sym elemTpr (MirReference tpr root path) idx elemSize
-  | Just Refl <- testEquality tpr (VectorRepr elemTpr) =
-      return $ MirReference elemTpr root (VectorIndex_RefPath elemTpr path idx)
-  | AsBaseType btpr <- asBaseType elemTpr,
-    Just Refl <- testEquality tpr (UsizeArrayRepr btpr) =
-      return $ MirReference elemTpr root (ArrayIndex_RefPath btpr path idx)
-  | Just Refl <- testEquality tpr MirAggregateRepr = do
-      offset <- liftIO $ bvMul sym idx =<< wordLit sym elemSize
-      return $ MirReference elemTpr root (AgElem_RefPath offset elemSize elemTpr path)
-  | otherwise = leafAbort $ GenericSimError $
-      "subindex requires a reference to a VectorRepr, a UsizeArrayRepr of " ++
-      "a Crucible base type, or a MirAggregateRepr, but got a reference to " ++
-      show tpr
-subindexMirRefLeaf _sym _elemTpr (MirReference_Integer {}) _idx _elemSize =
-    leafAbort $ GenericSimError $
-        "attempted subindex on the result of an integer-to-pointer cast"
 
 
 subjustMirRefLeaf ::

--- a/crucible-mir/src/Mir/Intrinsics/Syntax.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Syntax.hs
@@ -125,6 +125,7 @@ import Mir.Intrinsics.Reference
     mirRef_offsetWrapIO,
     mirRef_peelIndexMA,
     mirRef_tryOffsetFromIO,
+    mirRef_vecIndexIO,
     newMirRefIO,
     readMirRefMA,
     subfieldMirRefIO,
@@ -209,6 +210,12 @@ data MirStmt :: (CrucibleType -> Type) -> CrucibleType -> Type where
   -- TODO: remove this once `MirRef_AgOffset` is implemented
   MirRef_AgElem_Unsized ::
      !(f UsizeType) ->
+     !(f MirReferenceType) ->
+     MirStmt f MirReferenceType
+  -- | Index into a @crucible::vector::Vector@ (_not_ a @std::vec::Vec@)
+  MirRef_VecIndex ::
+     !(f UsizeType) ->
+     !(TypeRepr tp) ->
      !(f MirReferenceType) ->
      MirStmt f MirReferenceType
   MirRef_Eq ::
@@ -403,6 +410,7 @@ instance TypeApp MirStmt where
     MirSubvariantRef _ _ _ _ -> MirReferenceRepr
     MirSubindexRef _ _ _ _ -> MirReferenceRepr
     MirSubjustRef _ _ -> MirReferenceRepr
+    MirRef_VecIndex _ _ _ -> MirReferenceRepr
     MirRef_AgElem _ _ _ _ -> MirReferenceRepr
     MirRef_AgElem_Unsized _ _ -> MirReferenceRepr
     MirRef_Eq _ _ -> BoolRepr
@@ -440,6 +448,7 @@ instance PrettyApp MirStmt where
     MirSubvariantRef _ _ x idx -> "subvariantRef" <+> pp x <+> viaShow idx
     MirSubindexRef _ x idx sz -> "subindexRef" <+> pp x <+> pp idx <+> viaShow sz
     MirSubjustRef _ x -> "subjustRef" <+> pp x
+    MirRef_VecIndex idx _ ref -> "mirRef_vecIndex" <+> pp idx <+> pp ref
     MirRef_AgElem off _ _ ref -> "mirRef_agElem" <+> pp off <+> pp ref
     MirRef_AgElem_Unsized off ref -> "mirRef_agElem_unsized" <+> pp off <+> pp ref
     MirRef_Eq x y -> "mirRef_eq" <+> pp x <+> pp y
@@ -508,6 +517,8 @@ execMirStmt stmt s = withStateBackend s $ \bak ->
          readOnly s $ subindexMirRefIO bak iTypes tpr ref idx elemSize
        MirSubjustRef tpr (regValue -> ref) ->
          readOnly s $ subjustMirRefIO bak iTypes tpr ref
+       MirRef_VecIndex (regValue -> idx) tpr (regValue -> ref) ->
+         readOnly s $ mirRef_vecIndexIO bak iTypes idx tpr ref
        MirRef_AgElem (regValue -> off) sz tpr (regValue -> ref) ->
          readOnly s $ mirRef_agElemIO bak iTypes off sz tpr ref
        MirRef_AgElem_Unsized (regValue -> off) (regValue -> ref) ->

--- a/crucible-mir/src/Mir/Intrinsics/Syntax.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Syntax.hs
@@ -120,6 +120,7 @@ import Mir.Intrinsics.Reference
     mirRef_agElemIO,
     mirRef_agElem_unsizedIO,
     mirRef_aggregateAsChunksIO,
+    mirRef_arrayIndexIO,
     mirRef_eqIO,
     mirRef_offsetMA,
     mirRef_offsetWrapIO,
@@ -210,6 +211,12 @@ data MirStmt :: (CrucibleType -> Type) -> CrucibleType -> Type where
   -- TODO: remove this once `MirRef_AgOffset` is implemented
   MirRef_AgElem_Unsized ::
      !(f UsizeType) ->
+     !(f MirReferenceType) ->
+     MirStmt f MirReferenceType
+  -- | Index into a symbolic @crucible::array::Array<T>@ (_not_ a @[T; N]@)
+  MirRef_ArrayIndex ::
+     !(f UsizeType) ->
+     !(TypeRepr tp) ->
      !(f MirReferenceType) ->
      MirStmt f MirReferenceType
   -- | Index into a @crucible::vector::Vector@ (_not_ a @std::vec::Vec@)
@@ -410,6 +417,7 @@ instance TypeApp MirStmt where
     MirSubvariantRef _ _ _ _ -> MirReferenceRepr
     MirSubindexRef _ _ _ _ -> MirReferenceRepr
     MirSubjustRef _ _ -> MirReferenceRepr
+    MirRef_ArrayIndex _ _ _ -> MirReferenceRepr
     MirRef_VecIndex _ _ _ -> MirReferenceRepr
     MirRef_AgElem _ _ _ _ -> MirReferenceRepr
     MirRef_AgElem_Unsized _ _ -> MirReferenceRepr
@@ -448,6 +456,7 @@ instance PrettyApp MirStmt where
     MirSubvariantRef _ _ x idx -> "subvariantRef" <+> pp x <+> viaShow idx
     MirSubindexRef _ x idx sz -> "subindexRef" <+> pp x <+> pp idx <+> viaShow sz
     MirSubjustRef _ x -> "subjustRef" <+> pp x
+    MirRef_ArrayIndex idx _ ref -> "mirRef_arrayIndex" <+> pp idx <+> pp ref
     MirRef_VecIndex idx _ ref -> "mirRef_vecIndex" <+> pp idx <+> pp ref
     MirRef_AgElem off _ _ ref -> "mirRef_agElem" <+> pp off <+> pp ref
     MirRef_AgElem_Unsized off ref -> "mirRef_agElem_unsized" <+> pp off <+> pp ref
@@ -517,6 +526,8 @@ execMirStmt stmt s = withStateBackend s $ \bak ->
          readOnly s $ subindexMirRefIO bak iTypes tpr ref idx elemSize
        MirSubjustRef tpr (regValue -> ref) ->
          readOnly s $ subjustMirRefIO bak iTypes tpr ref
+       MirRef_ArrayIndex (regValue -> idx) tpr (regValue -> ref) ->
+         readOnly s $ mirRef_arrayIndexIO bak iTypes idx tpr ref
        MirRef_VecIndex (regValue -> idx) tpr (regValue -> ref) ->
          readOnly s $ mirRef_vecIndexIO bak iTypes idx tpr ref
        MirRef_AgElem (regValue -> off) sz tpr (regValue -> ref) ->

--- a/crucible-mir/src/Mir/Intrinsics/Syntax.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Syntax.hs
@@ -130,7 +130,6 @@ import Mir.Intrinsics.Reference
     newMirRefIO,
     readMirRefMA,
     subfieldMirRefIO,
-    subindexMirRefIO,
     subjustMirRefIO,
     subvariantMirRefIO,
     writeMirRefIO,
@@ -186,13 +185,6 @@ data MirStmt :: (CrucibleType -> Type) -> CrucibleType -> Type where
      !(CtxRepr variantsCtx) ->
      !(f MirReferenceType) ->
      !(Index variantsCtx tp) ->
-     MirStmt f MirReferenceType
-  MirSubindexRef ::
-     !(TypeRepr tp) ->
-     !(f MirReferenceType) ->
-     !(f UsizeType) ->
-     -- | Size of the element, in bytes
-     !Word ->
      MirStmt f MirReferenceType
   MirSubjustRef ::
      !(TypeRepr tp) ->
@@ -415,7 +407,6 @@ instance TypeApp MirStmt where
     MirDropRef _    -> UnitRepr
     MirSubfieldRef _ _ _ -> MirReferenceRepr
     MirSubvariantRef _ _ _ _ -> MirReferenceRepr
-    MirSubindexRef _ _ _ _ -> MirReferenceRepr
     MirSubjustRef _ _ -> MirReferenceRepr
     MirRef_ArrayIndex _ _ _ -> MirReferenceRepr
     MirRef_VecIndex _ _ _ -> MirReferenceRepr
@@ -454,7 +445,6 @@ instance PrettyApp MirStmt where
     MirDropRef x    -> "dropMirRef" <+> pp x
     MirSubfieldRef _ x idx -> "subfieldRef" <+> pp x <+> viaShow idx
     MirSubvariantRef _ _ x idx -> "subvariantRef" <+> pp x <+> viaShow idx
-    MirSubindexRef _ x idx sz -> "subindexRef" <+> pp x <+> pp idx <+> viaShow sz
     MirSubjustRef _ x -> "subjustRef" <+> pp x
     MirRef_ArrayIndex idx _ ref -> "mirRef_arrayIndex" <+> pp idx <+> pp ref
     MirRef_VecIndex idx _ ref -> "mirRef_vecIndex" <+> pp idx <+> pp ref
@@ -522,8 +512,6 @@ execMirStmt stmt s = withStateBackend s $ \bak ->
          readOnly s $ subfieldMirRefIO bak iTypes ctx0 ref idx
        MirSubvariantRef tp0 ctx0 (regValue -> ref) idx ->
          readOnly s $ subvariantMirRefIO bak iTypes tp0 ctx0 ref idx
-       MirSubindexRef tpr (regValue -> ref) (regValue -> idx) elemSize ->
-         readOnly s $ subindexMirRefIO bak iTypes tpr ref idx elemSize
        MirSubjustRef tpr (regValue -> ref) ->
          readOnly s $ subjustMirRefIO bak iTypes tpr ref
        MirRef_ArrayIndex (regValue -> idx) tpr (regValue -> ref) ->

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -393,7 +393,7 @@ staticSlicePlace len ty did = do
             () <- case tpr_found of
                 MirAggregateRepr -> return ()
                 _ -> mirFail $
-                    "staticSlicePlace: wrong type: expected vector, found " ++ show tpr_found
+                    "staticSlicePlace: wrong type: expected aggregate, found " ++ show tpr_found
             ref <- globalMirRef gv
             elemSize <- tySizeM ty
             ref' <- subindexRef tpr ref (R.App $ usizeLit 0) elemSize

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -26,7 +26,6 @@
 module Mir.Trans(transCollection,transStatics,RustModule(..)
                 , readMirRef
                 , writeMirRef
-                , subindexRef
                 , evalBinOp
                 , evalOperand
                 , vectorCopy, aggregateCopy_constLen
@@ -283,7 +282,7 @@ transConstVal ty tp cv = mirFail $
 --    * construct a reference to the global variable
 --      (with globalMirRef rather than constMirRef, that's the point of
 --      all this)
---    * apply subindexRef as above
+--    * apply mirRef_agElem
 --    * cons up the length
 --    * call mkStruct
 --    * cons up the final MirExp
@@ -396,7 +395,7 @@ staticSlicePlace len ty did = do
                     "staticSlicePlace: wrong type: expected aggregate, found " ++ show tpr_found
             ref <- globalMirRef gv
             elemSize <- tySizeM ty
-            ref' <- subindexRef tpr ref (R.App $ usizeLit 0) elemSize
+            ref' <- mirRef_agElem (R.App $ usizeLit 0) elemSize tpr ref
             let len' = R.App $ usizeLit $ fromIntegral len
             return $ MirPlace tpr ref' (SliceMeta len')
         Nothing -> mirFail $ "cannot find static variable " ++ fmt did
@@ -980,7 +979,7 @@ evalCast' ck ty1 e ty2  = do
         -> do
           Some tpr <- tyToReprM t1
           elemSize <- tySizeM t1
-          MirExp MirReferenceRepr <$> subindexRef tpr e' (R.App $ usizeLit 0) elemSize
+          MirExp MirReferenceRepr <$> mirRef_agElem (R.App $ usizeLit 0) elemSize tpr e'
 
       --  *const [u8] <-> *const str (no-ops)
       (M.Misc, M.TyRawPtr (M.TySlice (M.TyUint M.B8)) m1, M.TyRawPtr M.TyStr m2)
@@ -1162,7 +1161,7 @@ evalCast' ck ty1 e ty2  = do
         Some elem_tp <- tyToReprM ty
         let len   = R.App $ usizeLit (fromIntegral sz)
         elemSize <- tySizeM ty
-        ref' <- subindexRef elem_tp ref (R.App $ usizeLit 0) elemSize
+        ref' <- mirRef_agElem (R.App $ usizeLit 0) elemSize elem_tp ref
         let tup   = S.mkStruct mirSliceCtxRepr
                         (Ctx.Empty Ctx.:> ref' Ctx.:> len)
         return $ MirExp MirSliceRepr tup
@@ -1699,7 +1698,8 @@ evalPlaceProj ty (MirPlace tpr ref meta) (M.Index idxVar) = case (ty, tpr, meta)
         idx' <- getIdx idxVar
         Some elemTpr <- tyToReprM elemTy
         elemSize <- tySizeM elemTy
-        MirPlace elemTpr <$> subindexRef elemTpr ref idx' elemSize <*> pure NoMeta
+        let elemOff = R.App $ usizeMul idx' (R.App $ usizeLit $ fromIntegral elemSize)
+        MirPlace elemTpr <$> mirRef_agElem elemOff elemSize elemTpr ref <*> pure NoMeta
 
     (M.TySlice elemTy, elemTpr, SliceMeta len) -> do
         idx <- getIdx idxVar
@@ -1722,7 +1722,8 @@ evalPlaceProj ty (MirPlace tpr ref meta) (M.ConstantIndex idx _minLen fromEnd) =
         idx' <- getIdx idx (R.App $ usizeLit $ fromIntegral sz) fromEnd
         Some elemTpr <- tyToReprM elemTy
         elemSize <- tySizeM elemTy
-        MirPlace elemTpr <$> subindexRef elemTpr ref idx' elemSize <*> pure NoMeta
+        let elemOff = R.App $ usizeMul idx' (R.App $ usizeLit $ fromIntegral elemSize)
+        MirPlace elemTpr <$> mirRef_agElem elemOff elemSize elemTpr ref <*> pure NoMeta
 
     (M.TySlice elemTy, elemTpr, SliceMeta len) -> do
         idx' <- getIdx idx len fromEnd

--- a/crucible-mir/src/Mir/TransCustom.hs
+++ b/crucible-mir/src/Mir/TransCustom.hs
@@ -349,11 +349,10 @@ vector_as_slice_impl (Substs [t]) =
     Just $ CustomOp $ \_ ops -> case ops of
         [MirExp MirReferenceRepr e] -> do
             Some tpr <- tyToReprM t
-            elemSize <- tySizeM t
             -- This is similar to `&mut [T; n] -> &mut [T]` unsizing.
             v <- readMirRef (C.VectorRepr tpr) e
             let end = R.App $ vectorSizeUsize R.App v
-            e' <- subindexRef tpr e (R.App $ usizeLit 0) elemSize
+            e' <- mirRef_vecIndex (R.App $ usizeLit 0) tpr e
             let tup = S.mkStruct
                     (Ctx.Empty Ctx.:> MirReferenceRepr Ctx.:> knownRepr)
                     (Ctx.Empty Ctx.:> e' Ctx.:> end)

--- a/crucible-mir/src/Mir/TransCustom.hs
+++ b/crucible-mir/src/Mir/TransCustom.hs
@@ -768,7 +768,8 @@ intrinsics_copy = ( ["core", "intrinsics", "copy"], \substs -> case substs of
             (srcAg, srcIdx) <- mirRef_peelIndex src elemSize
             srcSnapAg <- readMirRef MirAggregateRepr srcAg
             srcSnapRoot <- constMirRef MirAggregateRepr srcSnapAg
-            srcSnap <- subindexRef elemTpr srcSnapRoot srcIdx elemSize
+            let srcElemOff = R.App $ usizeMul srcIdx (R.App $ usizeLit $ fromIntegral elemSize)
+            srcSnap <- mirRef_agElem srcElemOff elemSize elemTpr srcSnapRoot
 
             ptrCopy elemTpr srcSnap dest count elemSize
             MirExp MirAggregateRepr <$> mirAggregate_zst
@@ -1527,7 +1528,7 @@ slice_as_chunks_cast_hook_common mut = (["core", "slice", "{impl}", hookLoc, "cr
                 elemSize <- tySizeM elemTy
                 let chunkSize = elemSize * fromIntegral elemsPerChunk
                 arrayOfChunksPtr <- mirRef_aggregateAsChunks (R.App $ usizeLit $ fromIntegral chunkSize) numChunks elemPtr
-                firstChunkPtr <- subindexRef MirAggregateRepr arrayOfChunksPtr (R.App $ usizeLit 0) chunkSize
+                firstChunkPtr <- mirRef_agElem (R.App $ usizeLit 0) chunkSize MirAggregateRepr arrayOfChunksPtr
                 pure (MirExp MirReferenceRepr firstChunkPtr)
             _ -> mirFail $ "bad monomorphization of "
                 ++ Text.unpack hookLoc ++ "::crucible_cast_hook: "
@@ -1953,9 +1954,9 @@ allocate = (["crucible", "alloc", "allocate"], \substs -> case substs of
             ag <- mirAggregate_uninit agSize
             ref <- newMirRef MirAggregateRepr
             writeMirRef MirAggregateRepr ref ag
-            -- `subindexRef` doesn't do a bounds check (those happen on deref
+            -- `mirRef_agElem` doesn't do a bounds check (those happen on deref
             -- instead), so this works even when len is 0.
-            ptr <- subindexRef elemTpr ref (R.App $ usizeLit 0) elemSize
+            ptr <- mirRef_agElem (R.App $ usizeLit 0) elemSize elemTpr ref
             return $ MirExp MirReferenceRepr ptr
         _ -> mirFail $ "BUG: invalid arguments to allocate: " ++ show ops
     _ -> Nothing)
@@ -1971,7 +1972,7 @@ allocate_zeroed = (["crucible", "alloc", "allocate_zeroed"], \substs -> case sub
 
             ref <- newMirRef MirAggregateRepr
             writeMirRef MirAggregateRepr ref ag
-            ptr <- subindexRef elemTpr ref (R.App $ usizeLit 0) elemSize
+            ptr <- mirRef_agElem (R.App $ usizeLit 0) elemSize elemTpr ref
             return $ MirExp MirReferenceRepr ptr
         _ -> mirFail $ "BUG: invalid arguments to allocate: " ++ show ops
     _ -> Nothing)

--- a/crucible-mir/src/Mir/TransCustom.hs
+++ b/crucible-mir/src/Mir/TransCustom.hs
@@ -449,8 +449,7 @@ array_as_slice_impl (Substs [t]) =
           MirExp UsizeRepr start,
           MirExp UsizeRepr len ] -> do
             Some tpr <- tyToReprM t
-            elemSize <- tySizeM t
-            ptr <- subindexRef tpr e start elemSize
+            ptr <- mirRef_arrayIndex start tpr e
             return $ MirExp MirSliceRepr $ mkSlice ptr len
         _ -> mirFail $ "bad arguments for Array::as_slice: " ++ show ops
 array_as_slice_impl _ = Nothing


### PR DESCRIPTION
Remove the `MirSubindexRef` MIR intrinsic, and replace its uses with both new (`MirRef_ArrayIndex`, `MirRef_VecIndex`) and existing (`MirRef_AgElem`) allocation-specific indexing forms. This substitution ought to preserve existing indexing functionality.

This is possible because all current indexing occurs in places where we know whether the backing allocation is a `MirAggregate`, an `Array`, or a `Vector`, and it's desirable as a precursor to aggregate-flattening (#1499), because it avoids a potential issue with `Vector`s and/or `Array`s appearing in flattened aggregates. (In short, in a world where all aggregates are flattened and we have a reference to e.g. a `Vector` field within an aggregate, and want to access an element of the `Vector`, it turns out to be difficult to know that we need to extend that reference with the special `VectorIndex_RefPath` variant, rather than simply offsetting further forward in the aggregate on the assumption that the `Vector`'s elements have been flattened into the aggregate.)

This will require some small changes to SAW, which uses the indexing intrinsic this removes in a few places, but all such uses can be replaced with allocation-specific alternatives. I'll open a corresponding PR for that shortly.