### PR TITLE
`crucible-mir`: flattened `MirAggregate`s

### DIFF
--- a/crucible-mir-syntax/src/Lang/Crucible/MIR/Syntax.hs
+++ b/crucible-mir-syntax/src/Lang/Crucible/MIR/Syntax.hs
@@ -36,6 +36,7 @@ import Lang.Crucible.Syntax.Monad qualified as Parse
 
 import Mir.Intrinsics (MIR)
 import Mir.Intrinsics qualified as Mir
+import Mir.Mir (OpSize(..))
 
 -- | A 'ParserHooks' instance that adds no further extensions to the language.
 emptyParserHooks :: ParserHooks ext
@@ -61,6 +62,8 @@ mirParserHooks hooks =
 mirTypeParser :: MonadSyntax Atomic m => m (Some TypeRepr)
 mirTypeParser = Parse.describe "MIR type" $ do
   _ <- referenceTypeParser
+  -- XXX: if you're implementing parsing for `MirAggregateRepr`, please first
+  -- read Note [Reference operation sizes] below.
   pure (Some Mir.MirReferenceRepr)
 
 referenceTypeParser :: MonadSyntax Atomic m => m ()
@@ -96,7 +99,7 @@ mirAtomParser =
             Parse.isType
             (Parse.operands (Ctx.Empty Ctx.:> Mir.MirReferenceRepr))
         let (Ctx.Empty, ref) = Ctx.decompose assign
-        let stmt = Mir.MirReadRef tpr ref
+        let stmt = Mir.MirReadRef tpr opSize ref
         Some <$> Parse.freshAtom loc (Reg.EvalExt stmt)
 
       Atom.AtomName "ref-write" -> Parse.describe "MIR ref-write arguments" $ do
@@ -105,7 +108,7 @@ mirAtomParser =
           assign <- Parse.operands (Ctx.Empty Ctx.:> Mir.MirReferenceRepr Ctx.:> tpr)
           let (rest, val) = Ctx.decompose assign
           let (Ctx.Empty, ref) = Ctx.decompose rest
-          let stmt = Mir.MirWriteRef tpr ref val
+          let stmt = Mir.MirWriteRef tpr ref opSize val
           Some <$> Parse.freshAtom loc (Reg.EvalExt stmt)
 
       Atom.AtomName "ref-drop" -> Parse.describe "MIR ref-drop arguments" $ do
@@ -116,3 +119,23 @@ mirAtomParser =
         Some <$> Parse.freshAtom loc (Reg.EvalExt stmt)
 
       _ -> empty
+  where
+    {-
+    Note [Reference operation sizes]
+
+    Reference manipulation operations generally require the size of the type on
+    which they're operating, to account for the operation potentially taking
+    place within a `MirAggregate`, where the size of memory on which to operate
+    isn't otherwise obvious. `crucible-mir-syntax` isn't capable of expressing
+    aggregates or operations on them (see #1485), though - it only understands
+    introduction, read/write, and elimination of references to Crucible base
+    types, and we happen to know that these operations ignore their size
+    parameter for those types. So, instead of requiring that the user provide a
+    numeric size, we use the special `All` size.
+
+    This is fine for operations on base types, but if `crucible-mir-syntax` were
+    to support aggregate operations, it would need to also require numeric sizes
+    as arguments to `ref-{read,write}` operations, or implement special
+    `ref-{read,write}-sized` operations for aggregates in particular.
+    -}
+    opSize = All

--- a/crucible-mir-syntax/test-data/ref.out.good
+++ b/crucible-mir-syntax/test-data/ref.out.good
@@ -15,9 +15,9 @@ test-ref
   % 4:21
   $1 = bVLit(8, BV 42)
   % 5:5
-  $2 = writeMirRef $0 <- $1
+  $2 = writeMirRef <alloc> $0 <- $1
   % 6:19
-  $3 = readMirRef $0
+  $3 = readMirRef <alloc> $0
   % 7:14
   $4 = baseIsEq(BaseBVRepr 8, $1, $3)
   % 7:43

--- a/crucible-mir-syntax/test-data/ref.out.good
+++ b/crucible-mir-syntax/test-data/ref.out.good
@@ -15,9 +15,9 @@ test-ref
   % 4:21
   $1 = bVLit(8, BV 42)
   % 5:5
-  $2 = writeMirRef <alloc> $0 <- $1
+  $2 = writeMirRef <all> $0 <- $1
   % 6:19
-  $3 = readMirRef <alloc> $0
+  $3 = readMirRef <all> $0
   % 7:14
   $4 = baseIsEq(BaseBVRepr 8, $1, $3)
   % 7:43

--- a/crucible-mir/CHANGELOG.md
+++ b/crucible-mir/CHANGELOG.md
@@ -34,6 +34,16 @@ This release supports [version
   `Mir.Intrinsics.Reference.subindexMirRef{IO,Leaf,Sim}`), and migrate existing
   uses to allocation-specific intrinsics for aggregates, sybmolic arrays, and
   vectors (`Mir.Generator.{mirRef_agElem,mirRef_arrayIndex,mirRef_vecIndex}`).
+* Introduce an invariant that `MirAggregate`s are "flattened" - that is, that no
+  `MirAggregate` will contain an _immediate_ entry that is itself a
+  `MirAggregate`. See `Mir.Intrinsics.Aggregate.MirAggregate`'s documentation
+  for details.
+* Replace the `mirRef_agElem*` family of intrinsics with `mirRef_agOffset*`. The
+  latter represent generic, untyped byte offset operations into an aggregate.
+* Add type size parameters to several intrinsics, including those for reading
+  from/writing to references.
+* Remove the `mirRef_aggregateAsChunks*` family of intrinsics. The flattened
+  aggregate representation is rich enough that these became no-ops.
 
 # 0.6 -- 2026-01-29
 

--- a/crucible-mir/src/Mir/FancyMuxTree.hs
+++ b/crucible-mir/src/Mir/FancyMuxTree.hs
@@ -262,11 +262,16 @@ leafUpdatePartExpr bak mux x (PE q y) = do
             return $ mkPE pq xy
 
 -- | Like `leafUpdatePartExpr`, but instead of unconditionally writing a new
--- value, modify an already-existing value if one exists.
+-- value, modify an already-existing value, conditional on the current leaf
+-- being active.
 leafModifyPartExpr ::
     (IsSymBackend sym bak, MonadIO m) =>
     bak ->
     (Pred sym -> a -> a -> m a) ->
+    -- | If some value @v@ inhabits the leaf and its leaf predicate is true,
+    -- this will receive @Just v@. If no value inhabits the leaf, this will
+    -- receive @Nothing@. If the leaf predicate is known to be false, this will
+    -- not be called.
     (Maybe a -> m a) ->
     PartExpr (Pred sym) a ->
     MuxLeafT sym m (PartExpr (Pred sym) a)

--- a/crucible-mir/src/Mir/FancyMuxTree.hs
+++ b/crucible-mir/src/Mir/FancyMuxTree.hs
@@ -403,7 +403,7 @@ zipFancyMuxTrees' :: MonadAssert sym bak m =>
     FancyMuxTree sym a -> FancyMuxTree sym b -> m c
 zipFancyMuxTrees' bak f mux tx ty = zipFancyMuxTrees bak f mux tx ty >>= \my -> case my of
     Just y -> return y
-    Nothing -> liftIO $ addFailedAssertion bak $ GenericSimError $
+    Nothing -> maFail bak $ GenericSimError $
         "attempted to read empty mux tree"
 
 mergeFancyMuxTree :: (IsExprBuilder sym, OrdSkel a, MonadIO m) =>

--- a/crucible-mir/src/Mir/FancyMuxTree.hs
+++ b/crucible-mir/src/Mir/FancyMuxTree.hs
@@ -261,6 +261,30 @@ leafUpdatePartExpr bak mux x (PE q y) = do
             xy <- lift $ mux p x y
             return $ mkPE pq xy
 
+-- | Like `leafUpdatePartExpr`, but instead of unconditionally writing a new
+-- value, modify an already-existing value if one exists.
+leafModifyPartExpr ::
+    (IsSymBackend sym bak, MonadIO m) =>
+    bak ->
+    (Pred sym -> a -> a -> m a) ->
+    (Maybe a -> m a) ->
+    PartExpr (Pred sym) a ->
+    MuxLeafT sym m (PartExpr (Pred sym) a)
+leafModifyPartExpr _bak _mux modify Unassigned =
+    mkPE <$> leafPredicate <*> lift (modify Nothing)
+leafModifyPartExpr bak mux modify (PE oldPred oldVal) = do
+    let sym = backendGetSym bak
+    currPred <- leafPredicate
+    case asConstantPred currPred of
+        Just True -> mkPE (truePred sym) <$> lift (modify (Just oldVal))
+        Just False -> return $ PE oldPred oldVal
+        Nothing -> do
+            newPred <- liftIO $ orPred sym currPred oldPred
+            muxed <- lift $ do
+                newVal <- modify (Just oldVal)
+                mux currPred newVal oldVal
+            return $ mkPE newPred muxed
+
 -- | Set a PartExpr to Unassigned, conditional on the current leaf being
 -- active.
 leafClearPartExpr :: (IsSymBackend sym bak, MonadIO m) =>

--- a/crucible-mir/src/Mir/Generator.hs
+++ b/crucible-mir/src/Mir/Generator.hs
@@ -725,14 +725,6 @@ mirRef_peelIndex ref elemSize = do
     pair <- G.extensionStmt $ MirRef_PeelIndex ref elemSize
     return (S.getStruct i1of2 pair, S.getStruct i2of2 pair)
 
-mirRef_aggregateAsChunks ::
-  R.Expr MIR s UsizeType ->
-  R.Expr MIR s UsizeType ->
-  R.Expr MIR s MirReferenceType ->
-  MirGenerator h s ret (R.Expr MIR s MirReferenceType)
-mirRef_aggregateAsChunks chunkSize numChunks ref =
-    G.extensionStmt $ MirRef_AggregateAsChunks chunkSize numChunks ref
-
 debugPrintMirRef ::
   String ->
   R.Expr MIR s MirReferenceType ->

--- a/crucible-mir/src/Mir/Generator.hs
+++ b/crucible-mir/src/Mir/Generator.hs
@@ -603,9 +603,11 @@ dropMirRef refExp = void $ G.extensionStmt (MirDropRef refExp)
 
 readMirRef ::
   C.TypeRepr tp ->
+  -- | The size of the value to read.
+  OpSize ->
   R.Expr MIR s MirReferenceType ->
   MirGenerator h s ret (R.Expr MIR s tp)
-readMirRef tp refExp = G.extensionStmt (MirReadRef tp refExp)
+readMirRef tp tySize refExp = G.extensionStmt (MirReadRef tp tySize refExp)
 
 writeMirRef ::
   C.TypeRepr tp ->

--- a/crucible-mir/src/Mir/Generator.hs
+++ b/crucible-mir/src/Mir/Generator.hs
@@ -639,12 +639,6 @@ subjustRef ::
   MirGenerator h s ret (R.Expr MIR s MirReferenceType)
 subjustRef tp ref = G.extensionStmt (MirSubjustRef tp ref)
 
-mirRef_agElem_unsized ::
-  R.Expr MIR s UsizeType ->
-  R.Expr MIR s MirReferenceType ->
-  MirGenerator h s ret (R.Expr MIR s MirReferenceType)
-mirRef_agElem_unsized off ref = G.extensionStmt $ MirRef_AgElem_Unsized off ref
-
 mirRef_agOffset ::
   R.Expr MIR s UsizeType ->
   R.Expr MIR s MirReferenceType ->

--- a/crucible-mir/src/Mir/Generator.hs
+++ b/crucible-mir/src/Mir/Generator.hs
@@ -662,6 +662,12 @@ mirRef_agElem_unsized ::
   MirGenerator h s ret (R.Expr MIR s MirReferenceType)
 mirRef_agElem_unsized off ref = G.extensionStmt $ MirRef_AgElem_Unsized off ref
 
+mirRef_agOffset ::
+  R.Expr MIR s UsizeType ->
+  R.Expr MIR s MirReferenceType ->
+  MirGenerator h s ret (R.Expr MIR s MirReferenceType)
+mirRef_agOffset off ref = G.extensionStmt $ MirRef_AgOffset off ref
+
 -- | Index into a symbolic @crucible::array::Array<T>@ (_not_ a @[T; N]@)
 mirRef_arrayIndex ::
   R.Expr MIR s UsizeType ->

--- a/crucible-mir/src/Mir/Generator.hs
+++ b/crucible-mir/src/Mir/Generator.hs
@@ -612,9 +612,11 @@ readMirRef tp tySize refExp = G.extensionStmt (MirReadRef tp tySize refExp)
 writeMirRef ::
   C.TypeRepr tp ->
   R.Expr MIR s MirReferenceType ->
+  -- | The size of the value to write.
+  OpSize ->
   R.Expr MIR s tp ->
   MirGenerator h s ret ()
-writeMirRef tp ref x = void $ G.extensionStmt (MirWriteRef tp ref x)
+writeMirRef tp ref writeSize x = void $ G.extensionStmt (MirWriteRef tp ref writeSize x)
 
 subfieldRef ::
   C.CtxRepr ctx ->

--- a/crucible-mir/src/Mir/Generator.hs
+++ b/crucible-mir/src/Mir/Generator.hs
@@ -639,23 +639,6 @@ subjustRef ::
   MirGenerator h s ret (R.Expr MIR s MirReferenceType)
 subjustRef tp ref = G.extensionStmt (MirSubjustRef tp ref)
 
-mirRef_agElem ::
-  R.Expr MIR s UsizeType ->
-  Word ->
-  C.TypeRepr tp ->
-  R.Expr MIR s MirReferenceType ->
-  MirGenerator h s ret (R.Expr MIR s MirReferenceType)
-mirRef_agElem off sz tpr ref = G.extensionStmt $ MirRef_AgElem off sz tpr ref
-
-mirRef_agElem_constOffset ::
-  Word ->
-  Word ->
-  C.TypeRepr tp ->
-  R.Expr MIR s MirReferenceType ->
-  MirGenerator h s ret (R.Expr MIR s MirReferenceType)
-mirRef_agElem_constOffset off sz tpr ref =
-  mirRef_agElem (R.App $ usizeLit $ fromIntegral off) sz tpr ref
-
 mirRef_agElem_unsized ::
   R.Expr MIR s UsizeType ->
   R.Expr MIR s MirReferenceType ->

--- a/crucible-mir/src/Mir/Generator.hs
+++ b/crucible-mir/src/Mir/Generator.hs
@@ -645,6 +645,12 @@ mirRef_agOffset ::
   MirGenerator h s ret (R.Expr MIR s MirReferenceType)
 mirRef_agOffset off ref = G.extensionStmt $ MirRef_AgOffset off ref
 
+mirRef_agOffset_const ::
+  Word ->
+  R.Expr MIR s MirReferenceType ->
+  MirGenerator h s ret (R.Expr MIR s MirReferenceType)
+mirRef_agOffset_const off ref = mirRef_agOffset (R.App $ usizeLit $ fromIntegral off) ref
+
 -- | Index into a symbolic @crucible::array::Array<T>@ (_not_ a @[T; N]@)
 mirRef_arrayIndex ::
   R.Expr MIR s UsizeType ->

--- a/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
@@ -68,12 +68,13 @@ import GHC.TypeLits
     TypeError,
   )
 
-import Control.Monad (foldM, forM, forM_, liftM, when)
+import Control.Monad (foldM, forM, forM_, liftM, unless, when)
 import Control.Monad.Except (MonadError (..), runExceptT, throwError)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Trans (lift)
 
 import Data.BitVector.Sized qualified as BV
+import Data.Either (fromRight)
 import Data.IntMap (IntMap)
 import Data.IntMap qualified as IntMap
 import Data.Kind (Type)
@@ -104,7 +105,7 @@ import Lang.Crucible.Types
   )
 
 import What4.Concrete (fromConcreteBV)
-import What4.Interface (IsExprBuilder (..), Pred, SymExpr, asAffineVar, asBV)
+import What4.Interface (IsExprBuilder (..), Pred, SymExpr, asAffineVar, asBV, asConstantPred)
 import What4.Partial (PartExpr, justPartExpr, mergePartial, pattern PE, pattern Unassigned)
 
 import Mir.FancyMuxTree
@@ -116,7 +117,7 @@ import Mir.FancyMuxTree
     subMuxLeafMA,
   )
 import Mir.Intrinsics.Size (UsizeType, wordLit)
-import Mir.Mir (OpSize)
+import Mir.Mir (OpSize (..))
 
 --------------------------------------------------------------
 -- A MirAggregateType is a collection of elements of any type, with each entry
@@ -293,6 +294,8 @@ readMirAggregateWithSymOffset ::
   MirAggregate sym ->
   MuxLeafT sym m (RegValue sym tp)
 readMirAggregateWithSymOffset bak iteFn off readSize tpr ag@(MirAggregate totalSize m)
+  | MirAggregateRepr <- tpr =
+      readSubaggregateWithSymOffset bak iteFn readSize off ag
   | Just (fromIntegral . BV.asUnsigned -> off') <- asBV off = do
       case IntMap.lookup off' m of
         Nothing -> leafAbort $ agNoValueAtOffsetSimError off' totalSize
@@ -333,6 +336,39 @@ readMirAggregateWithSymOffset bak iteFn off readSize tpr ag@(MirAggregate totalS
     offsetLit = wordLit sym
     iteFn' = liftIteFnMaybe sym tpr iteFn
 
+readSubaggregateWithSymOffset ::
+  forall sym bak m.
+  MonadAssert sym bak m =>
+  bak ->
+  (Pred sym -> MirAggregate sym -> MirAggregate sym -> IO (MirAggregate sym)) ->
+  OpSize ->
+  RegValue sym UsizeType ->
+  MirAggregate sym ->
+  MuxLeafT sym m (MirAggregate sym)
+readSubaggregateWithSymOffset bak iteFn readSize off ag@(MirAggregate sz _)
+  | Just (fromIntegral . BV.asUnsigned -> off') <- asBV off = do
+      let err e = leafAbort $ GenericSimError $ "readSubaggregateWithSymOffset: " <> e
+      either err pure (readConcrete off' ag)
+  | otherwise = do
+      liftIO $ foldM
+        (\ag' candidateOff -> do
+          isTheOffset <- bvEq sym off =<< offsetLit candidateOff
+          iteFn isTheOffset (fromRight ag' $ readConcrete candidateOff ag') ag')
+        ag
+        (init [0 .. sz])
+  where
+    snd3 (_, x, _) = x
+    sym = backendGetSym bak
+    offsetLit = wordLit sym
+
+    readConcrete off' ag' = do
+      case readSize of
+        All ->
+          snd <$> mirAggregate_split off' ag'
+        Width width ->
+          snd3 <$> mirAggregate_split3 off' (off' + width) ag'
+
+
 adjustMirAggregateWithSymOffset ::
   forall sym bak tp.
   (IsSymBackend sym bak) =>
@@ -344,6 +380,8 @@ adjustMirAggregateWithSymOffset ::
   MirAggregate sym ->
   MuxLeafT sym IO (MirAggregate sym)
 adjustMirAggregateWithSymOffset bak iteFn off tpr f ag@(MirAggregate totalSize m)
+  | MirAggregateRepr <- tpr =
+      adjustSubaggregateWithSymOffset bak iteFn off f ag
   | Just (fromIntegral . BV.asUnsigned -> off') <- asBV off = do
       MirAggregateEntry sz tpr' rvPart <- case IntMap.lookup off' m of
         Just x -> return x
@@ -398,6 +436,46 @@ adjustMirAggregateWithSymOffset bak iteFn off tpr f ag@(MirAggregate totalSize m
     offsetLit = wordLit sym
     iteFn' = liftIteFnMaybe sym tpr iteFn
 
+adjustSubaggregateWithSymOffset ::
+  forall sym bak.
+  (IsSymBackend sym bak) =>
+  bak ->
+  (Pred sym -> MirAggregate sym -> MirAggregate sym -> IO (MirAggregate sym)) ->
+  RegValue sym UsizeType ->
+  (MirAggregate sym -> MuxLeafT sym IO (MirAggregate sym)) ->
+  MirAggregate sym ->
+  MuxLeafT sym IO (MirAggregate sym)
+adjustSubaggregateWithSymOffset bak iteFn off f ag@(MirAggregate sz _)
+  | Just (fromIntegral . BV.asUnsigned -> off') <- asBV off =
+      adjustConcrete off'
+  | otherwise = do
+      foldM
+        (\ag' candidateOff -> do
+          isTheOffset <- liftIO $ bvEq sym off =<< offsetLit candidateOff
+          subAg <- adjustConcrete candidateOff
+          liftIO $ iteFn isTheOffset subAg ag')
+        ag
+        (init [0 .. sz])
+  where
+    adjustConcrete off' = do
+      case mirAggregate_split off' ag of
+        Right (MirAggregate leftSz leftAg, r@(MirAggregate rightSz _rightAg)) -> do
+          MirAggregate rightSz' rightAg' <- f r
+          let rightAg'' = IntMap.mapKeysMonotonic (\o -> o + fromIntegral off') rightAg'
+          when (rightSz /= rightSz') $
+            panic "adjustSubaggregateWithSymOffset"
+              [ "adjusting function changed aggregate size"
+              , "was " <> show rightSz <> ", became " <> show rightSz'
+              ]
+          unless (IntMap.disjoint leftAg rightAg'') $
+            panic "adjustSubaggregateWithSymOffset"
+              [ "aggregates weren't disjoint" ]
+          pure $ MirAggregate (leftSz + rightSz) (rightAg'' <> leftAg)
+        Left err -> leafAbort $ GenericSimError $
+          "adjustSubaggregateWithSymOffset: " <> err
+
+    sym = backendGetSym bak
+    offsetLit = wordLit sym
 
 -- | Given a list of valid entry spans @(fromOffset, toOffset)@ in this
 -- aggregate, create a predicate that the provided offset appears among their
@@ -565,11 +643,39 @@ mirAggregate_entries :: sym -> MirAggregate sym -> [(Word, MirAggregateEntry sym
 mirAggregate_entries _sym (MirAggregate _totalSize m) =
   [(fromIntegral off, entry) | (off, entry) <- IntMap.toList m]
 
+foldMWithKey :: Monad m => (b -> Int -> a -> m b) -> b -> IntMap a -> m b
+foldMWithKey f z m = IntMap.foldlWithKey' f' (pure z) m
+  where
+    f' accM key val = do
+      acc <- accM
+      f acc key val
+
 mirAggregate_insert ::
+  (IsSymInterface sym) =>
   Word ->
   MirAggregateEntry sym ->
   MirAggregate sym ->
   Either String (MirAggregate sym)
+mirAggregate_insert outerAgOff (MirAggregateEntry entrySz MirAggregateRepr entryP) outerAg = case entryP of
+  Unassigned -> pure outerAg
+  PE p (MirAggregate innerAgSz innerAgEntries) -> case asConstantPred p of
+    _ | innerAgSz /= entrySz -> Left $
+      "mirAggregate_insert: when adding a `MirAggregate` as an entry, " <>
+      "the `MirAggregateEntry`-derived size was " <> show entrySz <> ", " <>
+      "but the `MirAggregate` value had size " <> show innerAgSz
+    Just False ->
+      pure outerAg
+    Just True -> do
+      let addEntry ag (fromIntegral -> entryOff) entry =
+            mirAggregate_insert (outerAgOff + entryOff) entry ag
+      foldMWithKey addEntry outerAg innerAgEntries
+    -- Note: this case doesn't seem to show up in practice, but if it does,
+    -- consider lifting this function to a monadic context in which it can
+    -- manipulate predicates, so that it can add entries the conjunction of
+    -- their own individual predicates and the overarching entry's predicate,
+    -- `entryP`.
+    Nothing -> Left $
+      "mirAggregate_insert: unsupported: `MirAggregate` as entry with symbolic predicate"
 mirAggregate_insert off entry@(MirAggregateEntry sz tpr _) (MirAggregate totalSize m) = do
   -- For now, we require that either there are no entries overlapping the byte
   -- range `off .. off + sz`, or there is an entry covering exactly that range
@@ -943,6 +1049,10 @@ mirAggregate_getIO ::
     TypeRepr tp ->
     MirAggregate sym ->
     IO (RegValue sym tp)
+mirAggregate_getIO bak off sz MirAggregateRepr ag =
+  case mirAggregate_split3 off (off + sz) ag of
+    Right (_toLeft, mid, _toRight) -> pure mid
+    Left err -> addFailedAssertion bak $ GenericSimError $ "mirAggregate_getIO: " <> err
 mirAggregate_getIO bak off sz tpr (MirAggregate _ m) = do
   -- TODO: deduplicate logic between this and readMirAg* concrete case?
   MirAggregateEntry sz' tpr' rvPart <- case IntMap.lookup (fromIntegral off) m of

--- a/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
@@ -116,6 +116,7 @@ import Mir.FancyMuxTree
     subMuxLeafMA,
   )
 import Mir.Intrinsics.Size (UsizeType, wordLit)
+import Mir.Mir (OpSize)
 
 --------------------------------------------------------------
 -- A MirAggregateType is a collection of elements of any type, with each entry
@@ -287,10 +288,11 @@ readMirAggregateWithSymOffset ::
   bak ->
   (Pred sym -> RegValue sym tp -> RegValue sym tp -> IO (RegValue sym tp)) ->
   RegValue sym UsizeType ->
+  OpSize ->
   TypeRepr tp ->
   MirAggregate sym ->
   MuxLeafT sym m (RegValue sym tp)
-readMirAggregateWithSymOffset bak iteFn off tpr ag@(MirAggregate totalSize m)
+readMirAggregateWithSymOffset bak iteFn off readSize tpr ag@(MirAggregate totalSize m)
   | Just (fromIntegral . BV.asUnsigned -> off') <- asBV off = do
       case IntMap.lookup off' m of
         Nothing -> leafAbort $ agNoValueAtOffsetSimError off' totalSize

--- a/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
@@ -48,9 +48,7 @@ module Mir.Intrinsics.Aggregate
     mirAggregate_split,
     mirAggregate_split3,
     mirAggregate_chunk,
-    mirAggregate_toChunks,
     mirAggregate_concat,
-    mirAggregate_fromChunks,
     concreteAllocSize,
     mirAggregate_uninitIO,
     mirAggregate_zstSim,
@@ -68,8 +66,7 @@ import GHC.TypeLits
     TypeError,
   )
 
-import Control.Monad (foldM, forM, forM_, liftM, unless, when)
-import Control.Monad.Except (MonadError (..), runExceptT, throwError)
+import Control.Monad (foldM, forM, unless, when)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Trans (lift)
 
@@ -106,7 +103,7 @@ import Lang.Crucible.Types
 
 import What4.Concrete (fromConcreteBV)
 import What4.Interface (IsExprBuilder (..), Pred, SymExpr, asAffineVar, asBV, asConstantPred)
-import What4.Partial (PartExpr, justPartExpr, mergePartial, pattern PE, pattern Unassigned)
+import What4.Partial (justPartExpr, mergePartial, pattern PE, pattern Unassigned)
 
 import Mir.FancyMuxTree
   ( MonadAssert,
@@ -868,26 +865,6 @@ mirAggregate_chunk off chunkSize ag@(MirAggregate totalSize _) = do
   (_, chunkAg, _) <- mirAggregate_split3 off (off + chunkSize) ag
   return chunkAg
 
--- | Split a `MirAggregate` into an array of equal-sized chunks.
-mirAggregate_toChunks ::
-  IsSymInterface sym =>
-  sym ->
-  -- | Starting offset within the input aggregate
-  Word ->
-  -- | Size in bytes of each chunk
-  Word ->
-  -- | Number of chunks to produce
-  Word ->
-  -- | Input aggregate
-  MirAggregate sym ->
-  Either String (MirAggregate sym)
-mirAggregate_toChunks sym off chunkSize numChunks ag = do
-  entries <- forM (init [0 .. numChunks]) $ \i -> do
-    chunk <- mirAggregate_chunk (off + i * chunkSize) chunkSize ag
-    return (fromIntegral $ i * chunkSize,
-      MirAggregateEntry chunkSize MirAggregateRepr (justPartExpr sym chunk))
-  return $ MirAggregate (numChunks * chunkSize) (IntMap.fromAscList entries)
-
 -- | Concatenate two `MirAggregate`s, producing a new aggregate with all the
 -- entries of the first followed by all the entries of the second.  The entries
 -- of the second aggregate are offset by the size of the first.
@@ -898,91 +875,6 @@ mirAggregate_concat ::
 mirAggregate_concat (MirAggregate totalSize1 m1) (MirAggregate totalSize2 m2) =
   let m' = m1 <> IntMap.mapKeysMonotonic (+ fromIntegral totalSize1) m2
   in MirAggregate (totalSize1 + totalSize2) m'
-
--- | Merge an array of chunks into a single `MirAggregate`.  Each entry of
--- the input aggregate should be a `MirAggregate`; the entries of that
--- sub-aggregate will be placed in the output starting at an offset computed
--- from the offset of the sub-aggregate.  Returns `Left` if some aggregates in
--- the input would cover overlapping ranges.
---
--- Returns `Left` if any of the sub-aggregates has a zero-sized entry at the
--- end of its range (i.e. with @off == totalSize@).  This check can be removed
--- once we properly enforce the invariant that `MirAggregate`s must not contain
--- zero-sized entries.
-mirAggregate_fromChunks ::
-  forall sym.
-  IsSymInterface sym =>
-  sym ->
-  -- | Input aggregate
-  MirAggregate sym ->
-  IO (Either String (MirAggregate sym))
-mirAggregate_fromChunks sym chunkedAg@(MirAggregate chunkedTotalSize _) = runExceptT $ do
-  let chunkedEntries = mirAggregate_entries sym chunkedAg
-  -- For each initialized chunk, we collect:
-  -- 1. The offset of the chunk within the outer aggregate
-  -- 2. The "outer size" of the chunk, meaning the size of its entry within the
-  --    outer aggregate
-  -- 3. The predicate under which the chunk is initialized (each chunk, like
-  --    any aggregate entry, may be conditionally uninitialized)
-  -- 4. The map of offsets and entries within the aggrgegate.
-  chunkParts <- do
-    let f :: MonadError String m => (Word, MirAggregateEntry sym) ->
-          m (Maybe (Word, Word, Pred sym, IntMap (MirAggregateEntry sym)))
-        f (off, MirAggregateEntry chunkEntrySize tpr rv) = do
-          case tpr of
-            MirAggregateRepr ->
-              case rv of
-                Unassigned -> return Nothing
-                PE outerPred (MirAggregate chunkAgSize m) ->
-                  if chunkEntrySize /= chunkAgSize
-                    then panic "mirAggregate_fromChunks"
-                          ["chunk entry size " <> show chunkEntrySize <> " does not match its aggregate's size " <> show chunkAgSize ]
-                    else return $ Just (off, chunkAgSize, outerPred, m)
-            _ -> throwError $
-              "expected all chunks to be MirAggregateRepr, but got " ++ show tpr
-                ++ " (size " ++ show chunkEntrySize ++ ") at offset " ++ show off
-    liftM Maybe.catMaybes $ mapM f chunkedEntries
-
-  -- Check for disjointness.  `chunkParts` is sorted by starting offset, so we
-  -- can just compare pairs of consecutive elements.
-  forM_ (zip chunkParts (Prelude.drop 1 chunkParts)) $
-    \((off1, sz1, _, _), (off2, sz2, _, _)) -> do
-      when (off1 > off2 || off2 - off1 < sz1) $ panic "mirAggregate_fromChunks"
-        [ "overlapping chunks"
-        , "at " ++ show off1 ++ " .. " ++ show (off1 + sz1)
-        , "and " ++ show off2 ++ " .. " ++ show (off2 + sz2)
-        ]
-
-  ms <- forM chunkParts $ \(off, sz, outerPred, m) -> do
-    -- Check that there are no zero-sized entries at the end.
-    when (IntMap.member (fromIntegral sz) m) $ throwError $
-      "unsupported zero-sized entry at chunk end, in chunk at " ++ show off
-
-    -- Check that the chunk doesn't extend past the expected end of the
-    -- combined aggregate.
-    let start = off
-    let end = start + sz
-    when (end > chunkedTotalSize) $ throwError $
-      "chunk at " ++ show off ++ " extends past end: covers "
-        ++ show start ++ " .. " ++ show end
-        ++ " in output of size " ++ show chunkedTotalSize
-
-    -- Entries within each aggregate are valid only if the outer aggregate is
-    -- itself valid.
-    let restrictPred :: MonadIO m => PartExpr (Pred sym) a ->
-          m (PartExpr (Pred sym) a)
-        restrictPred Unassigned = return Unassigned
-        restrictPred (PE innerPred rv) = do
-          restrictedPred <- liftIO $ andPred sym outerPred innerPred
-          return $ PE restrictedPred rv
-    m' <- forM m $ \(MirAggregateEntry sz' tpr rv) ->
-      MirAggregateEntry sz' tpr <$> restrictPred rv
-
-    -- Adjust offsets.
-    return $ IntMap.mapKeysMonotonic (+ fromIntegral start) m'
-
-  let combinedM = mconcat ms
-  return $ MirAggregate chunkedTotalSize combinedM
 
 concreteAllocSize ::
     IsSymBackend sym bak =>

--- a/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
@@ -913,11 +913,17 @@ mirAggregate_replicateIO bak elemSz elemTpr elemVal lenSym = do
   let sym = backendGetSym bak
   len <- concreteAllocSize bak lenSym
   let totalSize = fromIntegral len * elemSz
+  let ag = MirAggregate totalSize mempty
   let entries =
-        [(fromIntegral i * fromIntegral elemSz,
+        [(fromIntegral i * elemSz,
           MirAggregateEntry elemSz elemTpr (justPartExpr sym elemVal))
         | i <- init [0 .. len]]
-  return $ MirAggregate totalSize (IntMap.fromAscList entries)
+  let insert ag' (off, entry) = mirAggregate_insert off entry ag'
+  case foldM insert ag entries of
+    Right ag' ->
+      pure ag'
+    Left err ->
+      addFailedAssertion bak $ GenericSimError $ "mirAggregate_replicateIO: " <> err
 
 mirAggregate_resizeIO ::
     IsSymBackend sym bak =>

--- a/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
@@ -66,7 +66,7 @@ import GHC.TypeLits
     TypeError,
   )
 
-import Control.Monad (foldM, forM, unless, when)
+import Control.Monad (foldM, forM, when)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Trans (lift)
 
@@ -455,7 +455,7 @@ adjustSubaggregateWithSymOffset ::
   OpSize ->
   MirAggregate sym ->
   MuxLeafT sym IO (MirAggregate sym)
-adjustSubaggregateWithSymOffset bak iteFn off f adjSize ag@(MirAggregate sz _)
+adjustSubaggregateWithSymOffset bak iteFn off f adjSize ag@(MirAggregate agSize _)
   | Just (fromIntegral . BV.asUnsigned -> off') <- asBV off =
       adjustConcrete off'
   | otherwise = do
@@ -465,27 +465,34 @@ adjustSubaggregateWithSymOffset bak iteFn off f adjSize ag@(MirAggregate sz _)
           subAg <- adjustConcrete candidateOff
           liftIO $ iteFn isTheOffset subAg ag')
         ag
-        (init [0 .. sz])
+        (init [0 .. agSize])
   where
     adjustConcrete off' = do
-      case mirAggregate_split off' ag of
-        Right (MirAggregate leftSz leftAg, r@(MirAggregate rightSz _rightAg)) -> do
-          MirAggregate rightSz' rightAg' <- f r
-          let rightAg'' = IntMap.mapKeysMonotonic (\o -> o + fromIntegral off') rightAg'
-          when (rightSz /= rightSz') $
-            panic "adjustSubaggregateWithSymOffset"
-              [ "adjusting function changed aggregate size"
-              , "was " <> show rightSz <> ", became " <> show rightSz'
-              ]
-          unless (IntMap.disjoint leftAg rightAg'') $
-            panic "adjustSubaggregateWithSymOffset"
-              [ "aggregates weren't disjoint" ]
-          pure $ MirAggregate (leftSz + rightSz) (rightAg'' <> leftAg)
-        Left err -> leafAbort $ GenericSimError $
-          "adjustSubaggregateWithSymOffset: " <> err
+      let sz = case adjSize of All -> agSize - off'; Width w -> w
+
+      adjAg@(MirAggregate adjAgSz _) <- case mirAggregate_chunk off' sz ag of
+        Right a -> pure a
+        Left err -> die err
+
+      adjAg'@(MirAggregate adjAgSz' _) <- f adjAg
+      when (adjAgSz /= adjAgSz') $
+        panic "adjustSubaggregateWithSymOffset"
+          [ "adjusting function changed aggregate size"
+          , "was " <> show adjAgSz <> ", became " <> show adjAgSz'
+          ]
+
+      ag' <- case mirAggregate_clear (Just off') (Just $ off' + sz) ag of
+        Right a -> pure a
+        Left err -> die err
+      let adjAgEntry = MirAggregateEntry adjAgSz' MirAggregateRepr (justPartExpr sym adjAg')
+      case mirAggregate_insert off' adjAgEntry ag' of
+        Right a -> pure a
+        Left err -> die err
 
     sym = backendGetSym bak
     offsetLit = wordLit sym
+    die err =
+      leafAbort $ GenericSimError $ "adjustSubaggregateWithSymOffset: " <> err
 
 -- | Given a list of valid entry spans @(fromOffset, toOffset)@ in this
 -- aggregate, create a predicate that the provided offset appears among their
@@ -885,6 +892,44 @@ mirAggregate_chunk off chunkSize ag@(MirAggregate totalSize _) = do
       ++ " is too big for aggregate of size " ++ show totalSize
   (_, chunkAg, _) <- mirAggregate_split3 off (off + chunkSize) ag
   return chunkAg
+
+-- | Remove all entries between the given offsets in the aggregate. This will
+-- return an error if an entry overlaps one of the given offsets.
+--
+-- - @mirAggregate_clear (Just off1) (Just off2)@: remove entries starting at or
+--   after offset @off1@ and ending at or before offset @off2@
+-- - @mirAggregate_clear (Just off1) Nothing@: remove all entries starting at or
+--   after offset @off1@
+-- - @mirAggregate_clear Nothing (Just off2)@: remove entries ending at or
+--   before offset @off2@
+-- - @mirAggregate_clear Nothing Nothing@: remove all entries
+mirAggregate_clear ::
+  Maybe Word ->
+  Maybe Word ->
+  MirAggregate sym ->
+  Either String (MirAggregate sym)
+mirAggregate_clear fromM toM (MirAggregate sz entries) = do
+  let from = Maybe.fromMaybe 0 fromM
+  let to = Maybe.fromMaybe sz toM
+
+  let keep (fromIntegral -> eOff) (MirAggregateEntry eSz _ _) =
+        eOff >= to || eOff + eSz <= from
+  let entries' = IntMap.filterWithKey keep entries
+
+  failOnOverlap "left" from entries'
+  failOnOverlap "right" to entries'
+
+  pure (MirAggregate sz entries')
+  where
+    failOnOverlap boundaryKind boundaryOff entries' =
+      case IntMap.lookupLT (fromIntegral boundaryOff) entries' of
+        Just (fromIntegral -> eOff, MirAggregateEntry eSz _ _)
+          | eOff + eSz > boundaryOff ->
+            Left $
+              "mirAggregate_clear: " <>
+              boundaryKind <> " boundary " <> show boundaryOff <>
+              " splits entry at " <> show eOff <> ".." <> show (eOff + eSz)
+        _ -> pure ()
 
 -- | Concatenate two `MirAggregate`s, producing a new aggregate with all the
 -- entries of the first followed by all the entries of the second.  The entries

--- a/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
@@ -356,6 +356,16 @@ readSubaggregateWithSymOffset bak iteFn readSize off ag@(MirAggregate agSize _)
   | Just (fromIntegral . BV.asUnsigned -> off') <- asBV off =
     readConcrete off'
   | otherwise = do
+      -- Do some static winnowing of the offsets we need to check. Don't try to
+      -- read at an offset if:
+      -- - There isn't a large enough sub-aggregate starting at that offset
+      -- - Extracting a sub-aggregate starting at that offset would split an
+      --   aggregate entry
+      let sizedAgOffsets = case readSize of
+            All -> init [0 .. agSize] -- not sure this `init` is necessary...
+            Width w -> [0 .. agSize - w]
+      let nonSplittingAgOffsets = filter (not . offsetSplitsEntry ag) sizedAgOffsets
+
       -- We're muxing together reads of sub-aggregates starting at each possible
       -- offset in `ag`. If a read operation (via `readConcrete`) at a given
       -- candidate offset fails, we'll assert that that offset wasn't equal to
@@ -369,7 +379,7 @@ readSubaggregateWithSymOffset bak iteFn readSize off ag@(MirAggregate agSize _)
             Just subAg -> liftIO $ iteFn' isTheOffset (justPartExpr sym subAg) origAgP
             Nothing -> pure origAgP)
         Unassigned
-        (init [0 .. agSize])
+        nonSplittingAgOffsets
 
       -- We've used `Unassigned` as the base case for the above mux so we'll be
       -- left with `Unassigned` in failure cases, and can propagate that error
@@ -475,6 +485,16 @@ adjustSubaggregateWithSymOffset bak iteFn off f adjSize ag@(MirAggregate agSize 
   | Just (fromIntegral . BV.asUnsigned -> off') <- asBV off =
       adjustConcrete off'
   | otherwise = do
+      -- Do some static winnowing of the offsets we need to check. Don't try to
+      -- read at an offset if:
+      -- - There isn't a large enough sub-aggregate starting at that offset
+      -- - Extracting a sub-aggregate starting at that offset would split an
+      --   aggregate entry
+      let sizedAgOffsets = case adjSize of
+            All -> init [0 .. agSize] -- not sure this `init` is necessary...
+            Width w -> [0 .. agSize - w]
+      let nonSplittingAgOffsets = filter (not . offsetSplitsEntry ag) sizedAgOffsets
+
       foldM
         (\origAg candidateOff -> do
           isTheOffset <- liftIO $ bvEq sym off =<< offsetLit candidateOff
@@ -483,7 +503,7 @@ adjustSubaggregateWithSymOffset bak iteFn off f adjSize ag@(MirAggregate agSize 
             Just adjustedAg -> liftIO $ iteFn isTheOffset adjustedAg origAg
             Nothing -> pure origAg)
         ag
-        (init [0 .. agSize])
+        nonSplittingAgOffsets
   where
     adjustConcrete off' = do
       let sz = case adjSize of All -> agSize - off'; Width w -> w
@@ -948,6 +968,15 @@ mirAggregate_clear fromM toM (MirAggregate sz entries) = do
               boundaryKind <> " boundary " <> show boundaryOff <>
               " splits entry at " <> show eOff <> ".." <> show (eOff + eSz)
         _ -> pure ()
+
+-- | Does this offset occur in the middle of an entry in this aggregate?
+offsetSplitsEntry :: MirAggregate sym -> Word -> Bool
+offsetSplitsEntry (MirAggregate _ entries) off =
+  case IntMap.lookupLT (fromIntegral off) entries of
+    Just (fromIntegral -> eOff, MirAggregateEntry eSz _ _) ->
+      eOff + eSz > off
+    _ ->
+      False
 
 -- | Concatenate two `MirAggregate`s, producing a new aggregate with all the
 -- entries of the first followed by all the entries of the second.  The entries

--- a/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
@@ -755,17 +755,25 @@ writeMirAggregateWithSymOffset bak iteFn off writeSize tpr val ag
 -- valid but there's no entry there, and @Left errorMessage@ if offset is
 -- invalid (in the middle of some entry) or the type @tpr@ is incorrect.
 mirAggregate_lookup ::
+  IsSymInterface sym =>
+  sym ->
+  Word ->
   Word ->
   TypeRepr tp ->
   MirAggregate sym ->
   Either String (RegValue sym (MaybeType tp))
-mirAggregate_lookup off tpr (MirAggregate totalSize m) = do
-  case IntMap.lookupLE (fromIntegral off) m of
+mirAggregate_lookup sym off sz tpr ag@(MirAggregate totalSize m) = case tpr of
+  MirAggregateRepr -> case mirAggregate_split3 off (off + sz) ag of
+    Right (_toLeft, mid, _toRight) -> Right $ justPartExpr sym mid
+    Left err -> die err
+  _ -> case IntMap.lookupLE (fromIntegral off) m of
     _ | off >= totalSize ->
       die $ "offset " ++ show off ++ " is out of range "
         ++ "for aggregate total size " ++ show totalSize
     Nothing -> Right Unassigned
     Just (fromIntegral -> off', MirAggregateEntry sz' tpr' rv)
+      | sz /= sz' -> die $ "size mismatch at offset " ++ show off ++ ": "
+          ++ show sz ++ " != " ++ show sz'
       | off' == off -> do
           case testEquality tpr tpr' of
             Nothing -> die $ "type mismatch at offset " ++ show off ++ ": "

--- a/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
@@ -71,7 +71,6 @@ import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Trans (lift)
 
 import Data.BitVector.Sized qualified as BV
-import Data.Either (fromRight)
 import Data.IntMap (IntMap)
 import Data.IntMap qualified as IntMap
 import Data.Kind (Type)
@@ -353,28 +352,45 @@ readSubaggregateWithSymOffset ::
   RegValue sym UsizeType ->
   MirAggregate sym ->
   MuxLeafT sym m (MirAggregate sym)
-readSubaggregateWithSymOffset bak iteFn readSize off ag@(MirAggregate sz _)
-  | Just (fromIntegral . BV.asUnsigned -> off') <- asBV off = do
-      let err e = leafAbort $ GenericSimError $ "readSubaggregateWithSymOffset: " <> e
-      either err pure (readConcrete off' ag)
+readSubaggregateWithSymOffset bak iteFn readSize off ag@(MirAggregate agSize _)
+  | Just (fromIntegral . BV.asUnsigned -> off') <- asBV off =
+    readConcrete off'
   | otherwise = do
-      liftIO $ foldM
-        (\ag' candidateOff -> do
-          isTheOffset <- bvEq sym off =<< offsetLit candidateOff
-          iteFn isTheOffset (fromRight ag' $ readConcrete candidateOff ag') ag')
-        ag
-        (init [0 .. sz])
+      -- We're muxing together reads of sub-aggregates starting at each possible
+      -- offset in `ag`. If a read operation (via `readConcrete`) at a given
+      -- candidate offset fails, we'll assert that that offset wasn't equal to
+      -- `off`, the actual symbolic offset. (This attempt and potential negative
+      -- assertion occurs via `subMuxLeafMA`.)
+      agPMux <- foldM
+        (\origAgP candidateOff -> do
+          isTheOffset <- liftIO $ bvEq sym off =<< offsetLit candidateOff
+          subAgM <- subMuxLeafMA bak (readConcrete candidateOff) isTheOffset
+          case subAgM of
+            Just subAg -> liftIO $ iteFn' isTheOffset (justPartExpr sym subAg) origAgP
+            Nothing -> pure origAgP)
+        Unassigned
+        (init [0 .. agSize])
+
+      -- We've used `Unassigned` as the base case for the above mux so we'll be
+      -- left with `Unassigned` in failure cases, and can propagate that error
+      -- via `leafReadPartExpr`.
+      let sizeMsg = case readSize of All -> ""; Width w -> " of size " <> show w
+      leafReadPartExpr bak agPMux $
+        GenericSimError $
+          "readSubaggregateWithSymOffset: in aggregate of size " <> show agSize <>
+          ", no subaggregate value" <> sizeMsg <> " at symbolic offset"
   where
-    snd3 (_, x, _) = x
+    readConcrete off' = do
+      let sz = case readSize of All -> agSize - off'; Width w -> w
+      case mirAggregate_chunk off' sz ag of
+        Right a -> pure a
+        Left err -> die err
+
+    iteFn' = liftIteFnMaybe sym MirAggregateRepr iteFn
     sym = backendGetSym bak
     offsetLit = wordLit sym
-
-    readConcrete off' ag' = do
-      case readSize of
-        All ->
-          snd <$> mirAggregate_split off' ag'
-        Width width ->
-          snd3 <$> mirAggregate_split3 off' (off' + width) ag'
+    die err =
+      leafAbort $ GenericSimError $ "readSubaggregateWithSymOffset: " <> err
 
 
 adjustMirAggregateWithSymOffset ::

--- a/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
@@ -385,11 +385,12 @@ adjustMirAggregateWithSymOffset ::
   RegValue sym UsizeType ->
   TypeRepr tp ->
   (RegValue sym tp -> MuxLeafT sym IO (RegValue sym tp)) ->
+  OpSize ->
   MirAggregate sym ->
   MuxLeafT sym IO (MirAggregate sym)
-adjustMirAggregateWithSymOffset bak iteFn off tpr f ag@(MirAggregate totalSize m)
+adjustMirAggregateWithSymOffset bak iteFn off tpr f adjSize ag@(MirAggregate totalSize m)
   | MirAggregateRepr <- tpr =
-      adjustSubaggregateWithSymOffset bak iteFn off f ag
+      adjustSubaggregateWithSymOffset bak iteFn off f adjSize ag
   | Just (fromIntegral . BV.asUnsigned -> off') <- asBV off = do
       MirAggregateEntry sz tpr' rvPart <- case IntMap.lookup off' m of
         Just x -> return x
@@ -451,9 +452,10 @@ adjustSubaggregateWithSymOffset ::
   (Pred sym -> MirAggregate sym -> MirAggregate sym -> IO (MirAggregate sym)) ->
   RegValue sym UsizeType ->
   (MirAggregate sym -> MuxLeafT sym IO (MirAggregate sym)) ->
+  OpSize ->
   MirAggregate sym ->
   MuxLeafT sym IO (MirAggregate sym)
-adjustSubaggregateWithSymOffset bak iteFn off f ag@(MirAggregate sz _)
+adjustSubaggregateWithSymOffset bak iteFn off f adjSize ag@(MirAggregate sz _)
   | Just (fromIntegral . BV.asUnsigned -> off') <- asBV off =
       adjustConcrete off'
   | otherwise = do
@@ -744,7 +746,7 @@ writeMirAggregateWithSymOffset bak iteFn off writeSize tpr val ag
   -- Symbolic case: overwrite an existing entry with `adjustMirAggregateWithSymOffset`.
   -- Creating a new entry at a symbolic offset is not allowed.
   | otherwise = do
-      adjustMirAggregateWithSymOffset bak iteFn off tpr (\_oldVal -> return val) ag
+      adjustMirAggregateWithSymOffset bak iteFn off tpr (\_oldVal -> return val) writeSize ag
 
   where
     sym = backendGetSym bak

--- a/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
@@ -136,14 +136,15 @@ import Mir.Mir (OpSize (..))
 --
 -- We enforce an invariant on `MirAggregate`s that they are "flattened" - that
 -- is, no `MirAggregate` will contain an _immediate_ `MirAggregateEntry` that is
--- itself a `MirAggregate`. (A `MirAggregate` can still appear nested within
--- another `MirAggregate.) Clients shouldn't need to care about this flattening;
--- it's legal for a client to insert one `MirAggregate`-type `MirAggregateEntry`
--- into a `MirAggregate` or read one `MirAggregate`-type `MirAggregateEntry`
--- from within a `MirAggregate`, but we implement those operations by inserting
--- each entry from the sub-aggregate into the larger aggregate or by
--- constructing an ad-hoc sub-aggregate with entries from the larger aggregate,
--- respectively.
+-- itself a `MirAggregate`. (A `MirAggregate` can still appear _nested_ within
+-- another `MirAggregate indirectly, e.g. a `MirAggregate` inside a
+-- `RustEnumRepr` inside another `MirAggregate`.) Clients shouldn't need to care
+-- about this flattening; it's legal for a client to insert one
+-- `MirAggregate`-type `MirAggregateEntry` into a `MirAggregate` or read one
+-- `MirAggregate`-type `MirAggregateEntry` from within a `MirAggregate`, but we
+-- implement those operations by inserting each entry from the sub-aggregate
+-- into the larger aggregate or by constructing an ad-hoc sub-aggregate with
+-- entries from the larger aggregate, respectively.
 data MirAggregate sym where
   MirAggregate ::
     -- | Total size in bytes.  No entry can extend beyond this limit.

--- a/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
@@ -713,20 +713,26 @@ writeMirAggregateWithSymOffset ::
   bak ->
   (Pred sym -> RegValue sym tp -> RegValue sym tp -> IO (RegValue sym tp)) ->
   RegValue sym UsizeType ->
-  Word ->
+  OpSize ->
   TypeRepr tp ->
   RegValue sym tp ->
   MirAggregate sym ->
   MuxLeafT sym IO (MirAggregate sym)
-writeMirAggregateWithSymOffset bak iteFn off sz tpr val ag
+writeMirAggregateWithSymOffset bak iteFn off writeSize tpr val ag
   -- Concrete case: insert a new entry or overwrite an existing one with
   -- `mirAggregate_insert`.
   | Just (fromIntegral . BV.asUnsigned -> off') <- asBV off = do
-      let entry = MirAggregateEntry sz tpr $ justPartExpr sym val
-      case mirAggregate_insert off' entry ag of
-        Left err -> leafAbort $ GenericSimError err
-        Right ag' -> return ag'
-
+    entry <- case (writeSize, tpr) of
+      (All, MirAggregateRepr) -> do
+        let MirAggregate subAgSz _ = val
+        pure $ MirAggregateEntry subAgSz tpr $ justPartExpr sym val
+      (All, _) ->
+        die "unsupported: writing non-aggregate value of unknown/unspecified size"
+      (Width w, _) ->
+        pure $ MirAggregateEntry w tpr $ justPartExpr sym val
+    case mirAggregate_insert off' entry ag of
+      Left err -> die err
+      Right ag' -> return ag'
   -- Symbolic case: overwrite an existing entry with `adjustMirAggregateWithSymOffset`.
   -- Creating a new entry at a symbolic offset is not allowed.
   | otherwise = do
@@ -734,6 +740,7 @@ writeMirAggregateWithSymOffset bak iteFn off sz tpr val ag
 
   where
     sym = backendGetSym bak
+    die msg = leafAbort $ GenericSimError $ "writeMirAggregateWithSymOffset: " <> msg
 
 -- | Look up a value in a `MirAggregate`.  This returns @Right maybeVal@ if it
 -- finds a value at the requested offset, @Right Unassigned@ if the offset is

--- a/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
@@ -721,9 +721,12 @@ mirAggregate_insert outerAgOff (MirAggregateEntry entrySz MirAggregateRepr entry
     Just False ->
       pure outerAg
     Just True -> do
+      outerAg' <- case mirAggregate_clear (Just outerAgOff) (Just $ outerAgOff + innerAgSz) outerAg of
+        Left err -> Left $ "mirAggregate_insert: error when clearing existing entries: " <> err
+        Right a -> pure a
       let addEntry ag (fromIntegral -> entryOff) entry =
             mirAggregate_insert (outerAgOff + entryOff) entry ag
-      foldMWithKey addEntry outerAg innerAgEntries
+      foldMWithKey addEntry outerAg' innerAgEntries
     -- Note: this case doesn't seem to show up in practice, but if it does,
     -- consider lifting this function to a monadic context in which it can
     -- manipulate predicates, so that it can add entries the conjunction of

--- a/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
@@ -460,10 +460,12 @@ adjustSubaggregateWithSymOffset bak iteFn off f adjSize ag@(MirAggregate agSize 
       adjustConcrete off'
   | otherwise = do
       foldM
-        (\ag' candidateOff -> do
+        (\origAg candidateOff -> do
           isTheOffset <- liftIO $ bvEq sym off =<< offsetLit candidateOff
-          subAg <- adjustConcrete candidateOff
-          liftIO $ iteFn isTheOffset subAg ag')
+          adjustedAgM <- subMuxLeafMA bak (adjustConcrete candidateOff) isTheOffset
+          case adjustedAgM of
+            Just adjustedAg -> liftIO $ iteFn isTheOffset adjustedAg origAg
+            Nothing -> pure origAg)
         ag
         (init [0 .. agSize])
   where

--- a/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
@@ -134,6 +134,17 @@ import Mir.Mir (OpSize (..))
 -- to partially overlap old ones - they must either be disjoint from all
 -- existing entries, or fully overwrite an existing entry.  Read operations
 -- must also touch exactly one entry.
+--
+-- We enforce an invariant on `MirAggregate`s that they are "flattened" - that
+-- is, no `MirAggregate` will contain an _immediate_ `MirAggregateEntry` that is
+-- itself a `MirAggregate`. (A `MirAggregate` can still appear nested within
+-- another `MirAggregate.) Clients shouldn't need to care about this flattening;
+-- it's legal for a client to insert one `MirAggregate`-type `MirAggregateEntry`
+-- into a `MirAggregate` or read one `MirAggregate`-type `MirAggregateEntry`
+-- from within a `MirAggregate`, but we implement those operations by inserting
+-- each entry from the sub-aggregate into the larger aggregate or by
+-- constructing an ad-hoc sub-aggregate with entries from the larger aggregate,
+-- respectively.
 data MirAggregate sym where
   MirAggregate ::
     -- | Total size in bytes.  No entry can extend beyond this limit.

--- a/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
@@ -386,14 +386,18 @@ readSubaggregateWithSymOffset bak iteFn readSize off ag@(MirAggregate agSize _)
       -- We've used `Unassigned` as the base case for the above mux so we'll be
       -- left with `Unassigned` in failure cases, and can propagate that error
       -- via `leafReadPartExpr`.
-      let sizeMsg = case readSize of All -> ""; Width w -> " of size " <> show w
+      let sizeMsg = case readSize of
+                      All -> ""
+                      Width w -> " of size " <> show w
       leafReadPartExpr bak agPMux $
         GenericSimError $
           "readSubaggregateWithSymOffset: in aggregate of size " <> show agSize <>
           ", no subaggregate value" <> sizeMsg <> " at symbolic offset"
   where
     readConcrete off' = do
-      let sz = case readSize of All -> agSize - off'; Width w -> w
+      let sz = case readSize of
+                All -> agSize - off'
+                Width w -> w
       case mirAggregate_chunk off' sz ag of
         Right a -> pure a
         Left err -> die err
@@ -508,7 +512,9 @@ adjustSubaggregateWithSymOffset bak iteFn off f adjSize ag@(MirAggregate agSize 
         nonSplittingAgOffsets
   where
     adjustConcrete off' = do
-      let sz = case adjSize of All -> agSize - off'; Width w -> w
+      let sz = case adjSize of
+                All -> agSize - off'
+                Width w -> w
 
       adjAg@(MirAggregate adjAgSz _) <- case mirAggregate_chunk off' sz ag of
         Right a -> pure a

--- a/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
@@ -40,6 +40,7 @@ module Mir.Intrinsics.Aggregate
     addToRun,
     mkRun,
     Run (..),
+    mirAggregate_capacity,
     mirAggregate_entries,
     mirAggregate_insert,
     writeMirAggregateWithSymOffset,
@@ -532,6 +533,10 @@ adjustSubaggregateWithSymOffset bak iteFn off f adjSize ag@(MirAggregate agSize 
     offsetLit = wordLit sym
     die err =
       leafAbort $ GenericSimError $ "adjustSubaggregateWithSymOffset: " <> err
+
+-- | The capacity, in bytes, of the aggregate
+mirAggregate_capacity :: MirAggregate sym -> Word
+mirAggregate_capacity (MirAggregate l _) = l
 
 -- | Given a list of valid entry spans @(fromOffset, toOffset)@ in this
 -- aggregate, create a predicate that the provided offset appears among their

--- a/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
@@ -72,6 +72,7 @@ import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Trans (lift)
 
 import Data.BitVector.Sized qualified as BV
+import Data.Foldable.WithIndex (ifoldlM)
 import Data.IntMap (IntMap)
 import Data.IntMap qualified as IntMap
 import Data.Kind (Type)
@@ -710,13 +711,6 @@ mirAggregate_entries :: sym -> MirAggregate sym -> [(Word, MirAggregateEntry sym
 mirAggregate_entries _sym (MirAggregate _totalSize m) =
   [(fromIntegral off, entry) | (off, entry) <- IntMap.toList m]
 
-foldMWithKey :: Monad m => (b -> Int -> a -> m b) -> b -> IntMap a -> m b
-foldMWithKey f z m = IntMap.foldlWithKey' f' (pure z) m
-  where
-    f' accM key val = do
-      acc <- accM
-      f acc key val
-
 mirAggregate_insert ::
   (IsSymInterface sym) =>
   Word ->
@@ -736,9 +730,9 @@ mirAggregate_insert outerAgOff (MirAggregateEntry entrySz MirAggregateRepr entry
       outerAg' <- case mirAggregate_clear (Just outerAgOff) (Just $ outerAgOff + innerAgSz) outerAg of
         Left err -> Left $ "mirAggregate_insert: error when clearing existing entries: " <> err
         Right a -> pure a
-      let addEntry ag (fromIntegral -> entryOff) entry =
+      let addEntry (fromIntegral -> entryOff) ag entry =
             mirAggregate_insert (outerAgOff + entryOff) entry ag
-      foldMWithKey addEntry outerAg' innerAgEntries
+      ifoldlM addEntry outerAg' innerAgEntries
     -- Note: this case doesn't seem to show up in practice, but if it does,
     -- consider lifting this function to a monadic context in which it can
     -- manipulate predicates, so that it can add entries the conjunction of

--- a/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
@@ -34,6 +34,7 @@ module Mir.Intrinsics.Aggregate
     agNoValueAtOffsetSimError,
     agNoValueAtSymbolicOffsetSimError,
     readMirAggregateWithSymOffset,
+    readSubaggregateWithConcreteOffset,
     adjustMirAggregateWithSymOffset,
     offsetInSpans,
     foldRuns,
@@ -395,19 +396,30 @@ readSubaggregateWithSymOffset bak iteFn readSize off ag@(MirAggregate agSize _)
           "readSubaggregateWithSymOffset: in aggregate of size " <> show agSize <>
           ", no subaggregate value" <> sizeMsg <> " at symbolic offset"
   where
-    readConcrete off' = do
-      let sz = case readSize of
-                All -> agSize - off'
-                Width w -> w
-      case mirAggregate_chunk off' sz ag of
-        Right a -> pure a
-        Left err -> die err
-
+    readConcrete off' = readSubaggregateWithConcreteOffset bak readSize off' ag
     iteFn' = liftIteFnMaybe sym MirAggregateRepr iteFn
     sym = backendGetSym bak
     offsetLit = wordLit sym
+
+readSubaggregateWithConcreteOffset ::
+  forall sym bak m.
+  MonadAssert sym bak m =>
+  bak ->
+  OpSize ->
+  Word ->
+  MirAggregate sym ->
+  MuxLeafT sym m (MirAggregate sym)
+readSubaggregateWithConcreteOffset _bak readSize off ag@(MirAggregate agSize _) = do
+  let sz = case readSize of
+            All -> agSize - off
+            Width w -> w
+  case mirAggregate_chunk off sz ag of
+    Right a -> pure a
+    Left err -> die err
+  where
     die err =
-      leafAbort $ GenericSimError $ "readSubaggregateWithSymOffset: " <> err
+      leafAbort $ GenericSimError $ "readSubaggregateWithConcreteOffset: " <> err
+
 
 
 adjustMirAggregateWithSymOffset ::

--- a/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
@@ -981,23 +981,30 @@ mirAggregate_clear fromM toM (MirAggregate sz entries) = do
   pure (MirAggregate sz entries')
   where
     failOnOverlap boundaryKind boundaryOff entries' =
-      case IntMap.lookupLT (fromIntegral boundaryOff) entries' of
-        Just (fromIntegral -> eOff, MirAggregateEntry eSz _ _)
-          | eOff + eSz > boundaryOff ->
-            Left $
-              "mirAggregate_clear: " <>
-              boundaryKind <> " boundary " <> show boundaryOff <>
-              " splits entry at " <> show eOff <> ".." <> show (eOff + eSz)
-        _ -> pure ()
+      case offsetSplitsEntry' entries' boundaryOff of
+        Left (lo, hi) ->
+          Left $
+            "mirAggregate_clear: " <>
+            boundaryKind <> " boundary " <> show boundaryOff <>
+            " splits entry at " <> show lo <> ".." <> show hi
+        Right () -> return ()
 
 -- | Does this offset occur in the middle of an entry in this aggregate?
 offsetSplitsEntry :: MirAggregate sym -> Word -> Bool
 offsetSplitsEntry (MirAggregate _ entries) off =
+  case offsetSplitsEntry' entries off of
+    Left _ -> True
+    Right () -> False
+
+offsetSplitsEntry' :: IntMap (MirAggregateEntry sym) -> Word -> Either (Word, Word) ()
+offsetSplitsEntry' entries off =
   case IntMap.lookupLT (fromIntegral off) entries of
     Just (fromIntegral -> eOff, MirAggregateEntry eSz _ _) ->
-      eOff + eSz > off
+      if eOff + eSz > off
+        then Left (eOff, eOff + eSz)
+        else Right ()
     _ ->
-      False
+      Right ()
 
 -- | Concatenate two `MirAggregate`s, producing a new aggregate with all the
 -- entries of the first followed by all the entries of the second.  The entries

--- a/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Aggregate.hs
@@ -366,7 +366,7 @@ readSubaggregateWithSymOffset bak iteFn readSize off ag@(MirAggregate agSize _)
       -- - Extracting a sub-aggregate starting at that offset would split an
       --   aggregate entry
       let sizedAgOffsets = case readSize of
-            All -> init [0 .. agSize] -- not sure this `init` is necessary...
+            All -> [0 .. agSize]
             Width w -> [0 .. agSize - w]
       let nonSplittingAgOffsets = filter (not . offsetSplitsEntry ag) sizedAgOffsets
 
@@ -510,7 +510,7 @@ adjustSubaggregateWithSymOffset bak iteFn off f adjSize ag@(MirAggregate agSize 
       -- - Extracting a sub-aggregate starting at that offset would split an
       --   aggregate entry
       let sizedAgOffsets = case adjSize of
-            All -> init [0 .. agSize] -- not sure this `init` is necessary...
+            All -> [0 .. agSize]
             Width w -> [0 .. agSize - w]
       let nonSplittingAgOffsets = filter (not . offsetSplitsEntry ag) sizedAgOffsets
 

--- a/crucible-mir/src/Mir/Intrinsics/Reference.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Reference.hs
@@ -534,6 +534,7 @@ writeRefPath ::
   IntrinsicTypes sym ->
   RegValue sym tp ->
   MirReferencePath sym tp tp' ->
+  OpSize ->
   RegValue sym tp' ->
   MuxLeafT sym IO (RegValue sym tp)
 -- Special case: when the final path segment is `Just_RefPath`, we can write to
@@ -543,23 +544,23 @@ writeRefPath ::
 --
 -- There is a similar special case above for MirWriteRef with Empty_RefPath,
 -- which allows writing to an uninitialized MirReferenceRoot.
-writeRefPath bak iTypes v (Just_RefPath _tp path) x =
+writeRefPath bak iTypes v (Just_RefPath _tp path) _writeSize x =
   adjustRefPath bak iTypes v path (\_ -> return $ justPartExpr (backendGetSym bak) x)
 -- TODO remove these cases?  should be equivalent to the `adjustRefPath` cases below
-writeRefPath bak iTypes v (VectorIndex_RefPath tp path idx) x = do
+writeRefPath bak iTypes v (VectorIndex_RefPath tp path idx) _writeSize x = do
   adjustRefPath bak iTypes v path (\vec ->
     leafAdjustVectorWithSymIndex bak (muxRegForType (backendGetSym bak) iTypes tp) vec idx (\_ ->
       return x))
-writeRefPath bak iTypes v (ArrayIndex_RefPath _btp path idx) x = do
+writeRefPath bak iTypes v (ArrayIndex_RefPath _btp path idx) _writeSize x = do
   adjustRefPath bak iTypes v path (\arr ->
     liftIO $ arrayUpdate (backendGetSym bak) arr (Empty :> idx) x)
 -- For `MirAggregate`, `writeRefPath` with a concrete index can insert a new
 -- entry into the aggregate.
-writeRefPath bak iTypes v (AgElem_RefPath idx sz tpr path) x = do
+writeRefPath bak iTypes v (AgElem_RefPath idx sz tpr path) _writeSize x = do
   adjustRefPath bak iTypes v path (\v' -> do
     writeMirAggregateWithSymOffset bak (muxRegForType (backendGetSym bak) iTypes tpr)
       idx sz tpr x v')
-writeRefPath bak iTypes v path x =
+writeRefPath bak iTypes v path _writeSize x =
   adjustRefPath bak iTypes v path (\_ -> return x)
 
 adjustRefPath ::
@@ -858,14 +859,15 @@ writeMirRefSim ::
     IsSymInterface sym =>
     TypeRepr tp ->
     MirReferenceMux sym ->
+    OpSize ->
     RegValue sym tp ->
     OverrideSim m sym ext rtp args ret ()
-writeMirRefSim tpr ref x = do
+writeMirRefSim tpr ref writeSize x = do
     s <- get
     let gs0 = s ^. stateTree.actFrame.gpGlobals
     let iTypes = ctxIntrinsicTypes $ s ^. stateContext
     ovrWithBackend $ \bak -> do
-      gs1 <- liftIO $ writeMirRefIO bak gs0 iTypes tpr ref x
+      gs1 <- liftIO $ writeMirRefIO bak gs0 iTypes tpr ref writeSize x
       put $ s & stateTree.actFrame.gpGlobals .~ gs1
 
 writeMirRefIO ::
@@ -875,12 +877,13 @@ writeMirRefIO ::
     IntrinsicTypes sym ->
     TypeRepr tp ->
     MirReferenceMux sym ->
+    OpSize ->
     RegValue sym tp ->
     IO (SymGlobalState sym)
-writeMirRefIO bak gs iTypes tpr (MirReferenceMux ref) x =
+writeMirRefIO bak gs iTypes tpr (MirReferenceMux ref) writeSize x =
     foldFancyMuxTree
         bak
-        (\gs' ref' -> writeMirRefLeaf bak gs' iTypes tpr ref' x)
+        (\gs' ref' -> writeMirRefLeaf bak gs' iTypes tpr ref' writeSize x)
         gs
         ref
 
@@ -891,15 +894,16 @@ writeMirRefLeaf ::
     IntrinsicTypes sym ->
     TypeRepr tp ->
     MirReference sym ->
+    OpSize ->
     RegValue sym tp ->
     MuxLeafT sym IO (SymGlobalState sym)
-writeMirRefLeaf bak gs iTypes tpr ref val =
+writeMirRefLeaf bak gs iTypes tpr ref writeSize val =
   typedLeafOp "write" tpr ref $ \root path ->
     case path of
       Empty_RefPath -> writeRefRoot bak gs iTypes root val
       _ -> do
         x <- readRefRoot bak gs root
-        x' <- writeRefPath bak iTypes x path val
+        x' <- writeRefPath bak iTypes x path writeSize val
         writeRefRoot bak gs iTypes root x'
 
 

--- a/crucible-mir/src/Mir/Intrinsics/Reference.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Reference.hs
@@ -61,8 +61,6 @@ module Mir.Intrinsics.Reference
     subvariantMirRefIO,
     subjustMirRefLeaf,
     subjustMirRefIO,
-    mirRef_agElemLeaf,
-    mirRef_agElemIO,
     mirRef_agElem_unsizedLeaf,
     mirRef_agElem_unsizedIO,
     mirRef_agOffsetLeaf,
@@ -1045,30 +1043,6 @@ mirRef_vecIndexIO ::
 mirRef_vecIndexIO bak iTypes idx elemTpr ref =
   modifyRefMuxMA bak iTypes (mirRef_vecIndexLeaf bak idx elemTpr) ref
 
-
-mirRef_agElemLeaf ::
-    (IsSymBackend sym bak) =>
-    bak ->
-    RegValue sym UsizeType ->
-    Word ->
-    TypeRepr tp ->
-    MirReference sym ->
-    MuxLeafT sym IO (MirReference sym)
-mirRef_agElemLeaf bak off sz tpr ref =
-  typedLeafOp "MirAggregate element projection" bak MirAggregateRepr ref $ \root path -> do
-    return $ MirReference tpr root (AgElem_RefPath off sz tpr path)
-
-mirRef_agElemIO ::
-    IsSymBackend sym bak =>
-    bak ->
-    IntrinsicTypes sym ->
-    RegValue sym UsizeType ->
-    Word ->
-    TypeRepr tp ->
-    MirReferenceMux sym ->
-    IO (MirReferenceMux sym)
-mirRef_agElemIO bak iTypes off sz tpr ref =
-    modifyRefMuxMA bak iTypes (mirRef_agElemLeaf bak off sz tpr) ref
 
 mirRef_agElem_unsizedLeaf ::
     IsSymBackend sym bak =>

--- a/crucible-mir/src/Mir/Intrinsics/Reference.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Reference.hs
@@ -574,15 +574,14 @@ writeRefPath bak iTypes v (ArrayIndex_RefPath _btp path idx) _writeSize x = do
     liftIO $ arrayUpdate (backendGetSym bak) arr (Empty :> idx) x)
 -- For `MirAggregate`, `writeRefPath` with a concrete index can insert a new
 -- entry into the aggregate.
-writeRefPath bak iTypes v (AgElem_RefPath idx sz tpr path) _writeSize x = do
+writeRefPath bak iTypes v (AgElem_RefPath idx _sz tpr path) writeSize x = do
   adjustRefPath bak iTypes v path (\v' -> do
     writeMirAggregateWithSymOffset bak (muxRegForType (backendGetSym bak) iTypes tpr)
-      idx sz tpr x v')
-writeRefPath bak iTypes v (AgOffset_RefPath off path) _writeSize x = do
+      idx writeSize tpr x v')
+writeRefPath bak iTypes v (AgOffset_RefPath off path) writeSize x = do
   adjustRefPath bak iTypes v path (\v' -> do
     let mux = muxRegForType (backendGetSym bak) iTypes MirAggregateRepr
-    let MirAggregate sz _ = x
-    writeMirAggregateWithSymOffset bak mux off sz MirAggregateRepr x v')
+    writeMirAggregateWithSymOffset bak mux off writeSize MirAggregateRepr x v')
 writeRefPath bak iTypes v path _writeSize x =
   adjustRefPath bak iTypes v path (\_ -> return x)
 

--- a/crucible-mir/src/Mir/Intrinsics/Reference.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Reference.hs
@@ -65,6 +65,8 @@ module Mir.Intrinsics.Reference
     mirRef_agElemIO,
     mirRef_agElem_unsizedLeaf,
     mirRef_agElem_unsizedIO,
+    mirRef_agOffsetLeaf,
+    mirRef_agOffsetIO,
     mirRef_arrayIndexLeaf,
     mirRef_arrayIndexIO,
     mirRef_vecIndexLeaf,
@@ -294,6 +296,13 @@ data MirReferencePath sym :: CrucibleType -> CrucibleType -> Type where
     !(TypeRepr tp) ->
     !(MirReferencePath sym tp_base MirAggregateType) ->
     MirReferencePath sym tp_base tp
+  -- | Given a reference to an aggregate, shift that reference forward within
+  -- the same aggregate by a number of bytes.
+  AgOffset_RefPath ::
+    -- | How many bytes to shift forward by
+    !(RegValue sym UsizeType) ->
+    !(MirReferencePath sym tp_base MirAggregateType) ->
+    MirReferencePath sym tp_base MirAggregateType
   -- | Reinterpret a portion of a `MirAggregate` as an array of equal-sized
   -- chunks.  This is used to implement @<[T]>::as_chunks@ and several related
   -- methods.  We can get rid of this once `MirAggregate` flattening is
@@ -337,6 +346,7 @@ instance IsSymInterface sym => Show (MirReferencePath sym tp tp') where
     show (VectorIndex_RefPath tpr p idx) = "(VectorIndex_RefPath " ++ show tpr ++ " " ++ show p ++ " " ++ show (printSymExpr idx) ++ ")"
     show (ArrayIndex_RefPath btpr p idx) = "(ArrayIndex_RefPath " ++ show btpr ++ " " ++ show p ++ " " ++ show (printSymExpr idx) ++ ")"
     show (AgElem_RefPath off sz tpr p) = "(AgElem_RefPath " ++ show (printSymExpr off) ++ " " ++ show sz ++ " " ++ show tpr ++ " " ++ show p ++ ")"
+    show (AgOffset_RefPath off p) = "(AgOffset_RefPath " ++ show (printSymExpr off) ++ " " ++ show p ++ ")"
     show (AggregateAsChunks_RefPath off chunkSize numChunks p) = "(AggregateAsChunks_RefPath " ++ show off ++ " " ++ show chunkSize ++ " " ++ show numChunks ++ " " ++ show p ++ ")"
 
 instance IsSymInterface sym => Show (MirReference sym) where
@@ -393,6 +403,10 @@ instance OrdSkel (MirReference sym) where
             compare sz1 sz2 <> compareSkelF tpr1 tpr2 <> cmpPath p1 p2
         cmpPath (AgElem_RefPath _ _ _ _) _ = LT
         cmpPath _ (AgElem_RefPath _ _ _ _) = GT
+        cmpPath (AgOffset_RefPath _off1 p1) (AgOffset_RefPath _off2 p2) =
+            cmpPath p1 p2
+        cmpPath (AgOffset_RefPath _ _) _ = LT
+        cmpPath _ (AgOffset_RefPath _ _) = GT
         cmpPath (AggregateAsChunks_RefPath off1 chunkSize1 numChunks1 p1)
                 (AggregateAsChunks_RefPath off2 chunkSize2 numChunks2 p2) =
             compare off1 off2 <> compare chunkSize1 chunkSize2 <> compare numChunks1 numChunks2
@@ -518,6 +532,10 @@ readRefPath bak iTypes v readSize = \case
   AgElem_RefPath off _sz tpr path -> do
     ag <- readRefPath bak iTypes v All path
     readMirAggregateWithSymOffset bak (muxRegForType (backendGetSym bak) iTypes tpr) off readSize tpr ag
+  AgOffset_RefPath off path -> do
+    ag <- readRefPath bak iTypes v All path
+    let mux = muxRegForType (backendGetSym bak) iTypes MirAggregateRepr
+    readMirAggregateWithSymOffset bak mux off readSize MirAggregateRepr ag
   AggregateAsChunks_RefPath off chunkSize numChunks path -> do
     let sym = backendGetSym bak
     ag <- readRefPath bak iTypes v All path
@@ -560,6 +578,11 @@ writeRefPath bak iTypes v (AgElem_RefPath idx sz tpr path) _writeSize x = do
   adjustRefPath bak iTypes v path (\v' -> do
     writeMirAggregateWithSymOffset bak (muxRegForType (backendGetSym bak) iTypes tpr)
       idx sz tpr x v')
+writeRefPath bak iTypes v (AgOffset_RefPath off path) _writeSize x = do
+  adjustRefPath bak iTypes v path (\v' -> do
+    let mux = muxRegForType (backendGetSym bak) iTypes MirAggregateRepr
+    let MirAggregate sz _ = x
+    writeMirAggregateWithSymOffset bak mux off sz MirAggregateRepr x v')
 writeRefPath bak iTypes v path _writeSize x =
   adjustRefPath bak iTypes v path (\_ -> return x)
 
@@ -601,6 +624,10 @@ adjustRefPath bak iTypes v path0 adj = case path0 of
       adjustRefPath bak iTypes v path (\v' -> do
         adjustMirAggregateWithSymOffset bak (muxRegForType (backendGetSym bak) iTypes tpr)
           idx tpr adj v')
+  AgOffset_RefPath off path -> do
+      adjustRefPath bak iTypes v path (\v' ->
+        let mux = muxRegForType (backendGetSym bak) iTypes MirAggregateRepr
+         in adjustMirAggregateWithSymOffset bak mux off MirAggregateRepr adj v')
   AggregateAsChunks_RefPath off chunkSize numChunks path ->
       adjustRefPath bak iTypes v path $ \ag -> do
         let sym = backendGetSym bak
@@ -659,6 +686,10 @@ muxRefPath sym c path1 path2 = case (path1,path2) of
          do off' <- lift $ bvIte sym c off1 off2
             p' <- muxRefPath sym c p1 p2
             return (AgElem_RefPath off' sz tpr p')
+  (AgOffset_RefPath off1 p1, AgOffset_RefPath off2 p2) ->
+         do off' <- lift $ bvIte sym c off1 off2
+            p' <- muxRefPath sym c p1 p2
+            return (AgOffset_RefPath off' p')
   (AggregateAsChunks_RefPath off chunkSize numChunks p1, AggregateAsChunks_RefPath _ _ _ p2) ->
          do p' <- muxRefPath sym c p1 p2
             return (AggregateAsChunks_RefPath off chunkSize numChunks p')
@@ -670,6 +701,7 @@ muxRefPath sym c path1 path2 = case (path1,path2) of
   (VectorIndex_RefPath {}, _) -> mzero
   (ArrayIndex_RefPath {}, _) -> mzero
   (AgElem_RefPath {}, _) -> mzero
+  (AgOffset_RefPath {}, _) -> mzero
   (AggregateAsChunks_RefPath {}, _) -> mzero
 
 
@@ -1095,6 +1127,31 @@ mirRef_agElem_unsizedIO bak gs iTypes off ref =
     modifyRefMuxMA bak iTypes (mirRef_agElem_unsizedLeaf bak gs iTypes off) ref
 
 
+mirRef_agOffsetLeaf ::
+    IsSymInterface sym =>
+    sym ->
+    RegValue sym UsizeType ->
+    MirReference sym ->
+    MuxLeafT sym IO (MirReference sym)
+mirRef_agOffsetLeaf sym off ref =
+  typedLeafOp "MirAggregate offset" MirAggregateRepr ref $ \root path ->
+    case path of
+      AgOffset_RefPath oldOff oldPath -> do
+        newOff <- liftIO $ bvAdd sym off oldOff
+        return $ MirReference MirAggregateRepr root (AgOffset_RefPath newOff oldPath)
+      _ -> return $ MirReference MirAggregateRepr root (AgOffset_RefPath off path)
+
+mirRef_agOffsetIO ::
+    IsSymBackend sym bak =>
+    bak ->
+    IntrinsicTypes sym ->
+    RegValue sym UsizeType ->
+    MirReferenceMux sym ->
+    IO (MirReferenceMux sym)
+mirRef_agOffsetIO bak iTypes off ref =
+    modifyRefMuxMA bak iTypes (mirRef_agOffsetLeaf (backendGetSym bak) off) ref
+
+
 refRootEq ::
     IsSymInterface sym =>
     sym ->
@@ -1151,6 +1208,10 @@ refPathEq sym (AgElem_RefPath off1 _sz1 _tpr1 p1) (AgElem_RefPath off2 _sz2 _tpr
     --   different layout sizes.
     pEq <- refPathEq sym p1 p2
     liftIO $ andPred sym offEq pEq
+refPathEq sym (AgOffset_RefPath off1 p1) (AgOffset_RefPath off2 p2) = do
+    offEq <- liftIO $ bvEq sym off1 off2
+    pEq <- refPathEq sym p1 p2
+    liftIO $ andPred sym offEq pEq
 refPathEq sym (AggregateAsChunks_RefPath off1 chunkSize1 numChunks1 p1)
         (AggregateAsChunks_RefPath off2 chunkSize2 numChunks2 p2)
   | off1 == off2, chunkSize1 == chunkSize2, numChunks1 == numChunks2 = do
@@ -1163,6 +1224,7 @@ refPathEq sym (Just_RefPath {}) _ = return $ falsePred sym
 refPathEq sym (VectorIndex_RefPath {}) _ = return $ falsePred sym
 refPathEq sym (ArrayIndex_RefPath {}) _ = return $ falsePred sym
 refPathEq sym (AgElem_RefPath {}) _ = return $ falsePred sym
+refPathEq sym (AgOffset_RefPath {}) _ = return $ falsePred sym
 refPathEq sym (AggregateAsChunks_RefPath {}) _ = return $ falsePred sym
 
 mirRef_eqLeaf ::
@@ -1232,6 +1294,8 @@ reverseRefPath = go RrpNil
         go (ArrayIndex_RefPath btpr Empty_RefPath idx `RrpCons` acc) rp
     go acc (AgElem_RefPath off sz tpr rp) =
         go (AgElem_RefPath off sz tpr Empty_RefPath `RrpCons` acc) rp
+    go acc (AgOffset_RefPath off rp) =
+        go (AgOffset_RefPath off Empty_RefPath `RrpCons` acc) rp
     go acc (AggregateAsChunks_RefPath off chunkSize numChunks rp) =
         go (AggregateAsChunks_RefPath off chunkSize numChunks Empty_RefPath `RrpCons` acc) rp
 
@@ -1241,6 +1305,7 @@ popIndex :: MirReferencePath sym tp tp' -> Some (MirReferencePath sym tp)
 popIndex (VectorIndex_RefPath _ p _) = Some p
 popIndex (ArrayIndex_RefPath _ p _) = Some p
 popIndex (AgElem_RefPath _ _ _ p) = Some p
+popIndex (AgOffset_RefPath _ p) = Some p
 popIndex p = Some p
 
 refRootOverlaps :: IsSymInterface sym => sym ->
@@ -1322,6 +1387,23 @@ refPathOverlaps sym path1 path2 = do
         pEq <- go rrp1 rrp2
         liftIO $ andPred sym overlaps pEq
 
+    go (AgOffset_RefPath _ _ `RrpCons` rrp1) (AgOffset_RefPath _ _ `RrpCons` rrp2) =
+        go rrp1 rrp2
+    go (AgElem_RefPath offE sz _ _ `RrpCons` rrp2) (AgOffset_RefPath offO _ `RrpCons` rrp1) = do
+        -- These two overlap if `offE + sz > offO`
+        szBv <- wordLit sym sz
+        offESz <- liftIO $ bvAdd sym offE szBv
+        overlaps <- liftIO $ bvUge sym offESz offO
+        pEq <- go rrp1 rrp2
+        liftIO $ andPred sym overlaps pEq
+    go (AgOffset_RefPath offO _ `RrpCons` rrp1) (AgElem_RefPath offE sz _ _ `RrpCons` rrp2) = do
+        -- These two overlap if `offE + sz > offO`
+        szBv <- wordLit sym sz
+        offESz <- liftIO $ bvAdd sym offE szBv
+        overlaps <- liftIO $ bvUge sym offESz offO
+        pEq <- go rrp1 rrp2
+        liftIO $ andPred sym overlaps pEq
+
     go (AggregateAsChunks_RefPath off1 chunkSize1 numChunks1 _ `RrpCons` rrp1)
           (AggregateAsChunks_RefPath off2 chunkSize2 numChunks2 _ `RrpCons` rrp2)
       | (off1, chunkSize1, numChunks1) == (off2, chunkSize2, numChunks2) = do
@@ -1379,6 +1461,7 @@ refPathOverlaps sym path1 path2 = do
     go (VectorIndex_RefPath {} `RrpCons` _) _ = return $ falsePred sym
     go (ArrayIndex_RefPath {} `RrpCons` _) _ = return $ falsePred sym
     go (AgElem_RefPath {} `RrpCons` _) _ = return $ falsePred sym
+    go (AgOffset_RefPath {} `RrpCons` _) _ = return $ falsePred sym
 
 -- | Check whether the memory accessible through `ref1` overlaps the memory
 -- accessible through `ref2`.
@@ -1509,6 +1592,12 @@ mirRef_offsetWrapLeaf bak (MirReference tpr root (AgElem_RefPath elemOff _elemSi
     extraOff <- liftIO $ bvMul sym numElems =<< wordLit sym elemSize
     elemOff' <- liftIO $ bvAdd sym elemOff extraOff
     return $ MirReference tpr root $ AgElem_RefPath elemOff' elemSize tpr' path
+mirRef_offsetWrapLeaf bak (MirReference tpr root (AgOffset_RefPath off path)) numElems elemSize = do
+    let sym = backendGetSym bak
+    -- `wrapping_offset` puts no restrictions on the arithmetic performed.
+    extraOff <- liftIO $ bvMul sym numElems =<< wordLit sym elemSize
+    off' <- liftIO $ bvAdd sym off extraOff
+    return $ MirReference tpr root $ AgOffset_RefPath off' path
 mirRef_offsetWrapLeaf bak ref@(MirReference _ _ _) offset _elemSize = do
     let sym = backendGetSym bak
     isZero <- liftIO $ bvEq sym offset =<< bvZero sym knownNat
@@ -1550,6 +1639,26 @@ mirRef_tryOffsetFromLeaf bak elemSize (MirReference _ root1 path1) (MirReference
             offset <- liftIO $ bvSub sym idx1 idx2
             return $ mkPE similar offset
         (AgElem_RefPath off1 _ _ path1', AgElem_RefPath off2 _ _ path2') -> do
+            -- Use the `elemSize` parameter instead of the element size stored in the
+            -- reference path to avoid using a type-incorrect size when
+            -- operating on a reference that's been cast to a type that doesn't
+            -- match its original representation. (Same rationale as described
+            -- in `mirRef_offsetWrapLeaf`.)
+            pathEq <- refPathEq sym path1' path2'
+            similar <- liftIO $ andPred sym rootEq pathEq
+            byteOffset <- liftIO $ bvSub sym off1 off2
+            elemSize' <- liftIO $ wordLit sym elemSize
+            elemOffset <- liftIO $ bvSdiv sym byteOffset elemSize'
+
+            when (elemSize > 1) $ do
+              byteOffset' <- liftIO $ bvMul sym elemOffset elemSize'
+              byteOffsetIsSizeMultiple <- liftIO $ bvEq sym byteOffset byteOffset'
+              leafAssert bak byteOffsetIsSizeMultiple $
+                GenericSimError $
+                  "offset_from: byte offset not a multiple of `size_of::<T>` (" <> show elemSize <> ")"
+
+            return $ mkPE similar elemOffset
+        (AgOffset_RefPath off1 path1', AgOffset_RefPath off2 path2') -> do
             -- Use the `elemSize` parameter instead of the element size stored in the
             -- reference path to avoid using a type-incorrect size when
             -- operating on a reference that's been cast to a type that doesn't
@@ -1618,6 +1727,18 @@ mirRef_peelIndexLeaf bak _elemSize (MirReference _tpr root (ArrayIndex_RefPath b
     let ref = MirReferenceMux $ toFancyMuxTree sym $ MirReference (UsizeArrayRepr btpr) root path
     return $ Empty :> RV ref :> RV idx
 mirRef_peelIndexLeaf bak elemSize (MirReference _tpr root (AgElem_RefPath off _sz _tpr' path)) = do
+    let sym = backendGetSym bak
+    elemSizeBV <- liftIO $ wordLit sym elemSize
+
+    offModSz <- liftIO $ bvUrem sym off elemSizeBV
+    offModSzIsZero <- liftIO $ bvEq sym offModSz =<< wordLit sym 0
+    leafAssert bak offModSzIsZero $ Unsupported callStack $
+        "expected element offset to be a multiple of element size (" ++ show elemSize ++ ")"
+
+    idx <- liftIO $ bvUdiv sym off elemSizeBV
+    let ref = MirReferenceMux $ toFancyMuxTree sym $ MirReference MirAggregateRepr root path
+    return $ Empty :> RV ref :> RV idx
+mirRef_peelIndexLeaf bak elemSize (MirReference _tpr root (AgOffset_RefPath off path)) = do
     let sym = backendGetSym bak
     elemSizeBV <- liftIO $ wordLit sym elemSize
 
@@ -1899,6 +2020,19 @@ mirRef_aggregateAsChunksLeaf ::
     MuxLeafT sym IO (MirReference sym)
 mirRef_aggregateAsChunksLeaf chunkSizeSym numChunksSym
         (MirReference _tpr root (AgElem_RefPath offSym _sz _tpr' path)) = do
+    chunkSize <- requireConcrete "chunk size" chunkSizeSym
+    numChunks <- requireConcrete "number of chunks" numChunksSym
+    off <- requireConcrete "slice offset within parent array" offSym
+    return $ MirReference MirAggregateRepr root
+      (AggregateAsChunks_RefPath off chunkSize numChunks path)
+  where
+    requireConcrete desc symExp =
+      case asBV symExp of
+        Just bv -> return $ fromIntegral $ BV.asUnsigned bv
+        Nothing -> leafAbort $ GenericSimError $
+          "aggregateAsChunks requires " ++ desc ++ " to be concrete"
+mirRef_aggregateAsChunksLeaf chunkSizeSym numChunksSym
+        (MirReference _tpr root (AgOffset_RefPath offSym path)) = do
     chunkSize <- requireConcrete "chunk size" chunkSizeSym
     numChunks <- requireConcrete "number of chunks" numChunksSym
     off <- requireConcrete "slice offset within parent array" offSym

--- a/crucible-mir/src/Mir/Intrinsics/Reference.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Reference.hs
@@ -519,27 +519,27 @@ writeRefPath ::
 -- There is a similar special case above for MirWriteRef with Empty_RefPath,
 -- which allows writing to an uninitialized MirReferenceRoot.
 writeRefPath bak iTypes v (Just_RefPath _tp path) _writeSize x =
-  adjustRefPath bak iTypes v path (\_ -> return $ justPartExpr (backendGetSym bak) x)
+  adjustRefPath bak iTypes v path All (\_ -> return $ justPartExpr (backendGetSym bak) x)
 -- TODO remove these cases?  should be equivalent to the `adjustRefPath` cases below
 writeRefPath bak iTypes v (VectorIndex_RefPath tp path idx) _writeSize x = do
-  adjustRefPath bak iTypes v path (\vec ->
+  adjustRefPath bak iTypes v path All (\vec ->
     leafAdjustVectorWithSymIndex bak (muxRegForType (backendGetSym bak) iTypes tp) vec idx (\_ ->
       return x))
 writeRefPath bak iTypes v (ArrayIndex_RefPath _btp path idx) _writeSize x = do
-  adjustRefPath bak iTypes v path (\arr ->
+  adjustRefPath bak iTypes v path All (\arr ->
     liftIO $ arrayUpdate (backendGetSym bak) arr (Empty :> idx) x)
 -- For `MirAggregate`, `writeRefPath` with a concrete index can insert a new
 -- entry into the aggregate.
 writeRefPath bak iTypes v (AgElem_RefPath idx tpr path) writeSize x = do
-  adjustRefPath bak iTypes v path (\v' -> do
+  adjustRefPath bak iTypes v path All (\v' -> do
     writeMirAggregateWithSymOffset bak (muxRegForType (backendGetSym bak) iTypes tpr)
       idx writeSize tpr x v')
 writeRefPath bak iTypes v (AgOffset_RefPath off path) writeSize x = do
-  adjustRefPath bak iTypes v path (\v' -> do
+  adjustRefPath bak iTypes v path All (\v' -> do
     let mux = muxRegForType (backendGetSym bak) iTypes MirAggregateRepr
     writeMirAggregateWithSymOffset bak mux off writeSize MirAggregateRepr x v')
 writeRefPath bak iTypes v path _writeSize x =
-  adjustRefPath bak iTypes v path (\_ -> return x)
+  adjustRefPath bak iTypes v path All (\_ -> return x)
 
 adjustRefPath ::
   (IsSymBackend sym bak) =>
@@ -547,40 +547,41 @@ adjustRefPath ::
   IntrinsicTypes sym ->
   RegValue sym tp ->
   MirReferencePath sym tp tp' ->
+  OpSize ->
   (RegValue sym tp' -> MuxLeafT sym IO (RegValue sym tp')) ->
   MuxLeafT sym IO (RegValue sym tp)
-adjustRefPath bak iTypes v path0 adj = case path0 of
+adjustRefPath bak iTypes v path0 adjSize adj = case path0 of
   Empty_RefPath -> adj v
   Field_RefPath _ctx path fld ->
-      adjustRefPath bak iTypes v path
+      adjustRefPath bak iTypes v path All
         (\x -> adjustM (\x' -> RV <$> adj (unRV x')) fld x)
   Variant_RefPath _ _ctx path fld ->
       -- TODO: report an error if variant `fld` is not selected
-      adjustRefPath bak iTypes v path (field @1 (\(RV x) ->
+      adjustRefPath bak iTypes v path All (field @1 (\(RV x) ->
         RV <$> adjustM (\x' -> VB <$> mapM adj (unVB x')) fld x))
   Just_RefPath tp path ->
-      adjustRefPath bak iTypes v path $ \v' -> do
+      adjustRefPath bak iTypes v path All $ \v' -> do
           let msg = ReadBeforeWriteSimError $
                   "attempted to modify uninitialized Maybe of type " ++ show tp
           v'' <- leafReadPartExpr bak v' msg
           mv <- adj v''
           return $ justPartExpr (backendGetSym bak) mv
   VectorIndex_RefPath tp path idx ->
-      adjustRefPath bak iTypes v path (\v' ->
+      adjustRefPath bak iTypes v path All (\v' ->
         leafAdjustVectorWithSymIndex bak (muxRegForType (backendGetSym bak) iTypes tp) v' idx adj)
   ArrayIndex_RefPath _btp path idx ->
-      adjustRefPath bak iTypes v path (\arr -> do
+      adjustRefPath bak iTypes v path All (\arr -> do
         let sym = backendGetSym bak
         let arrIdx = Empty :> idx
         x <- liftIO $ arrayLookup sym arr arrIdx
         x' <- adj x
         liftIO $ arrayUpdate sym arr arrIdx x')
   AgElem_RefPath idx tpr path ->
-      adjustRefPath bak iTypes v path (\v' -> do
+      adjustRefPath bak iTypes v path All (\v' -> do
         adjustMirAggregateWithSymOffset bak (muxRegForType (backendGetSym bak) iTypes tpr)
           idx tpr adj v')
   AgOffset_RefPath off path -> do
-      adjustRefPath bak iTypes v path (\v' ->
+      adjustRefPath bak iTypes v path All (\v' ->
         let mux = muxRegForType (backendGetSym bak) iTypes MirAggregateRepr
          in adjustMirAggregateWithSymOffset bak mux off MirAggregateRepr adj v')
 

--- a/crucible-mir/src/Mir/Intrinsics/Reference.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Reference.hs
@@ -61,8 +61,6 @@ module Mir.Intrinsics.Reference
     subvariantMirRefIO,
     subjustMirRefLeaf,
     subjustMirRefIO,
-    mirRef_agElem_unsizedLeaf,
-    mirRef_agElem_unsizedIO,
     mirRef_agOffsetLeaf,
     mirRef_agOffsetIO,
     mirRef_arrayIndexLeaf,
@@ -117,7 +115,6 @@ import Lens.Micro ((^.), (.~))
 
 import Data.BitVector.Sized qualified as BV
 import Data.Function ((&))
-import Data.IntMap qualified as IntMap
 import Data.Kind (Type)
 import Data.Parameterized.Context
   ( Ctx,
@@ -209,7 +206,6 @@ import Mir.FancyMuxTree
   )
 import Mir.Intrinsics.Aggregate
   ( MirAggregate (..),
-    MirAggregateEntry (..),
     MirAggregateType,
     adjustMirAggregateWithSymOffset,
     readMirAggregateWithSymOffset,
@@ -1042,38 +1038,6 @@ mirRef_vecIndexIO ::
     IO (MirReferenceMux sym)
 mirRef_vecIndexIO bak iTypes idx elemTpr ref =
   modifyRefMuxMA bak iTypes (mirRef_vecIndexLeaf bak idx elemTpr) ref
-
-
-mirRef_agElem_unsizedLeaf ::
-    IsSymBackend sym bak =>
-    bak ->
-    SymGlobalState sym ->
-    IntrinsicTypes sym ->
-    RegValue sym UsizeType ->
-    MirReference sym ->
-    MuxLeafT sym IO (MirReference sym)
-mirRef_agElem_unsizedLeaf bak gs iTypes off ref =
-  typedLeafOp "MirAggregate unsized element projection" bak MirAggregateRepr ref $ \root path -> do
-    offConcrete <- case asBV off of
-      Just bv -> return $ fromIntegral $ BV.asUnsigned bv
-      Nothing -> leafAbort $ GenericSimError $
-        "mirRef_agElem_unsized: offset must be concrete, but got " ++ show (printSymExpr off)
-    MirAggregate _ m <- readMirRefLeaf bak gs iTypes MirAggregateRepr All ref
-    (sz, Some entryTpr) <- case IntMap.lookup offConcrete m of
-      Just (MirAggregateEntry sz entryTpr _) -> return (sz, Some entryTpr)
-      Nothing -> return (0, Some MirAggregateRepr)
-    return $ MirReference entryTpr root (AgElem_RefPath off sz entryTpr path)
-
-mirRef_agElem_unsizedIO ::
-    IsSymBackend sym bak =>
-    bak ->
-    SymGlobalState sym ->
-    IntrinsicTypes sym ->
-    RegValue sym UsizeType ->
-    MirReferenceMux sym ->
-    IO (MirReferenceMux sym)
-mirRef_agElem_unsizedIO bak gs iTypes off ref =
-    modifyRefMuxMA bak iTypes (mirRef_agElem_unsizedLeaf bak gs iTypes off) ref
 
 
 mirRef_agOffsetLeaf ::

--- a/crucible-mir/src/Mir/Intrinsics/Reference.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Reference.hs
@@ -788,6 +788,11 @@ typedLeafOp desc bak expectTpr (MirReference tpr root path) k
       -- TODO: hardcoded size=0
       let elemPath = AgElem_RefPath off 0 expectTpr origPath
       k root elemPath
+  | MirAggregateRepr <- tpr = do
+      -- See Note [Aggregate zero-offsets]
+      zero <- liftIO $ wordLit (backendGetSym bak) 0
+      let offPath = AgOffset_RefPath zero path
+      typedLeafOp desc bak expectTpr (MirReference tpr root offPath) k
   | otherwise = leafAbort $ GenericSimError $
       desc ++ " requires a reference to " ++ show expectTpr
         ++ ", but got a reference to " ++ show tpr
@@ -795,6 +800,15 @@ typedLeafOp desc _ _ (MirReference_Integer _) _ =
     leafAbort $ GenericSimError $
         "attempted " ++ desc ++ " on the result of an integer-to-pointer cast"
 
+{-
+Note [Aggregate zero-offsets]
+
+We consider a reference path with a `MirAggregate` pointee, but without an
+`AgOffset_RefPath` terminator, to be equivalent to the same path with an
+`AgOffset_RefPath` terminator with an offset of zero. This helps us to mimic
+e.g. Rust's lack of disambiguation between pointers to collections and pointers
+to collections' first element.
+-}
 
 readMirRefSim :: IsSymInterface sym =>
     TypeRepr tp ->
@@ -1173,6 +1187,16 @@ refPathEq sym (AgOffset_RefPath off1 p1) (AgOffset_RefPath off2 p2) = do
     offEq <- liftIO $ bvEq sym off1 off2
     pEq <- refPathEq sym p1 p2
     liftIO $ andPred sym offEq pEq
+refPathEq sym (AgOffset_RefPath off1 p1) p2 = do
+    -- See Note [Aggregate zero-offsets]
+    offEq <- liftIO $ bvEq sym off1 =<< wordLit sym 0
+    pEq <- refPathEq sym p1 p2
+    liftIO $ andPred sym offEq pEq
+refPathEq sym p1 (AgOffset_RefPath off2 p2) = do
+    -- See Note [Aggregate zero-offsets]
+    offEq <- liftIO $ bvEq sym off2 =<< wordLit sym 0
+    pEq <- refPathEq sym p1 p2
+    liftIO $ andPred sym offEq pEq
 
 refPathEq sym Empty_RefPath _ = return $ falsePred sym
 refPathEq sym (Field_RefPath {}) _ = return $ falsePred sym
@@ -1181,7 +1205,6 @@ refPathEq sym (Just_RefPath {}) _ = return $ falsePred sym
 refPathEq sym (VectorIndex_RefPath {}) _ = return $ falsePred sym
 refPathEq sym (ArrayIndex_RefPath {}) _ = return $ falsePred sym
 refPathEq sym (AgElem_RefPath {}) _ = return $ falsePred sym
-refPathEq sym (AgOffset_RefPath {}) _ = return $ falsePred sym
 
 mirRef_eqLeaf ::
     IsSymInterface sym =>
@@ -1357,6 +1380,16 @@ refPathOverlaps sym path1 path2 = do
         overlaps <- liftIO $ bvUge sym offESz offO
         pEq <- go rrp1 rrp2
         liftIO $ andPred sym overlaps pEq
+    go (AgOffset_RefPath off _ `RrpCons` rrp1) rrp2
+      | Just bv <- asBV off
+      , 0 <- BV.asUnsigned bv =
+        -- See Note [Aggregate zero-offsets]
+        go rrp1 rrp2
+    go rrp1 (AgOffset_RefPath off _ `RrpCons` rrp2)
+      | Just bv <- asBV off
+      , 0 <- BV.asUnsigned bv =
+        -- See Note [Aggregate zero-offsets]
+        go rrp1 rrp2
 
     go (Field_RefPath {} `RrpCons` _) _ = return $ falsePred sym
     go (Variant_RefPath {} `RrpCons` _) _ = return $ falsePred sym
@@ -1501,6 +1534,11 @@ mirRef_offsetWrapLeaf bak (MirReference tpr root (AgOffset_RefPath off path)) nu
     extraOff <- liftIO $ bvMul sym numElems =<< wordLit sym elemSize
     off' <- liftIO $ bvAdd sym off extraOff
     return $ MirReference tpr root $ AgOffset_RefPath off' path
+mirRef_offsetWrapLeaf bak (MirReference MirAggregateRepr root path) offset elemSize = do
+    -- See Note [Aggregate zero-offsets]
+    zero <- liftIO $ wordLit (backendGetSym bak) 0
+    let offPath = AgOffset_RefPath zero path
+    mirRef_offsetWrapLeaf bak (MirReference MirAggregateRepr root offPath) offset elemSize
 mirRef_offsetWrapLeaf bak ref@(MirReference _ _ _) offset _elemSize = do
     let sym = backendGetSym bak
     isZero <- liftIO $ bvEq sym offset =<< bvZero sym knownNat
@@ -1525,7 +1563,7 @@ mirRef_tryOffsetFromLeaf ::
     MirReference sym ->
     MirReference sym ->
     MuxLeafT sym IO (RegValue sym (MaybeType IsizeType))
-mirRef_tryOffsetFromLeaf bak elemSize (MirReference _ root1 path1) (MirReference _ root2 path2) = do
+mirRef_tryOffsetFromLeaf bak elemSize r1@(MirReference tp1 root1 path1) r2@(MirReference tp2 root2 path2) = do
     let sym = backendGetSym bak
     rootEq <- refRootEq sym root1 root2
     case (path1, path2) of
@@ -1581,6 +1619,18 @@ mirRef_tryOffsetFromLeaf bak elemSize (MirReference _ root1 path1) (MirReference
                   "offset_from: byte offset not a multiple of `size_of::<T>` (" <> show elemSize <> ")"
 
             return $ mkPE similar elemOffset
+        (AgOffset_RefPath _ _, _)
+          | MirAggregateRepr <- tp2 -> do
+            -- See Note [Aggregate zero-offsets]
+            zero <- wordLit sym 0
+            let r2' = MirReference tp2 root2 (AgOffset_RefPath zero path2)
+            mirRef_tryOffsetFromLeaf bak elemSize r1 r2'
+        (_, AgOffset_RefPath _ _)
+          | MirAggregateRepr <- tp1 -> do
+            -- See Note [Aggregate zero-offsets]
+            zero <- wordLit sym 0
+            let r1' = MirReference tp1 root1 (AgOffset_RefPath zero path1)
+            mirRef_tryOffsetFromLeaf bak elemSize r1' r2
         _ -> do
             pathEq <- refPathEq sym path1 path2
             similar <- liftIO $ andPred sym rootEq pathEq
@@ -1651,6 +1701,12 @@ mirRef_peelIndexLeaf bak elemSize (MirReference _tpr root (AgOffset_RefPath off 
         "expected element offset to be a multiple of element size (" ++ show elemSize ++ ")"
 
     idx <- liftIO $ bvUdiv sym off elemSizeBV
+    let ref = MirReferenceMux $ toFancyMuxTree sym $ MirReference MirAggregateRepr root path
+    return $ Empty :> RV ref :> RV idx
+mirRef_peelIndexLeaf bak _elemSize (MirReference MirAggregateRepr root path) = do
+    -- See Note [Aggregate zero-offsets]
+    let sym = backendGetSym bak
+    idx <- liftIO $ wordLit sym 0
     let ref = MirReferenceMux $ toFancyMuxTree sym $ MirReference MirAggregateRepr root path
     return $ Empty :> RV ref :> RV idx
 mirRef_peelIndexLeaf _bak _elemSize (MirReference _ _ _) =

--- a/crucible-mir/src/Mir/Intrinsics/Reference.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Reference.hs
@@ -279,8 +279,6 @@ data MirReferencePath sym :: CrucibleType -> CrucibleType -> Type where
   -- | Access an entry in a `MirAggregate`.
   AgElem_RefPath ::
     !(RegValue sym UsizeType) ->
-    -- | Size in bytes of the entry to access
-    !Word ->
     !(TypeRepr tp) ->
     !(MirReferencePath sym tp_base MirAggregateType) ->
     MirReferencePath sym tp_base tp
@@ -319,7 +317,7 @@ instance IsSymInterface sym => Show (MirReferencePath sym tp tp') where
     show (Just_RefPath tpr p) = "(Just_RefPath " ++ show tpr ++ " " ++ show p ++ ")"
     show (VectorIndex_RefPath tpr p idx) = "(VectorIndex_RefPath " ++ show tpr ++ " " ++ show p ++ " " ++ show (printSymExpr idx) ++ ")"
     show (ArrayIndex_RefPath btpr p idx) = "(ArrayIndex_RefPath " ++ show btpr ++ " " ++ show p ++ " " ++ show (printSymExpr idx) ++ ")"
-    show (AgElem_RefPath off sz tpr p) = "(AgElem_RefPath " ++ show (printSymExpr off) ++ " " ++ show sz ++ " " ++ show tpr ++ " " ++ show p ++ ")"
+    show (AgElem_RefPath off tpr p) = "(AgElem_RefPath " ++ show (printSymExpr off) ++ " " ++ show tpr ++ " " ++ show p ++ ")"
     show (AgOffset_RefPath off p) = "(AgOffset_RefPath " ++ show (printSymExpr off) ++ " " ++ show p ++ ")"
 
 instance IsSymInterface sym => Show (MirReference sym) where
@@ -372,10 +370,10 @@ instance OrdSkel (MirReference sym) where
             compareSkelF btpr1 btpr2 <> cmpPath p1 p2
         cmpPath (ArrayIndex_RefPath _ _ _) _ = LT
         cmpPath _ (ArrayIndex_RefPath _ _ _) = GT
-        cmpPath (AgElem_RefPath _off1 sz1 tpr1 p1) (AgElem_RefPath _off2 sz2 tpr2 p2) =
-            compare sz1 sz2 <> compareSkelF tpr1 tpr2 <> cmpPath p1 p2
-        cmpPath (AgElem_RefPath _ _ _ _) _ = LT
-        cmpPath _ (AgElem_RefPath _ _ _ _) = GT
+        cmpPath (AgElem_RefPath _off1 tpr1 p1) (AgElem_RefPath _off2 tpr2 p2) =
+            compareSkelF tpr1 tpr2 <> cmpPath p1 p2
+        cmpPath (AgElem_RefPath _ _ _) _ = LT
+        cmpPath _ (AgElem_RefPath _ _ _) = GT
         cmpPath (AgOffset_RefPath _off1 p1) (AgOffset_RefPath _off2 p2) =
             cmpPath p1 p2
 
@@ -496,7 +494,7 @@ readRefPath bak iTypes v readSize = \case
   ArrayIndex_RefPath _btp path idx ->
     do arr <- readRefPath bak iTypes v All path
        liftIO $ arrayLookup (backendGetSym bak) arr (Empty :> idx)
-  AgElem_RefPath off _sz tpr path -> do
+  AgElem_RefPath off tpr path -> do
     ag <- readRefPath bak iTypes v All path
     readMirAggregateWithSymOffset bak (muxRegForType (backendGetSym bak) iTypes tpr) off readSize tpr ag
   AgOffset_RefPath off path -> do
@@ -532,7 +530,7 @@ writeRefPath bak iTypes v (ArrayIndex_RefPath _btp path idx) _writeSize x = do
     liftIO $ arrayUpdate (backendGetSym bak) arr (Empty :> idx) x)
 -- For `MirAggregate`, `writeRefPath` with a concrete index can insert a new
 -- entry into the aggregate.
-writeRefPath bak iTypes v (AgElem_RefPath idx _sz tpr path) writeSize x = do
+writeRefPath bak iTypes v (AgElem_RefPath idx tpr path) writeSize x = do
   adjustRefPath bak iTypes v path (\v' -> do
     writeMirAggregateWithSymOffset bak (muxRegForType (backendGetSym bak) iTypes tpr)
       idx writeSize tpr x v')
@@ -577,7 +575,7 @@ adjustRefPath bak iTypes v path0 adj = case path0 of
         x <- liftIO $ arrayLookup sym arr arrIdx
         x' <- adj x
         liftIO $ arrayUpdate sym arr arrIdx x')
-  AgElem_RefPath idx _sz tpr path ->
+  AgElem_RefPath idx tpr path ->
       adjustRefPath bak iTypes v path (\v' -> do
         adjustMirAggregateWithSymOffset bak (muxRegForType (backendGetSym bak) iTypes tpr)
           idx tpr adj v')
@@ -621,10 +619,10 @@ muxRefPath sym c path1 path2 = case (path1,path2) of
          do p' <- muxRefPath sym c p1 p2
             i' <- lift $ bvIte sym c i1 i2
             return (ArrayIndex_RefPath btp p' i')
-  (AgElem_RefPath off1 sz tpr p1, AgElem_RefPath off2 _ _ p2) ->
+  (AgElem_RefPath off1 tpr p1, AgElem_RefPath off2 _ p2) ->
          do off' <- lift $ bvIte sym c off1 off2
             p' <- muxRefPath sym c p1 p2
-            return (AgElem_RefPath off' sz tpr p')
+            return (AgElem_RefPath off' tpr p')
   (AgOffset_RefPath off1 p1, AgOffset_RefPath off2 p2) ->
          do off' <- lift $ bvIte sym c off1 off2
             p' <- muxRefPath sym c p1 p2
@@ -779,8 +777,7 @@ typedLeafOp desc bak expectTpr (MirReference tpr root path) k
   | Just Refl <- testEquality tpr expectTpr =
       k root path
   | AgOffset_RefPath off origPath <- path = do
-      -- TODO: hardcoded size=0
-      let elemPath = AgElem_RefPath off 0 expectTpr origPath
+      let elemPath = AgElem_RefPath off expectTpr origPath
       k root elemPath
   | MirAggregateRepr <- tpr = do
       -- See Note [Aggregate zero-offsets]
@@ -1107,7 +1104,7 @@ refPathEq sym (ArrayIndex_RefPath btpr1 p1 idx1) (ArrayIndex_RefPath btpr2 p2 id
     pEq <- refPathEq sym p1 p2
     idxEq <- liftIO $ bvEq sym idx1 idx2
     liftIO $ andPred sym pEq idxEq
-refPathEq sym (AgElem_RefPath off1 _sz1 _tpr1 p1) (AgElem_RefPath off2 _sz2 _tpr2 p2) = do
+refPathEq sym (AgElem_RefPath off1 _tpr1 p1) (AgElem_RefPath off2 _tpr2 p2) = do
     offEq <- liftIO $ bvEq sym off1 off2
     -- NB: Don't check the following for equality:
     --
@@ -1209,8 +1206,8 @@ reverseRefPath = go RrpNil
         go (VectorIndex_RefPath tpr Empty_RefPath idx `RrpCons` acc) rp
     go acc (ArrayIndex_RefPath btpr rp idx) =
         go (ArrayIndex_RefPath btpr Empty_RefPath idx `RrpCons` acc) rp
-    go acc (AgElem_RefPath off sz tpr rp) =
-        go (AgElem_RefPath off sz tpr Empty_RefPath `RrpCons` acc) rp
+    go acc (AgElem_RefPath off tpr rp) =
+        go (AgElem_RefPath off tpr Empty_RefPath `RrpCons` acc) rp
     go acc (AgOffset_RefPath off rp) =
         go (AgOffset_RefPath off Empty_RefPath `RrpCons` acc) rp
 
@@ -1219,7 +1216,7 @@ reverseRefPath = go RrpNil
 popIndex :: MirReferencePath sym tp tp' -> Some (MirReferencePath sym tp)
 popIndex (VectorIndex_RefPath _ p _) = Some p
 popIndex (ArrayIndex_RefPath _ p _) = Some p
-popIndex (AgElem_RefPath _ _ _ p) = Some p
+popIndex (AgElem_RefPath _ _ p) = Some p
 popIndex (AgOffset_RefPath _ p) = Some p
 popIndex p = Some p
 
@@ -1435,19 +1432,12 @@ mirRef_offsetWrapLeaf bak (MirReference tpr root (ArrayIndex_RefPath btpr path i
     -- `wrapping_offset` puts no restrictions on the arithmetic performed.
     idx' <- liftIO $ bvAdd sym idx numElems
     return $ MirReference tpr root $ ArrayIndex_RefPath btpr path idx'
-mirRef_offsetWrapLeaf bak (MirReference tpr root (AgElem_RefPath elemOff _elemSize tpr' path)) numElems elemSize = do
-    -- Note that we ignore the element size associated with the `AgElem_RefPath`
-    -- we're processing in favor of the one we're given as a parameter. This
-    -- accommodates patterns like casting `*const u32` to `*const u8`, using
-    -- `offset` on the latter, then casting back to the former. The cast isn't
-    -- (currently) implemented to change the element size in the
-    -- `AgElem_RefPath`, so to use that size in that case would have us
-    -- improperly offset by 4 bytes (i.e. the size of a `u32`) at a time.
+mirRef_offsetWrapLeaf bak (MirReference tpr root (AgElem_RefPath elemOff tpr' path)) numElems elemSize = do
     let sym = backendGetSym bak
     -- `wrapping_offset` puts no restrictions on the arithmetic performed.
     extraOff <- liftIO $ bvMul sym numElems =<< wordLit sym elemSize
     elemOff' <- liftIO $ bvAdd sym elemOff extraOff
-    return $ MirReference tpr root $ AgElem_RefPath elemOff' elemSize tpr' path
+    return $ MirReference tpr root $ AgElem_RefPath elemOff' tpr' path
 mirRef_offsetWrapLeaf bak (MirReference tpr root (AgOffset_RefPath off path)) numElems elemSize = do
     let sym = backendGetSym bak
     -- `wrapping_offset` puts no restrictions on the arithmetic performed.
@@ -1499,12 +1489,7 @@ mirRef_tryOffsetFromLeaf bak elemSize r1@(MirReference tp1 root1 path1) r2@(MirR
             -- TODO: implement overflow checks, similar to `offset`
             offset <- liftIO $ bvSub sym idx1 idx2
             return $ mkPE similar offset
-        (AgElem_RefPath off1 _ _ path1', AgElem_RefPath off2 _ _ path2') -> do
-            -- Use the `elemSize` parameter instead of the element size stored in the
-            -- reference path to avoid using a type-incorrect size when
-            -- operating on a reference that's been cast to a type that doesn't
-            -- match its original representation. (Same rationale as described
-            -- in `mirRef_offsetWrapLeaf`.)
+        (AgElem_RefPath off1 _ path1', AgElem_RefPath off2 _ path2') -> do
             pathEq <- refPathEq sym path1' path2'
             similar <- liftIO $ andPred sym rootEq pathEq
             byteOffset <- liftIO $ bvSub sym off1 off2
@@ -1520,11 +1505,6 @@ mirRef_tryOffsetFromLeaf bak elemSize r1@(MirReference tp1 root1 path1) r2@(MirR
 
             return $ mkPE similar elemOffset
         (AgOffset_RefPath off1 path1', AgOffset_RefPath off2 path2') -> do
-            -- Use the `elemSize` parameter instead of the element size stored in the
-            -- reference path to avoid using a type-incorrect size when
-            -- operating on a reference that's been cast to a type that doesn't
-            -- match its original representation. (Same rationale as described
-            -- in `mirRef_offsetWrapLeaf`.)
             pathEq <- refPathEq sym path1' path2'
             similar <- liftIO $ andPred sym rootEq pathEq
             byteOffset <- liftIO $ bvSub sym off1 off2
@@ -1599,7 +1579,7 @@ mirRef_peelIndexLeaf bak _elemSize (MirReference _tpr root (ArrayIndex_RefPath b
     let sym = backendGetSym bak
     let ref = MirReferenceMux $ toFancyMuxTree sym $ MirReference (UsizeArrayRepr btpr) root path
     return $ Empty :> RV ref :> RV idx
-mirRef_peelIndexLeaf bak elemSize (MirReference _tpr root (AgElem_RefPath off _sz _tpr' path)) = do
+mirRef_peelIndexLeaf bak elemSize (MirReference _tpr root (AgElem_RefPath off _tpr' path)) = do
     let sym = backendGetSym bak
     elemSizeBV <- liftIO $ wordLit sym elemSize
 
@@ -1705,9 +1685,9 @@ mirRef_peelFieldMA bak iTypes fieldReprs idx (MirReferenceMux ref) =
 -- | Peel off an outermost 'AgElem_RefPath'. Given a pointer to a field of an
 -- aggregate, this produces a pointer to the containing struct.
 --
--- This function takes in the expected offset and size of the field within the
--- aggregate. If the 'AgElem_RefPath' is actually for a different offset or
--- size, it will raise an error.
+-- This function takes in the expected offset of the field within the aggregate.
+-- If the 'AgElem_RefPath' is actually for a different offset, it will raise an
+-- error.
 --
 -- If the outermost path segment isn't 'AgElem_RefPath', this operation raises
 -- an error.
@@ -1715,14 +1695,12 @@ mirRef_peelAgElemLeaf ::
     (IsSymBackend sym bak, MonadAssert sym bak m) =>
     bak ->
     Word {-^ The expected offset -} ->
-    Word {-^ The expected size -} ->
     MirReference sym {-^ The field pointer -} ->
     MuxLeafT sym m (MirReferenceMux sym)
-mirRef_peelAgElemLeaf bak off sz (MirReference _tpr root path) = do
+mirRef_peelAgElemLeaf bak off (MirReference _tpr root path) = do
     let sym = backendGetSym bak
     case path of
-      AgElem_RefPath off' sz' _ path'
-        | sz' == sz -> do
+      AgElem_RefPath off' _ path' -> do
           offEq <- liftIO $ bvEq sym off' =<< wordLit sym off
           leafAssert bak offEq $ Unsupported callStack $
             "peelAgElem offset mismatch; expected " ++ show off
@@ -1730,14 +1708,10 @@ mirRef_peelAgElemLeaf bak off sz (MirReference _tpr root path) = do
           return $ MirReferenceMux $
             toFancyMuxTree sym $ MirReference MirAggregateRepr root path'
 
-        | otherwise ->
-          leafAbort $ Unsupported callStack $
-            "peelAgElem size mismatch; expected " ++ show sz
-              ++ ", but got " ++ show sz'
       _ ->
         leafAbort $ Unsupported callStack $
           "peelAgElem not implemented for this RefPath kind"
-mirRef_peelAgElemLeaf _ _ _ _ =
+mirRef_peelAgElemLeaf _ _ _ =
     leafAbort $ Unsupported callStack $
       "cannot perform peelAgElem on invalid pointer"
 
@@ -1746,12 +1720,11 @@ mirRef_peelAgElemMA ::
     bak ->
     IntrinsicTypes sym ->
     Word {-^ The expected offset -} ->
-    Word {-^ The expected size -} ->
     MirReferenceMux sym ->
     m (MirReferenceMux sym)
-mirRef_peelAgElemMA bak iTypes off sz (MirReferenceMux ref) =
+mirRef_peelAgElemMA bak iTypes off (MirReferenceMux ref) =
     let sym = backendGetSym bak in
-    readFancyMuxTree' bak (mirRef_peelAgElemLeaf bak off sz)
+    readFancyMuxTree' bak (mirRef_peelAgElemLeaf bak off)
         (muxRegForType sym iTypes MirReferenceRepr) ref
 
 
@@ -1820,11 +1793,7 @@ mirRef_indexAndLenLeaf bak gs iTypes _elemSize (MirReference tpr root (VectorInd
 mirRef_indexAndLenLeaf _bak _gs _iTypes _elemSize (MirReference _tpr _root (ArrayIndex_RefPath {})) =
     leafAbort $ Unsupported callStack
         "can't compute allocation length for Array, which is unbounded"
-mirRef_indexAndLenLeaf bak gs iTypes elemSize (MirReference _tpr root (AgElem_RefPath elemOff _elemSize _tpr' path)) = do
-    -- Use an `elemSize` parameter instead of the element size stored in the
-    -- reference path to avoid using a type-incorrect size when operating on a
-    -- reference that's been cast to a type that doesn't match its original
-    -- representation. (Same rationale as described in `mirRef_offsetWrapLeaf`.)
+mirRef_indexAndLenLeaf bak gs iTypes elemSize (MirReference _tpr root (AgElem_RefPath elemOff _tpr' path)) = do
     let sym = backendGetSym bak
     let parentTpr = MirAggregateRepr
     let parent = MirReference parentTpr root path

--- a/crucible-mir/src/Mir/Intrinsics/Reference.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Reference.hs
@@ -101,8 +101,6 @@ module Mir.Intrinsics.Reference
     mirRef_indexAndLenLeaf,
     mirRef_indexAndLenIO,
     mirRef_indexAndLenSim,
-    mirRef_aggregateAsChunksLeaf,
-    mirRef_aggregateAsChunksIO,
   )
 where
 
@@ -216,10 +214,6 @@ import Mir.Intrinsics.Aggregate
     MirAggregateEntry (..),
     MirAggregateType,
     adjustMirAggregateWithSymOffset,
-    mirAggregate_concat,
-    mirAggregate_fromChunks,
-    mirAggregate_split3,
-    mirAggregate_toChunks,
     readMirAggregateWithSymOffset,
     writeMirAggregateWithSymOffset,
     pattern MirAggregateRepr,
@@ -303,20 +297,6 @@ data MirReferencePath sym :: CrucibleType -> CrucibleType -> Type where
     !(RegValue sym UsizeType) ->
     !(MirReferencePath sym tp_base MirAggregateType) ->
     MirReferencePath sym tp_base MirAggregateType
-  -- | Reinterpret a portion of a `MirAggregate` as an array of equal-sized
-  -- chunks.  This is used to implement @<[T]>::as_chunks@ and several related
-  -- methods.  We can get rid of this once `MirAggregate` flattening is
-  -- implemented.
-  AggregateAsChunks_RefPath ::
-    -- | Starting offset within the input aggregate
-    !Word ->
-    -- | Size in bytes of each chunk
-    !Word ->
-    -- | Number of chunks to produce
-    !Word ->
-    -- | Path to the input aggregate
-    !(MirReferencePath sym tp_base MirAggregateType) ->
-    MirReferencePath sym tp_base MirAggregateType
 
 data MirReference sym where
   MirReference ::
@@ -347,7 +327,6 @@ instance IsSymInterface sym => Show (MirReferencePath sym tp tp') where
     show (ArrayIndex_RefPath btpr p idx) = "(ArrayIndex_RefPath " ++ show btpr ++ " " ++ show p ++ " " ++ show (printSymExpr idx) ++ ")"
     show (AgElem_RefPath off sz tpr p) = "(AgElem_RefPath " ++ show (printSymExpr off) ++ " " ++ show sz ++ " " ++ show tpr ++ " " ++ show p ++ ")"
     show (AgOffset_RefPath off p) = "(AgOffset_RefPath " ++ show (printSymExpr off) ++ " " ++ show p ++ ")"
-    show (AggregateAsChunks_RefPath off chunkSize numChunks p) = "(AggregateAsChunks_RefPath " ++ show off ++ " " ++ show chunkSize ++ " " ++ show numChunks ++ " " ++ show p ++ ")"
 
 instance IsSymInterface sym => Show (MirReference sym) where
     show (MirReference tpr root path) = "(MirReference " ++ show tpr ++ " " ++ show (refRootType root) ++ " " ++ show root ++ " " ++ show path ++ ")"
@@ -405,12 +384,6 @@ instance OrdSkel (MirReference sym) where
         cmpPath _ (AgElem_RefPath _ _ _ _) = GT
         cmpPath (AgOffset_RefPath _off1 p1) (AgOffset_RefPath _off2 p2) =
             cmpPath p1 p2
-        cmpPath (AgOffset_RefPath _ _) _ = LT
-        cmpPath _ (AgOffset_RefPath _ _) = GT
-        cmpPath (AggregateAsChunks_RefPath off1 chunkSize1 numChunks1 p1)
-                (AggregateAsChunks_RefPath off2 chunkSize2 numChunks2 p2) =
-            compare off1 off2 <> compare chunkSize1 chunkSize2 <> compare numChunks1 numChunks2
-              <> cmpPath p1 p2
 
 refRootType :: MirReferenceRoot sym tp -> TypeRepr tp
 refRootType (RefCell_RefRoot r) = refType r
@@ -536,15 +509,6 @@ readRefPath bak iTypes v readSize = \case
     ag <- readRefPath bak iTypes v All path
     let mux = muxRegForType (backendGetSym bak) iTypes MirAggregateRepr
     readMirAggregateWithSymOffset bak mux off readSize MirAggregateRepr ag
-  AggregateAsChunks_RefPath off chunkSize numChunks path -> do
-    let sym = backendGetSym bak
-    ag <- readRefPath bak iTypes v All path
-    chunkedAg <- case mirAggregate_toChunks sym off chunkSize numChunks ag of
-      Left err -> die $ "mirAggregate_toChunks: " ++ err
-      Right x -> return x
-    return chunkedAg
-  where
-    die msg = leafAbort $ Unsupported callStack $ "readRefPath: " ++ msg
 
 writeRefPath ::
   (IsSymBackend sym bak) =>
@@ -627,24 +591,6 @@ adjustRefPath bak iTypes v path0 adj = case path0 of
       adjustRefPath bak iTypes v path (\v' ->
         let mux = muxRegForType (backendGetSym bak) iTypes MirAggregateRepr
          in adjustMirAggregateWithSymOffset bak mux off MirAggregateRepr adj v')
-  AggregateAsChunks_RefPath off chunkSize numChunks path ->
-      adjustRefPath bak iTypes v path $ \ag -> do
-        let sym = backendGetSym bak
-        (beforeAg, midAg, afterAg) <-
-          case mirAggregate_split3 off (off + chunkSize * numChunks) ag of
-            Left err -> die $ "mirAggregate_split3: " ++ err
-            Right x -> return x
-        chunkedAg <- case mirAggregate_toChunks sym 0 chunkSize numChunks midAg of
-          Left err -> die $ "mirAggregate_toChunks: " ++ err
-          Right x -> return x
-        chunkedAg' <- adj chunkedAg
-        midAg' <- liftIO (mirAggregate_fromChunks sym chunkedAg') >>= \case
-          Left err -> die $ "mirAggregate_fromChunks: " ++ err
-          Right x -> return x
-        let ag' = (beforeAg `mirAggregate_concat` midAg') `mirAggregate_concat` afterAg
-        return ag'
-  where
-    die msg = leafAbort $ Unsupported callStack $ "adjustRefPath: " ++ msg
 
 muxRefPath ::
   IsSymInterface sym =>
@@ -689,9 +635,6 @@ muxRefPath sym c path1 path2 = case (path1,path2) of
          do off' <- lift $ bvIte sym c off1 off2
             p' <- muxRefPath sym c p1 p2
             return (AgOffset_RefPath off' p')
-  (AggregateAsChunks_RefPath off chunkSize numChunks p1, AggregateAsChunks_RefPath _ _ _ p2) ->
-         do p' <- muxRefPath sym c p1 p2
-            return (AggregateAsChunks_RefPath off chunkSize numChunks p')
 
   (Empty_RefPath {}, _) -> mzero
   (Field_RefPath {}, _) -> mzero
@@ -701,7 +644,6 @@ muxRefPath sym c path1 path2 = case (path1,path2) of
   (ArrayIndex_RefPath {}, _) -> mzero
   (AgElem_RefPath {}, _) -> mzero
   (AgOffset_RefPath {}, _) -> mzero
-  (AggregateAsChunks_RefPath {}, _) -> mzero
 
 
 muxRef' :: forall sym.
@@ -1218,10 +1160,6 @@ refPathEq sym (AgOffset_RefPath off1 p1) (AgOffset_RefPath off2 p2) = do
     offEq <- liftIO $ bvEq sym off1 off2
     pEq <- refPathEq sym p1 p2
     liftIO $ andPred sym offEq pEq
-refPathEq sym (AggregateAsChunks_RefPath off1 chunkSize1 numChunks1 p1)
-        (AggregateAsChunks_RefPath off2 chunkSize2 numChunks2 p2)
-  | off1 == off2, chunkSize1 == chunkSize2, numChunks1 == numChunks2 = do
-    refPathEq sym p1 p2
 
 refPathEq sym Empty_RefPath _ = return $ falsePred sym
 refPathEq sym (Field_RefPath {}) _ = return $ falsePred sym
@@ -1231,7 +1169,6 @@ refPathEq sym (VectorIndex_RefPath {}) _ = return $ falsePred sym
 refPathEq sym (ArrayIndex_RefPath {}) _ = return $ falsePred sym
 refPathEq sym (AgElem_RefPath {}) _ = return $ falsePred sym
 refPathEq sym (AgOffset_RefPath {}) _ = return $ falsePred sym
-refPathEq sym (AggregateAsChunks_RefPath {}) _ = return $ falsePred sym
 
 mirRef_eqLeaf ::
     IsSymInterface sym =>
@@ -1302,8 +1239,6 @@ reverseRefPath = go RrpNil
         go (AgElem_RefPath off sz tpr Empty_RefPath `RrpCons` acc) rp
     go acc (AgOffset_RefPath off rp) =
         go (AgOffset_RefPath off Empty_RefPath `RrpCons` acc) rp
-    go acc (AggregateAsChunks_RefPath off chunkSize numChunks rp) =
-        go (AggregateAsChunks_RefPath off chunkSize numChunks Empty_RefPath `RrpCons` acc) rp
 
 -- | If the final step of `path` is an indexing-related `RefPath`, remove it.
 -- Otherwise, return `path` unchanged.
@@ -1409,57 +1344,6 @@ refPathOverlaps sym path1 path2 = do
         overlaps <- liftIO $ bvUge sym offESz offO
         pEq <- go rrp1 rrp2
         liftIO $ andPred sym overlaps pEq
-
-    go (AggregateAsChunks_RefPath off1 chunkSize1 numChunks1 _ `RrpCons` rrp1)
-          (AggregateAsChunks_RefPath off2 chunkSize2 numChunks2 _ `RrpCons` rrp2)
-      | (off1, chunkSize1, numChunks1) == (off2, chunkSize2, numChunks2) = do
-        -- Conversions match exactly.  We can recurse on `rrp1` and `rrp2`
-        -- since they'll both be applied to the same shape of aggregate.
-        go rrp1 rrp2
-      | end1 <- toInteger off1 + (toInteger chunkSize1 * toInteger numChunks1),
-        end2 <- toInteger off2 + (toInteger chunkSize2 * toInteger numChunks2),
-        toInteger off1 < end2 && toInteger off2 < end1 = do
-        -- Conversion regions overlap.  Rather than try to handle `rrp1` and
-        -- `rrp2` precisely (accounting for possibly different starting offsets
-        -- and chunk shapes), we conservatively assume that the remaining paths
-        -- may also overlap.
-        return $ truePred sym
-      | otherwise = do
-        -- Conversion regions don't overlap at all.
-        return $ falsePred sym
-    -- `AggregateAsChunks_RefPath` overlaps with some `AgElem_RefPath` paths.
-    go (AggregateAsChunks_RefPath off1 chunkSize1 numChunks1 _ `RrpCons` _rrp1)
-          (AgElem_RefPath off2 sz2 _tpr2 _ `RrpCons` _rrp2) = do
-      let end1 = off1 + (chunkSize1 * numChunks1)
-      szBv2 <- wordLit sym sz2
-      end2 <- liftIO $ bvAdd sym off2 szBv2
-      -- Check `off1 < end2 && off2 < end1`
-      offBv1 <- wordLit sym off1
-      endBv1 <- wordLit sym end1
-      overlapsPart1 <- liftIO $ bvUlt sym offBv1 end2
-      overlapsPart2 <- liftIO $ bvUlt sym off2 endBv1
-      -- If the two regions overlap, conservatively assume that the rest of the
-      -- path may also overlap, and return true without considering `rrp1` and
-      -- `rrp2`.
-      liftIO $ andPred sym overlapsPart1 overlapsPart2
-    go (AgElem_RefPath off1 sz1 _tpr1 _ `RrpCons` _rrp1)
-          (AggregateAsChunks_RefPath off2 chunkSize2 numChunks2 _ `RrpCons` _rrp2) = do
-      let end2 = off2 + (chunkSize2 * numChunks2)
-      szBv1 <- wordLit sym sz1
-      end1 <- liftIO $ bvAdd sym off1 szBv1
-      -- Check `off1 < end2 && off2 < end1`
-      offBv2 <- wordLit sym off2
-      endBv2 <- wordLit sym end2
-      overlapsPart1 <- liftIO $ bvUlt sym off1 endBv2
-      overlapsPart2 <- liftIO $ bvUlt sym offBv2 end1
-      -- If the two regions overlap, conservatively assume that the rest of the
-      -- path may also overlap, and return true without considering `rrp1` and
-      -- `rrp2`.
-      liftIO $ andPred sym overlapsPart1 overlapsPart2
-    -- Any other cases involving `AggregateAsChunks_RefPath` we conservatively
-    -- assume may overlap.
-    go (AggregateAsChunks_RefPath {} `RrpCons` _) _ = return $ truePred sym
-    go _ (AggregateAsChunks_RefPath {} `RrpCons` _) = return $ truePred sym
 
     go (Field_RefPath {} `RrpCons` _) _ = return $ falsePred sym
     go (Variant_RefPath {} `RrpCons` _) _ = return $ falsePred sym
@@ -2016,54 +1900,3 @@ mirRef_indexAndLenSim ref elemSize = do
        let gs = s ^. stateTree.actFrame.gpGlobals
        let iTypes = ctxIntrinsicTypes $ s ^. stateContext
        liftIO $ mirRef_indexAndLenIO bak gs iTypes ref elemSize
-
-
-mirRef_aggregateAsChunksLeaf ::
-    IsSymInterface sym =>
-    RegValue sym UsizeType ->
-    RegValue sym UsizeType ->
-    MirReference sym ->
-    MuxLeafT sym IO (MirReference sym)
-mirRef_aggregateAsChunksLeaf chunkSizeSym numChunksSym
-        (MirReference _tpr root (AgElem_RefPath offSym _sz _tpr' path)) = do
-    chunkSize <- requireConcrete "chunk size" chunkSizeSym
-    numChunks <- requireConcrete "number of chunks" numChunksSym
-    off <- requireConcrete "slice offset within parent array" offSym
-    return $ MirReference MirAggregateRepr root
-      (AggregateAsChunks_RefPath off chunkSize numChunks path)
-  where
-    requireConcrete desc symExp =
-      case asBV symExp of
-        Just bv -> return $ fromIntegral $ BV.asUnsigned bv
-        Nothing -> leafAbort $ GenericSimError $
-          "aggregateAsChunks requires " ++ desc ++ " to be concrete"
-mirRef_aggregateAsChunksLeaf chunkSizeSym numChunksSym
-        (MirReference _tpr root (AgOffset_RefPath offSym path)) = do
-    chunkSize <- requireConcrete "chunk size" chunkSizeSym
-    numChunks <- requireConcrete "number of chunks" numChunksSym
-    off <- requireConcrete "slice offset within parent array" offSym
-    return $ MirReference MirAggregateRepr root
-      (AggregateAsChunks_RefPath off chunkSize numChunks path)
-  where
-    requireConcrete desc symExp =
-      case asBV symExp of
-        Just bv -> return $ fromIntegral $ BV.asUnsigned bv
-        Nothing -> leafAbort $ GenericSimError $
-          "aggregateAsChunks requires " ++ desc ++ " to be concrete"
-mirRef_aggregateAsChunksLeaf _ _ (MirReference _ _ _) =
-    leafAbort $ Unsupported callStack $
-        "aggregateAsChunks requires a pointer to an aggregate element (AgElem_RefPath)"
-mirRef_aggregateAsChunksLeaf _ _ _ = do
-    leafAbort $ Unsupported callStack $
-        "cannot perform aggregateAsChunks on invalid pointer"
-
-mirRef_aggregateAsChunksIO ::
-    IsSymBackend sym bak =>
-    bak ->
-    IntrinsicTypes sym ->
-    RegValue sym UsizeType ->
-    RegValue sym UsizeType ->
-    MirReferenceMux sym ->
-    IO (MirReferenceMux sym)
-mirRef_aggregateAsChunksIO bak iTypes chunkSizeSym numChunksSym ref =
-    modifyRefMuxMA bak iTypes (mirRef_aggregateAsChunksLeaf chunkSizeSym numChunksSym) ref

--- a/crucible-mir/src/Mir/Intrinsics/Reference.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Reference.hs
@@ -226,6 +226,7 @@ import Mir.Intrinsics.Array (UsizeArrayType, pattern UsizeArrayRepr)
 import Mir.Intrinsics.Enum (RustEnumType, pattern RustEnumRepr)
 import Mir.Intrinsics.Size (IsizeType, UsizeType, wordLit, pattern IsizeRepr)
 import Mir.Intrinsics.Vector (leafAdjustVectorWithSymIndex, leafIndexVectorWithSymIndex)
+import Mir.Mir (OpSize (..))
 
 
 --------------------------------------------------------------
@@ -490,35 +491,36 @@ readRefPath ::
   bak ->
   IntrinsicTypes sym ->
   RegValue sym tp ->
+  OpSize ->
   MirReferencePath sym tp tp' ->
   MuxLeafT sym m (RegValue sym tp')
-readRefPath bak iTypes v = \case
+readRefPath bak iTypes v readSize = \case
   Empty_RefPath -> return v
   Field_RefPath _ctx path fld ->
-    do flds <- readRefPath bak iTypes v path
+    do flds <- readRefPath bak iTypes v All path
        return $ unRV $ flds ! fld
   Variant_RefPath _ ctx path fld ->
-    do (Empty :> _discr :> RV variant) <- readRefPath bak iTypes v path
+    do (Empty :> _discr :> RV variant) <- readRefPath bak iTypes v All path
        let msg = GenericSimError $
                "attempted to read from wrong variant (" ++ show fld ++ " of " ++ show ctx ++ ")"
        leafReadPartExpr bak (unVB $ variant ! fld) msg
   Just_RefPath tp path ->
-    do v' <- readRefPath bak iTypes v path
+    do v' <- readRefPath bak iTypes v All path
        let msg = ReadBeforeWriteSimError $
                "attempted to read from uninitialized Maybe of type " ++ show tp
        leafReadPartExpr bak v' msg
   VectorIndex_RefPath tp path idx ->
-    do v' <- readRefPath bak iTypes v path
+    do v' <- readRefPath bak iTypes v All path
        leafIndexVectorWithSymIndex bak (muxRegForType (backendGetSym bak) iTypes tp) v' idx
   ArrayIndex_RefPath _btp path idx ->
-    do arr <- readRefPath bak iTypes v path
+    do arr <- readRefPath bak iTypes v All path
        liftIO $ arrayLookup (backendGetSym bak) arr (Empty :> idx)
   AgElem_RefPath off _sz tpr path -> do
-    ag <- readRefPath bak iTypes v path
-    readMirAggregateWithSymOffset bak (muxRegForType (backendGetSym bak) iTypes tpr) off tpr ag
+    ag <- readRefPath bak iTypes v All path
+    readMirAggregateWithSymOffset bak (muxRegForType (backendGetSym bak) iTypes tpr) off readSize tpr ag
   AggregateAsChunks_RefPath off chunkSize numChunks path -> do
     let sym = backendGetSym bak
-    ag <- readRefPath bak iTypes v path
+    ag <- readRefPath bak iTypes v All path
     chunkedAg <- case mirAggregate_toChunks sym off chunkSize numChunks ag of
       Left err -> die $ "mirAggregate_toChunks: " ++ err
       Right x -> return x
@@ -813,14 +815,16 @@ typedLeafOp desc _ (MirReference_Integer _) _ =
 
 
 readMirRefSim :: IsSymInterface sym =>
-    TypeRepr tp -> MirReferenceMux sym ->
+    TypeRepr tp ->
+    OpSize ->
+    MirReferenceMux sym ->
     OverrideSim m sym ext rtp args ret (RegValue sym tp)
-readMirRefSim tpr ref =
+readMirRefSim tpr readSize ref =
   ovrWithBackend $ \bak ->
    do s <- get
       let gs = s ^. stateTree.actFrame.gpGlobals
       let iTypes = ctxIntrinsicTypes $ s ^. stateContext
-      liftIO $ readMirRefMA bak gs iTypes tpr ref
+      liftIO $ readMirRefMA bak gs iTypes tpr readSize ref
 
 readMirRefMA ::
     MonadAssert sym bak m =>
@@ -828,10 +832,11 @@ readMirRefMA ::
     SymGlobalState sym ->
     IntrinsicTypes sym ->
     TypeRepr tp ->
+    OpSize ->
     MirReferenceMux sym ->
     m (RegValue sym tp)
-readMirRefMA bak gs iTypes tpr ref =
-    readRefMuxMA bak iTypes tpr (readMirRefLeaf bak gs iTypes tpr) ref
+readMirRefMA bak gs iTypes tpr readSize ref =
+    readRefMuxMA bak iTypes tpr (readMirRefLeaf bak gs iTypes tpr readSize) ref
 
 readMirRefLeaf ::
     (MonadAssert sym bak m) =>
@@ -839,12 +844,13 @@ readMirRefLeaf ::
     SymGlobalState sym ->
     IntrinsicTypes sym ->
     TypeRepr tp ->
+    OpSize ->
     MirReference sym ->
     MuxLeafT sym m (RegValue sym tp)
-readMirRefLeaf bak gs iTypes tpr ref =
+readMirRefLeaf bak gs iTypes tpr readSize ref =
   typedLeafOp "read" tpr ref $ \root path -> do
     v <- readRefRoot bak gs root
-    v' <- readRefPath bak iTypes v path
+    v' <- readRefPath bak iTypes v readSize path
     return v'
 
 
@@ -1067,7 +1073,7 @@ mirRef_agElem_unsizedLeaf bak gs iTypes off ref =
       Just bv -> return $ fromIntegral $ BV.asUnsigned bv
       Nothing -> leafAbort $ GenericSimError $
         "mirRef_agElem_unsized: offset must be concrete, but got " ++ show (printSymExpr off)
-    MirAggregate _ m <- readMirRefLeaf bak gs iTypes MirAggregateRepr ref
+    MirAggregate _ m <- readMirRefLeaf bak gs iTypes MirAggregateRepr All ref
     (sz, Some entryTpr) <- case IntMap.lookup offConcrete m of
       Just (MirAggregateEntry sz entryTpr _) -> return (sz, Some entryTpr)
       Nothing -> return (0, Some MirAggregateRepr)
@@ -1803,7 +1809,7 @@ mirRef_indexAndLenLeaf bak gs iTypes _elemSize (MirReference tpr root (VectorInd
     let sym = backendGetSym bak
     let parentTpr = VectorRepr tpr
     let parent = MirReference parentTpr root path
-    parentVec <- readMirRefLeaf bak gs iTypes parentTpr parent
+    parentVec <- readMirRefLeaf bak gs iTypes parentTpr All parent
     let lenInteger = toInteger $ V.length parentVec
     len <- liftIO $ bvLit sym knownNat $ BV.mkBV knownNat lenInteger
     return (idx, len)
@@ -1818,7 +1824,7 @@ mirRef_indexAndLenLeaf bak gs iTypes elemSize (MirReference _tpr root (AgElem_Re
     let sym = backendGetSym bak
     let parentTpr = MirAggregateRepr
     let parent = MirReference parentTpr root path
-    parentAg <- readMirRefLeaf bak gs iTypes parentTpr parent
+    parentAg <- readMirRefLeaf bak gs iTypes parentTpr All parent
     let MirAggregate totalSize _ = parentAg
     when (totalSize `mod` elemSize /= 0) $
        leafAbort $ Unsupported callStack $

--- a/crucible-mir/src/Mir/Intrinsics/Reference.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Reference.hs
@@ -1282,42 +1282,24 @@ refPathOverlaps sym path1 path2 = do
         rrpEq <- go rrp1 rrp2
         idxEq <- liftIO $ bvEq sym idx1 idx2
         liftIO $ andPred sym rrpEq idxEq
-    go (AgElem_RefPath off1 sz1 _tpr1 _ `RrpCons` rrp1)
-        (AgElem_RefPath off2 sz2 _tpr2 _ `RrpCons` rrp2) = do
-        szBv1 <- wordLit sym sz1
-        szBv2 <- wordLit sym sz2
-        offSz1 <- liftIO $ bvAdd sym off1 szBv1
-        offSz2 <- liftIO $ bvAdd sym off2 szBv2
-        -- FIXME: is this math correct?
-        -- Check that `[off1 .. off1 + sz1]` overlaps `[off2 .. off2 + sz2]`.
-        -- This check is unique to AgElem_RefPath because its sub-locations may
-        -- not necessarily be disjoint from each other.
-        overlapsPart1 <- liftIO $ bvUle sym offSz1 off2
-        overlapsPart2 <- liftIO $ bvUle sym offSz2 off1
-        overlaps <- liftIO $ andPred sym overlapsPart1 overlapsPart2
-        -- NB: Don't check the TypeReprs for equality, as pointers with the
-        -- same memory addresses can have different types if pointer casting is
-        -- involved (see the crux-mir/test/conc_eval/tuple/ref_path_equality.rs
-        -- test case for an example).
-        pEq <- go rrp1 rrp2
-        liftIO $ andPred sym overlaps pEq
 
+    -- Overlap checks on paths into aggregates are conservative; we will report
+    -- overlap if two `RefPath`s point to any place within the same aggregate.
+    -- This is in line with Rust's memory model, which generally permits
+    -- (unsafe) access to memory throughout an aggregate from a pointer into
+    -- that aggregate.
+    --
+    -- If this turns out to be overly conservative, we'll likely need to have
+    -- callers provide some extra information about how much memory is
+    -- accessible from the end of a given `RefPath`
+    go (AgElem_RefPath {} `RrpCons` rrp1) (AgElem_RefPath {} `RrpCons` rrp2) = do
+        go rrp1 rrp2
     go (AgOffset_RefPath _ _ `RrpCons` rrp1) (AgOffset_RefPath _ _ `RrpCons` rrp2) =
         go rrp1 rrp2
-    go (AgElem_RefPath offE sz _ _ `RrpCons` rrp2) (AgOffset_RefPath offO _ `RrpCons` rrp1) = do
-        -- These two overlap if `offE + sz > offO`
-        szBv <- wordLit sym sz
-        offESz <- liftIO $ bvAdd sym offE szBv
-        overlaps <- liftIO $ bvUge sym offESz offO
-        pEq <- go rrp1 rrp2
-        liftIO $ andPred sym overlaps pEq
-    go (AgOffset_RefPath offO _ `RrpCons` rrp1) (AgElem_RefPath offE sz _ _ `RrpCons` rrp2) = do
-        -- These two overlap if `offE + sz > offO`
-        szBv <- wordLit sym sz
-        offESz <- liftIO $ bvAdd sym offE szBv
-        overlaps <- liftIO $ bvUge sym offESz offO
-        pEq <- go rrp1 rrp2
-        liftIO $ andPred sym overlaps pEq
+    go (AgElem_RefPath {} `RrpCons` rrp2) (AgOffset_RefPath _ _ `RrpCons` rrp1) = do
+        go rrp1 rrp2
+    go (AgOffset_RefPath _ _ `RrpCons` rrp1) (AgElem_RefPath {} `RrpCons` rrp2) = do
+        go rrp1 rrp2
     go (AgOffset_RefPath off _ `RrpCons` rrp1) rrp2
       | Just bv <- asBV off
       , 0 <- BV.asUnsigned bv =

--- a/crucible-mir/src/Mir/Intrinsics/Reference.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Reference.hs
@@ -826,9 +826,11 @@ newConstMirRef sym tpr v = MirReferenceMux $ toFancyMuxTree sym $
 -- | Helper for defining a `MuxLeafT` operation that works only for
 -- `MirReference`s with a specific pointee type `tp`.  If the `MirReference`
 -- argument is a valid reference (not `MirReference_Integer`) with pointee type
--- `tp`, this calls `k` on the reference's parts; otherwise, this fails.
--- `desc` is a human-readable description of the operation, which is used in
--- the `leafAbort` error message.
+-- `tp`, this calls `k` on the reference's parts. Otherwise, if the reference
+-- points to an (offset into an) aggregate, this calls `k` on the result of
+-- projecting into the aggregate. Otherwise, this fails. `desc` is a
+-- human-readable description of the operation, which is used in the `leafAbort`
+-- error message.
 typedLeafOp ::
     Monad m =>
     String ->
@@ -837,7 +839,12 @@ typedLeafOp ::
     (forall tp0. MirReferenceRoot sym tp0 -> MirReferencePath sym tp0 tp -> MuxLeafT sym m a) ->
     MuxLeafT sym m a
 typedLeafOp desc expectTpr (MirReference tpr root path) k
-  | Just Refl <- testEquality tpr expectTpr = k root path
+  | Just Refl <- testEquality tpr expectTpr =
+      k root path
+  | AgOffset_RefPath off origPath <- path = do
+      -- TODO: hardcoded size=0
+      let elemPath = AgElem_RefPath off 0 expectTpr origPath
+      k root elemPath
   | otherwise = leafAbort $ GenericSimError $
       desc ++ " requires a reference to " ++ show expectTpr
         ++ ", but got a reference to " ++ show tpr

--- a/crucible-mir/src/Mir/Intrinsics/Reference.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Reference.hs
@@ -579,11 +579,11 @@ adjustRefPath bak iTypes v path0 adjSize adj = case path0 of
   AgElem_RefPath idx tpr path ->
       adjustRefPath bak iTypes v path All (\v' -> do
         adjustMirAggregateWithSymOffset bak (muxRegForType (backendGetSym bak) iTypes tpr)
-          idx tpr adj v')
+          idx tpr adj adjSize v')
   AgOffset_RefPath off path -> do
       adjustRefPath bak iTypes v path All (\v' ->
         let mux = muxRegForType (backendGetSym bak) iTypes MirAggregateRepr
-         in adjustMirAggregateWithSymOffset bak mux off MirAggregateRepr adj v')
+         in adjustMirAggregateWithSymOffset bak mux off MirAggregateRepr adj adjSize v')
 
 muxRefPath ::
   IsSymInterface sym =>

--- a/crucible-mir/src/Mir/Intrinsics/Reference.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Reference.hs
@@ -774,13 +774,14 @@ newConstMirRef sym tpr v = MirReferenceMux $ toFancyMuxTree sym $
 -- human-readable description of the operation, which is used in the `leafAbort`
 -- error message.
 typedLeafOp ::
-    Monad m =>
+    (MonadAssert sym bak m, IsSymBackend sym bak) =>
     String ->
+    bak ->
     TypeRepr tp ->
     MirReference sym ->
     (forall tp0. MirReferenceRoot sym tp0 -> MirReferencePath sym tp0 tp -> MuxLeafT sym m a) ->
     MuxLeafT sym m a
-typedLeafOp desc expectTpr (MirReference tpr root path) k
+typedLeafOp desc bak expectTpr (MirReference tpr root path) k
   | Just Refl <- testEquality tpr expectTpr =
       k root path
   | AgOffset_RefPath off origPath <- path = do
@@ -790,7 +791,7 @@ typedLeafOp desc expectTpr (MirReference tpr root path) k
   | otherwise = leafAbort $ GenericSimError $
       desc ++ " requires a reference to " ++ show expectTpr
         ++ ", but got a reference to " ++ show tpr
-typedLeafOp desc _ (MirReference_Integer _) _ =
+typedLeafOp desc _ _ (MirReference_Integer _) _ =
     leafAbort $ GenericSimError $
         "attempted " ++ desc ++ " on the result of an integer-to-pointer cast"
 
@@ -829,7 +830,7 @@ readMirRefLeaf ::
     MirReference sym ->
     MuxLeafT sym m (RegValue sym tp)
 readMirRefLeaf bak gs iTypes tpr readSize ref =
-  typedLeafOp "read" tpr ref $ \root path -> do
+  typedLeafOp "read" bak tpr ref $ \root path -> do
     v <- readRefRoot bak gs root
     v' <- readRefPath bak iTypes v readSize path
     return v'
@@ -878,7 +879,7 @@ writeMirRefLeaf ::
     RegValue sym tp ->
     MuxLeafT sym IO (SymGlobalState sym)
 writeMirRefLeaf bak gs iTypes tpr ref writeSize val =
-  typedLeafOp "write" tpr ref $ \root path ->
+  typedLeafOp "write" bak tpr ref $ \root path ->
     case path of
       Empty_RefPath -> writeRefRoot bak gs iTypes root val
       _ -> do
@@ -912,12 +913,14 @@ dropMirRefIO bak gs (MirReferenceMux ref) =
 
 
 subfieldMirRefLeaf ::
+    (IsSymBackend sym bak) =>
+    bak ->
     CtxRepr ctx ->
     MirReference sym ->
     Index ctx tp ->
     MuxLeafT sym IO (MirReference sym)
-subfieldMirRefLeaf ctx ref idx =
-  typedLeafOp "subfield" (StructRepr ctx) ref $ \root path -> do
+subfieldMirRefLeaf bak ctx ref idx =
+  typedLeafOp "subfield" bak (StructRepr ctx) ref $ \root path -> do
     let tpr = ctx ! idx
     return $ MirReference tpr root (Field_RefPath ctx path idx)
 
@@ -930,17 +933,19 @@ subfieldMirRefIO ::
     Index ctx tp ->
     IO (MirReferenceMux sym)
 subfieldMirRefIO bak iTypes ctx ref idx =
-    modifyRefMuxMA bak iTypes (\ref' -> subfieldMirRefLeaf ctx ref' idx) ref
+    modifyRefMuxMA bak iTypes (\ref' -> subfieldMirRefLeaf bak ctx ref' idx) ref
 
 
 subvariantMirRefLeaf ::
+    (IsSymBackend sym bak) =>
+    bak ->
     TypeRepr discrTp ->
     CtxRepr variantsCtx ->
     MirReference sym ->
     Index variantsCtx tp ->
     MuxLeafT sym IO (MirReference sym)
-subvariantMirRefLeaf discrTpr ctx ref idx =
-  typedLeafOp "subvariant" (RustEnumRepr discrTpr ctx) ref $ \root path -> do
+subvariantMirRefLeaf bak discrTpr ctx ref idx =
+  typedLeafOp "subvariant" bak (RustEnumRepr discrTpr ctx) ref $ \root path -> do
     let tpr = ctx ! idx
     return $ MirReference tpr root (Variant_RefPath discrTpr ctx path idx)
 
@@ -954,15 +959,17 @@ subvariantMirRefIO ::
     Index variantsCtx tp ->
     IO (MirReferenceMux sym)
 subvariantMirRefIO bak iTypes tp ctx ref idx =
-    modifyRefMuxMA bak iTypes (\ref' -> subvariantMirRefLeaf tp ctx ref' idx) ref
+    modifyRefMuxMA bak iTypes (\ref' -> subvariantMirRefLeaf bak tp ctx ref' idx) ref
 
 
 subjustMirRefLeaf ::
+    (IsSymBackend sym bak) =>
+    bak ->
     TypeRepr tp ->
     MirReference sym ->
     MuxLeafT sym IO (MirReference sym)
-subjustMirRefLeaf tpr ref =
-  typedLeafOp "subjust" (MaybeRepr tpr) ref $ \root path -> do
+subjustMirRefLeaf bak tpr ref =
+  typedLeafOp "subjust" bak (MaybeRepr tpr) ref $ \root path -> do
     return $ MirReference tpr root (Just_RefPath tpr path)
 
 subjustMirRefIO ::
@@ -973,17 +980,19 @@ subjustMirRefIO ::
     MirReferenceMux sym ->
     IO (MirReferenceMux sym)
 subjustMirRefIO bak iTypes tpr ref =
-    modifyRefMuxMA bak iTypes (subjustMirRefLeaf tpr) ref
+    modifyRefMuxMA bak iTypes (subjustMirRefLeaf bak tpr) ref
 
 
 mirRef_arrayIndexLeaf ::
+    (IsSymBackend sym bak) =>
+    bak ->
     RegValue sym UsizeType ->
     TypeRepr tp ->
     MirReference sym ->
     MuxLeafT sym IO (MirReference sym)
-mirRef_arrayIndexLeaf idx elemTpr ref = case asBaseType elemTpr of
+mirRef_arrayIndexLeaf bak idx elemTpr ref = case asBaseType elemTpr of
   AsBaseType baseTpr ->
-    typedLeafOp "Crucible Array index" (UsizeArrayRepr baseTpr) ref $ \root path -> do
+    typedLeafOp "Crucible Array index" bak (UsizeArrayRepr baseTpr) ref $ \root path -> do
       return $ MirReference elemTpr root (ArrayIndex_RefPath baseTpr path idx)
   _ -> leafAbort $ GenericSimError $
     "Crucible Array-indexing operates on arrays of a Crucible base type, but saw one of " <> show elemTpr
@@ -997,16 +1006,18 @@ mirRef_arrayIndexIO ::
     MirReferenceMux sym ->
     IO (MirReferenceMux sym)
 mirRef_arrayIndexIO bak iTypes idx elemTpr ref =
-  modifyRefMuxMA bak iTypes (mirRef_arrayIndexLeaf idx elemTpr) ref
+  modifyRefMuxMA bak iTypes (mirRef_arrayIndexLeaf bak idx elemTpr) ref
 
 
 mirRef_vecIndexLeaf ::
+    (IsSymBackend sym bak) =>
+    bak ->
     RegValue sym UsizeType ->
     TypeRepr tp ->
     MirReference sym ->
     MuxLeafT sym IO (MirReference sym)
-mirRef_vecIndexLeaf idx elemTpr ref =
-  typedLeafOp "Crucible Vector index" (VectorRepr elemTpr) ref $ \root path -> do
+mirRef_vecIndexLeaf bak idx elemTpr ref =
+  typedLeafOp "Crucible Vector index" bak (VectorRepr elemTpr) ref $ \root path -> do
     return $ MirReference elemTpr root (VectorIndex_RefPath elemTpr path idx)
 
 mirRef_vecIndexIO ::
@@ -1018,17 +1029,19 @@ mirRef_vecIndexIO ::
     MirReferenceMux sym ->
     IO (MirReferenceMux sym)
 mirRef_vecIndexIO bak iTypes idx elemTpr ref =
-  modifyRefMuxMA bak iTypes (mirRef_vecIndexLeaf idx elemTpr) ref
+  modifyRefMuxMA bak iTypes (mirRef_vecIndexLeaf bak idx elemTpr) ref
 
 
 mirRef_agElemLeaf ::
+    (IsSymBackend sym bak) =>
+    bak ->
     RegValue sym UsizeType ->
     Word ->
     TypeRepr tp ->
     MirReference sym ->
     MuxLeafT sym IO (MirReference sym)
-mirRef_agElemLeaf off sz tpr ref =
-  typedLeafOp "MirAggregate element projection" MirAggregateRepr ref $ \root path -> do
+mirRef_agElemLeaf bak off sz tpr ref =
+  typedLeafOp "MirAggregate element projection" bak MirAggregateRepr ref $ \root path -> do
     return $ MirReference tpr root (AgElem_RefPath off sz tpr path)
 
 mirRef_agElemIO ::
@@ -1041,7 +1054,7 @@ mirRef_agElemIO ::
     MirReferenceMux sym ->
     IO (MirReferenceMux sym)
 mirRef_agElemIO bak iTypes off sz tpr ref =
-    modifyRefMuxMA bak iTypes (mirRef_agElemLeaf off sz tpr) ref
+    modifyRefMuxMA bak iTypes (mirRef_agElemLeaf bak off sz tpr) ref
 
 mirRef_agElem_unsizedLeaf ::
     IsSymBackend sym bak =>
@@ -1052,7 +1065,7 @@ mirRef_agElem_unsizedLeaf ::
     MirReference sym ->
     MuxLeafT sym IO (MirReference sym)
 mirRef_agElem_unsizedLeaf bak gs iTypes off ref =
-  typedLeafOp "MirAggregate unsized element projection" MirAggregateRepr ref $ \root path -> do
+  typedLeafOp "MirAggregate unsized element projection" bak MirAggregateRepr ref $ \root path -> do
     offConcrete <- case asBV off of
       Just bv -> return $ fromIntegral $ BV.asUnsigned bv
       Nothing -> leafAbort $ GenericSimError $
@@ -1076,16 +1089,16 @@ mirRef_agElem_unsizedIO bak gs iTypes off ref =
 
 
 mirRef_agOffsetLeaf ::
-    IsSymInterface sym =>
-    sym ->
+    (IsSymBackend sym bak) =>
+    bak ->
     RegValue sym UsizeType ->
     MirReference sym ->
     MuxLeafT sym IO (MirReference sym)
-mirRef_agOffsetLeaf sym off ref =
-  typedLeafOp "MirAggregate offset" MirAggregateRepr ref $ \root path ->
+mirRef_agOffsetLeaf bak off ref =
+  typedLeafOp "MirAggregate offset" bak MirAggregateRepr ref $ \root path ->
     case path of
       AgOffset_RefPath oldOff oldPath -> do
-        newOff <- liftIO $ bvAdd sym off oldOff
+        newOff <- liftIO $ bvAdd (backendGetSym bak) off oldOff
         return $ MirReference MirAggregateRepr root (AgOffset_RefPath newOff oldPath)
       _ -> return $ MirReference MirAggregateRepr root (AgOffset_RefPath off path)
 
@@ -1097,7 +1110,7 @@ mirRef_agOffsetIO ::
     MirReferenceMux sym ->
     IO (MirReferenceMux sym)
 mirRef_agOffsetIO bak iTypes off ref =
-    modifyRefMuxMA bak iTypes (mirRef_agOffsetLeaf (backendGetSym bak) off) ref
+    modifyRefMuxMA bak iTypes (mirRef_agOffsetLeaf bak off) ref
 
 
 refRootEq ::
@@ -1772,23 +1785,23 @@ mirRef_peelAgElemMA bak iTypes off sz (MirReferenceMux ref) =
 -- If the outermost path segment isn't 'Just_RefPath', this operation raises an
 -- error.
 mirRef_peelJustLeaf ::
-    (IsSymInterface sym, MonadIO m) =>
-    sym ->
+    (IsSymBackend sym bak, MonadAssert sym bak m) =>
+    bak ->
     TypeRepr tp {-^ The type inside the @MaybeType@ -} ->
     MirReference sym ->
     MuxLeafT sym m (MirReferenceMux sym)
-mirRef_peelJustLeaf sym tpr ref =
-  typedLeafOp "peelJust" tpr ref $ \root path ->
+mirRef_peelJustLeaf bak tpr ref =
+  typedLeafOp "peelJust" bak tpr ref $ \root path ->
     case path of
       Just_RefPath _ path' ->
         return $ MirReferenceMux $
-          toFancyMuxTree sym $ MirReference (MaybeRepr tpr) root path'
+          toFancyMuxTree (backendGetSym bak) $ MirReference (MaybeRepr tpr) root path'
       _ ->
         leafAbort $ Unsupported callStack $
           "peelJust not implemented for this RefPath kind"
 
 mirRef_peelJustMA ::
-    MonadAssert sym bak m =>
+    (IsSymBackend sym bak, MonadAssert sym bak m) =>
     bak ->
     IntrinsicTypes sym ->
     TypeRepr tp ->
@@ -1796,7 +1809,7 @@ mirRef_peelJustMA ::
     m (MirReferenceMux sym)
 mirRef_peelJustMA bak iTypes tpr (MirReferenceMux ref) =
     let sym = backendGetSym bak in
-    readFancyMuxTree' bak (mirRef_peelJustLeaf sym tpr)
+    readFancyMuxTree' bak (mirRef_peelJustLeaf bak tpr)
         (muxRegForType sym iTypes MirReferenceRepr) ref
 
 

--- a/crucible-mir/src/Mir/Intrinsics/Reference.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Reference.hs
@@ -1129,12 +1129,12 @@ mirRef_agOffsetMA bak iTypes off ref =
 
 
 refRootEq ::
-    IsSymInterface sym =>
-    sym ->
+    (IsSymBackend sym bak) =>
+    bak ->
     MirReferenceRoot sym tp1 ->
     MirReferenceRoot sym tp2 ->
     MuxLeafT sym IO (RegValue sym BoolType)
-refRootEq sym r1 r2 = case (r1, r2) of
+refRootEq bak r1 r2 = case (r1, r2) of
   (RefCell_RefRoot rc1, RefCell_RefRoot rc2)
     | Just Refl <- testEquality rc1 rc2 ->
       return $ truePred sym
@@ -1149,35 +1149,37 @@ refRootEq sym r1 r2 = case (r1, r2) of
     return $ falsePred sym
   (Const_RefRoot {}, _) ->
     return $ falsePred sym
+  where
+    sym = backendGetSym bak
 
 refPathEq ::
-    IsSymInterface sym =>
-    sym ->
+    (IsSymBackend sym bak) =>
+    bak ->
     MirReferencePath sym tp_base1 tp1 ->
     MirReferencePath sym tp_base2 tp2 ->
     MuxLeafT sym IO (RegValue sym BoolType)
-refPathEq sym path1 path2 = case (path1, path2) of
+refPathEq bak path1 path2 = case (path1, path2) of
   (Empty_RefPath, Empty_RefPath) ->
     return $ truePred sym
   (Field_RefPath ctx1 p1 idx1, Field_RefPath ctx2 p2 idx2)
     | Just Refl <- testEquality ctx1 ctx2
     , Just Refl <- testEquality idx1 idx2 ->
-      refPathEq sym p1 p2
+      refPathEq bak p1 p2
   (Variant_RefPath _ ctx1 p1 idx1, Variant_RefPath _ ctx2 p2 idx2)
     | Just Refl <- testEquality ctx1 ctx2
     , Just Refl <- testEquality idx1 idx2 ->
-      refPathEq sym p1 p2
+      refPathEq bak p1 p2
   (Just_RefPath tpr1 p1, Just_RefPath tpr2 p2)
     | Just Refl <- testEquality tpr1 tpr2 ->
-      refPathEq sym p1 p2
+      refPathEq bak p1 p2
   (VectorIndex_RefPath tpr1 p1 idx1, VectorIndex_RefPath tpr2 p2 idx2)
     | Just Refl <- testEquality tpr1 tpr2 -> do
-      pEq <- refPathEq sym p1 p2
+      pEq <- refPathEq bak p1 p2
       idxEq <- liftIO $ bvEq sym idx1 idx2
       liftIO $ andPred sym pEq idxEq
   (ArrayIndex_RefPath btpr1 p1 idx1, ArrayIndex_RefPath btpr2 p2 idx2)
     | Just Refl <- testEquality btpr1 btpr2 -> do
-      pEq <- refPathEq sym p1 p2
+      pEq <- refPathEq bak p1 p2
       idxEq <- liftIO $ bvEq sym idx1 idx2
       liftIO $ andPred sym pEq idxEq
   (AgElem_RefPath off1 _tpr1 p1, AgElem_RefPath off2 _tpr2 p2) -> do
@@ -1192,21 +1194,21 @@ refPathEq sym path1 path2 = case (path1, path2) of
     --
     -- * The sizes (_sz{1,2}), as pointers of different types may have
     --   different layout sizes.
-    pEq <- refPathEq sym p1 p2
+    pEq <- refPathEq bak p1 p2
     liftIO $ andPred sym offEq pEq
   (AgOffset_RefPath off1 p1, AgOffset_RefPath off2 p2) -> do
     offEq <- liftIO $ bvEq sym off1 off2
-    pEq <- refPathEq sym p1 p2
+    pEq <- refPathEq bak p1 p2
     liftIO $ andPred sym offEq pEq
   (AgOffset_RefPath off1 p1, p2) -> do
     -- See Note [Aggregate zero-offsets]
     offEq <- liftIO $ bvEq sym off1 =<< wordLit sym 0
-    pEq <- refPathEq sym p1 p2
+    pEq <- refPathEq bak p1 p2
     liftIO $ andPred sym offEq pEq
   (p1, AgOffset_RefPath off2 p2) -> do
     -- See Note [Aggregate zero-offsets]
     offEq <- liftIO $ bvEq sym off2 =<< wordLit sym 0
-    pEq <- refPathEq sym p1 p2
+    pEq <- refPathEq bak p1 p2
     liftIO $ andPred sym offEq pEq
   (Empty_RefPath, _) ->
     return $ falsePred sym
@@ -1222,23 +1224,27 @@ refPathEq sym path1 path2 = case (path1, path2) of
     return $ falsePred sym
   (AgElem_RefPath {}, _) ->
     return $ falsePred sym
+  where
+    sym = backendGetSym bak
 
 mirRef_eqLeaf ::
-    IsSymInterface sym =>
-    sym ->
+    (IsSymBackend sym bak) =>
+    bak ->
     MirReference sym ->
     MirReference sym ->
     MuxLeafT sym IO (RegValue sym BoolType)
-mirRef_eqLeaf sym ref1 ref2 = case (ref1, ref2) of
+mirRef_eqLeaf bak ref1 ref2 = case (ref1, ref2) of
   (MirReference _ root1 path1, MirReference _ root2 path2) -> do
-    rootEq <- refRootEq sym root1 root2
-    pathEq <- refPathEq sym path1 path2
+    rootEq <- refRootEq bak root1 root2
+    pathEq <- refPathEq bak path1 path2
     liftIO $ andPred sym rootEq pathEq
   (MirReference_Integer i1, MirReference_Integer i2) ->
     liftIO $ isEq sym i1 i2
   (_, _) ->
     -- All valid references are disjoint from all integer references.
     return $ falsePred sym
+  where
+    sym = backendGetSym bak
 
 mirRef_eqIO ::
     (IsSymBackend sym bak) =>
@@ -1248,7 +1254,7 @@ mirRef_eqIO ::
     IO (RegValue sym BoolType)
 mirRef_eqIO bak (MirReferenceMux r1) (MirReferenceMux r2) =
     let sym = backendGetSym bak in
-    zipFancyMuxTrees' bak (mirRef_eqLeaf sym) (itePred sym) r1 r2
+    zipFancyMuxTrees' bak (mirRef_eqLeaf bak) (itePred sym) r1 r2
 
 
 -- | An ordinary `MirReferencePath sym tp tp''` is represented "inside-out": to
@@ -1558,22 +1564,22 @@ mirRef_tryOffsetFromLeaf ::
     MuxLeafT sym IO (RegValue sym (MaybeType IsizeType))
 mirRef_tryOffsetFromLeaf bak elemSize r1@(MirReference tp1 root1 path1) r2@(MirReference tp2 root2 path2) = do
     let sym = backendGetSym bak
-    rootEq <- refRootEq sym root1 root2
+    rootEq <- refRootEq bak root1 root2
     case (path1, path2) of
         (VectorIndex_RefPath _ path1' idx1, VectorIndex_RefPath _ path2' idx2) -> do
-            pathEq <- refPathEq sym path1' path2'
+            pathEq <- refPathEq bak path1' path2'
             similar <- liftIO $ andPred sym rootEq pathEq
             -- TODO: implement overflow checks, similar to `offset`
             offset <- liftIO $ bvSub sym idx1 idx2
             return $ mkPE similar offset
         (ArrayIndex_RefPath _ path1' idx1, ArrayIndex_RefPath _ path2' idx2) -> do
-            pathEq <- refPathEq sym path1' path2'
+            pathEq <- refPathEq bak path1' path2'
             similar <- liftIO $ andPred sym rootEq pathEq
             -- TODO: implement overflow checks, similar to `offset`
             offset <- liftIO $ bvSub sym idx1 idx2
             return $ mkPE similar offset
         (AgElem_RefPath off1 _ path1', AgElem_RefPath off2 _ path2') -> do
-            pathEq <- refPathEq sym path1' path2'
+            pathEq <- refPathEq bak path1' path2'
             similar <- liftIO $ andPred sym rootEq pathEq
             byteOffset <- liftIO $ bvSub sym off1 off2
             elemSize' <- liftIO $ wordLit sym elemSize
@@ -1588,7 +1594,7 @@ mirRef_tryOffsetFromLeaf bak elemSize r1@(MirReference tp1 root1 path1) r2@(MirR
 
             return $ mkPE similar elemOffset
         (AgOffset_RefPath off1 path1', AgOffset_RefPath off2 path2') -> do
-            pathEq <- refPathEq sym path1' path2'
+            pathEq <- refPathEq bak path1' path2'
             similar <- liftIO $ andPred sym rootEq pathEq
             byteOffset <- liftIO $ bvSub sym off1 off2
             elemSize' <- liftIO $ wordLit sym elemSize
@@ -1615,7 +1621,7 @@ mirRef_tryOffsetFromLeaf bak elemSize r1@(MirReference tp1 root1 path1) r2@(MirR
             let r1' = MirReference tp1 root1 (AgOffset_RefPath zero path1)
             mirRef_tryOffsetFromLeaf bak elemSize r1' r2
         _ -> do
-            pathEq <- refPathEq sym path1 path2
+            pathEq <- refPathEq bak path1 path2
             similar <- liftIO $ andPred sym rootEq pathEq
             liftIO $ mkPE similar <$> bvZero sym knownNat
 mirRef_tryOffsetFromLeaf bak _elemSize (MirReference_Integer i1) (MirReference_Integer i2) = do

--- a/crucible-mir/src/Mir/Intrinsics/Reference.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Reference.hs
@@ -1193,16 +1193,10 @@ refPathEq bak path1 path2 = case (path1, path2) of
       liftIO $ andPred sym pEq idxEq
   (AgElem_RefPath off1 _tpr1 p1, AgElem_RefPath off2 _tpr2 p2) -> do
     offEq <- liftIO $ bvEq sym off1 off2
-    -- NB: Don't check the following for equality:
-    --
-   --
-    -- * The TypeReprs (_tpr{1,2}), as pointers with the same memory addresses
-    --   can have different types if pointer casting is involved (see the
-    --   crux-mir/test/conc_eval/tuple/ref_path_equality.rs test case for an
-    --   example).
-    --
-    -- * The sizes (_sz{1,2}), as pointers of different types may have
-    --   different layout sizes.
+    -- NB: Don't check the TypeReprs (_tpr{1,2}) for equality, as pointers with
+    -- the same memory addresses can have different types if pointer casting is
+    -- involved (see the crux-mir/test/conc_eval/tuple/ref_path_equality.rs
+    -- test case for an example).
     pEq <- refPathEq bak p1 p2
     liftIO $ andPred sym offEq pEq
   (AgOffset_RefPath off1 p1, AgOffset_RefPath off2 p2) -> do
@@ -1414,8 +1408,9 @@ refPathOverlaps sym path1 path2 = do
     go (AgElem_RefPath {} `RrpCons` _) _ = return $ falsePred sym
     go (AgOffset_RefPath {} `RrpCons` _) _ = return $ falsePred sym
 
--- | Check whether the memory accessible through `ref1` overlaps the memory
--- accessible through `ref2`.
+-- | Check whether the memory accessible through `ref1` migt overlap the memory
+-- accessible through `ref2`.  This is a conservative check, and may report
+-- overlap in some non-overlapping cases.
 mirRef_overlapsLeaf ::
     IsSymInterface sym =>
     sym ->

--- a/crucible-mir/src/Mir/Intrinsics/Reference.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Reference.hs
@@ -196,6 +196,7 @@ import Mir.FancyMuxTree
     leafClearPartExpr,
     leafPredicate,
     leafReadPartExpr,
+    leafModifyPartExpr,
     leafUpdatePartExpr,
     mapFancyMuxTree,
     mergeFancyMuxTree,
@@ -210,6 +211,9 @@ import Mir.Intrinsics.Aggregate
     adjustMirAggregateWithSymOffset,
     readMirAggregateWithSymOffset,
     writeMirAggregateWithSymOffset,
+    mirAggregate_capacity,
+    mirAggregate_insert,
+    MirAggregateEntry (..),
     pattern MirAggregateRepr,
   )
 import Mir.Intrinsics.Array (UsizeArrayType, pattern UsizeArrayRepr)
@@ -423,6 +427,41 @@ writeRefRoot bak gs iTypes (GlobalVar_RefRoot gv) v = do
                 show gv ++ " of type " ++ show tpr
     return $ insertGlobal gv newv gs
 writeRefRoot _bak _gs _iTypes (Const_RefRoot tpr _) _ =
+    leafAbort $ GenericSimError $
+        "Cannot write to Const_RefRoot (of type " ++ show tpr ++ ")"
+
+-- | Like `writeRefRoot`, but instead of unconditionally writing the new value,
+-- apply a modification to an existing value, if there is one.
+modifyRefRoot :: forall sym bak tp.
+    (IsSymBackend sym bak) =>
+    bak ->
+    SymGlobalState sym ->
+    IntrinsicTypes sym ->
+    MirReferenceRoot sym tp ->
+    (Maybe (RegValue sym tp) -> IO (RegValue sym tp)) ->
+    MuxLeafT sym IO (SymGlobalState sym)
+modifyRefRoot bak gs iTypes (RefCell_RefRoot rc) modify = do
+    let sym = backendGetSym bak
+    let tpr = refType rc
+    let mux p a b = liftIO $ muxRegForType sym iTypes tpr p a b
+    let oldv = lookupRef rc gs
+    newv <- leafModifyPartExpr bak mux modify oldv
+    return $ updateRef rc newv gs
+modifyRefRoot bak gs iTypes (GlobalVar_RefRoot gv) modify = do
+    let sym = backendGetSym bak
+    let tpr = globalType gv
+    p <- leafPredicate
+    newv <- case lookupGlobal gv gs of
+        old | Just True <- asConstantPred p -> liftIO $ modify old
+        Just oldv -> liftIO $ do
+            newv <- modify (Just oldv)
+            muxRegForType sym iTypes tpr p newv oldv
+        -- GlobalVars can't be conditionally initialized.
+        Nothing -> leafAbort $ ReadBeforeWriteSimError $
+            "attempted conditional write to uninitialized global " ++
+                show gv ++ " of type " ++ show tpr
+    return $ insertGlobal gv newv gs
+modifyRefRoot _bak _gs _iTypes (Const_RefRoot tpr _) _ =
     leafAbort $ GenericSimError $
         "Cannot write to Const_RefRoot (of type " ++ show tpr ++ ")"
 
@@ -875,6 +914,7 @@ writeMirRefIO bak gs iTypes tpr (MirReferenceMux ref) writeSize x =
         ref
 
 writeMirRefLeaf ::
+    forall bak sym tp.
     (IsSymBackend sym bak) =>
     bak ->
     SymGlobalState sym ->
@@ -887,12 +927,37 @@ writeMirRefLeaf ::
 writeMirRefLeaf bak gs iTypes tpr ref writeSize val =
   typedLeafOp "write" bak tpr ref $ \root path ->
     case path of
-      Empty_RefPath -> writeRefRoot bak gs iTypes root val
+      Empty_RefPath ->
+        case tpr of
+            MirAggregateRepr ->
+                -- If an aggregate already inhabits the destination, we may not
+                -- want to unconditionally overwrite it, as `writeRefRoot` would
+                -- do - we may instead need to write elements from the source
+                -- aggregate to the destination, to accommodate
+                -- aggregate-flattening. `modifyRefRoot` lets us discriminate on
+                -- whether or not the destination aggregate exists, and `modify`
+                -- so discriminates.
+                --
+                -- See also Note [Aggregate zero-offsets] - this is a case of
+                -- that equivalence.
+                modifyRefRoot bak gs iTypes root (modify val)
+            _ ->
+                writeRefRoot bak gs iTypes root val
       _ -> do
         x <- readRefRoot bak gs root
         x' <- writeRefPath bak iTypes x path writeSize val
         writeRefRoot bak gs iTypes root x'
-
+  where
+    modify :: MirAggregate sym -> Maybe (MirAggregate sym) -> IO (MirAggregate sym)
+    modify newAg oldAgM = case oldAgM of
+        Nothing -> pure newAg
+        Just oldAg -> do
+            let newSz = mirAggregate_capacity newAg
+            let newVal = justPartExpr (backendGetSym bak) newAg
+            let entry = MirAggregateEntry newSz MirAggregateRepr newVal
+            case mirAggregate_insert 0 entry oldAg of
+                Left err -> fail err
+                Right new -> pure new
 
 dropMirRefLeaf ::
     (IsSymBackend sym bak) =>

--- a/crucible-mir/src/Mir/Intrinsics/Reference.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Reference.hs
@@ -1134,16 +1134,21 @@ refRootEq ::
     MirReferenceRoot sym tp1 ->
     MirReferenceRoot sym tp2 ->
     MuxLeafT sym IO (RegValue sym BoolType)
-refRootEq sym (RefCell_RefRoot rc1) (RefCell_RefRoot rc2)
-  | Just Refl <- testEquality rc1 rc2 = return $ truePred sym
-refRootEq sym (GlobalVar_RefRoot gv1) (GlobalVar_RefRoot gv2)
-  | Just Refl <- testEquality gv1 gv2 = return $ truePred sym
-refRootEq _sym (Const_RefRoot _ _) (Const_RefRoot _ _) =
+refRootEq sym r1 r2 = case (r1, r2) of
+  (RefCell_RefRoot rc1, RefCell_RefRoot rc2)
+    | Just Refl <- testEquality rc1 rc2 ->
+      return $ truePred sym
+  (GlobalVar_RefRoot gv1, GlobalVar_RefRoot gv2)
+    | Just Refl <- testEquality gv1 gv2 ->
+      return $ truePred sym
+  (Const_RefRoot _ _, Const_RefRoot _ _) ->
     leafAbort $ Unsupported callStack $ "Cannot compare Const_RefRoots"
-
-refRootEq sym (RefCell_RefRoot {}) _ = return $ falsePred sym
-refRootEq sym (GlobalVar_RefRoot {}) _ = return $ falsePred sym
-refRootEq sym (Const_RefRoot {}) _ = return $ falsePred sym
+  (RefCell_RefRoot {}, _) ->
+    return $ falsePred sym
+  (GlobalVar_RefRoot {}, _) ->
+    return $ falsePred sym
+  (Const_RefRoot {}, _) ->
+    return $ falsePred sym
 
 refPathEq ::
     IsSymInterface sym =>
@@ -1151,26 +1156,31 @@ refPathEq ::
     MirReferencePath sym tp_base1 tp1 ->
     MirReferencePath sym tp_base2 tp2 ->
     MuxLeafT sym IO (RegValue sym BoolType)
-refPathEq sym Empty_RefPath Empty_RefPath = return $ truePred sym
-refPathEq sym (Field_RefPath ctx1 p1 idx1) (Field_RefPath ctx2 p2 idx2)
-  | Just Refl <- testEquality ctx1 ctx2
-  , Just Refl <- testEquality idx1 idx2 = refPathEq sym p1 p2
-refPathEq sym (Variant_RefPath _ ctx1 p1 idx1) (Variant_RefPath _ ctx2 p2 idx2)
-  | Just Refl <- testEquality ctx1 ctx2
-  , Just Refl <- testEquality idx1 idx2 = refPathEq sym p1 p2
-refPathEq sym (Just_RefPath tpr1 p1) (Just_RefPath tpr2 p2)
-  | Just Refl <- testEquality tpr1 tpr2 = refPathEq sym p1 p2
-refPathEq sym (VectorIndex_RefPath tpr1 p1 idx1) (VectorIndex_RefPath tpr2 p2 idx2)
-  | Just Refl <- testEquality tpr1 tpr2 = do
-    pEq <- refPathEq sym p1 p2
-    idxEq <- liftIO $ bvEq sym idx1 idx2
-    liftIO $ andPred sym pEq idxEq
-refPathEq sym (ArrayIndex_RefPath btpr1 p1 idx1) (ArrayIndex_RefPath btpr2 p2 idx2)
-  | Just Refl <- testEquality btpr1 btpr2 = do
-    pEq <- refPathEq sym p1 p2
-    idxEq <- liftIO $ bvEq sym idx1 idx2
-    liftIO $ andPred sym pEq idxEq
-refPathEq sym (AgElem_RefPath off1 _tpr1 p1) (AgElem_RefPath off2 _tpr2 p2) = do
+refPathEq sym path1 path2 = case (path1, path2) of
+  (Empty_RefPath, Empty_RefPath) ->
+    return $ truePred sym
+  (Field_RefPath ctx1 p1 idx1, Field_RefPath ctx2 p2 idx2)
+    | Just Refl <- testEquality ctx1 ctx2
+    , Just Refl <- testEquality idx1 idx2 ->
+      refPathEq sym p1 p2
+  (Variant_RefPath _ ctx1 p1 idx1, Variant_RefPath _ ctx2 p2 idx2)
+    | Just Refl <- testEquality ctx1 ctx2
+    , Just Refl <- testEquality idx1 idx2 ->
+      refPathEq sym p1 p2
+  (Just_RefPath tpr1 p1, Just_RefPath tpr2 p2)
+    | Just Refl <- testEquality tpr1 tpr2 ->
+      refPathEq sym p1 p2
+  (VectorIndex_RefPath tpr1 p1 idx1, VectorIndex_RefPath tpr2 p2 idx2)
+    | Just Refl <- testEquality tpr1 tpr2 -> do
+      pEq <- refPathEq sym p1 p2
+      idxEq <- liftIO $ bvEq sym idx1 idx2
+      liftIO $ andPred sym pEq idxEq
+  (ArrayIndex_RefPath btpr1 p1 idx1, ArrayIndex_RefPath btpr2 p2 idx2)
+    | Just Refl <- testEquality btpr1 btpr2 -> do
+      pEq <- refPathEq sym p1 p2
+      idxEq <- liftIO $ bvEq sym idx1 idx2
+      liftIO $ andPred sym pEq idxEq
+  (AgElem_RefPath off1 _tpr1 p1, AgElem_RefPath off2 _tpr2 p2) -> do
     offEq <- liftIO $ bvEq sym off1 off2
     -- NB: Don't check the following for equality:
     --
@@ -1184,28 +1194,34 @@ refPathEq sym (AgElem_RefPath off1 _tpr1 p1) (AgElem_RefPath off2 _tpr2 p2) = do
     --   different layout sizes.
     pEq <- refPathEq sym p1 p2
     liftIO $ andPred sym offEq pEq
-refPathEq sym (AgOffset_RefPath off1 p1) (AgOffset_RefPath off2 p2) = do
+  (AgOffset_RefPath off1 p1, AgOffset_RefPath off2 p2) -> do
     offEq <- liftIO $ bvEq sym off1 off2
     pEq <- refPathEq sym p1 p2
     liftIO $ andPred sym offEq pEq
-refPathEq sym (AgOffset_RefPath off1 p1) p2 = do
+  (AgOffset_RefPath off1 p1, p2) -> do
     -- See Note [Aggregate zero-offsets]
     offEq <- liftIO $ bvEq sym off1 =<< wordLit sym 0
     pEq <- refPathEq sym p1 p2
     liftIO $ andPred sym offEq pEq
-refPathEq sym p1 (AgOffset_RefPath off2 p2) = do
+  (p1, AgOffset_RefPath off2 p2) -> do
     -- See Note [Aggregate zero-offsets]
     offEq <- liftIO $ bvEq sym off2 =<< wordLit sym 0
     pEq <- refPathEq sym p1 p2
     liftIO $ andPred sym offEq pEq
-
-refPathEq sym Empty_RefPath _ = return $ falsePred sym
-refPathEq sym (Field_RefPath {}) _ = return $ falsePred sym
-refPathEq sym (Variant_RefPath {}) _ = return $ falsePred sym
-refPathEq sym (Just_RefPath {}) _ = return $ falsePred sym
-refPathEq sym (VectorIndex_RefPath {}) _ = return $ falsePred sym
-refPathEq sym (ArrayIndex_RefPath {}) _ = return $ falsePred sym
-refPathEq sym (AgElem_RefPath {}) _ = return $ falsePred sym
+  (Empty_RefPath, _) ->
+    return $ falsePred sym
+  (Field_RefPath {}, _) ->
+    return $ falsePred sym
+  (Variant_RefPath {}, _) ->
+    return $ falsePred sym
+  (Just_RefPath {}, _) ->
+    return $ falsePred sym
+  (VectorIndex_RefPath {}, _) ->
+    return $ falsePred sym
+  (ArrayIndex_RefPath {}, _) ->
+    return $ falsePred sym
+  (AgElem_RefPath {}, _) ->
+    return $ falsePred sym
 
 mirRef_eqLeaf ::
     IsSymInterface sym =>
@@ -1213,13 +1229,14 @@ mirRef_eqLeaf ::
     MirReference sym ->
     MirReference sym ->
     MuxLeafT sym IO (RegValue sym BoolType)
-mirRef_eqLeaf sym (MirReference _ root1 path1) (MirReference _ root2 path2) = do
+mirRef_eqLeaf sym ref1 ref2 = case (ref1, ref2) of
+  (MirReference _ root1 path1, MirReference _ root2 path2) -> do
     rootEq <- refRootEq sym root1 root2
     pathEq <- refPathEq sym path1 path2
     liftIO $ andPred sym rootEq pathEq
-mirRef_eqLeaf sym (MirReference_Integer i1) (MirReference_Integer i2) =
+  (MirReference_Integer i1, MirReference_Integer i2) ->
     liftIO $ isEq sym i1 i2
-mirRef_eqLeaf sym _ _ =
+  (_, _) ->
     -- All valid references are disjoint from all integer references.
     return $ falsePred sym
 

--- a/crucible-mir/src/Mir/Intrinsics/Reference.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Reference.hs
@@ -1828,9 +1828,24 @@ mirRef_peelJustMA bak iTypes tpr (MirReferenceMux ref) =
         (muxRegForType sym iTypes MirReferenceRepr) ref
 
 
--- | Compute the index of `ref` within its containing allocation, along with
--- the length of that allocation.  This is useful for determining the amount of
--- memory accessible through all valid offsets of `ref`.
+-- | Compute the index of @ref@ within its containing allocation, along with the
+-- length of that allocation.  This is useful for determining the amount of
+-- memory accessible through all valid offsets of @ref@, but beware: when
+-- calculating the index and length, it assumes that the allocation is
+-- homogenous, containing only elements of the type at the end of the provided
+-- @RefPath@. This can lead to strange answers for @MirAggregate@-backed
+-- allocations in particular. Consider a struct like:
+--
+-- > #[repr(C)]
+-- > struct Foo {
+-- >   a: u16,
+-- >   b: [u8; 2],
+-- > }
+--
+-- If we have some @foo: Foo@ and apply this intrinsic to @&foo.a@, it will
+-- report that the allocation is of length two (@size_of_val(&foo.a) /
+-- size_of_val(&foo)@), while applying it to @&foo.b[0]@ will report that the
+-- allocation is of length four (@size_of_val(&foo.b[0]) / size_of_val(&foo)@).
 --
 -- Note that unlike `peelIndex`:
 --
@@ -1880,6 +1895,39 @@ mirRef_indexAndLenLeaf bak gs iTypes elemSize (MirReference _tpr root (AgElem_Re
 
     offDivSz <- liftIO $ bvUdiv sym elemOff elemSizeBV
     return (offDivSz, len)
+mirRef_indexAndLenLeaf bak gs iTypes elemSize (MirReference _tpr root (AgOffset_RefPath elemOff path)) = do
+    let sym = backendGetSym bak
+    let parentTpr = MirAggregateRepr
+    let parent = MirReference parentTpr root path
+    parentAg <- readMirRefLeaf bak gs iTypes parentTpr All parent
+    let MirAggregate totalSize _ = parentAg
+    when (totalSize `mod` elemSize /= 0) $
+       leafAbort $ Unsupported callStack $
+           "expected aggregate size (" ++ show totalSize ++ ") to be a multiple of "
+               ++ "element size (" ++ show elemSize ++ ")"
+    let lenWord = totalSize `div` elemSize
+    len <- liftIO $ bvLit sym knownNat $ BV.mkBV knownNat $ fromIntegral lenWord
+
+    elemSizeBV <- liftIO $ wordLit sym elemSize
+    offModSz <- liftIO $ bvUrem sym elemOff elemSizeBV
+    offModSzIsZero <- liftIO $ bvEq sym offModSz =<< wordLit sym 0
+    leafAssert bak offModSzIsZero $ Unsupported callStack $
+        "expected element offset to be a multiple of element size (" ++ show elemSize ++ ")"
+
+    offDivSz <- liftIO $ bvUdiv sym elemOff elemSizeBV
+    return (offDivSz, len)
+mirRef_indexAndLenLeaf bak gs iTypes elemSize (MirReference MirAggregateRepr root path) = do
+    -- This case follows the `AgOffset_RefPath` case to accommodate aggregate
+    -- references with no/zero offsets. See Note [Aggregate zero-offsets].
+    let sym = backendGetSym bak
+    zero <- liftIO $ wordLit sym 0
+    let parentTpr = MirAggregateRepr
+    let parent = MirReference parentTpr root path
+    parentAg <- readMirRefLeaf bak gs iTypes parentTpr All parent
+    let MirAggregate totalSize _ = parentAg
+    let lenWord = totalSize `div` elemSize
+    len <- liftIO $ wordLit sym lenWord
+    return (zero, len)
 mirRef_indexAndLenLeaf bak _ _ _elemSize (MirReference _ _ _) = do
     let sym = backendGetSym bak
     idx <- liftIO $ bvLit sym knownNat $ BV.mkBV knownNat 0

--- a/crucible-mir/src/Mir/Intrinsics/Reference.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Reference.hs
@@ -809,6 +809,12 @@ newConstMirRef sym tpr v = MirReferenceMux $ toFancyMuxTree sym $
 -- projecting into the aggregate. Otherwise, this fails. `desc` is a
 -- human-readable description of the operation, which is used in the `leafAbort`
 -- error message.
+--
+-- When the reference points to a `MirAggregate` but some other @expectTpr@ is
+-- requested, this will add an `AgElem_RefPath` with the requested type.  This
+-- allows a reference to a `MirAggregate` offset containing type @T@ to be used
+-- as if it's a reference directly to @T@.  For example, this means @&x@,
+-- @&xs[3]@, and @xs.as_ptr().add(3)@ are all handled similarly.
 typedLeafOp ::
     (MonadAssert sym bak m, IsSymBackend sym bak) =>
     String ->
@@ -820,14 +826,13 @@ typedLeafOp ::
 typedLeafOp desc bak expectTpr (MirReference tpr root path) k
   | Just Refl <- testEquality tpr expectTpr =
       k root path
-  | AgOffset_RefPath off origPath <- path = do
-      let elemPath = AgElem_RefPath off expectTpr origPath
-      k root elemPath
   | MirAggregateRepr <- tpr = do
-      -- See Note [Aggregate zero-offsets]
-      zero <- liftIO $ wordLit (backendGetSym bak) 0
-      let offPath = AgOffset_RefPath zero path
-      typedLeafOp desc bak expectTpr (MirReference tpr root offPath) k
+      elemPath <- case path of
+        AgOffset_RefPath off agPath -> return $ AgElem_RefPath off expectTpr agPath
+        _ -> do
+          zero <- liftIO $ wordLit (backendGetSym bak) 0
+          return $ AgElem_RefPath zero expectTpr path
+      k root elemPath
   | otherwise = leafAbort $ GenericSimError $
       desc ++ " requires a reference to " ++ show expectTpr
         ++ ", but got a reference to " ++ show tpr

--- a/crucible-mir/src/Mir/Intrinsics/Reference.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Reference.hs
@@ -90,8 +90,8 @@ module Mir.Intrinsics.Reference
     mirRef_peelIndexMA,
     mirRef_peelFieldLeaf,
     mirRef_peelFieldMA,
-    mirRef_peelAgElemLeaf,
-    mirRef_peelAgElemMA,
+    mirRef_peelAgOffsetLeaf,
+    mirRef_peelAgOffsetMA,
     mirRef_peelJustLeaf,
     mirRef_peelJustMA,
     mirRef_indexAndLenLeaf,
@@ -1748,49 +1748,56 @@ mirRef_peelFieldMA bak iTypes fieldReprs idx (MirReferenceMux ref) =
         (muxRegForType sym iTypes MirReferenceRepr) ref
 
 
--- | Peel off an outermost 'AgElem_RefPath'. Given a pointer to a field of an
+-- | Peel off an outermost 'AgOffset_RefPath'. Given a pointer to a field of an
 -- aggregate, this produces a pointer to the containing struct.
 --
 -- This function takes in the expected offset of the field within the aggregate.
--- If the 'AgElem_RefPath' is actually for a different offset, it will raise an
+-- If the 'AgOffset_RefPath' is actually for a different offset, it will raise an
 -- error.
 --
--- If the outermost path segment isn't 'AgElem_RefPath', this operation raises
+-- If the outermost path segment isn't 'AgOffset_RefPath', this operation raises
 -- an error.
-mirRef_peelAgElemLeaf ::
+mirRef_peelAgOffsetLeaf ::
     (IsSymBackend sym bak, MonadAssert sym bak m) =>
     bak ->
     Word {-^ The expected offset -} ->
     MirReference sym {-^ The field pointer -} ->
     MuxLeafT sym m (MirReferenceMux sym)
-mirRef_peelAgElemLeaf bak off (MirReference _tpr root path) = do
+mirRef_peelAgOffsetLeaf bak off (MirReference tpr root path) = do
     let sym = backendGetSym bak
     case path of
-      AgElem_RefPath off' _ path' -> do
+      AgOffset_RefPath off' path' -> do
           offEq <- liftIO $ bvEq sym off' =<< wordLit sym off
           leafAssert bak offEq $ Unsupported callStack $
-            "peelAgElem offset mismatch; expected " ++ show off
+            "peelAgOffset offset mismatch; expected " ++ show off
               ++ ", but got " ++ show (printSymExpr off')
           return $ MirReferenceMux $
             toFancyMuxTree sym $ MirReference MirAggregateRepr root path'
-
+      _ | MirAggregateRepr <- tpr -> do
+          -- See Note [Aggregate zero-offsets]
+          when (off /= 0) $ 
+            leafAbort $ Unsupported callStack $
+              "peelAgOffset offset mismatch; expected " ++ show off
+                ++ ", but got 0"
+          return $ MirReferenceMux $
+            toFancyMuxTree sym $ MirReference MirAggregateRepr root path
       _ ->
         leafAbort $ Unsupported callStack $
-          "peelAgElem not implemented for this RefPath kind"
-mirRef_peelAgElemLeaf _ _ _ =
+          "peelAgOffset not implemented for this RefPath kind"
+mirRef_peelAgOffsetLeaf _ _ _ =
     leafAbort $ Unsupported callStack $
-      "cannot perform peelAgElem on invalid pointer"
+      "cannot perform peelAgOffset on invalid pointer"
 
-mirRef_peelAgElemMA ::
+mirRef_peelAgOffsetMA ::
     MonadAssert sym bak m =>
     bak ->
     IntrinsicTypes sym ->
     Word {-^ The expected offset -} ->
     MirReferenceMux sym ->
     m (MirReferenceMux sym)
-mirRef_peelAgElemMA bak iTypes off (MirReferenceMux ref) =
+mirRef_peelAgOffsetMA bak iTypes off (MirReferenceMux ref) =
     let sym = backendGetSym bak in
-    readFancyMuxTree' bak (mirRef_peelAgElemLeaf bak off)
+    readFancyMuxTree' bak (mirRef_peelAgOffsetLeaf bak off)
         (muxRegForType sym iTypes MirReferenceRepr) ref
 
 

--- a/crucible-mir/src/Mir/Intrinsics/Reference.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Reference.hs
@@ -62,7 +62,7 @@ module Mir.Intrinsics.Reference
     subjustMirRefLeaf,
     subjustMirRefIO,
     mirRef_agOffsetLeaf,
-    mirRef_agOffsetIO,
+    mirRef_agOffsetMA,
     mirRef_arrayIndexLeaf,
     mirRef_arrayIndexIO,
     mirRef_vecIndexLeaf,
@@ -1104,11 +1104,11 @@ mirRef_vecIndexIO bak iTypes idx elemTpr ref =
 
 
 mirRef_agOffsetLeaf ::
-    (IsSymBackend sym bak) =>
+    (MonadAssert sym bak m) =>
     bak ->
     RegValue sym UsizeType ->
     MirReference sym ->
-    MuxLeafT sym IO (MirReference sym)
+    MuxLeafT sym m (MirReference sym)
 mirRef_agOffsetLeaf bak off ref =
   typedLeafOp "MirAggregate offset" bak MirAggregateRepr ref $ \root path ->
     case path of
@@ -1117,14 +1117,14 @@ mirRef_agOffsetLeaf bak off ref =
         return $ MirReference MirAggregateRepr root (AgOffset_RefPath newOff oldPath)
       _ -> return $ MirReference MirAggregateRepr root (AgOffset_RefPath off path)
 
-mirRef_agOffsetIO ::
-    IsSymBackend sym bak =>
+mirRef_agOffsetMA ::
+    (MonadAssert sym bak m) =>
     bak ->
     IntrinsicTypes sym ->
     RegValue sym UsizeType ->
     MirReferenceMux sym ->
-    IO (MirReferenceMux sym)
-mirRef_agOffsetIO bak iTypes off ref =
+    m (MirReferenceMux sym)
+mirRef_agOffsetMA bak iTypes off ref =
     modifyRefMuxMA bak iTypes (mirRef_agOffsetLeaf bak off) ref
 
 

--- a/crucible-mir/src/Mir/Intrinsics/Reference.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Reference.hs
@@ -70,7 +70,7 @@ module Mir.Intrinsics.Reference
     refRootEq,
     refPathEq,
     mirRef_eqLeaf,
-    mirRef_eqIO,
+    mirRef_eqMA,
     ReversedRefPath (..),
     reverseRefPath,
     popIndex,
@@ -1129,11 +1129,11 @@ mirRef_agOffsetMA bak iTypes off ref =
 
 
 refRootEq ::
-    (IsSymBackend sym bak) =>
+    (MonadAssert sym bak m) =>
     bak ->
     MirReferenceRoot sym tp1 ->
     MirReferenceRoot sym tp2 ->
-    MuxLeafT sym IO (RegValue sym BoolType)
+    MuxLeafT sym m (RegValue sym BoolType)
 refRootEq bak r1 r2 = case (r1, r2) of
   (RefCell_RefRoot rc1, RefCell_RefRoot rc2)
     | Just Refl <- testEquality rc1 rc2 ->
@@ -1153,11 +1153,11 @@ refRootEq bak r1 r2 = case (r1, r2) of
     sym = backendGetSym bak
 
 refPathEq ::
-    (IsSymBackend sym bak) =>
+    (MonadAssert sym bak m) =>
     bak ->
     MirReferencePath sym tp_base1 tp1 ->
     MirReferencePath sym tp_base2 tp2 ->
-    MuxLeafT sym IO (RegValue sym BoolType)
+    MuxLeafT sym m (RegValue sym BoolType)
 refPathEq bak path1 path2 = case (path1, path2) of
   (Empty_RefPath, Empty_RefPath) ->
     return $ truePred sym
@@ -1228,11 +1228,11 @@ refPathEq bak path1 path2 = case (path1, path2) of
     sym = backendGetSym bak
 
 mirRef_eqLeaf ::
-    (IsSymBackend sym bak) =>
+    (MonadAssert sym bak m) =>
     bak ->
     MirReference sym ->
     MirReference sym ->
-    MuxLeafT sym IO (RegValue sym BoolType)
+    MuxLeafT sym m (RegValue sym BoolType)
 mirRef_eqLeaf bak ref1 ref2 = case (ref1, ref2) of
   (MirReference _ root1 path1, MirReference _ root2 path2) -> do
     rootEq <- refRootEq bak root1 root2
@@ -1246,15 +1246,15 @@ mirRef_eqLeaf bak ref1 ref2 = case (ref1, ref2) of
   where
     sym = backendGetSym bak
 
-mirRef_eqIO ::
-    (IsSymBackend sym bak) =>
+mirRef_eqMA ::
+    (MonadAssert sym bak m) =>
     bak ->
     MirReferenceMux sym ->
     MirReferenceMux sym ->
-    IO (RegValue sym BoolType)
-mirRef_eqIO bak (MirReferenceMux r1) (MirReferenceMux r2) =
+    m (RegValue sym BoolType)
+mirRef_eqMA bak (MirReferenceMux r1) (MirReferenceMux r2) =
     let sym = backendGetSym bak in
-    zipFancyMuxTrees' bak (mirRef_eqLeaf bak) (itePred sym) r1 r2
+    zipFancyMuxTrees' bak (mirRef_eqLeaf bak) (\c t e -> liftIO $ itePred sym c t e) r1 r2
 
 
 -- | An ordinary `MirReferencePath sym tp tp''` is represented "inside-out": to

--- a/crucible-mir/src/Mir/Intrinsics/Reference.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Reference.hs
@@ -210,6 +210,7 @@ import Mir.Intrinsics.Aggregate
     MirAggregateType,
     adjustMirAggregateWithSymOffset,
     readMirAggregateWithSymOffset,
+    readSubaggregateWithConcreteOffset,
     writeMirAggregateWithSymOffset,
     mirAggregate_capacity,
     mirAggregate_insert,
@@ -510,34 +511,37 @@ readRefPath ::
   IntrinsicTypes sym ->
   RegValue sym tp ->
   OpSize ->
+  TypeRepr tp ->
   MirReferencePath sym tp tp' ->
   MuxLeafT sym m (RegValue sym tp')
-readRefPath bak iTypes v readSize = \case
-  Empty_RefPath -> return v
+readRefPath bak iTypes v readSize rootTpr = \case
+  Empty_RefPath
+    | MirAggregateRepr <- rootTpr -> readSubaggregateWithConcreteOffset bak readSize 0 v
+    | otherwise -> return v
   Field_RefPath _ctx path fld ->
-    do flds <- readRefPath bak iTypes v All path
+    do flds <- readRefPath bak iTypes v All rootTpr path
        return $ unRV $ flds ! fld
   Variant_RefPath _ ctx path fld ->
-    do (Empty :> _discr :> RV variant) <- readRefPath bak iTypes v All path
+    do (Empty :> _discr :> RV variant) <- readRefPath bak iTypes v All rootTpr path
        let msg = GenericSimError $
                "attempted to read from wrong variant (" ++ show fld ++ " of " ++ show ctx ++ ")"
        leafReadPartExpr bak (unVB $ variant ! fld) msg
   Just_RefPath tp path ->
-    do v' <- readRefPath bak iTypes v All path
+    do v' <- readRefPath bak iTypes v All rootTpr path
        let msg = ReadBeforeWriteSimError $
                "attempted to read from uninitialized Maybe of type " ++ show tp
        leafReadPartExpr bak v' msg
   VectorIndex_RefPath tp path idx ->
-    do v' <- readRefPath bak iTypes v All path
+    do v' <- readRefPath bak iTypes v All rootTpr path
        leafIndexVectorWithSymIndex bak (muxRegForType (backendGetSym bak) iTypes tp) v' idx
   ArrayIndex_RefPath _btp path idx ->
-    do arr <- readRefPath bak iTypes v All path
+    do arr <- readRefPath bak iTypes v All rootTpr path
        liftIO $ arrayLookup (backendGetSym bak) arr (Empty :> idx)
   AgElem_RefPath off tpr path -> do
-    ag <- readRefPath bak iTypes v All path
+    ag <- readRefPath bak iTypes v All rootTpr path
     readMirAggregateWithSymOffset bak (muxRegForType (backendGetSym bak) iTypes tpr) off readSize tpr ag
   AgOffset_RefPath off path -> do
-    ag <- readRefPath bak iTypes v All path
+    ag <- readRefPath bak iTypes v All rootTpr path
     let mux = muxRegForType (backendGetSym bak) iTypes MirAggregateRepr
     readMirAggregateWithSymOffset bak mux off readSize MirAggregateRepr ag
 
@@ -877,7 +881,7 @@ readMirRefLeaf ::
 readMirRefLeaf bak gs iTypes tpr readSize ref =
   typedLeafOp "read" bak tpr ref $ \root path -> do
     v <- readRefRoot bak gs root
-    v' <- readRefPath bak iTypes v readSize path
+    v' <- readRefPath bak iTypes v readSize (refRootType root) path
     return v'
 
 

--- a/crucible-mir/src/Mir/Intrinsics/Size.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Size.hs
@@ -91,6 +91,8 @@ import What4.Interface (bvLit)
 
 -- Rust usize/isize representation
 
+-- This choice of bit width presumes 64-bit architectures. In the longer term,
+-- we'd prefer not to hardcode that presumption - see #1384.
 type SizeBits = 64
 
 type UsizeType = BVType SizeBits

--- a/crucible-mir/src/Mir/Intrinsics/Syntax.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Syntax.hs
@@ -117,7 +117,6 @@ import Mir.Intrinsics.Reference
     MirReferenceRoot (..),
     MirReferenceType,
     dropMirRefIO,
-    mirRef_agElem_unsizedIO,
     mirRef_agOffsetIO,
     mirRef_arrayIndexIO,
     mirRef_eqIO,
@@ -193,15 +192,6 @@ data MirStmt :: (CrucibleType -> Type) -> CrucibleType -> Type where
      MirStmt f MirReferenceType
   MirSubjustRef ::
      !(TypeRepr tp) ->
-     !(f MirReferenceType) ->
-     MirStmt f MirReferenceType
-  -- | Like `MirRef_AgElem`, but the size and `TypeRepr` are inferred by
-  -- inspecting the aggregate.  This reads from memory instead of simply
-  -- adjusting the `MirReferencePath`, so it's best avoided if possible.
-  --
-  -- TODO: remove this once `MirRef_AgOffset` is implemented
-  MirRef_AgElem_Unsized ::
-     !(f UsizeType) ->
      !(f MirReferenceType) ->
      MirStmt f MirReferenceType
   -- | Given a reference to an aggregate, produce a reference to the
@@ -405,7 +395,6 @@ instance TypeApp MirStmt where
     MirSubjustRef _ _ -> MirReferenceRepr
     MirRef_ArrayIndex _ _ _ -> MirReferenceRepr
     MirRef_VecIndex _ _ _ -> MirReferenceRepr
-    MirRef_AgElem_Unsized _ _ -> MirReferenceRepr
     MirRef_AgOffset _ _ -> MirReferenceRepr
     MirRef_Eq _ _ -> BoolRepr
     MirRef_Offset _ _ _ -> MirReferenceRepr
@@ -442,7 +431,6 @@ instance PrettyApp MirStmt where
     MirSubjustRef _ x -> "subjustRef" <+> pp x
     MirRef_ArrayIndex idx _ ref -> "mirRef_arrayIndex" <+> pp idx <+> pp ref
     MirRef_VecIndex idx _ ref -> "mirRef_vecIndex" <+> pp idx <+> pp ref
-    MirRef_AgElem_Unsized off ref -> "mirRef_agElem_unsized" <+> pp off <+> pp ref
     MirRef_AgOffset off ref -> "mirRef_agOffset" <+> pp off <+> pp ref
     MirRef_Eq x y -> "mirRef_eq" <+> pp x <+> pp y
     MirRef_Offset p o s -> "mirRef_offset" <+> pp p <+> pp o <+> viaShow s
@@ -511,8 +499,6 @@ execMirStmt stmt s = withStateBackend s $ \bak ->
          readOnly s $ mirRef_arrayIndexIO bak iTypes idx tpr ref
        MirRef_VecIndex (regValue -> idx) tpr (regValue -> ref) ->
          readOnly s $ mirRef_vecIndexIO bak iTypes idx tpr ref
-       MirRef_AgElem_Unsized (regValue -> off) (regValue -> ref) ->
-         readOnly s $ mirRef_agElem_unsizedIO bak gs iTypes off ref
        MirRef_AgOffset (regValue -> off) (regValue -> ref) ->
          readOnly s $ mirRef_agOffsetIO bak iTypes off ref
        MirRef_Eq (regValue -> r1) (regValue -> r2) ->

--- a/crucible-mir/src/Mir/Intrinsics/Syntax.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Syntax.hs
@@ -119,6 +119,7 @@ import Mir.Intrinsics.Reference
     dropMirRefIO,
     mirRef_agElemIO,
     mirRef_agElem_unsizedIO,
+    mirRef_agOffsetIO,
     mirRef_aggregateAsChunksIO,
     mirRef_arrayIndexIO,
     mirRef_eqIO,
@@ -208,6 +209,12 @@ data MirStmt :: (CrucibleType -> Type) -> CrucibleType -> Type where
   --
   -- TODO: remove this once `MirRef_AgOffset` is implemented
   MirRef_AgElem_Unsized ::
+     !(f UsizeType) ->
+     !(f MirReferenceType) ->
+     MirStmt f MirReferenceType
+  -- | Given a reference to an aggregate, produce a reference to the
+  -- tail of that aggregate, starting at the given offset.
+  MirRef_AgOffset ::
      !(f UsizeType) ->
      !(f MirReferenceType) ->
      MirStmt f MirReferenceType
@@ -418,6 +425,7 @@ instance TypeApp MirStmt where
     MirRef_VecIndex _ _ _ -> MirReferenceRepr
     MirRef_AgElem _ _ _ _ -> MirReferenceRepr
     MirRef_AgElem_Unsized _ _ -> MirReferenceRepr
+    MirRef_AgOffset _ _ -> MirReferenceRepr
     MirRef_Eq _ _ -> BoolRepr
     MirRef_Offset _ _ _ -> MirReferenceRepr
     MirRef_OffsetWrap _ _ _ -> MirReferenceRepr
@@ -456,6 +464,7 @@ instance PrettyApp MirStmt where
     MirRef_VecIndex idx _ ref -> "mirRef_vecIndex" <+> pp idx <+> pp ref
     MirRef_AgElem off _ _ ref -> "mirRef_agElem" <+> pp off <+> pp ref
     MirRef_AgElem_Unsized off ref -> "mirRef_agElem_unsized" <+> pp off <+> pp ref
+    MirRef_AgOffset off ref -> "mirRef_agOffset" <+> pp off <+> pp ref
     MirRef_Eq x y -> "mirRef_eq" <+> pp x <+> pp y
     MirRef_Offset p o s -> "mirRef_offset" <+> pp p <+> pp o <+> viaShow s
     MirRef_OffsetWrap p o s -> "mirRef_offsetWrap" <+> pp p <+> pp o <+> viaShow s
@@ -528,6 +537,8 @@ execMirStmt stmt s = withStateBackend s $ \bak ->
          readOnly s $ mirRef_agElemIO bak iTypes off sz tpr ref
        MirRef_AgElem_Unsized (regValue -> off) (regValue -> ref) ->
          readOnly s $ mirRef_agElem_unsizedIO bak gs iTypes off ref
+       MirRef_AgOffset (regValue -> off) (regValue -> ref) ->
+         readOnly s $ mirRef_agOffsetIO bak iTypes off ref
        MirRef_Eq (regValue -> r1) (regValue -> r2) ->
          readOnly s $ mirRef_eqIO bak r1 r2
        MirRef_Offset (regValue -> ref) (regValue -> off) elemSize ->

--- a/crucible-mir/src/Mir/Intrinsics/Syntax.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Syntax.hs
@@ -120,7 +120,6 @@ import Mir.Intrinsics.Reference
     mirRef_agElemIO,
     mirRef_agElem_unsizedIO,
     mirRef_agOffsetIO,
-    mirRef_aggregateAsChunksIO,
     mirRef_arrayIndexIO,
     mirRef_eqIO,
     mirRef_offsetMA,
@@ -271,16 +270,6 @@ data MirStmt :: (CrucibleType -> Type) -> CrucibleType -> Type where
      -- | The size of the element, in bytes
      !Word ->
      MirStmt f (StructType (EmptyCtx ::> MirReferenceType ::> UsizeType))
-  -- | Given a pointer to an element, return a pointer to an array constructed
-  -- by viewing the next @chunkSize * numChunks@ elements as an array of
-  -- arrays.
-  MirRef_AggregateAsChunks ::
-     -- | Size in bytes of each chunk (must be concrete)
-     !(f UsizeType) ->
-     -- | Number of chunks to produce (must be concrete)
-     !(f UsizeType) ->
-     !(f MirReferenceType) ->
-     MirStmt f MirReferenceType
   -- | Print the internal representation of a `MirReference` for debugging.
   -- This is similar to the behavior of @crucible::dump_rv@, but it's easier to
   -- call an intrinsic from inside `Mir.Trans` / `Mir.TransCustom` cases than
@@ -431,7 +420,6 @@ instance TypeApp MirStmt where
     MirRef_OffsetWrap _ _ _ -> MirReferenceRepr
     MirRef_TryOffsetFrom _ _ _ -> MaybeRepr IsizeRepr
     MirRef_PeelIndex _ _ -> StructRepr (Empty :> MirReferenceRepr :> UsizeRepr)
-    MirRef_AggregateAsChunks _ _ _ -> MirReferenceRepr
     DebugPrintMirRef _ _ -> UnitRepr
     VectorSnoc tp _ _ -> VectorRepr tp
     VectorHead tp _ -> MaybeRepr tp
@@ -470,7 +458,6 @@ instance PrettyApp MirStmt where
     MirRef_OffsetWrap p o s -> "mirRef_offsetWrap" <+> pp p <+> pp o <+> viaShow s
     MirRef_TryOffsetFrom p o s -> "mirRef_tryOffsetFrom" <+> pp p <+> pp o <+> viaShow s
     MirRef_PeelIndex p s -> "mirRef_peelIndex" <+> pp p <+> viaShow s
-    MirRef_AggregateAsChunks chunkSize numChunks p -> "mirRef_aggregateAsChunks" <+> pp chunkSize <+> pp numChunks <+> pp p
     DebugPrintMirRef s p -> "debugPrintMirRef" <+> pp s <+> pp p
     VectorSnoc _ v e -> "vectorSnoc" <+> pp v <+> pp e
     VectorHead _ v -> "vectorHead" <+> pp v
@@ -549,8 +536,6 @@ execMirStmt stmt s = withStateBackend s $ \bak ->
          readOnly s $ mirRef_tryOffsetFromIO bak iTypes elemSize r1 r2
        MirRef_PeelIndex (regValue -> ref) elemSize -> do
          readOnly s $ mirRef_peelIndexMA bak iTypes ref elemSize
-       MirRef_AggregateAsChunks (regValue -> chunkSize) (regValue -> numChunks) (regValue -> ref) -> do
-         readOnly s $ mirRef_aggregateAsChunksIO bak iTypes chunkSize numChunks ref
        DebugPrintMirRef (regValue -> desc) (regValue -> ref) -> do
          readOnly s $ putStrLn $ "debugPrintMirRef (" ++ show (printSymExpr desc)
            ++ "): " ++ show ref

--- a/crucible-mir/src/Mir/Intrinsics/Syntax.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Syntax.hs
@@ -117,7 +117,6 @@ import Mir.Intrinsics.Reference
     MirReferenceRoot (..),
     MirReferenceType,
     dropMirRefIO,
-    mirRef_agElemIO,
     mirRef_agElem_unsizedIO,
     mirRef_agOffsetIO,
     mirRef_arrayIndexIO,
@@ -193,12 +192,6 @@ data MirStmt :: (CrucibleType -> Type) -> CrucibleType -> Type where
      !(Index variantsCtx tp) ->
      MirStmt f MirReferenceType
   MirSubjustRef ::
-     !(TypeRepr tp) ->
-     !(f MirReferenceType) ->
-     MirStmt f MirReferenceType
-  MirRef_AgElem ::
-     !(f UsizeType) ->
-     !Word ->
      !(TypeRepr tp) ->
      !(f MirReferenceType) ->
      MirStmt f MirReferenceType
@@ -412,7 +405,6 @@ instance TypeApp MirStmt where
     MirSubjustRef _ _ -> MirReferenceRepr
     MirRef_ArrayIndex _ _ _ -> MirReferenceRepr
     MirRef_VecIndex _ _ _ -> MirReferenceRepr
-    MirRef_AgElem _ _ _ _ -> MirReferenceRepr
     MirRef_AgElem_Unsized _ _ -> MirReferenceRepr
     MirRef_AgOffset _ _ -> MirReferenceRepr
     MirRef_Eq _ _ -> BoolRepr
@@ -450,7 +442,6 @@ instance PrettyApp MirStmt where
     MirSubjustRef _ x -> "subjustRef" <+> pp x
     MirRef_ArrayIndex idx _ ref -> "mirRef_arrayIndex" <+> pp idx <+> pp ref
     MirRef_VecIndex idx _ ref -> "mirRef_vecIndex" <+> pp idx <+> pp ref
-    MirRef_AgElem off _ _ ref -> "mirRef_agElem" <+> pp off <+> pp ref
     MirRef_AgElem_Unsized off ref -> "mirRef_agElem_unsized" <+> pp off <+> pp ref
     MirRef_AgOffset off ref -> "mirRef_agOffset" <+> pp off <+> pp ref
     MirRef_Eq x y -> "mirRef_eq" <+> pp x <+> pp y
@@ -520,8 +511,6 @@ execMirStmt stmt s = withStateBackend s $ \bak ->
          readOnly s $ mirRef_arrayIndexIO bak iTypes idx tpr ref
        MirRef_VecIndex (regValue -> idx) tpr (regValue -> ref) ->
          readOnly s $ mirRef_vecIndexIO bak iTypes idx tpr ref
-       MirRef_AgElem (regValue -> off) sz tpr (regValue -> ref) ->
-         readOnly s $ mirRef_agElemIO bak iTypes off sz tpr ref
        MirRef_AgElem_Unsized (regValue -> off) (regValue -> ref) ->
          readOnly s $ mirRef_agElem_unsizedIO bak gs iTypes off ref
        MirRef_AgOffset (regValue -> off) (regValue -> ref) ->

--- a/crucible-mir/src/Mir/Intrinsics/Syntax.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Syntax.hs
@@ -142,6 +142,7 @@ import Mir.Intrinsics.Size
     pattern UsizeRepr,
   )
 import Mir.Intrinsics.Vector (vectorDropIO, vectorTakeIO)
+import Mir.Mir (OpSize)
 
 -- | Sigil type indicating the MIR syntax extension
 data MIR
@@ -165,6 +166,9 @@ data MirStmt :: (CrucibleType -> Type) -> CrucibleType -> Type where
      MirStmt f MirReferenceType
   MirReadRef ::
      !(TypeRepr tp) ->
+     -- | The size of the value to read, in bytes. This must be known concretely
+     -- at symbolic execution time.
+     !OpSize ->
      !(f MirReferenceType) ->
      MirStmt f tp
   MirWriteRef ::
@@ -402,7 +406,7 @@ instance TypeApp MirStmt where
     MirIntegerToRef _ -> MirReferenceRepr
     MirGlobalRef _ -> MirReferenceRepr
     MirConstRef _ _ -> MirReferenceRepr
-    MirReadRef tp _ -> tp
+    MirReadRef tp _ _ -> tp
     MirWriteRef _ _ _ -> UnitRepr
     MirDropRef _    -> UnitRepr
     MirSubfieldRef _ _ _ -> MirReferenceRepr
@@ -440,7 +444,7 @@ instance PrettyApp MirStmt where
     MirIntegerToRef i -> "integerToMirRef" <+> pp i
     MirGlobalRef gv -> "globalMirRef" <+> pretty gv
     MirConstRef _ v -> "constMirRef" <+> pp v
-    MirReadRef _ x  -> "readMirRef" <+> pp x
+    MirReadRef _ sz x  -> "readMirRef" <+> pretty sz <+> pp x
     MirWriteRef _ x y -> "writeMirRef" <+> pp x <+> "<-" <+> pp y
     MirDropRef x    -> "dropMirRef" <+> pp x
     MirSubfieldRef _ x idx -> "subfieldRef" <+> pp x <+> viaShow idx
@@ -502,8 +506,8 @@ execMirStmt stmt s = withStateBackend s $ \bak ->
          do let r = MirReference tpr (Const_RefRoot tpr v) Empty_RefPath
             return (mkRef r, s)
 
-       MirReadRef tpr (regValue -> ref) ->
-         readOnly s $ readMirRefMA bak gs iTypes tpr ref
+       MirReadRef tpr readSize (regValue -> ref) ->
+         readOnly s $ readMirRefMA bak gs iTypes tpr readSize ref
        MirWriteRef tpr (regValue -> ref) (regValue -> x) ->
          writeOnly s $ writeMirRefIO bak gs iTypes tpr ref x
        MirDropRef (regValue -> ref) ->

--- a/crucible-mir/src/Mir/Intrinsics/Syntax.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Syntax.hs
@@ -174,6 +174,8 @@ data MirStmt :: (CrucibleType -> Type) -> CrucibleType -> Type where
   MirWriteRef ::
      !(TypeRepr tp) ->
      !(f MirReferenceType) ->
+     -- | The size of the value to write.
+     !OpSize ->
      !(f tp) ->
      MirStmt f UnitType
   MirDropRef ::
@@ -407,7 +409,7 @@ instance TypeApp MirStmt where
     MirGlobalRef _ -> MirReferenceRepr
     MirConstRef _ _ -> MirReferenceRepr
     MirReadRef tp _ _ -> tp
-    MirWriteRef _ _ _ -> UnitRepr
+    MirWriteRef _ _ _ _ -> UnitRepr
     MirDropRef _    -> UnitRepr
     MirSubfieldRef _ _ _ -> MirReferenceRepr
     MirSubvariantRef _ _ _ _ -> MirReferenceRepr
@@ -445,7 +447,7 @@ instance PrettyApp MirStmt where
     MirGlobalRef gv -> "globalMirRef" <+> pretty gv
     MirConstRef _ v -> "constMirRef" <+> pp v
     MirReadRef _ sz x  -> "readMirRef" <+> pretty sz <+> pp x
-    MirWriteRef _ x y -> "writeMirRef" <+> pp x <+> "<-" <+> pp y
+    MirWriteRef _ x sz y -> "writeMirRef" <+> pretty sz <+> pp x <+> "<-" <+> pp y
     MirDropRef x    -> "dropMirRef" <+> pp x
     MirSubfieldRef _ x idx -> "subfieldRef" <+> pp x <+> viaShow idx
     MirSubvariantRef _ _ x idx -> "subvariantRef" <+> pp x <+> viaShow idx
@@ -508,8 +510,8 @@ execMirStmt stmt s = withStateBackend s $ \bak ->
 
        MirReadRef tpr readSize (regValue -> ref) ->
          readOnly s $ readMirRefMA bak gs iTypes tpr readSize ref
-       MirWriteRef tpr (regValue -> ref) (regValue -> x) ->
-         writeOnly s $ writeMirRefIO bak gs iTypes tpr ref x
+       MirWriteRef tpr (regValue -> ref) writeSize (regValue -> x) ->
+         writeOnly s $ writeMirRefIO bak gs iTypes tpr ref writeSize x
        MirDropRef (regValue -> ref) ->
          writeOnly s $ dropMirRefIO bak gs ref
        MirSubfieldRef ctx0 (regValue -> ref) idx ->

--- a/crucible-mir/src/Mir/Intrinsics/Syntax.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Syntax.hs
@@ -117,7 +117,7 @@ import Mir.Intrinsics.Reference
     MirReferenceRoot (..),
     MirReferenceType,
     dropMirRefIO,
-    mirRef_agOffsetIO,
+    mirRef_agOffsetMA,
     mirRef_arrayIndexIO,
     mirRef_eqIO,
     mirRef_offsetMA,
@@ -500,7 +500,7 @@ execMirStmt stmt s = withStateBackend s $ \bak ->
        MirRef_VecIndex (regValue -> idx) tpr (regValue -> ref) ->
          readOnly s $ mirRef_vecIndexIO bak iTypes idx tpr ref
        MirRef_AgOffset (regValue -> off) (regValue -> ref) ->
-         readOnly s $ mirRef_agOffsetIO bak iTypes off ref
+         readOnly s $ mirRef_agOffsetMA bak iTypes off ref
        MirRef_Eq (regValue -> r1) (regValue -> r2) ->
          readOnly s $ mirRef_eqIO bak r1 r2
        MirRef_Offset (regValue -> ref) (regValue -> off) elemSize ->

--- a/crucible-mir/src/Mir/Intrinsics/Syntax.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Syntax.hs
@@ -164,8 +164,7 @@ data MirStmt :: (CrucibleType -> Type) -> CrucibleType -> Type where
      MirStmt f MirReferenceType
   MirReadRef ::
      !(TypeRepr tp) ->
-     -- | The size of the value to read, in bytes. This must be known concretely
-     -- at symbolic execution time.
+     -- | The size of the value to read.
      !OpSize ->
      !(f MirReferenceType) ->
      MirStmt f tp

--- a/crucible-mir/src/Mir/Intrinsics/Syntax.hs
+++ b/crucible-mir/src/Mir/Intrinsics/Syntax.hs
@@ -119,7 +119,7 @@ import Mir.Intrinsics.Reference
     dropMirRefIO,
     mirRef_agOffsetMA,
     mirRef_arrayIndexIO,
-    mirRef_eqIO,
+    mirRef_eqMA,
     mirRef_offsetMA,
     mirRef_offsetWrapIO,
     mirRef_peelIndexMA,
@@ -502,7 +502,7 @@ execMirStmt stmt s = withStateBackend s $ \bak ->
        MirRef_AgOffset (regValue -> off) (regValue -> ref) ->
          readOnly s $ mirRef_agOffsetMA bak iTypes off ref
        MirRef_Eq (regValue -> r1) (regValue -> r2) ->
-         readOnly s $ mirRef_eqIO bak r1 r2
+         readOnly s $ mirRef_eqMA bak r1 r2
        MirRef_Offset (regValue -> ref) (regValue -> off) elemSize ->
          readOnly s $ mirRef_offsetMA bak iTypes ref off elemSize
        MirRef_OffsetWrap (regValue -> ref) (regValue -> off) elemSize ->

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -39,6 +39,8 @@ import Lens.Micro.TH (makeLenses)
 
 import GHC.Generics
 
+import Prettyprinter (Pretty(..))
+
 import Mir.DefId
 
 import Data.Coerce(coerce)
@@ -755,7 +757,23 @@ onlyVariant (Adt name kind _ _ _ _ _) = error $
     "expected " ++ show kind ++ " " ++ show name ++ " to have only one variant"
 
 
+--------------------------------------------------------------------------------
+-- OpSize
 
+-- | Several operations need to know how many bytes are occupied by the Rust
+-- values being operated on - use this structure to provide that information.
+data OpSize
+  = -- | A statically-known width, in bytes.
+    Width Word
+  | -- | A dynamic width, generally meant for reading entire allocations,
+    -- regardless of size.
+    All
+  deriving (Eq, Ord)
+
+instance Pretty OpSize where
+  pretty s = case s of
+    Width w -> pretty w
+    All -> "<alloc>"
 
 
 --------------------------------------------------------------------------------------

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -773,7 +773,7 @@ data OpSize
 instance Pretty OpSize where
   pretty s = case s of
     Width w -> pretty w
-    All -> "<alloc>"
+    All -> "<all>"
 
 
 --------------------------------------------------------------------------------------

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -1545,11 +1545,12 @@ evalPlaceProj ty (MirPlace tpr ref NoMeta) M.Deref = do
         CTyBox t -> doRef t
         _ -> mirFail $ "deref not supported on " ++ show ty
   where
-    -- These values presume 64-bit architectures. In the longer term, we'd
-    -- prefer not to hardcode that presumption - see #1384.
+    ptrBytes :: Word
+    ptrBytes = fromIntegral (C.intValue (C.knownNat @SizeBits)) `div` 8
+
     ptrOpSize, fatPtrOpSize :: OpSize
-    ptrOpSize = Width 8
-    fatPtrOpSize = Width 16
+    ptrOpSize    = Width      ptrBytes
+    fatPtrOpSize = Width (2 * ptrBytes)
 
     doRef :: M.Ty -> MirGenerator h s ret (MirPlace s)
     doRef (M.TySlice ty') | MirSliceRepr <- tpr = doSlice ty' ref
@@ -2945,10 +2946,7 @@ dispatchFromDyn dynTraitName recvTy recvExp die = do
                 [(fldIdx, fld)] -> do
                   fieldExp <- lift $ getStructField ty fldIdx mirExp
                   fieldExp' <- go (fld ^. fty) fieldExp
-                    -- This value presumes a 64-bit architecture. In the longer
-                    -- term, we'd prefer not to hardcode that presumption - see
-                    -- #1384.
-                  let ptrSize = 8
+                  let ptrSize = fromIntegral (C.intValue (C.knownNat @SizeBits)) `div` 8
                   lift $ buildWrapperAggregate ptrSize fieldExp'
                 fs ->
                   lift $ die

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -1717,7 +1717,7 @@ evalPlaceProj ty (MirPlace tpr ref meta) (M.Index idxVar) = case (ty, tpr, meta)
         Some elemTpr <- tyToReprM elemTy
         elemSize <- tySizeM elemTy
         let elemOff = R.App $ usizeMul idx' (R.App $ usizeLit $ fromIntegral elemSize)
-        MirPlace elemTpr <$> mirRef_agElem elemOff elemSize elemTpr ref <*> pure NoMeta
+        MirPlace elemTpr <$> mirRef_agOffset elemOff ref <*> pure NoMeta
 
     (M.TySlice elemTy, elemTpr, SliceMeta len) -> do
         idx <- getIdx idxVar
@@ -1741,7 +1741,7 @@ evalPlaceProj ty (MirPlace tpr ref meta) (M.ConstantIndex idx _minLen fromEnd) =
         Some elemTpr <- tyToReprM elemTy
         elemSize <- tySizeM elemTy
         let elemOff = R.App $ usizeMul idx' (R.App $ usizeLit $ fromIntegral elemSize)
-        MirPlace elemTpr <$> mirRef_agElem elemOff elemSize elemTpr ref <*> pure NoMeta
+        MirPlace elemTpr <$> mirRef_agOffset elemOff ref <*> pure NoMeta
 
     (M.TySlice elemTy, elemTpr, SliceMeta len) -> do
         idx' <- getIdx idx len fromEnd

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -348,14 +348,15 @@ typedVarInfo name tpr = do
                     ++ ", but it has type " ++ show tpr' ++ " instead"
             return vi
 
-readVar :: C.TypeRepr tp -> VarInfo s tp -> MirGenerator h s ret (R.Expr MIR s tp)
-readVar tpr vi = G.readReg (varInfoReg vi) >>= readMirRef tpr
+readVar :: C.TypeRepr tp -> Word ->VarInfo s tp -> MirGenerator h s ret (R.Expr MIR s tp)
+readVar tpr tySize vi = G.readReg (varInfoReg vi) >>= readMirRef tpr (Width tySize)
 
 varExp :: HasCallStack => M.Var -> MirGenerator h s ret (MirExp s)
 varExp (M.Var vname' _ vty _) = do
     Some tpr <- tyToReprM vty
+    tySize <- tySizeM vty
     vi <- typedVarInfo vname' tpr
-    x <- readVar tpr vi
+    x <- readVar tpr tySize vi
     return $ MirExp tpr x
 
 varPlace :: HasCallStack => M.Var -> MirGenerator h s ret (MirPlace s)
@@ -400,10 +401,10 @@ staticSlicePlace len ty did = do
         Nothing -> mirFail $ "cannot find static variable " ++ fmt did
 
 -- NOTE: The return var in the MIR output is always "_0"
-getReturnExp :: HasCallStack => C.TypeRepr ret -> MirGenerator h s ret (R.Expr MIR s ret)
-getReturnExp tpr = do
+getReturnExp :: HasCallStack => C.TypeRepr ret -> Word -> MirGenerator h s ret (R.Expr MIR s ret)
+getReturnExp tpr tySize = do
     vi <- typedVarInfo "_0" tpr
-    readVar tpr vi
+    readVar tpr tySize vi
 
 
 -- ** Expressions: Operations and Aggregates
@@ -434,7 +435,9 @@ derefExp pointeeTy (MirExp MirReferenceRepr e) = do
 derefExp _pointeeTy (MirExp tpr _) = mirFail $ "don't know how to deref " ++ show tpr
 
 readPlace :: HasCallStack => M.Ty -> MirPlace s -> MirGenerator h s ret (MirExp s)
-readPlace _ty (MirPlace tpr r NoMeta) = MirExp tpr <$> readMirRef tpr r
+readPlace ty (MirPlace tpr r NoMeta) = do
+    tySize <- tySizeM ty
+    MirExp tpr <$> readMirRef tpr (Width tySize) r
 readPlace ty (MirPlace tpr _ meta) =
     mirFail $ "don't know how to read from place with metadata " ++ show meta
         ++ " (type " ++ show ty ++ ", repr " ++ show tpr ++ ")"
@@ -1551,6 +1554,10 @@ evalPlaceProj ty (MirPlace tpr ref NoMeta) M.Deref = do
         CTyBox t -> doRef t
         _ -> mirFail $ "deref not supported on " ++ show ty
   where
+    ptrOpSize, fatPtrOpSize :: OpSize
+    ptrOpSize = Width 8
+    fatPtrOpSize = Width 16
+
     doRef :: M.Ty -> MirGenerator h s ret (MirPlace s)
     doRef (M.TySlice ty') | MirSliceRepr <- tpr = doSlice ty' ref
     doRef M.TyStr | MirSliceRepr <- tpr = doSlice (M.TyUint M.B8) ref
@@ -1562,7 +1569,7 @@ evalPlaceProj ty (MirPlace tpr ref NoMeta) M.Deref = do
         -- This use of `tyToReprM` is okay because `TyDynamic` and other
         -- unsized cases are handled above.
         Some tpr' <- tyToReprM ty'
-        MirPlace tpr' <$> readMirRef tpr ref <*> pure NoMeta
+        MirPlace tpr' <$> readMirRef tpr ptrOpSize ref <*> pure NoMeta
     doRef _ = mirFail $ "deref: bad repr for " ++ show ty ++ ": " ++ show tpr
 
     -- Slice types [U] are unsized, so we handle them differently. Given a
@@ -1580,7 +1587,7 @@ evalPlaceProj ty (MirPlace tpr ref NoMeta) M.Deref = do
         -- This use of `tyToReprM` is okay because we know the element type of
         -- a slice is always sized.
         Some tpr' <- tyToReprM ty'
-        slice <- readMirRef MirSliceRepr ref'
+        slice <- readMirRef MirSliceRepr fatPtrOpSize ref'
         let ptr = getSlicePtr slice
         let len = getSliceLen slice
         return $ MirPlace tpr' ptr (SliceMeta len)
@@ -1602,7 +1609,7 @@ evalPlaceProj ty (MirPlace tpr ref NoMeta) M.Deref = do
     -- type like AnyType.
     doDyn :: R.Expr MIR s MirReferenceType -> MirGenerator h s ret (MirPlace s)
     doDyn ref' = do
-        dynRef <- readMirRef DynRefRepr ref'
+        dynRef <- readMirRef DynRefRepr fatPtrOpSize ref'
         let dynRefData = S.getStruct dynRefDataIndex dynRef
         let dynRefVtable = S.getStruct dynRefVtableIndex dynRef
         return $ MirPlace C.AnyRepr dynRefData (DynMeta dynRefVtable)
@@ -1626,7 +1633,7 @@ evalPlaceProj ty (MirPlace tpr ref NoMeta) M.Deref = do
         -- expect to check/use this type directly elsewhere, so we can get away
         -- with an `AnyRepr` placeholder.
         let adtRepr = C.AnyRepr
-        adtRef <- readMirRef MirSliceRepr ref'
+        adtRef <- readMirRef MirSliceRepr fatPtrOpSize ref'
         -- In both this case and the case of plain slices, `readMirRef` gives us
         -- access to a double-wide DST pointer. In both cases, the second half
         -- holds the slice length. In our case, the first half holds a pointer
@@ -1658,7 +1665,7 @@ evalPlaceProj ty (MirPlace tpr ref NoMeta) M.Deref = do
         -- value, we don't expect to check/use this type directly elsewhere, so
         -- we can get away with an `AnyRepr` placeholder.
         let adtRepr = C.AnyRepr
-        dynRef <- readMirRef DynRefRepr ref'
+        dynRef <- readMirRef DynRefRepr fatPtrOpSize ref'
         let adtPtr = S.getStruct dynRefDataIndex dynRef
         let vtable = S.getStruct dynRefVtableIndex dynRef
         return $ MirPlace adtRepr adtPtr (DynMeta vtable)
@@ -2024,8 +2031,6 @@ jumpToBlock bbi = do
 
 doReturn :: HasCallStack => C.TypeRepr ret -> MirGenerator h s ret a
 doReturn tr = do
-    e <- getReturnExp tr
-
     -- In static initializers, "local" variables stay live past the end of the
     -- function so that the initializer can return references to them.  For
     -- example, in `static R: &'static i32 = &1;`, the initializer stores `1`
@@ -2036,6 +2041,9 @@ doReturn tr = do
     -- To detect if the current function is a static initializer, we check if
     -- there's an entry in `statics` matching the current `fname`.
     fn <- expectFnContext
+    retSize <- tySizeM (fn ^. fsig . fsreturn_ty)
+    e <- getReturnExp tr retSize
+
     let curName = fn ^. fname
     isStatic <- use $ cs . collection . statics . to (Map.member curName)
     when (not isStatic) cleanupLocals
@@ -2730,16 +2738,17 @@ transVtableShim colState vtableName (VtableItem fnName defName)
         G.FunctionDef MIR FnState (C.AnyType :<: argTys) retTy (ST h)
     buildShimForByValue recvMirTy recvTy argTys implFH = \argsA -> (\x -> (fnState, x)) $ do
         let (recv, args) = splitMethodArgs @C.AnyType @argTys argsA (Ctx.size argTys)
-        recvValue <- if isZeroSized (colState ^. collection) recvMirTy
-            then do
+        recvSize <- tySizeM recvMirTy
+        recvValue <- case recvSize of
+            0 -> do
                 Refl <- testEqualityOrFail recvTy MirAggregateRepr $
                     "transVtableShim: expected receiver type to have MirAggregateRepr, "
                       ++ "but got " ++ show recvTy
                 mirAggregate_uninit_constSize 0
-            else do
+            _ -> do
                 recvDowncast <- G.fromJustExpr (R.App $ E.UnpackAny MirReferenceRepr recv)
                     (R.App $ E.StringLit $ fromString $ "bad receiver type for " ++ show fnName)
-                readMirRef recvTy recvDowncast
+                readMirRef recvTy (Width recvSize) recvDowncast
         G.tailCall (R.App $ E.HandleLit implFH) (recvValue <: args)
 
 splitMethodArgs :: forall recvTy argTys s.
@@ -3298,7 +3307,7 @@ vectorCopy tpr ptr0 len elemSize = do
     G.jumpToLambda c_id $ S.app $ E.VectorLit tpr mempty
   -- Else branch
   y_id <- G.defineBlockLabel $ do
-    elt0 <- readMirRef tpr ptr0
+    elt0 <- readMirRef tpr (Width elemSize) ptr0
     let out0 = S.app $ E.VectorReplicate tpr (S.app $ usizeToNat len) elt0
     iRef <- G.newRef $ S.app $ usizeLit 0
     ptrRef <- G.newRef ptr0
@@ -3309,7 +3318,7 @@ vectorCopy tpr ptr0 len elemSize = do
             (pos, do i <- G.readRef iRef
                      ptr <- G.readRef ptrRef
                      out1 <- G.readRef outRef
-                     elt <- readMirRef tpr ptr
+                     elt <- readMirRef tpr (Width elemSize) ptr
                      let i' = S.app $ usizeAdd i (S.app $ usizeLit 1)
                      ptr' <- mirRef_offset ptr (S.app $ usizeLit 1) elemSize
                      let out2 = S.app $ vectorSetUsize tpr R.App out1 i elt
@@ -3334,7 +3343,7 @@ aggregateCopy_constLen tpr ptr0 len size = do
   ag' <- foldM
     (\ag' i -> do
        ptr <- mirRef_offset ptr0 (S.app $ usizeLit $ fromIntegral i) size
-       elt <- readMirRef tpr ptr
+       elt <- readMirRef tpr (Width size) ptr
        mirAggregate_set (fromIntegral i * size) size tpr elt ag')
     ag (init [0 .. len])
   return ag'
@@ -3355,7 +3364,7 @@ ptrCopy tpr src dest len elemSize = do
             (pos, do i <- G.readRef iRef
                      src' <- mirRef_offset src i elemSize
                      dest' <- mirRef_offset dest i elemSize
-                     val <- readMirRef tpr src'
+                     val <- readMirRef tpr (Width elemSize) src'
                      writeMirRef tpr dest' val
                      let i' = S.app $ usizeAdd i (S.app $ usizeLit 1)
                      G.writeRef iRef i')

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -1545,6 +1545,8 @@ evalPlaceProj ty (MirPlace tpr ref NoMeta) M.Deref = do
         CTyBox t -> doRef t
         _ -> mirFail $ "deref not supported on " ++ show ty
   where
+    -- These values presume 64-bit architectures. In the longer term, we'd
+    -- prefer not to hardcode that presumption - see #1384.
     ptrOpSize, fatPtrOpSize :: OpSize
     ptrOpSize = Width 8
     fatPtrOpSize = Width 16

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -281,12 +281,11 @@ transConstVal ty tp cv = mirFail $
 --    * construct a reference to the global variable
 --      (with globalMirRef rather than constMirRef, that's the point of
 --      all this)
---    * apply mirRef_agElem
 --    * cons up the length
 --    * call mkStruct
 --    * cons up the final MirExp
 --
--- staticSlicePlace does the first four of these actions; addrOfPlace
+-- staticSlicePlace does the first three of these actions; addrOfPlace
 -- does the last two.
 --
 
@@ -394,10 +393,8 @@ staticSlicePlace len ty did = do
                 _ -> mirFail $
                     "staticSlicePlace: wrong type: expected aggregate, found " ++ show tpr_found
             ref <- globalMirRef gv
-            elemSize <- tySizeM ty
-            ref' <- mirRef_agElem (R.App $ usizeLit 0) elemSize tpr ref
             let len' = R.App $ usizeLit $ fromIntegral len
-            return $ MirPlace tpr ref' (SliceMeta len')
+            return $ MirPlace tpr ref (SliceMeta len')
         Nothing -> mirFail $ "cannot find static variable " ++ fmt did
 
 -- NOTE: The return var in the MIR output is always "_0"
@@ -973,13 +970,9 @@ evalCast' ck ty1 e ty2  = do
         | m1 == m2, MirExp MirSliceRepr e' <- e
         -> return $ MirExp MirReferenceRepr (getSlicePtr e')
 
-      --  *const [T; N] -> *const T (get first element)
+      --  *const [T; N] -> *const T (get first element) - a no-op
       (M.Misc, M.TyRawPtr (M.TyArray t1 _) m1, M.TyRawPtr t2 m2)
-        | t1 == t2, m1 == m2, MirExp MirReferenceRepr e' <- e
-        -> do
-          Some tpr <- tyToReprM t1
-          elemSize <- tySizeM t1
-          MirExp MirReferenceRepr <$> mirRef_agElem (R.App $ usizeLit 0) elemSize tpr e'
+        | t1 == t2, m1 == m2 -> pure e
 
       --  *const [u8] <-> *const str (no-ops)
       (M.Misc, M.TyRawPtr (M.TySlice (M.TyUint M.B8)) m1, M.TyRawPtr M.TyStr m2)
@@ -1162,12 +1155,9 @@ evalCast' ck ty1 e ty2  = do
     unsizeArray ty sz ty'
       | ty == ty', MirExp MirReferenceRepr ref <- e
       = do
-        Some elem_tp <- tyToReprM ty
         let len   = R.App $ usizeLit (fromIntegral sz)
-        elemSize <- tySizeM ty
-        ref' <- mirRef_agElem (R.App $ usizeLit 0) elemSize elem_tp ref
         let tup   = S.mkStruct mirSliceCtxRepr
-                        (Ctx.Empty Ctx.:> ref' Ctx.:> len)
+                        (Ctx.Empty Ctx.:> ref Ctx.:> len)
         return $ MirExp MirSliceRepr tup
       | otherwise = mirFail $
         "Type mismatch in cast: " ++ show ck ++ " " ++ show ty1 ++ " as " ++ show ty2

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -450,7 +450,8 @@ writePlace ty (MirPlace tpr ref NoMeta) (MirExp tpr' val) desc = do
     Refl <- testEqualityOrFail tpr tpr' $
         "ill-typed assignment of " ++ show tpr' ++ " (" ++ show ty
             ++ ") to " ++ show tpr ++ " " ++ desc
-    writeMirRef tpr ref val
+    tySize <- tySizeM ty
+    writeMirRef tpr ref (Width tySize) val
 writePlace ty (MirPlace tpr _ meta) _ desc =
     mirFail $ "don't know how to write to place with metadata " ++ show meta
         ++ " (type " ++ show ty ++ ", repr " ++ show tpr ++ ") " ++ desc
@@ -2261,6 +2262,7 @@ initLocals localVars = forM_ localVars $ \v -> do
     let name = v ^. varname
     let ty = v ^. varty
     Some tpr <- tyToReprM ty
+    tySize <- tySizeM ty
 
     optVal <- initialValue ty >>= \case
         Nothing -> return Nothing
@@ -2273,7 +2275,7 @@ initLocals localVars = forM_ localVars $ \v -> do
     ref <- newMirRef tpr
     case optVal of
         Nothing -> return ()
-        Just val -> writeMirRef tpr ref val
+        Just val -> writeMirRef tpr ref (Width tySize) val
     reg <- G.newReg ref
     let varinfo = Some $ VarInfo tpr reg
     varMap %= Map.insert name varinfo
@@ -2406,7 +2408,8 @@ genFn (M.Fn fname' argvars sig body@(MirBody localvars blocks _)) rettype inputs
                     "type mismatch in initialization of " ++ show (var ^. varname) ++ ": " ++
                         show inputTpr ++ " != " ++ show viTpr
                 ref <- G.readReg viReg
-                writeMirRef viTpr ref inputExpr
+                varSize <- tySizeM (var ^. varty)
+                writeMirRef viTpr ref (Width varSize) inputExpr
                 initArgs inputs' vars'
             _ -> mirFail $ "mismatched argument count for " ++ show fname'
 
@@ -3365,7 +3368,7 @@ ptrCopy tpr src dest len elemSize = do
                      src' <- mirRef_offset src i elemSize
                      dest' <- mirRef_offset dest i elemSize
                      val <- readMirRef tpr (Width elemSize) src'
-                     writeMirRef tpr dest' val
+                     writeMirRef tpr dest' (Width elemSize) val
                      let i' = S.app $ usizeAdd i (S.app $ usizeLit 1)
                      G.writeRef iRef i')
     G.dropRef iRef

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -2931,11 +2931,28 @@ dispatchFromDyn dynTraitName recvTy recvExp die = do
               -- one being coerced (if any field is being coerced).
               go ty' mirExp
             Nothing -> do
+              -- To implement `DispatchFromDyn<T>` for `U`, several conditions
+              -- must hold, including that `U` is a struct, and that its
+              -- definition must have exactly one non-ZST field, which is of the
+              -- type being coerced. For details, see
+              -- https://doc.rust-lang.org/std/ops/trait.DispatchFromDyn.html.
+              -- Accordingly, we ensure that we only operate on that field.
               let v = Maybe.fromJust $ adt ^? adtvariants . ix 0
-              fieldExps' <- forM (zip [0..] (v ^. vfields)) $ \(i, f) -> do
-                fieldExp <- lift $ getStructField ty i mirExp
-                go (f ^. fty) fieldExp
-              lift $ buildStruct adt fieldExps'
+              sizedFields <- forM (zip [0..] (v ^. vfields)) $ \(fldIdx, fld) -> do
+                sz <- lift $ tySizeM (fld ^. fty)
+                pure (sz, (fldIdx, fld))
+              case Maybe.mapMaybe (\(sz, f) -> if sz > 0 then Just f else Nothing) sizedFields of
+                [(fldIdx, fld)] -> do
+                  fieldExp <- lift $ getStructField ty fldIdx mirExp
+                  fieldExp' <- go (fld ^. fty) fieldExp
+                    -- This value presumes a 64-bit architecture. In the longer
+                    -- term, we'd prefer not to hardcode that presumption - see
+                    -- #1384.
+                  let ptrSize = 8
+                  lift $ buildWrapperAggregate ptrSize fieldExp'
+                fs ->
+                  lift $ die
+                    ["`DispatchFromDyn` invalid for DST with " <> show (length fs) <> " non-ZST fields"]
         _ -> return mirExp
     -- rustc only recurses into struct types to find the coerced field.  All
     -- other types are ignored.

--- a/crucible-mir/src/Mir/TransCustom.hs
+++ b/crucible-mir/src/Mir/TransCustom.hs
@@ -1955,16 +1955,12 @@ allocate = (["crucible", "alloc", "allocate"], \substs -> case substs of
         [MirExp UsizeRepr sz] -> do
             -- Create an uninitialized `MirAggregate` of length `len`, and
             -- return a pointer to its first element.
-            Some elemTpr <- tyToReprM elemTy
             elemSize <- tySizeM elemTy
             let agSize = R.App (usizeMul sz (R.App (usizeLit (fromIntegral elemSize))))
             ag <- mirAggregate_uninit agSize
             ref <- newMirRef MirAggregateRepr
             writeMirRef MirAggregateRepr ref All ag
-            -- `mirRef_agElem` doesn't do a bounds check (those happen on deref
-            -- instead), so this works even when len is 0.
-            ptr <- mirRef_agElem (R.App $ usizeLit 0) elemSize elemTpr ref
-            return $ MirExp MirReferenceRepr ptr
+            return $ MirExp MirReferenceRepr ref
         _ -> mirFail $ "BUG: invalid arguments to allocate: " ++ show ops
     _ -> Nothing)
 
@@ -1979,8 +1975,7 @@ allocate_zeroed = (["crucible", "alloc", "allocate_zeroed"], \substs -> case sub
 
             ref <- newMirRef MirAggregateRepr
             writeMirRef MirAggregateRepr ref All ag
-            ptr <- mirRef_agElem (R.App $ usizeLit 0) elemSize elemTpr ref
-            return $ MirExp MirReferenceRepr ptr
+            return $ MirExp MirReferenceRepr ref
         _ -> mirFail $ "BUG: invalid arguments to allocate: " ++ show ops
     _ -> Nothing)
 

--- a/crucible-mir/src/Mir/TransCustom.hs
+++ b/crucible-mir/src/Mir/TransCustom.hs
@@ -289,10 +289,11 @@ vector_replicate = ( ["crucible","vector","{impl}", "replicate"], ) $ \substs ->
 
 vector_len :: (ExplodedDefId, CustomRHS)
 vector_len = ( ["crucible","vector","{impl}", "len"], ) $ \substs -> case substs of
-    Substs [t] -> Just $ CustomOp $ \_ ops -> case ops of
-        [MirExp MirReferenceRepr eRef] -> do
+    Substs [t] -> Just $ CustomOp $ \opTys ops -> case (opTys, ops) of
+        ([TyRef selfTy _mut], [MirExp MirReferenceRepr eRef]) -> do
             Some tpr <- tyToReprM t
-            e <- readMirRef (C.VectorRepr tpr) eRef
+            selfSize <- tySizeM selfTy
+            e <- readMirRef (C.VectorRepr tpr) (Width selfSize) eRef
             return $ MirExp UsizeRepr (R.App $ vectorSizeUsize R.App e)
         _ -> mirFail $ "bad arguments for Vector::len: " ++ show ops
     _ -> Nothing
@@ -348,11 +349,12 @@ vector_pop_front = ( ["crucible","vector","{impl}", "pop_front"], ) $ \substs ->
 
 vector_as_slice_impl :: CustomRHS
 vector_as_slice_impl (Substs [t]) =
-    Just $ CustomOp $ \_ ops -> case ops of
-        [MirExp MirReferenceRepr e] -> do
+    Just $ CustomOp $ \opTys ops -> case (opTys, ops) of
+        ([TyRef selfTy _mut], [MirExp MirReferenceRepr e]) -> do
             Some tpr <- tyToReprM t
+            selfSize <- tySizeM selfTy
             -- This is similar to `&mut [T; n] -> &mut [T]` unsizing.
-            v <- readMirRef (C.VectorRepr tpr) e
+            v <- readMirRef (C.VectorRepr tpr) (Width selfSize) e
             let end = R.App $ vectorSizeUsize R.App v
             e' <- mirRef_vecIndex (R.App $ usizeLit 0) tpr e
             let tup = S.mkStruct
@@ -642,7 +644,7 @@ ptr_read_impl what substs =
             Some tpr <- tyToReprM ty
             case (sz, tpr) of
                 (0, MirAggregateRepr) -> MirExp tpr <$> mirAggregate_zst
-                _ -> MirExp tpr <$> readMirRef tpr ptr
+                _ -> MirExp tpr <$> readMirRef tpr (Width sz) ptr
         _ -> mirFail $ "bad arguments for " ++ what ++ ": " ++ show ops
     _ -> Nothing
 
@@ -665,8 +667,8 @@ ptr_swap = ( ["core", "ptr", "swap"], \substs -> case substs of
             sz <- tySizeM ty
             when (sz /= 0) $ do
                 Some tpr <- tyToReprM ty
-                x1 <- readMirRef tpr ptr1
-                x2 <- readMirRef tpr ptr2
+                x1 <- readMirRef tpr (Width sz) ptr1
+                x2 <- readMirRef tpr (Width sz) ptr2
                 writeMirRef tpr ptr1 x2
                 writeMirRef tpr ptr2 x1
             MirExp MirAggregateRepr <$> mirAggregate_zst
@@ -766,7 +768,7 @@ intrinsics_copy = ( ["core", "intrinsics", "copy"], \substs -> case substs of
             -- TODO: check for overlap and copy in reverse order if needed.
             -- This will let us avoid the temporary `constMirRef`.
             (srcAg, srcIdx) <- mirRef_peelIndex src elemSize
-            srcSnapAg <- readMirRef MirAggregateRepr srcAg
+            srcSnapAg <- readMirRef MirAggregateRepr All srcAg
             srcSnapRoot <- constMirRef MirAggregateRepr srcSnapAg
             let srcElemOff = R.App $ usizeMul srcIdx (R.App $ usizeLit $ fromIntegral elemSize)
             srcSnap <- mirRef_agElem srcElemOff elemSize elemTpr srcSnapRoot
@@ -1382,8 +1384,9 @@ mem_swap = (["core","mem", "swap"], \substs ->
     Substs [ty] -> Just $ CustomOp $ \ opTys ops -> case ops of
         [MirExp MirReferenceRepr e1, MirExp MirReferenceRepr e2] -> do
             Some tpr <- tyToReprM ty
-            val1 <- readMirRef tpr e1
-            val2 <- readMirRef tpr e2
+            tySize <- tySizeM ty
+            val1 <- readMirRef tpr (Width tySize) e1
+            val2 <- readMirRef tpr (Width tySize) e2
             writeMirRef tpr e1 val2
             writeMirRef tpr e2 val1
             MirExp MirAggregateRepr <$> mirAggregate_zst
@@ -1511,8 +1514,8 @@ array_from_ref = (["core", "array", "from_ref", "crucible_array_from_ref_hook"],
                 -- correctly implemented as a type cast, so that the input and
                 -- output are aliases.
                 Some elemRepr <- tyToReprM elemTy
-                elemVal <- readMirRef elemRepr elemRef
                 elemSize <- tySizeM elemTy
+                elemVal <- readMirRef elemRepr (Width elemSize) elemRef
                 ag <- mirAggregate_uninit_constSize elemSize
                 ag' <- mirAggregate_set 0 elemSize elemRepr elemVal ag
                 agRef <- constMirRef MirAggregateRepr ag'
@@ -1928,11 +1931,12 @@ bv_overflowing_binop name bop =
 bv_eq :: (ExplodedDefId, CustomRHS)
 bv_eq = (["crucible", "bitvector", "{impl}", "eq"], \substs -> case substs of
   Substs [sz] ->
-    Just $ CustomOp $ \_optys ops -> case ops of
-        [MirExp MirReferenceRepr r1, MirExp MirReferenceRepr r2]
+    Just $ CustomOp $ \opTys ops -> case (opTys, ops) of
+        ([TyRef selfTy _mut, _], [MirExp MirReferenceRepr r1, MirExp MirReferenceRepr r2])
           | Just (BVSize w) <- tyBvSize sz -> do
-            v1 <- readMirRef (C.BVRepr w) r1
-            v2 <- readMirRef (C.BVRepr w) r2
+            selfSize <- tySizeM selfTy
+            v1 <- readMirRef (C.BVRepr w) (Width selfSize) r1
+            v2 <- readMirRef (C.BVRepr w) (Width selfSize) r2
             return $ MirExp C.BoolRepr $ S.app $ E.BVEq w v1 v2
         _ -> mirFail $ "BUG: invalid arguments to bv_eq: " ++ show ops
   _ -> Nothing)
@@ -1940,11 +1944,12 @@ bv_eq = (["crucible", "bitvector", "{impl}", "eq"], \substs -> case substs of
 bv_lt :: (ExplodedDefId, CustomRHS)
 bv_lt = (["crucible", "bitvector", "{impl}", "lt"], \substs -> case substs of
   Substs [sz] ->
-    Just $ CustomOp $ \_optys ops -> case ops of
-        [MirExp MirReferenceRepr r1, MirExp MirReferenceRepr r2]
+    Just $ CustomOp $ \opTys ops -> case (opTys, ops) of
+        ([TyRef selfTy _mut, _], [MirExp MirReferenceRepr r1, MirExp MirReferenceRepr r2])
           | Just (BVSize w) <- tyBvSize sz -> do
-            v1 <- readMirRef (C.BVRepr w) r1
-            v2 <- readMirRef (C.BVRepr w) r2
+            selfSize <- tySizeM selfTy
+            v1 <- readMirRef (C.BVRepr w) (Width selfSize) r1
+            v2 <- readMirRef (C.BVRepr w) (Width selfSize) r2
             return $ MirExp C.BoolRepr $ S.app $ E.BVUlt w v1 v2
         _ -> mirFail $ "BUG: invalid arguments to bv_lt: " ++ show ops
   _ -> Nothing)
@@ -2028,7 +2033,7 @@ reallocate = (["crucible", "alloc", "reallocate"], \substs -> case substs of
             G.assertExpr isZero $
                 S.litExpr "bad pointer in reallocate: not the start of an allocation"
 
-            oldAg <- readMirRef MirAggregateRepr agPtr
+            oldAg <- readMirRef MirAggregateRepr All agPtr
             let newSize = R.App (usizeMul newLen (R.App (usizeLit (fromIntegral elemSize))))
             newAg <- mirAggregate_resize oldAg newSize
             newAgPtr <- newMirRef MirAggregateRepr
@@ -2069,7 +2074,8 @@ atomic_load_impl :: CustomRHS
 atomic_load_impl = \_substs -> Just $ CustomOp $ \opTys ops -> case (opTys, ops) of
     ([TyRawPtr ty _], [MirExp MirReferenceRepr ref]) -> do
         Some tpr <- tyToReprM ty
-        MirExp tpr <$> readMirRef tpr ref
+        tySize <- tySizeM ty
+        MirExp tpr <$> readMirRef tpr (Width tySize) ref
     _ -> mirFail $ "BUG: invalid arguments to atomic_load: " ++ show ops
 
 atomic_cxchg_impl :: CustomRHS
@@ -2077,7 +2083,8 @@ atomic_cxchg_impl = \_substs -> Just $ CustomOp $ \opTys ops -> case (opTys, ops
     ([_, ty, _], [MirExp MirReferenceRepr ref, MirExp tpr expect, MirExp tpr' val])
       | Just Refl <- testEquality tpr tpr'
       , C.BVRepr w <- tpr -> do
-        old <- readMirRef tpr ref
+        tySize <- tySizeM ty
+        old <- readMirRef tpr (Width tySize) ref
         let eq = R.App $ E.BVEq w old expect
         let new = R.App $ E.BVIte eq w val old
         writeMirRef tpr ref new
@@ -2113,15 +2120,17 @@ atomic_rmw_impl ::
         R.Expr MIR s MirReferenceType ->
         MirGenerator h s ret (R.Expr MIR s MirReferenceType)) ->
     CustomRHS
-atomic_rmw_impl name rmwBv rmwPtr = \_substs -> Just $ CustomOp $ \_ ops -> case ops of
-    [MirExp MirReferenceRepr ref, MirExp tpr val]
+atomic_rmw_impl name rmwBv rmwPtr = \_substs -> Just $ CustomOp $ \opTys ops -> case (opTys, ops) of
+    ([TyRawPtr ty _mut, _], [MirExp MirReferenceRepr ref, MirExp tpr val])
       | C.BVRepr w <- tpr -> do
-        old <- readMirRef tpr ref
+        size <- tySizeM ty
+        old <- readMirRef tpr (Width size) ref
         new <- rmwBv w old val
         writeMirRef tpr ref new
         return $ MirExp tpr old
       | MirReferenceRepr <- tpr -> do
-        old <- readMirRef tpr ref
+        size <- tySizeM ty
+        old <- readMirRef tpr (Width size) ref
         new <- rmwPtr old val
         writeMirRef tpr ref new
         return $ MirExp tpr old

--- a/crucible-mir/src/Mir/TransCustom.hs
+++ b/crucible-mir/src/Mir/TransCustom.hs
@@ -655,7 +655,7 @@ ptr_write_impl what substs =
         [MirExp MirReferenceRepr ptr, MirExp tpr val] -> do
             sz <- tySizeM ty
             when (sz /= 0) $ do
-                writeMirRef tpr ptr val
+                writeMirRef tpr ptr (Width sz) val
             MirExp MirAggregateRepr <$> mirAggregate_zst
         _ -> mirFail $ "bad arguments for " ++ what ++ ": " ++ show ops
     _ -> Nothing
@@ -669,8 +669,8 @@ ptr_swap = ( ["core", "ptr", "swap"], \substs -> case substs of
                 Some tpr <- tyToReprM ty
                 x1 <- readMirRef tpr (Width sz) ptr1
                 x2 <- readMirRef tpr (Width sz) ptr2
-                writeMirRef tpr ptr1 x2
-                writeMirRef tpr ptr2 x1
+                writeMirRef tpr ptr1 (Width sz) x2
+                writeMirRef tpr ptr2 (Width sz) x1
             MirExp MirAggregateRepr <$> mirAggregate_zst
         _ -> mirFail $ "bad arguments for ptr::swap: " ++ show ops
     _ -> Nothing)
@@ -1387,8 +1387,8 @@ mem_swap = (["core","mem", "swap"], \substs ->
             tySize <- tySizeM ty
             val1 <- readMirRef tpr (Width tySize) e1
             val2 <- readMirRef tpr (Width tySize) e2
-            writeMirRef tpr e1 val2
-            writeMirRef tpr e2 val1
+            writeMirRef tpr e1 (Width tySize) val2
+            writeMirRef tpr e2 (Width tySize) val1
             MirExp MirAggregateRepr <$> mirAggregate_zst
         _ -> mirFail $ "bad arguments to mem_swap: " ++ show (opTys, ops)
     _ -> Nothing)
@@ -1991,7 +1991,7 @@ allocate = (["crucible", "alloc", "allocate"], \substs -> case substs of
             let agSize = R.App (usizeMul sz (R.App (usizeLit (fromIntegral elemSize))))
             ag <- mirAggregate_uninit agSize
             ref <- newMirRef MirAggregateRepr
-            writeMirRef MirAggregateRepr ref ag
+            writeMirRef MirAggregateRepr ref All ag
             -- `mirRef_agElem` doesn't do a bounds check (those happen on deref
             -- instead), so this works even when len is 0.
             ptr <- mirRef_agElem (R.App $ usizeLit 0) elemSize elemTpr ref
@@ -2009,7 +2009,7 @@ allocate_zeroed = (["crucible", "alloc", "allocate_zeroed"], \substs -> case sub
             ag <- mirAggregate_replicate elemSize elemTpr zero len
 
             ref <- newMirRef MirAggregateRepr
-            writeMirRef MirAggregateRepr ref ag
+            writeMirRef MirAggregateRepr ref All ag
             ptr <- mirRef_agElem (R.App $ usizeLit 0) elemSize elemTpr ref
             return $ MirExp MirReferenceRepr ptr
         _ -> mirFail $ "BUG: invalid arguments to allocate: " ++ show ops
@@ -2037,7 +2037,7 @@ reallocate = (["crucible", "alloc", "reallocate"], \substs -> case substs of
             let newSize = R.App (usizeMul newLen (R.App (usizeLit (fromIntegral elemSize))))
             newAg <- mirAggregate_resize oldAg newSize
             newAgPtr <- newMirRef MirAggregateRepr
-            writeMirRef MirAggregateRepr newAgPtr newAg
+            writeMirRef MirAggregateRepr newAgPtr All newAg
             newAgElem <- mirRef_agElem idx elemSize elemTpr newAgPtr
             return $ MirExp MirReferenceRepr newAgElem
         _ -> mirFail $ "BUG: invalid arguments to reallocate: " ++ show ops
@@ -2064,9 +2064,10 @@ makeAtomicIntrinsics name variants rhs =
         | suffix <- "" : map ("_" <>) variants]
 
 atomic_store_impl :: CustomRHS
-atomic_store_impl = \_substs -> Just $ CustomOp $ \_ ops -> case ops of
-    [MirExp MirReferenceRepr ref, MirExp tpr val] -> do
-        writeMirRef tpr ref val
+atomic_store_impl = \_substs -> Just $ CustomOp $ \opTys ops -> case (opTys, ops) of
+    ([_, valTy], [MirExp MirReferenceRepr ref, MirExp tpr val]) -> do
+        valSize <- tySizeM valTy
+        writeMirRef tpr ref (Width valSize) val
         MirExp MirAggregateRepr <$> mirAggregate_zst
     _ -> mirFail $ "BUG: invalid arguments to atomic_store: " ++ show ops
 
@@ -2087,7 +2088,7 @@ atomic_cxchg_impl = \_substs -> Just $ CustomOp $ \opTys ops -> case (opTys, ops
         old <- readMirRef tpr (Width tySize) ref
         let eq = R.App $ E.BVEq w old expect
         let new = R.App $ E.BVIte eq w val old
-        writeMirRef tpr ref new
+        writeMirRef tpr ref (Width tySize) new
         -- This `TyTuple` type must exist somewhere in the `Collection` (as
         -- required by `buildTupleM`) because it's the return type of the
         -- function being overridden.
@@ -2126,13 +2127,13 @@ atomic_rmw_impl name rmwBv rmwPtr = \_substs -> Just $ CustomOp $ \opTys ops -> 
         size <- tySizeM ty
         old <- readMirRef tpr (Width size) ref
         new <- rmwBv w old val
-        writeMirRef tpr ref new
+        writeMirRef tpr ref (Width size) new
         return $ MirExp tpr old
       | MirReferenceRepr <- tpr -> do
         size <- tySizeM ty
         old <- readMirRef tpr (Width size) ref
         new <- rmwPtr old val
-        writeMirRef tpr ref new
+        writeMirRef tpr ref (Width size) new
         return $ MirExp tpr old
     _ -> mirFail $ "BUG: invalid arguments to atomic_" ++ name ++ ": " ++ show ops
 

--- a/crucible-mir/src/Mir/TransCustom.hs
+++ b/crucible-mir/src/Mir/TransCustom.hs
@@ -769,7 +769,7 @@ intrinsics_copy = ( ["core", "intrinsics", "copy"], \substs -> case substs of
             srcSnapAg <- readMirRef MirAggregateRepr All srcAg
             srcSnapRoot <- constMirRef MirAggregateRepr srcSnapAg
             let srcElemOff = R.App $ usizeMul srcIdx (R.App $ usizeLit $ fromIntegral elemSize)
-            srcSnap <- mirRef_agElem srcElemOff elemSize elemTpr srcSnapRoot
+            srcSnap <- mirRef_agOffset srcElemOff srcSnapRoot
 
             ptrCopy elemTpr srcSnap dest count elemSize
             MirExp MirAggregateRepr <$> mirAggregate_zst
@@ -1989,7 +1989,6 @@ reallocate = (["crucible", "alloc", "reallocate"], \substs -> case substs of
     Substs [elemTy] -> Just $ CustomOp $ \_ ops -> case ops of
         [ MirExp MirReferenceRepr ptr, MirExp UsizeRepr newLen ] -> do
             elemSize <- tySizeM elemTy
-            Some elemTpr <- tyToReprM elemTy
 
             (agPtr, idx) <- mirRef_peelIndex ptr elemSize
 
@@ -2002,7 +2001,7 @@ reallocate = (["crucible", "alloc", "reallocate"], \substs -> case substs of
             newAg <- mirAggregate_resize oldAg newSize
             newAgPtr <- newMirRef MirAggregateRepr
             writeMirRef MirAggregateRepr newAgPtr All newAg
-            newAgElem <- mirRef_agElem idx elemSize elemTpr newAgPtr
+            newAgElem <- mirRef_agOffset idx newAgPtr
             return $ MirExp MirReferenceRepr newAgElem
         _ -> mirFail $ "BUG: invalid arguments to reallocate: " ++ show ops
     _ -> Nothing)

--- a/crucible-mir/src/Mir/TransCustom.hs
+++ b/crucible-mir/src/Mir/TransCustom.hs
@@ -144,8 +144,6 @@ customOpDefs = Map.fromList $ [
                          , array_from_ref
                          , slice_from_ref
                          , slice_from_mut
-                         , slice_as_chunks_cast_hook
-                         , slice_as_chunks_mut_cast_hook
 
                          , vector_new
                          , vector_replicate
@@ -1551,35 +1549,6 @@ slice_from_ref = slice_from Immut
 
 slice_from_mut ::  (ExplodedDefId, CustomRHS)
 slice_from_mut = slice_from Mut
-
-slice_as_chunks_cast_hook_common :: Mutability -> (ExplodedDefId, CustomRHS)
-slice_as_chunks_cast_hook_common mut = (["core", "slice", "{impl}", hookLoc, "crucible_cast_hook"],
-    \_substs -> Just $ CustomOpNamed $ \fnName ops -> do
-        fn <- findFn fnName
-        -- Expected signature: fn(*const T) -> *const [T; N]
-        case (fn ^. fsig . fsreturn_ty, ops) of
-            (TyRawPtr (TyArray elemTy elemsPerChunk) m,
-              [MirExp MirReferenceRepr elemPtr, MirExp UsizeRepr numChunks])
-              | m == mut -> do
-                elemSize <- tySizeM elemTy
-                let chunkSize = elemSize * fromIntegral elemsPerChunk
-                arrayOfChunksPtr <- mirRef_aggregateAsChunks (R.App $ usizeLit $ fromIntegral chunkSize) numChunks elemPtr
-                firstChunkPtr <- mirRef_agElem (R.App $ usizeLit 0) chunkSize MirAggregateRepr arrayOfChunksPtr
-                pure (MirExp MirReferenceRepr firstChunkPtr)
-            _ -> mirFail $ "bad monomorphization of "
-                ++ Text.unpack hookLoc ++ "::crucible_cast_hook: "
-                ++ show (fnName, fn ^. fsig, ops)
-    )
-    where
-        hookLoc = case mut of
-            Immut -> "as_chunks_unchecked"
-            Mut -> "as_chunks_unchecked_mut"
-
-slice_as_chunks_cast_hook :: (ExplodedDefId, CustomRHS)
-slice_as_chunks_cast_hook = slice_as_chunks_cast_hook_common Immut
-
-slice_as_chunks_mut_cast_hook :: (ExplodedDefId, CustomRHS)
-slice_as_chunks_mut_cast_hook = slice_as_chunks_cast_hook_common Mut
 
 intrinsics_offset :: (ExplodedDefId, CustomRHS)
 intrinsics_offset = (["core", "intrinsics", "offset"], ptr_offset_impl)

--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -64,7 +64,7 @@ import qualified Mir.Mir as M
 import           Mir.Generator
     ( MirExp(..), MirPlace(..), PtrMetadata(..), MirGenerator, mirFail
     , subfieldRef, subvariantRef, subjustRef
-    , mirRef_agElem_constOffset, mirRef_agElem_unsized
+    , mirRef_agOffset
     , mirAggregate_uninit_constSize
     , mirAggregate_zst, mirAggregate_get, mirAggregate_set
     , cs, collection, discrMap, findAdt, arrayZeroed )
@@ -1640,7 +1640,7 @@ structFieldRef structTy i ref meta = do
       alignExp <- getVtableSlot dynTraitName vtableAlignSlotIdx UsizeRepr vtable
       let offExp = R.App $ usizeLit $ fromIntegral off
       let offExp' = padToAlign offExp alignExp
-      ref' <- mirRef_agElem_unsized offExp' ref
+      ref' <- mirRef_agOffset offExp' ref
       return $ MirPlace C.AnyRepr ref' meta
 
     SliceMeta _len | isLast -> do
@@ -1658,10 +1658,7 @@ structFieldRef structTy i ref meta = do
       -- No need for `padToAlign` here.  The correct alignment for the slice is
       -- statically known based on its element type, and the layout emitted by
       -- mir-json already includes the necessary padding for that alignment.
-      --
-      -- Can't use typed/sized `mirRef_agElem` here because it requires the
-      -- size to be a translation-time constant.
-      ref' <- mirRef_agElem_unsized offExp ref
+      ref' <- mirRef_agOffset offExp ref
 
       case optElemTy of
         Just elemTy -> do
@@ -1676,8 +1673,8 @@ structFieldRef structTy i ref meta = do
 
     _ -> do
       Some valTpr <- tyToReprM ty
-      sz <- tySizeM ty
-      ref' <- mirRef_agElem_constOffset off sz valTpr ref
+      let offExp = R.App $ usizeLit $ fromIntegral off
+      ref' <- mirRef_agOffset offExp ref
       return $ MirPlace valTpr ref' NoMeta
 
 
@@ -1715,8 +1712,8 @@ tupleFieldRef tupleTy i tpr ref = do
         Nothing -> mirFail $ "tupleFieldRef: field index " ++ show i ++
             " is out of range for tuple " ++ show tupleTy
     Some valTpr <- tyToReprM ty
-    sz <- tySizeM ty
-    ref' <- mirRef_agElem_constOffset off sz valTpr ref
+    let offExp = R.App $ usizeLit $ fromIntegral off
+    ref' <- mirRef_agOffset offExp ref
     return $ MirPlace valTpr ref' NoMeta
 
 -- | Provided a reference to a union, acquire a reference to the union field
@@ -1728,8 +1725,9 @@ unionFieldRef ::
   R.Expr MIR s MirReferenceType ->
   MirGenerator h s ret (MirPlace s)
 unionFieldRef unionAdt fieldIdx unionRef = do
-  UnionInfo _unionSize fieldOffset fieldSize fieldTpr <- unionInfo unionAdt fieldIdx
-  fieldRef <- mirRef_agElem_constOffset fieldOffset fieldSize fieldTpr unionRef
+  UnionInfo _unionSize fieldOffset _fieldSize fieldTpr <- unionInfo unionAdt fieldIdx
+  let fieldOffsetExp = R.App $ usizeLit $ fromIntegral fieldOffset
+  fieldRef <- mirRef_agOffset fieldOffsetExp unionRef
   pure $ MirPlace fieldTpr fieldRef NoMeta
 
 testEqualityOrFail :: TestEquality f => f a -> f b -> String -> MirGenerator h s ret (a :~: b)

--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -1665,12 +1665,10 @@ structFieldRef structTy i ref meta = do
 
       case optElemTy of
         Just elemTy -> do
-          -- Output is a slice reference.  Project into the first element of
-          -- the array.
+          -- Output is a slice reference, which has the same representation as
+          -- its element type.
           Some elemTpr <- tyToReprM elemTy
-          elemSz <- tySizeM elemTy
-          ref'' <- mirRef_agElem_constOffset 0 elemSz elemTpr ref'
-          return $ MirPlace elemTpr ref'' meta
+          return $ MirPlace elemTpr ref' meta
         Nothing -> do
           -- Output is a reference to a nested custom DST.  No additional
           -- projection is needed.

--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -915,6 +915,14 @@ buildAggregateMaybeM agTy xs = do
         ag0 (zip offsetsAndTys xs)
     return $ MirExp MirAggregateRepr ag1
 
+-- | Construct an aggregate that contains the given value, of the given size, at
+-- offset 0.
+buildWrapperAggregate :: Word -> MirExp s -> MirGenerator h s ret (MirExp s)
+buildWrapperAggregate sz (MirExp tpr rv) = do
+    ag0 <- mirAggregate_uninit_constSize sz
+    ag1 <- mirAggregate_set 0 sz tpr rv ag0
+    return $ MirExp MirAggregateRepr ag1
+
 -- | Build a tuple of type @tupleTy@, using @xs@ to initialize the fields.
 --
 -- @tupleTy@ must be present in the `M.Collection`, as decribed in Note

--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -1586,14 +1586,7 @@ union's fields. When interpreting this initialization:
   model.
 
 When reading from the union, we rely on this initialization behavior, by reading
-the offset-0, size-1 subrange of the `MirAggregate` - that is, the entire
-aggregate - regardless of the type/field being read.
-
-The choice to represent unions and their constituent fields as having size 1 is
-temporary, intended to match similar temporary behavior elsewhere, e.g. in tuple
-construction (see `buildTupleMaybeM`). In the medium term, we'll want to update
-this to incorporate size and layout information to compute and use the proper
-sizes and offsets for each field.
+the value from offset 0, regardless of the type/field being read.
 
 The type representation associated with a (subrange of a) `MirAggregate` is
 unspecified until the aggregate is written to, and fixed thereafter. This allows

--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -64,7 +64,7 @@ import qualified Mir.Mir as M
 import           Mir.Generator
     ( MirExp(..), MirPlace(..), PtrMetadata(..), MirGenerator, mirFail
     , subfieldRef, subvariantRef, subjustRef
-    , mirRef_agOffset
+    , mirRef_agOffset, mirRef_agOffset_const
     , mirAggregate_uninit_constSize
     , mirAggregate_zst, mirAggregate_get, mirAggregate_set
     , cs, collection, discrMap, findAdt, arrayZeroed )
@@ -1655,11 +1655,10 @@ structFieldRef structTy i ref meta = do
         Just f | M.TyStr <- f ^. M.fty -> return $ Just $ M.TyUint M.B8
         _ -> return Nothing
 
-      let offExp = R.App $ usizeLit $ fromIntegral off
       -- No need for `padToAlign` here.  The correct alignment for the slice is
       -- statically known based on its element type, and the layout emitted by
       -- mir-json already includes the necessary padding for that alignment.
-      ref' <- mirRef_agOffset offExp ref
+      ref' <- mirRef_agOffset_const off ref
 
       case optElemTy of
         Just elemTy -> do
@@ -1674,8 +1673,7 @@ structFieldRef structTy i ref meta = do
 
     _ -> do
       Some valTpr <- tyToReprM ty
-      let offExp = R.App $ usizeLit $ fromIntegral off
-      ref' <- mirRef_agOffset offExp ref
+      ref' <- mirRef_agOffset_const off ref
       return $ MirPlace valTpr ref' NoMeta
 
 
@@ -1713,8 +1711,7 @@ tupleFieldRef tupleTy i tpr ref = do
         Nothing -> mirFail $ "tupleFieldRef: field index " ++ show i ++
             " is out of range for tuple " ++ show tupleTy
     Some valTpr <- tyToReprM ty
-    let offExp = R.App $ usizeLit $ fromIntegral off
-    ref' <- mirRef_agOffset offExp ref
+    ref' <- mirRef_agOffset_const off ref
     return $ MirPlace valTpr ref' NoMeta
 
 -- | Provided a reference to a union, acquire a reference to the union field
@@ -1727,8 +1724,7 @@ unionFieldRef ::
   MirGenerator h s ret (MirPlace s)
 unionFieldRef unionAdt fieldIdx unionRef = do
   UnionInfo _unionSize fieldOffset _fieldSize fieldTpr <- unionInfo unionAdt fieldIdx
-  let fieldOffsetExp = R.App $ usizeLit $ fromIntegral fieldOffset
-  fieldRef <- mirRef_agOffset fieldOffsetExp unionRef
+  fieldRef <- mirRef_agOffset_const fieldOffset unionRef
   pure $ MirPlace fieldTpr fieldRef NoMeta
 
 testEqualityOrFail :: TestEquality f => f a -> f b -> String -> MirGenerator h s ret (a :~: b)

--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -1366,13 +1366,13 @@ unionInfo unionAdt fieldIdx = do
     Nothing -> die $ "field index " <> show fieldIdx <> " out of range"
 
   Some fieldTpr <- tyToReprM (unionField ^. M.fty)
+  fieldSize <- tySizeM $ unionField ^. M.fty
 
   pure $ UnionInfo unionSize fieldOffset fieldSize fieldTpr
   where
     -- See Note [union representation]
-    unionSize = 1
+    unionSize = unionAdt ^. M.adtSize
     fieldOffset = 0
-    fieldSize = unionSize
 
     die :: String -> MirGenerator h s ret a
     die s =
@@ -1567,16 +1567,15 @@ Note [union representation]
 
 Crucible represents Rust unions as `MirAggregate` values.
 
-A union's `MirAggregate` representation has size 1, regardless of the size (e.g.
-according to the `_adtSize` field) of the `Mir.Mir.Adt` that describes it.
+A union's `MirAggregate` representation has the same size as its `Mir.Mir.Adt`'s
+`_adtSize` field, which is also the same size as it has in the Rust memory
+model.
 
 A union is always initialized with a single expression representing one of the
 union's fields. When interpreting this initialization:
 - We declare that the given field appears at offset 0 in the `MirAggregate`,
   even if the field would appear at a nonzero offset according to Rust's memory
   model.
-- We declare that the given field has size 1, even if the field type's size on
-  its own would be smaller or larger.
 
 When reading from the union, we rely on this initialization behavior, by reading
 the offset-0, size-1 subrange of the `MirAggregate` - that is, the entire
@@ -2008,8 +2007,8 @@ initialValue (M.TyAdt nm _ _) = do
         M.Union ->
             -- Unions are default-initialized to an untyped `MirAggregate` of an
             -- appropriate size, like tuples. See Note [union representation]
-            -- for details, including some regarding this choice of size.
-            let unionSize = 1
+            -- for details.
+            let unionSize = adt ^. M.adtSize
             in Just . MirExp MirAggregateRepr <$> mirAggregate_uninit_constSize unionSize
 initialValue (M.TyFnDef _) = Just . MirExp MirAggregateRepr <$> mirAggregate_zst
 initialValue M.TyNever     = Just . MirExp MirAggregateRepr <$> mirAggregate_zst

--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -1663,13 +1663,13 @@ structFieldRef structTy i ref meta = do
 
       case optElemTy of
         Just elemTy -> do
-          -- Output is a slice reference, which has the same representation as
-          -- its element type.
+          -- Output is a reference to a slice, meaning a `MirPlace` with type
+          -- @elemTpr@ and the length metadata from the input reference.
           Some elemTpr <- tyToReprM elemTy
           return $ MirPlace elemTpr ref' meta
         Nothing -> do
-          -- Output is a reference to a nested custom DST.  No additional
-          -- projection is needed.
+          -- Output is a reference to a nested custom DST, so the `MirPlace`
+          -- type is `MirAggregateRepr` like in the input reference.
           return $ MirPlace MirAggregateRepr ref' meta
 
     _ -> do

--- a/crux-mir/src/Mir/Concurrency.hs
+++ b/crux-mir/src/Mir/Concurrency.hs
@@ -146,6 +146,7 @@ mirPathName p =
     VectorIndex_RefPath _ p' _ -> mirPathName p'
     ArrayIndex_RefPath _ p' _ -> mirPathName p'
     AgElem_RefPath _ _ _ p' -> mirPathName p'
+    AgOffset_RefPath _ p' -> mirPathName p'
     AggregateAsChunks_RefPath _ _ _ p' -> mirPathName p'
 
 -- | Match a the name of a polymorphic method with a possible instance by

--- a/crux-mir/src/Mir/Concurrency.hs
+++ b/crux-mir/src/Mir/Concurrency.hs
@@ -145,7 +145,7 @@ mirPathName p =
     Just_RefPath _ p' -> mirPathName p'
     VectorIndex_RefPath _ p' _ -> mirPathName p'
     ArrayIndex_RefPath _ p' _ -> mirPathName p'
-    AgElem_RefPath _ _ _ p' -> mirPathName p'
+    AgElem_RefPath _ _ p' -> mirPathName p'
     AgOffset_RefPath _ p' -> mirPathName p'
 
 -- | Match a the name of a polymorphic method with a possible instance by

--- a/crux-mir/src/Mir/Concurrency.hs
+++ b/crux-mir/src/Mir/Concurrency.hs
@@ -147,7 +147,6 @@ mirPathName p =
     ArrayIndex_RefPath _ p' _ -> mirPathName p'
     AgElem_RefPath _ _ _ p' -> mirPathName p'
     AgOffset_RefPath _ p' -> mirPathName p'
-    AggregateAsChunks_RefPath _ _ _ p' -> mirPathName p'
 
 -- | Match a the name of a polymorphic method with a possible instance by
 -- dropping the last segment

--- a/crux-mir/src/Mir/Language.hs
+++ b/crux-mir/src/Mir/Language.hs
@@ -569,27 +569,9 @@ showRegEntry col mty entry@(C.RegEntry tp rv) =
                      Just f -> show f
                      Nothing -> "Symbolic real"
 
-    (tupleTy@(TyTuple tys), MirAggregateRepr) -> do
-      layout <- case Map.lookup tupleTy (col ^. layouts) of
-        Just (Just x) -> return x
-        Nothing -> fail $ "missing layout for tuple type " ++ show tupleTy
-        Just Nothing -> fail $ "unsupported: unsized tuple type " ++ show tupleTy
-      fieldOffsets <- case layout ^. layFieldOffsets of
-        Just x -> return x
-        Nothing -> fail $ "missing field offsets for " ++ show tupleTy
-      strs <- forM (zip fieldOffsets tys) $ \(off, ty) -> do
-        case col ^? layouts . ix ty . _Just . laySize of
-          Just 0 -> showZSTValue ty
-          Just sz -> do
-            -- See Note [Printing flattened aggregates]
-            subAg <- case mirAggregate_chunk (fromIntegral off) (fromIntegral sz) rv of
-              Left err -> fail $ "showRegEntry: error extracting tuple element: " <> err
-              Right ag -> pure ag
-            showRegEntry col ty (C.RegEntry MirAggregateRepr subAg)
-          Nothing -> fail $ "impossible: got field offsets for tuple " ++ show tupleTy
-            ++ ", but no layout for element " ++ show ty ++ "?"
-
-      return $ "(" ++ List.intercalate ", " strs ++ ")"
+    (TyTuple _, MirAggregateRepr) -> do
+      fields <- showAgFields mty ("tuple type " <> show (pretty mty)) rv
+      return $ "(" ++ List.intercalate ", " fields ++ ")"
 
     -- Tagged union type
     (TyAdt name _ _, _)

--- a/crux-mir/src/Mir/Language.hs
+++ b/crux-mir/src/Mir/Language.hs
@@ -36,7 +36,6 @@ import qualified Data.BitVector.Sized as BV
 import qualified Data.Char       as Char
 import           Control.Monad
 import           Control.Monad.IO.Class
-import qualified Data.IntMap.Strict as IntMap
 import qualified Data.List       as List
 import           Data.Text (Text)
 import qualified Data.Text       as Text
@@ -100,8 +99,8 @@ import           Mir.Options (MIROptions(..), mirConfig)
 import           Mir.Overrides
 import           Mir.Intrinsics (MIR, mirExtImpl, mirIntrinsicTypes,
                     pattern RustEnumRepr, SomeRustEnumRepr(..),
-                    pattern MirAggregateRepr, MirAggregate(..), MirAggregateEntry(..),
-                    mirAggregate_lookup)
+                    pattern MirAggregateRepr, MirAggregate(..),
+                    mirAggregate_lookup, mirAggregate_chunk)
 import           Mir.Generator
 import           Mir.Generate (generateMIR)
 import qualified Mir.Log as Log
@@ -525,6 +524,28 @@ showRegEntry :: forall sym arg p rtp args ret
   -> C.OverrideSim p sym MIR rtp args ret String
 showRegEntry col mty entry@(C.RegEntry tp rv) =
   case (mty,tp) of
+    {-
+    Note [Printing flattened aggregates]
+
+    When we encounter types represented as `MirAggregate`s (tuples, arrays,
+    structs, etc.), we don't directly access _entries_ in those aggregates to
+    print them. Instead, we access _sub-aggregates_ and recurse on them. This
+    accommodates our aggregates being flattened; if we're printing e.g. a `[[u8;
+    2]; 2]`, we can't simply get the first element of its aggregate and print it
+    as `[u8; 2]`, because that element will be a `u8`.
+
+    This approach eventually yields recursive calls to print values of
+    base/non-aggregate types, but with aggregate representations, which we
+    handle with the case below.
+    -}
+    (ty, MirAggregateRepr) | aggregateLeafType ty -> do
+      C.Some tpr <- case tyToRepr col ty of
+        Right tpr -> pure tpr
+        Left err -> fail err
+      case mirAggregate_lookup 0 tpr rv of
+        Left err -> fail $ "showRegEntry: error accessing aggregate: " <> err
+        Right elemPart -> goMaybe ty tpr elemPart
+
     (TyBool, C.BoolRepr) -> return $ case W4.asConstantPred rv of
                      Just b -> if b then "true" else "false"
                      Nothing -> "Symbolic bool"
@@ -549,7 +570,6 @@ showRegEntry col mty entry@(C.RegEntry tp rv) =
                      Nothing -> "Symbolic real"
 
     (tupleTy@(TyTuple tys), MirAggregateRepr) -> do
-      let MirAggregate _ m = rv
       layout <- case Map.lookup tupleTy (col ^. layouts) of
         Just (Just x) -> return x
         Nothing -> fail $ "missing layout for tuple type " ++ show tupleTy
@@ -560,11 +580,12 @@ showRegEntry col mty entry@(C.RegEntry tp rv) =
       strs <- forM (zip fieldOffsets tys) $ \(off, ty) -> do
         case col ^? layouts . ix ty . _Just . laySize of
           Just 0 -> showZSTValue ty
-          Just _ -> do
-            case IntMap.lookup (fromIntegral off) m of
-              Just (MirAggregateEntry _ elemTpr elemRvPart) ->
-                goMaybe ty elemTpr elemRvPart
-              Nothing -> return "<uninit>"
+          Just sz -> do
+            -- See Note [Printing flattened aggregates]
+            subAg <- case mirAggregate_chunk (fromIntegral off) (fromIntegral sz) rv of
+              Left err -> fail $ "showRegEntry: error extracting tuple element: " <> err
+              Right ag -> pure ag
+            showRegEntry col ty (C.RegEntry MirAggregateRepr subAg)
           Nothing -> fail $ "impossible: got field offsets for tuple " ++ show tupleTy
             ++ ", but no layout for element " ++ show ty ++ "?"
 
@@ -639,22 +660,34 @@ showRegEntry col mty entry@(C.RegEntry tp rv) =
     (TyRef ty Immut, _) -> showRegEntry col ty (C.RegEntry tp rv)
 
     (TyArray ty len, MirAggregateRepr) -> do
-      case tyToRepr col ty of
-        Right (C.Some tpr) -> do
-          tySize <- case tySizedness col ty of
-            Sized s -> pure s
-            Unsized -> fail $ "showRegEntry: array of unsized type: " <> show ty
-          values <- forM (init [0 .. len]) $ \i -> do
-            case mirAggregate_lookup (fromIntegral i * tySize) tpr rv of
-              Left e -> return $ "error accessing " ++ show (pretty mty) ++ " aggregate: " ++ e
-              Right partVal -> goMaybe ty tpr partVal
-          return $ "[" ++ List.intercalate ", " values ++ "]"
-        Left e -> return $ "error handling type " ++ show (pretty ty) ++ ": " ++ e
+      tySize <- case tySizedness col ty of
+        Sized s -> pure s
+        Unsized -> fail $ "showRegEntry: array of unsized type: " <> show ty
+      values <- forM (init [0 .. len]) $ \i -> do
+        -- See Note [Printing flattened aggregates]
+        case mirAggregate_chunk (fromIntegral i * tySize) tySize rv of
+          Left e -> return $ "error accessing " ++ show (pretty mty) ++ " aggregate: " ++ e
+          Right subAg -> showRegEntry col ty (C.RegEntry MirAggregateRepr subAg)
+      return $ "[" ++ List.intercalate ", " values ++ "]"
 
     _ -> return $ "I don't know how to print result of type " ++ show (pretty mty, tp)
 
 
   where
+    -- | Does this type appear as an entry in a `MirAggregate`? Note that this
+    -- is only meant to handle the `Ty` variants that `showRegEntry` handles.
+    aggregateLeafType :: Ty -> Bool
+    aggregateLeafType ty = case ty of
+      TyBool -> True
+      TyChar -> True
+      TyInt _ -> True
+      TyUint _ -> True
+      TyFloat _ -> True
+      TyAdt name _ _
+        | Just adt <- findAdt' col name,
+          Enum _ <- adt ^. adtkind -> True
+      _ -> False
+
     readFields :: FieldCtxRepr ctx -> Ctx.Assignment (C.RegValue' sym) ctx ->
         [C.Some (C.RegEntry sym)]
     readFields Ctx.Empty Ctx.Empty = []
@@ -682,18 +715,17 @@ showRegEntry col mty entry@(C.RegEntry tp rv) =
     showAgFields :: Ty -> String -> MirAggregate sym ->
         C.OverrideSim p sym MIR rtp args ret [String]
     showAgFields agTy tyDesc ag = do
-      let MirAggregate _ m = ag
       fields <- case tyFields col agTy of
         Just x -> return x
         Nothing -> fail $ "missing fields for " ++ tyDesc
       strs <- forM fields $ \(off, ty) -> do
         case col ^? layouts . ix ty . _Just . laySize of
           Just 0 -> showZSTValue ty
-          Just _ -> do
-            case IntMap.lookup (fromIntegral off) m of
-              Just (MirAggregateEntry _ elemTpr elemRvPart) ->
-                goMaybe ty elemTpr elemRvPart
-              Nothing -> return "<uninit>"
+          Just sz -> do
+            -- See Note [Printing flattened aggregates]
+            case mirAggregate_chunk off (fromIntegral sz) ag of
+              Left err -> fail $ "showAgFields: error accessing aggregate: " <> show err
+              Right subAg -> showRegEntry col ty (C.RegEntry MirAggregateRepr subAg)
           Nothing -> fail $ "impossible: got field offsets for " ++ tyDesc
             ++ ", but no layout for element " ++ show ty ++ "?"
       return strs

--- a/crux-mir/src/Mir/Language.hs
+++ b/crux-mir/src/Mir/Language.hs
@@ -332,11 +332,11 @@ runTestsWithExtraOverrides initS bindExtra (cruxOpts, mirOpts) = do
              -- TODO: think about if/how to present this information when concurrency
              -- is enabled.
              when (not (concurrency mirOpts) && printResultOnly mirOpts) $ do
-                 str <- showRegEntry @sym col resTy res
+                 str <- showRegEntry (C.backendGetSym bak) col resTy res
                  liftIO $ outputLn str
 
              when (not (concurrency mirOpts) && not (printResultOnly mirOpts) && resTy /= TyTuple []) $ do
-                 str <- showRegEntry @sym col resTy res
+                 str <- showRegEntry (C.backendGetSym bak) col resTy res
                  liftIO $ output $ "returned " ++ str ++ ", "
 
     let printTest :: DefId -> Fun p sym ext args C.UnitType
@@ -518,11 +518,12 @@ setSimulatorVerbosity verbosity sym = do
 -------------------------------------------------------
 showRegEntry :: forall sym arg p rtp args ret
    . C.IsSymInterface sym
-  => Collection
+  => sym
+  -> Collection
   -> Ty
   -> C.RegEntry sym arg
   -> C.OverrideSim p sym MIR rtp args ret String
-showRegEntry col mty entry@(C.RegEntry tp rv) =
+showRegEntry sym col mty entry@(C.RegEntry tp rv) =
   case (mty,tp) of
     {-
     Note [Printing flattened aggregates]
@@ -542,7 +543,10 @@ showRegEntry col mty entry@(C.RegEntry tp rv) =
       C.Some tpr <- case tyToRepr col ty of
         Right tpr -> pure tpr
         Left err -> fail err
-      case mirAggregate_lookup 0 tpr rv of
+      sz <- case tySizedness col ty of
+        Sized s -> pure s
+        Unsized -> fail $ "showRegEntry: unsized type: " <> show (pretty ty)
+      case mirAggregate_lookup sym 0 sz tpr rv of
         Left err -> fail $ "showRegEntry: error accessing aggregate: " <> err
         Right elemPart -> goMaybe ty tpr elemPart
 
@@ -593,7 +597,7 @@ showRegEntry col mty entry@(C.RegEntry tp rv) =
         let showField fIdx fTy
               | Just transFieldIdx <- transFieldIdxM
               , fIdx == transFieldIdx =
-                showRegEntry col fTy entry
+                showRegEntry sym col fTy entry
               | otherwise =
                 showZSTValue fTy
         fieldStrs <- zipWithM showField [0..] fieldTys
@@ -639,7 +643,7 @@ showRegEntry col mty entry@(C.RegEntry tp rv) =
             Left err -> return err
             Right (variant, fieldStrs) -> showVariant variant fieldStrs
 
-    (TyRef ty Immut, _) -> showRegEntry col ty (C.RegEntry tp rv)
+    (TyRef ty Immut, _) -> showRegEntry sym col ty (C.RegEntry tp rv)
 
     (TyArray ty len, MirAggregateRepr) -> do
       tySize <- case tySizedness col ty of
@@ -649,7 +653,7 @@ showRegEntry col mty entry@(C.RegEntry tp rv) =
         -- See Note [Printing flattened aggregates]
         case mirAggregate_chunk (fromIntegral i * tySize) tySize rv of
           Left e -> return $ "error accessing " ++ show (pretty mty) ++ " aggregate: " ++ e
-          Right subAg -> showRegEntry col ty (C.RegEntry MirAggregateRepr subAg)
+          Right subAg -> showRegEntry sym col ty (C.RegEntry MirAggregateRepr subAg)
       return $ "[" ++ List.intercalate ", " values ++ "]"
 
     _ -> return $ "I don't know how to print result of type " ++ show (pretty mty, tp)
@@ -689,7 +693,7 @@ showRegEntry col mty entry@(C.RegEntry tp rv) =
       let fields = readFields fctx vs
       fieldStrs <-
         zipWithM
-          (\fieldTy (C.Some fieldEntry) -> showRegEntry col fieldTy fieldEntry)
+          (\fieldTy (C.Some fieldEntry) -> showRegEntry sym col fieldTy fieldEntry)
           (variant ^.. vfields . each . fty)
           fields
       return fieldStrs
@@ -707,7 +711,7 @@ showRegEntry col mty entry@(C.RegEntry tp rv) =
             -- See Note [Printing flattened aggregates]
             case mirAggregate_chunk off (fromIntegral sz) ag of
               Left err -> fail $ "showAgFields: error accessing aggregate: " <> show err
-              Right subAg -> showRegEntry col ty (C.RegEntry MirAggregateRepr subAg)
+              Right subAg -> showRegEntry sym col ty (C.RegEntry MirAggregateRepr subAg)
           Nothing -> fail $ "impossible: got field offsets for " ++ tyDesc
             ++ ", but no layout for element " ++ show ty ++ "?"
       return strs
@@ -721,7 +725,7 @@ showRegEntry col mty entry@(C.RegEntry tp rv) =
       case rvPart of
         W4.Unassigned -> return "<uninitialized>"
         W4.PE p rv'
-          | Just True <- W4.asConstantPred p -> showRegEntry col ty $ C.RegEntry tpr rv'
+          | Just True <- W4.asConstantPred p -> showRegEntry sym col ty $ C.RegEntry tpr rv'
           | otherwise ->return "<possibly uninitialized>"
 
     showVariant ::

--- a/crux-mir/src/Mir/Language.hs
+++ b/crux-mir/src/Mir/Language.hs
@@ -671,7 +671,11 @@ showRegEntry sym col mty entry@(C.RegEntry tp rv) =
       TyFloat _ -> True
       TyAdt name _ _
         | Just adt <- findAdt' col name,
-          Enum _ <- adt ^. adtkind -> True
+          Just ty' <- reprTransparentFieldTy col adt ->
+            aggregateLeafType ty'
+        | Just adt <- findAdt' col name,
+          Enum _ <- adt ^. adtkind ->
+            True
       _ -> False
 
     readFields :: FieldCtxRepr ctx -> Ctx.Assignment (C.RegValue' sym) ctx ->

--- a/crux-mir/src/Mir/Overrides.hs
+++ b/crux-mir/src/Mir/Overrides.hs
@@ -92,7 +92,7 @@ getString (Empty :> RV mirPtr :> RV lenExpr) = runMaybeT $ do
         iExpr <- liftIO $ bvLit sym knownNat (BV.mkBV knownNat i)
         let elemSize = 1 -- `&str`s are comprised of `u8`s
         elemPtr <- lift $ mirRef_offsetWrapSim mirPtr iExpr elemSize
-        bExpr <- lift $ readMirRefSim (BVRepr w) elemPtr
+        bExpr <- lift $ readMirRefSim (BVRepr w) (M.Width elemSize) elemPtr
         b <- readBV bExpr
         return $ fromIntegral b
     return $ Text.decodeUtf8 $ BS.pack bytes

--- a/crux-mir/src/Mir/Overrides.hs
+++ b/crux-mir/src/Mir/Overrides.hs
@@ -375,6 +375,8 @@ regEval bak baseEval = go
         ArrayIndex_RefPath btpr <$> goMirReferencePath p <*> go UsizeRepr idx
     goMirReferencePath (AgElem_RefPath off sz tpr p) =
         AgElem_RefPath <$> go UsizeRepr off <*> pure sz <*> pure tpr <*> goMirReferencePath p
+    goMirReferencePath (AgOffset_RefPath off p) =
+        AgOffset_RefPath <$> go UsizeRepr off <*> goMirReferencePath p
     goMirReferencePath (AggregateAsChunks_RefPath off chunkSize numChunks p) =
         AggregateAsChunks_RefPath off chunkSize numChunks <$> goMirReferencePath p
 

--- a/crux-mir/src/Mir/Overrides.hs
+++ b/crux-mir/src/Mir/Overrides.hs
@@ -373,8 +373,8 @@ regEval bak baseEval = go
         VectorIndex_RefPath tpr <$> goMirReferencePath p <*> go UsizeRepr idx
     goMirReferencePath (ArrayIndex_RefPath btpr p idx) =
         ArrayIndex_RefPath btpr <$> goMirReferencePath p <*> go UsizeRepr idx
-    goMirReferencePath (AgElem_RefPath off sz tpr p) =
-        AgElem_RefPath <$> go UsizeRepr off <*> pure sz <*> pure tpr <*> goMirReferencePath p
+    goMirReferencePath (AgElem_RefPath off tpr p) =
+        AgElem_RefPath <$> go UsizeRepr off <*> pure tpr <*> goMirReferencePath p
     goMirReferencePath (AgOffset_RefPath off p) =
         AgOffset_RefPath <$> go UsizeRepr off <*> goMirReferencePath p
 

--- a/crux-mir/src/Mir/Overrides.hs
+++ b/crux-mir/src/Mir/Overrides.hs
@@ -377,8 +377,6 @@ regEval bak baseEval = go
         AgElem_RefPath <$> go UsizeRepr off <*> pure sz <*> pure tpr <*> goMirReferencePath p
     goMirReferencePath (AgOffset_RefPath off p) =
         AgOffset_RefPath <$> go UsizeRepr off <*> goMirReferencePath p
-    goMirReferencePath (AggregateAsChunks_RefPath off chunkSize numChunks p) =
-        AggregateAsChunks_RefPath off chunkSize numChunks <$> goMirReferencePath p
 
     goMirAggregateEntry ::
         MirAggregateEntry sym ->

--- a/crux-mir/test/Test.hs
+++ b/crux-mir/test/Test.hs
@@ -211,11 +211,17 @@ sanitizeGoldenTestOutput = go
       | Just (before, _matched :: BS.ByteString, after, [preDisamb])
           <- matchM disambRE out
       = before <> preDisamb <> "<DISAMB>::" <> go after
+      | Just (before, _matched :: BS.ByteString, after, [] :: [BS.ByteString])
+          <- matchM nonceRE out
+      = before <> "<NONCE>" <> go after
       | otherwise
       = out
 
     disambRE :: Regex
     disambRE = makeRegex disambBS
+
+    nonceRE :: Regex
+    nonceRE = makeRegex nonceBS
 
     -- A disambiguator looks something like foo/a1b4j89a, i.e., an alphanumeric
     -- string that starts with an alphabetic character, followed by a forward
@@ -224,6 +230,13 @@ sanitizeGoldenTestOutput = go
     -- present when printing out a full DefId (e.g., foo/a1b4j89a::Bar::Baz).
     disambBS :: BS.ByteString
     disambBS = "([A-Za-z_]" <> alphaNum <> "*/)" <> mconcat (replicate 8 alphaNum) <> "::"
+
+    -- This is the `Show`n form of `Data.Parameterized.Nonce.Nonce`, which
+    -- contains a fresh integer value. `Nonce`s exist in `MirReferenceRoot`s,
+    -- and so appear in the output of `crucible::dump_rv` applied to a
+    -- `MirReference`.
+    nonceBS :: BS.ByteString
+    nonceBS = "Nonce \\{indexValue = [0-9]+\\}"
 
     alphaNum :: BS.ByteString
     alphaNum = "[A-Za-z0-9_]"

--- a/crux-mir/test/Test.hs
+++ b/crux-mir/test/Test.hs
@@ -211,6 +211,8 @@ sanitizeGoldenTestOutput = go
       | Just (before, _matched :: BS.ByteString, after, [preDisamb])
           <- matchM disambRE out
       = before <> preDisamb <> "<DISAMB>::" <> go after
+      -- TODO: this nonce sanitization ought to be able to be removed once
+      -- https://github.com/GaloisInc/crucible/issues/1843 is resolved.
       | Just (before, _matched :: BS.ByteString, after, [] :: [BS.ByteString])
           <- matchM nonceRE out
       = before <> "<NONCE>" <> go after

--- a/crux-mir/test/conc_eval/alloc/multi_type.rs
+++ b/crux-mir/test/conc_eval/alloc/multi_type.rs
@@ -1,4 +1,3 @@
-// FAIL: reads/writes still expect a u64 target, even after cast
 // Test storing values of different types in a single allocation.
 
 #[cfg_attr(crux, crux::test)]

--- a/crux-mir/test/conc_eval/array/nested.rs
+++ b/crux-mir/test/conc_eval/array/nested.rs
@@ -1,0 +1,34 @@
+use std::mem::transmute;
+
+#[cfg_attr(crux, crux::test)]
+pub fn crux_test() {
+    let xs: [[[u16; 1]; 2]; 4] = [[[1], [1]], [[2], [3]], [[5], [8]], [[13], [21]]];
+
+    let xs2 = unsafe { transmute::<_, [[[u16; 4]; 2]; 1]>(xs) };
+    assert_eq!(xs2[0][0], [1, 1, 2, 3]);
+    assert_eq!(xs2[0][1], [5, 8, 13, 21]);
+
+    let xs3 = unsafe { transmute::<_, [u16; 8]>(xs2) };
+    assert_eq!(xs3, [1, 1, 2, 3, 5, 8, 13, 21]);
+
+    let xs4 = &xs3[2..6];
+    assert_eq!(xs4.len(), 4);
+    assert_eq!(xs4[0], 2);
+    assert_eq!(xs4[1], 3);
+
+    let xs5 = &xs4[2] as *const u16;
+    assert_eq!(unsafe { *(xs5.offset(-2)) }, 2);
+    assert_eq!(unsafe { *(xs5.offset(-1)) }, 3);
+    assert_eq!(unsafe { *xs5 }, 5);
+    assert_eq!(unsafe { *(xs5.offset(1)) }, 8);
+
+    // We can move past either end of the slice `xs4`, as long as we remain
+    // within the bounds of the backing array `xs3`
+    assert_eq!(unsafe { *(xs5.offset(2)) }, 13);
+    assert_eq!(unsafe { *(xs5.offset(3)) }, 21);
+    assert_eq!(unsafe { *(xs5.offset(-3)) }, 1);
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/conc_eval/array/nested_transparent_enum.rs
+++ b/crux-mir/test/conc_eval/array/nested_transparent_enum.rs
@@ -1,0 +1,21 @@
+#[repr(transparent)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum E2 {
+    A([u8; 2]),
+}
+
+#[repr(transparent)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum E4 {
+    A([u8; 4]),
+}
+
+#[cfg_attr(crux, crux::test)]
+fn crux_test() {
+    let e2s = [E2::A([1, 2]), E2::A([3, 4])];
+    let _ = e2s.clone();
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/conc_eval/array/nested_transparent_struct.rs
+++ b/crux-mir/test/conc_eval/array/nested_transparent_struct.rs
@@ -1,0 +1,13 @@
+#[derive(Clone, Debug)]
+#[repr(transparent)]
+struct S([u8; 2]);
+
+#[cfg_attr(crux, crux::test)]
+pub fn crux_test() -> [S; 3] {
+    let xs = [S([1, 2]), S([3, 4]), S([5, 6])];
+    xs.clone()
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/conc_eval/array/overwrite_global.rs
+++ b/crux-mir/test/conc_eval/array/overwrite_global.rs
@@ -1,0 +1,18 @@
+//! This test checks that we can correctly write `MirAggregate`s to a reference
+//! with an `Empty_RefPath` that already contains a larger aggregate.
+
+static mut ARR2: [u8; 2] = [42u8; 2];
+
+#[cfg_attr(crux, crux::test)]
+fn crux_test() -> [u8; 2] {
+    let arr1_ref: &mut [u8; 1] = unsafe { std::mem::transmute(&mut ARR2) };
+    *arr1_ref = [0];
+    unsafe { ARR2[1] = 1 };
+    assert_eq!(unsafe { ARR2[0] }, 0);
+    assert_eq!(unsafe { ARR2[1] }, 1);
+    unsafe { ARR2 }
+}
+
+pub fn main() {
+    println!("{:?}", crux_test())
+}

--- a/crux-mir/test/conc_eval/array/overwrite_iter.rs
+++ b/crux-mir/test/conc_eval/array/overwrite_iter.rs
@@ -1,0 +1,18 @@
+//! This test checks that we can correctly write `MirAggregate`s to a reference
+//! with an `Empty_RefPath` that already contains a larger aggregate.
+
+#[cfg_attr(crux, crux::test)]
+fn crux_test() -> [[u8; 1]; 2] {
+    let xs = [42u8; 1];
+    let mut ys = [xs; 2];
+    for y in ys.iter_mut() {
+        *y = [0u8; 1];
+    }
+    assert_eq!(ys[0], [0]);
+    assert_eq!(ys[1], [0]);
+    ys
+}
+
+pub fn main() {
+    println!("{:?}", crux_test())
+}

--- a/crux-mir/test/conc_eval/array/overwrite_transmute.rs
+++ b/crux-mir/test/conc_eval/array/overwrite_transmute.rs
@@ -6,6 +6,9 @@ fn crux_test() -> [u8; 2] {
     let mut arr2: [u8; 2] = [42, 84];
     let arr1_ref: &mut [u8; 1] = unsafe { std::mem::transmute(&mut arr2) };
     *arr1_ref = [0];
+    // Check that `arr2[0]` was overwritten and `arr2[1]` was not.
+    assert_eq!(arr2[0], 0);
+    assert_eq!(arr2[1], 84);
     arr2[1] = 1;
     assert_eq!(arr2[0], 0);
     assert_eq!(arr2[1], 1);

--- a/crux-mir/test/conc_eval/array/overwrite_transmute.rs
+++ b/crux-mir/test/conc_eval/array/overwrite_transmute.rs
@@ -1,0 +1,17 @@
+//! This test checks that we can correctly write `MirAggregate`s to a reference
+//! with an `Empty_RefPath` that already contains a larger aggregate.
+
+#[cfg_attr(crux, crux::test)]
+fn crux_test() -> [u8; 2] {
+    let mut arr2: [u8; 2] = [42, 84];
+    let arr1_ref: &mut [u8; 1] = unsafe { std::mem::transmute(&mut arr2) };
+    *arr1_ref = [0];
+    arr2[1] = 1;
+    assert_eq!(arr2[0], 0);
+    assert_eq!(arr2[1], 1);
+    arr2
+}
+
+pub fn main() {
+    println!("{:?}", crux_test())
+}

--- a/crux-mir/test/conc_eval/mem/maybe_uninit_array.rs
+++ b/crux-mir/test/conc_eval/mem/maybe_uninit_array.rs
@@ -1,0 +1,19 @@
+// FAIL: read from uninitialized memory
+
+// This test ensures that writing `MaybeUninit::uninit()` to `xs[0]` properly
+// clears the aggregate entries from the tuple it originally held, which we can
+// observe as a failure to read from the cleared memory.
+
+use std::mem::MaybeUninit;
+
+#[cfg_attr(crux, crux::test)]
+fn crux_test() -> u32 {
+    let mut xs = [MaybeUninit::new((1, 2))];
+    xs[0] = MaybeUninit::uninit();
+    let x = unsafe { xs[0].assume_init_read() };
+    x.0 + x.1
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/conc_eval/ptr/unsize_slice_null.rs
+++ b/crux-mir/test/conc_eval/ptr/unsize_slice_null.rs
@@ -1,10 +1,7 @@
-// FAIL: can't unsize null pointers
 use std::ptr;
 
 #[cfg_attr(crux, crux::test)]
 fn crux_test() -> bool {
-    // The unsize step fails because it uses an indexing operation to go from `*const [i32; 2]` to
-    // `*const i32` (the data pointer of the resulting `*const [i32]`).
     let p = 0 as *const [i32; 2] as *const [i32];
     p.is_null()
 }

--- a/crux-mir/test/conc_eval/struct/transmute.rs
+++ b/crux-mir/test/conc_eval/struct/transmute.rs
@@ -1,0 +1,71 @@
+use std::mem::transmute;
+
+#[repr(C)]
+#[derive(Clone)]
+struct A(u8);
+
+#[repr(C)]
+#[derive(Clone)]
+struct B {
+    b: u8,
+}
+
+#[repr(C)]
+#[derive(Clone)]
+struct CD {
+    c: u8,
+    d: u8,
+}
+
+#[repr(transparent)]
+#[derive(Clone)]
+struct E {
+    e: u8,
+}
+
+#[repr(C)]
+#[derive(Clone)]
+struct S {
+    a: A,
+    b: B,
+    cd: CD,
+    e: E,
+}
+
+#[cfg_attr(crux, crux::test)]
+fn crux_test() {
+    let a = 97;
+    let b = 98;
+    let c = 99;
+    let d = 100;
+    let e = 101;
+
+    let s = S {
+        a: A(a),
+        b: B { b },
+        cd: CD { c, d },
+        e: E { e },
+    };
+
+    assert_eq!(s.a.0, a);
+    assert_eq!(s.b.b, b);
+    assert_eq!(s.cd.c, c);
+    assert_eq!(s.cd.d, d);
+    assert_eq!(s.e.e, e);
+
+    let arr8: [u8; 5] = unsafe { transmute(s.clone()) };
+    assert_eq!(arr8[0], s.a.0);
+    assert_eq!(arr8[1], s.b.b);
+    assert_eq!(arr8[2], s.cd.c);
+    assert_eq!(arr8[3], s.cd.d);
+    assert_eq!(arr8[4], s.e.e);
+
+    let r#str0 = unsafe { str::from_utf8_unchecked(&arr8) };
+    let r#str1 = unsafe { str::from_utf8_unchecked(&arr8[1..]) };
+    assert_eq!(r#str0, "abcde");
+    assert_eq!(r#str1, "bcde");
+}
+
+fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/conc_eval/struct/transmute.rs
+++ b/crux-mir/test/conc_eval/struct/transmute.rs
@@ -60,10 +60,10 @@ fn crux_test() {
     assert_eq!(arr8[3], s.cd.d);
     assert_eq!(arr8[4], s.e.e);
 
-    let r#str0 = unsafe { str::from_utf8_unchecked(&arr8) };
-    let r#str1 = unsafe { str::from_utf8_unchecked(&arr8[1..]) };
-    assert_eq!(r#str0, "abcde");
-    assert_eq!(r#str1, "bcde");
+    let str0 = unsafe { str::from_utf8_unchecked(&arr8) };
+    let str1 = unsafe { str::from_utf8_unchecked(&arr8[1..]) };
+    assert_eq!(str0, "abcde");
+    assert_eq!(str1, "bcde");
 }
 
 fn main() {

--- a/crux-mir/test/symb_eval/array/mux_offset.good
+++ b/crux-mir/test/symb_eval/array/mux_offset.good
@@ -14,66 +14,6 @@ failures:
 ---- mux_offset/<DISAMB>::fail_offset_ag[0] counterexamples ----
 [Crux] Found counterexample for verification goal
 [Crux]   test/symb_eval/array/mux_offset.rs:52:14: 52:62: error: in mux_offset/<DISAMB>::fail_offset_ag[0]
-[Crux]   readSubaggregateWithSymOffset: entry of size 4 at 8 spans split boundary at 9
-[Crux]   Context:
-[Crux]     test/symb_eval/array/mux_offset.rs:52:14: 52:62: mux_offset/<DISAMB>::fail_offset_ag[0]
-[Crux] Found counterexample for verification goal
-[Crux]   test/symb_eval/array/mux_offset.rs:52:14: 52:62: error: in mux_offset/<DISAMB>::fail_offset_ag[0]
-[Crux]   readSubaggregateWithSymOffset: entry of size 4 at 8 spans split boundary at 10
-[Crux]   Context:
-[Crux]     test/symb_eval/array/mux_offset.rs:52:14: 52:62: mux_offset/<DISAMB>::fail_offset_ag[0]
-[Crux] Found counterexample for verification goal
-[Crux]   test/symb_eval/array/mux_offset.rs:52:14: 52:62: error: in mux_offset/<DISAMB>::fail_offset_ag[0]
-[Crux]   readSubaggregateWithSymOffset: entry of size 4 at 8 spans split boundary at 11
-[Crux]   Context:
-[Crux]     test/symb_eval/array/mux_offset.rs:52:14: 52:62: mux_offset/<DISAMB>::fail_offset_ag[0]
-[Crux] Found counterexample for verification goal
-[Crux]   test/symb_eval/array/mux_offset.rs:52:14: 52:62: error: in mux_offset/<DISAMB>::fail_offset_ag[0]
-[Crux]   readSubaggregateWithSymOffset: entry of size 4 at 12 spans split boundary at 13
-[Crux]   Context:
-[Crux]     test/symb_eval/array/mux_offset.rs:52:14: 52:62: mux_offset/<DISAMB>::fail_offset_ag[0]
-[Crux] Found counterexample for verification goal
-[Crux]   test/symb_eval/array/mux_offset.rs:52:14: 52:62: error: in mux_offset/<DISAMB>::fail_offset_ag[0]
-[Crux]   readSubaggregateWithSymOffset: entry of size 4 at 12 spans split boundary at 14
-[Crux]   Context:
-[Crux]     test/symb_eval/array/mux_offset.rs:52:14: 52:62: mux_offset/<DISAMB>::fail_offset_ag[0]
-[Crux] Found counterexample for verification goal
-[Crux]   test/symb_eval/array/mux_offset.rs:52:14: 52:62: error: in mux_offset/<DISAMB>::fail_offset_ag[0]
-[Crux]   readSubaggregateWithSymOffset: entry of size 4 at 12 spans split boundary at 15
-[Crux]   Context:
-[Crux]     test/symb_eval/array/mux_offset.rs:52:14: 52:62: mux_offset/<DISAMB>::fail_offset_ag[0]
-[Crux] Found counterexample for verification goal
-[Crux]   test/symb_eval/array/mux_offset.rs:52:14: 52:62: error: in mux_offset/<DISAMB>::fail_offset_ag[0]
-[Crux]   readSubaggregateWithSymOffset: entry of size 4 at 16 spans split boundary at 17
-[Crux]   Context:
-[Crux]     test/symb_eval/array/mux_offset.rs:52:14: 52:62: mux_offset/<DISAMB>::fail_offset_ag[0]
-[Crux] Found counterexample for verification goal
-[Crux]   test/symb_eval/array/mux_offset.rs:52:14: 52:62: error: in mux_offset/<DISAMB>::fail_offset_ag[0]
-[Crux]   readSubaggregateWithSymOffset: entry of size 4 at 16 spans split boundary at 18
-[Crux]   Context:
-[Crux]     test/symb_eval/array/mux_offset.rs:52:14: 52:62: mux_offset/<DISAMB>::fail_offset_ag[0]
-[Crux] Found counterexample for verification goal
-[Crux]   test/symb_eval/array/mux_offset.rs:52:14: 52:62: error: in mux_offset/<DISAMB>::fail_offset_ag[0]
-[Crux]   readSubaggregateWithSymOffset: entry of size 4 at 16 spans split boundary at 19
-[Crux]   Context:
-[Crux]     test/symb_eval/array/mux_offset.rs:52:14: 52:62: mux_offset/<DISAMB>::fail_offset_ag[0]
-[Crux] Found counterexample for verification goal
-[Crux]   test/symb_eval/array/mux_offset.rs:52:14: 52:62: error: in mux_offset/<DISAMB>::fail_offset_ag[0]
-[Crux]   readSubaggregateWithSymOffset: entry of size 4 at 20 spans split boundary at 21
-[Crux]   Context:
-[Crux]     test/symb_eval/array/mux_offset.rs:52:14: 52:62: mux_offset/<DISAMB>::fail_offset_ag[0]
-[Crux] Found counterexample for verification goal
-[Crux]   test/symb_eval/array/mux_offset.rs:52:14: 52:62: error: in mux_offset/<DISAMB>::fail_offset_ag[0]
-[Crux]   readSubaggregateWithSymOffset: entry of size 4 at 20 spans split boundary at 22
-[Crux]   Context:
-[Crux]     test/symb_eval/array/mux_offset.rs:52:14: 52:62: mux_offset/<DISAMB>::fail_offset_ag[0]
-[Crux] Found counterexample for verification goal
-[Crux]   test/symb_eval/array/mux_offset.rs:52:14: 52:62: error: in mux_offset/<DISAMB>::fail_offset_ag[0]
-[Crux]   readSubaggregateWithSymOffset: entry of size 4 at 20 spans split boundary at 23
-[Crux]   Context:
-[Crux]     test/symb_eval/array/mux_offset.rs:52:14: 52:62: mux_offset/<DISAMB>::fail_offset_ag[0]
-[Crux] Found counterexample for verification goal
-[Crux]   test/symb_eval/array/mux_offset.rs:52:14: 52:62: error: in mux_offset/<DISAMB>::fail_offset_ag[0]
 [Crux]   readSubaggregateWithSymOffset: in aggregate of size 24, no subaggregate value of size 8 at symbolic offset
 [Crux]   Context:
 [Crux]     test/symb_eval/array/mux_offset.rs:52:14: 52:62: mux_offset/<DISAMB>::fail_offset_ag[0]
@@ -87,9 +27,9 @@ failures:
 
 [Crux-MIR] ---- FINAL RESULTS ----
 [Crux] Goal status:
-[Crux]   Total: 64
-[Crux]   Proved: 50
-[Crux]   Disproved: 14
+[Crux]   Total: 7
+[Crux]   Proved: 5
+[Crux]   Disproved: 2
 [Crux]   Incomplete: 0
 [Crux]   Unknown: 0
 [Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/array/mux_offset.good
+++ b/crux-mir/test/symb_eval/array/mux_offset.good
@@ -1,0 +1,95 @@
+test mux_offset/<DISAMB>::fail_offset_ag[0]: returned [Symbolic BV, Symbolic BV], [Crux] Attempting to prove verification conditions.
+FAILED
+test mux_offset/<DISAMB>::fail_offset_single[0]: returned Symbolic BV, [Crux] Attempting to prove verification conditions.
+FAILED
+test mux_offset/<DISAMB>::index[0]: returned (Symbolic BV, Symbolic BV), [Crux] Attempting to prove verification conditions.
+ok
+test mux_offset/<DISAMB>::offset_ag[0]: returned [Symbolic BV, Symbolic BV], [Crux] Attempting to prove verification conditions.
+ok
+test mux_offset/<DISAMB>::offset_single[0]: returned Symbolic BV, [Crux] Attempting to prove verification conditions.
+ok
+
+failures:
+
+---- mux_offset/<DISAMB>::fail_offset_ag[0] counterexamples ----
+[Crux] Found counterexample for verification goal
+[Crux]   test/symb_eval/array/mux_offset.rs:52:14: 52:62: error: in mux_offset/<DISAMB>::fail_offset_ag[0]
+[Crux]   readSubaggregateWithSymOffset: entry of size 4 at 8 spans split boundary at 9
+[Crux]   Context:
+[Crux]     test/symb_eval/array/mux_offset.rs:52:14: 52:62: mux_offset/<DISAMB>::fail_offset_ag[0]
+[Crux] Found counterexample for verification goal
+[Crux]   test/symb_eval/array/mux_offset.rs:52:14: 52:62: error: in mux_offset/<DISAMB>::fail_offset_ag[0]
+[Crux]   readSubaggregateWithSymOffset: entry of size 4 at 8 spans split boundary at 10
+[Crux]   Context:
+[Crux]     test/symb_eval/array/mux_offset.rs:52:14: 52:62: mux_offset/<DISAMB>::fail_offset_ag[0]
+[Crux] Found counterexample for verification goal
+[Crux]   test/symb_eval/array/mux_offset.rs:52:14: 52:62: error: in mux_offset/<DISAMB>::fail_offset_ag[0]
+[Crux]   readSubaggregateWithSymOffset: entry of size 4 at 8 spans split boundary at 11
+[Crux]   Context:
+[Crux]     test/symb_eval/array/mux_offset.rs:52:14: 52:62: mux_offset/<DISAMB>::fail_offset_ag[0]
+[Crux] Found counterexample for verification goal
+[Crux]   test/symb_eval/array/mux_offset.rs:52:14: 52:62: error: in mux_offset/<DISAMB>::fail_offset_ag[0]
+[Crux]   readSubaggregateWithSymOffset: entry of size 4 at 12 spans split boundary at 13
+[Crux]   Context:
+[Crux]     test/symb_eval/array/mux_offset.rs:52:14: 52:62: mux_offset/<DISAMB>::fail_offset_ag[0]
+[Crux] Found counterexample for verification goal
+[Crux]   test/symb_eval/array/mux_offset.rs:52:14: 52:62: error: in mux_offset/<DISAMB>::fail_offset_ag[0]
+[Crux]   readSubaggregateWithSymOffset: entry of size 4 at 12 spans split boundary at 14
+[Crux]   Context:
+[Crux]     test/symb_eval/array/mux_offset.rs:52:14: 52:62: mux_offset/<DISAMB>::fail_offset_ag[0]
+[Crux] Found counterexample for verification goal
+[Crux]   test/symb_eval/array/mux_offset.rs:52:14: 52:62: error: in mux_offset/<DISAMB>::fail_offset_ag[0]
+[Crux]   readSubaggregateWithSymOffset: entry of size 4 at 12 spans split boundary at 15
+[Crux]   Context:
+[Crux]     test/symb_eval/array/mux_offset.rs:52:14: 52:62: mux_offset/<DISAMB>::fail_offset_ag[0]
+[Crux] Found counterexample for verification goal
+[Crux]   test/symb_eval/array/mux_offset.rs:52:14: 52:62: error: in mux_offset/<DISAMB>::fail_offset_ag[0]
+[Crux]   readSubaggregateWithSymOffset: entry of size 4 at 16 spans split boundary at 17
+[Crux]   Context:
+[Crux]     test/symb_eval/array/mux_offset.rs:52:14: 52:62: mux_offset/<DISAMB>::fail_offset_ag[0]
+[Crux] Found counterexample for verification goal
+[Crux]   test/symb_eval/array/mux_offset.rs:52:14: 52:62: error: in mux_offset/<DISAMB>::fail_offset_ag[0]
+[Crux]   readSubaggregateWithSymOffset: entry of size 4 at 16 spans split boundary at 18
+[Crux]   Context:
+[Crux]     test/symb_eval/array/mux_offset.rs:52:14: 52:62: mux_offset/<DISAMB>::fail_offset_ag[0]
+[Crux] Found counterexample for verification goal
+[Crux]   test/symb_eval/array/mux_offset.rs:52:14: 52:62: error: in mux_offset/<DISAMB>::fail_offset_ag[0]
+[Crux]   readSubaggregateWithSymOffset: entry of size 4 at 16 spans split boundary at 19
+[Crux]   Context:
+[Crux]     test/symb_eval/array/mux_offset.rs:52:14: 52:62: mux_offset/<DISAMB>::fail_offset_ag[0]
+[Crux] Found counterexample for verification goal
+[Crux]   test/symb_eval/array/mux_offset.rs:52:14: 52:62: error: in mux_offset/<DISAMB>::fail_offset_ag[0]
+[Crux]   readSubaggregateWithSymOffset: entry of size 4 at 20 spans split boundary at 21
+[Crux]   Context:
+[Crux]     test/symb_eval/array/mux_offset.rs:52:14: 52:62: mux_offset/<DISAMB>::fail_offset_ag[0]
+[Crux] Found counterexample for verification goal
+[Crux]   test/symb_eval/array/mux_offset.rs:52:14: 52:62: error: in mux_offset/<DISAMB>::fail_offset_ag[0]
+[Crux]   readSubaggregateWithSymOffset: entry of size 4 at 20 spans split boundary at 22
+[Crux]   Context:
+[Crux]     test/symb_eval/array/mux_offset.rs:52:14: 52:62: mux_offset/<DISAMB>::fail_offset_ag[0]
+[Crux] Found counterexample for verification goal
+[Crux]   test/symb_eval/array/mux_offset.rs:52:14: 52:62: error: in mux_offset/<DISAMB>::fail_offset_ag[0]
+[Crux]   readSubaggregateWithSymOffset: entry of size 4 at 20 spans split boundary at 23
+[Crux]   Context:
+[Crux]     test/symb_eval/array/mux_offset.rs:52:14: 52:62: mux_offset/<DISAMB>::fail_offset_ag[0]
+[Crux] Found counterexample for verification goal
+[Crux]   test/symb_eval/array/mux_offset.rs:52:14: 52:62: error: in mux_offset/<DISAMB>::fail_offset_ag[0]
+[Crux]   readSubaggregateWithSymOffset: in aggregate of size 24, no subaggregate value of size 8 at symbolic offset
+[Crux]   Context:
+[Crux]     test/symb_eval/array/mux_offset.rs:52:14: 52:62: mux_offset/<DISAMB>::fail_offset_ag[0]
+
+---- mux_offset/<DISAMB>::fail_offset_single[0] counterexamples ----
+[Crux] Found counterexample for verification goal
+[Crux]   test/symb_eval/array/mux_offset.rs:61:14: 61:57: error: in mux_offset/<DISAMB>::fail_offset_single[0]
+[Crux]   no value or wrong type: the requested type is BVRepr 32
+[Crux]   Context:
+[Crux]     test/symb_eval/array/mux_offset.rs:61:14: 61:57: mux_offset/<DISAMB>::fail_offset_single[0]
+
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 64
+[Crux]   Proved: 50
+[Crux]   Disproved: 14
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
+[Crux] Overall status: Invalid.

--- a/crux-mir/test/symb_eval/array/mux_offset.rs
+++ b/crux-mir/test/symb_eval/array/mux_offset.rs
@@ -1,0 +1,62 @@
+//! These test cases are meant to exercise reading, or failing to read, elements
+//! and sub-aggregate at symbolic offsets within a `MirAggregate`.
+
+extern crate crucible;
+use crucible::Symbolic as _;
+
+use std::mem::{size_of, size_of_val};
+
+// A replacement for `ptr::byte_add`, whose uses `crucible-mir` can't translate.
+// See https://github.com/GaloisInc/crucible/issues/1844.
+unsafe fn byte_add<T>(p: *const T, off: usize) -> *const T {
+    p.cast::<u8>().add(off).cast::<T>()
+}
+
+static XS: [(u32, u32); 3] = [(1, 2), (3, 4), (5, 6)];
+static YS: &'static [(u32, u32)] = &XS;
+
+#[crux::test]
+fn index() -> (u32, u32) {
+    let idx = usize::symbolic_where("idx", |&idx| idx < YS.len());
+    YS[idx]
+}
+
+#[crux::test]
+fn offset_ag() -> [u32; 2] {
+    // A byte offset into `XS`/`YS` from which it should always be valid to read
+    // a `[u32; 2]`.
+    let off = usize::symbolic_where("off", |&off| {
+        off < size_of_val(&XS) - size_of::<[u32; 2]>() && off % 4 == 0
+    });
+
+    unsafe { *(byte_add(YS.as_ptr().cast::<[u32; 2]>(), off)) }
+}
+
+#[crux::test]
+fn offset_single() -> u32 {
+    // A byte offset into `XS`/`YS` from which it should always be valid to read
+    // a single `u32`.
+    let off = usize::symbolic_where("off", |&off| {
+        off < size_of_val(&XS) - size_of::<u32>() && off % 4 == 0
+    });
+
+    unsafe { *(byte_add(YS.as_ptr().cast::<u32>(), off)) }
+}
+
+#[crux::test]
+fn fail_offset_ag() -> [u32; 2] {
+    // A byte offset into `XS`/`YS` from which it should be potentially invalid
+    // to read a `[u32; 2]`.
+    let off = usize::symbolic_where("off", |&off| off < size_of_val(&XS) - size_of::<[u32; 2]>());
+
+    unsafe { *(byte_add(YS.as_ptr().cast::<[u32; 2]>(), off)) }
+}
+
+#[crux::test]
+fn fail_offset_single() -> u32 {
+    // A byte offset into `XS`/`YS` from which it should be potentially invalid
+    // to read a `u32`.
+    let off = usize::symbolic_where("off", |&off| off < size_of_val(&XS) - size_of::<u32>());
+
+    unsafe { *(byte_add(YS.as_ptr().cast::<u32>(), off)) }
+}

--- a/crux-mir/test/symb_eval/array/nested.good
+++ b/crux-mir/test/symb_eval/array/nested.good
@@ -1,0 +1,11 @@
+test nested/<DISAMB>::test[0]: [Crux] Attempting to prove verification conditions.
+ok
+
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 6
+[Crux]   Proved: 6
+[Crux]   Disproved: 0
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
+[Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/array/nested.good
+++ b/crux-mir/test/symb_eval/array/nested.good
@@ -3,8 +3,8 @@ ok
 
 [Crux-MIR] ---- FINAL RESULTS ----
 [Crux] Goal status:
-[Crux]   Total: 6
-[Crux]   Proved: 6
+[Crux]   Total: 1
+[Crux]   Proved: 1
 [Crux]   Disproved: 0
 [Crux]   Incomplete: 0
 [Crux]   Unknown: 0

--- a/crux-mir/test/symb_eval/array/nested.rs
+++ b/crux-mir/test/symb_eval/array/nested.rs
@@ -1,0 +1,9 @@
+extern crate crucible;
+use crucible::Symbolic as _;
+
+#[crux::test]
+fn test() {
+    let mut xs: [[u16; 2]; 2] = [[1, 2], [3, 4]];
+    let i = usize::symbolic_where("i", |&i| i < xs.len());
+    xs[i] = [0, 0];
+}

--- a/crux-mir/test/symb_eval/debug/dump_nested.good
+++ b/crux-mir/test/symb_eval/debug/dump_nested.good
@@ -1,0 +1,23 @@
+test dump_nested/<DISAMB>::test[0]: nested_tuple = {0..8 -> 0x4:[64]
+, 8..9 -> 0x1:[8]
+, 10..12 -> 0x2:[16]
+, 12..16 -> 0x3:[32]
+, 16..17 -> 0x5:[8]
+, 24..26 -> 0x6:[16]
+, 32..36 -> 0x7:[32]
+, 40..48 -> 0x8:[64]
+, size 48}
+nested_array = {0..2 -> 0x1:[16], 2..4 -> 0x2:[16], 4..6 -> 0x3:[16], 6..8 -> 0x4:[16], size 8}
+slice = {[((MirReference IntrinsicRepr MirAggregate [] IntrinsicRepr MirAggregate [] (RefCell_RefRoot <NONCE>) (AgOffset_RefPath 0x6:[64] Empty_RefPath)),true)]
+, 0x1:[64]}
+slice head = [((MirReference IntrinsicRepr MirAggregate [] IntrinsicRepr MirAggregate [] (RefCell_RefRoot <NONCE>) (AgOffset_RefPath 0x6:[64] Empty_RefPath)),true)]
+nested_struct = {0..1 -> 0x17:[8]
+, 2..4 -> 0x18:[16]
+, 4..8 -> 0x19:[32]
+, 8..12 -> 0x1a:[32]
+, size 12}
+ok
+
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
+[Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/debug/dump_nested.rs
+++ b/crux-mir/test/symb_eval/debug/dump_nested.rs
@@ -1,0 +1,52 @@
+extern crate crucible;
+use crucible::dump_rv;
+
+#[repr(C)]
+struct W {
+    w: u8,
+}
+
+#[repr(C)]
+struct X(u16);
+
+#[repr(C)]
+struct YZ {
+    y: u32,
+    z: u32,
+}
+
+#[repr(C)]
+struct S {
+    w: W,
+    x: X,
+    yz: YZ,
+}
+
+#[crux::test]
+fn test() {
+    // Note that the expected output for this may change if Rust changes the
+    // algorithm it uses to lay out tuples. However, the expected output should
+    // still reflect a flat, non-nested `MirAggregate`.
+    let nested_tuple = (((1u8, 2u16), 3u32, (4u64,), 5i8), (6i16, (7i32, 8i64)));
+    dump_rv("nested_tuple", nested_tuple);
+
+    // `nested_array`'s output should reflect a flattened aggregate.
+    let nested_array = [[1u16, 2], [3, 4]];
+    dump_rv("nested_array", nested_array);
+
+    // Dumping `slice` and `slice_head` shows that the `RegValue`s for both of
+    // them consist of precisely one use of `AgOffset_RefPath`, combining the
+    // two offsets involved in the `[1][1..]` indexing operation, rather than
+    // two separate `AgOffset`s.
+    let slice: &[u16] = &nested_array[1][1..];
+    dump_rv("slice", slice);
+    dump_rv("slice head", &slice[0]);
+
+    // `nested_struct`'s output should reflect a flattened aggregate.
+    let nested_struct = S {
+        w: W { w: 23 },
+        x: X(24),
+        yz: YZ { y: 25, z: 26 },
+    };
+    dump_rv("nested_struct", nested_struct);
+}

--- a/crux-mir/test/symb_eval/union/init_cond.good
+++ b/crux-mir/test/symb_eval/union/init_cond.good
@@ -6,7 +6,7 @@ failures:
 ---- init_cond/<DISAMB>::foo[0] counterexamples ----
 [Crux] Found counterexample for verification goal
 [Crux]   test/symb_eval/union/init_cond.rs:14:13: 18:6: error: in init_cond/<DISAMB>::foo[0]
-[Crux]   bad MirAggregate merge: offset 0: type mismatch: IntrinsicRepr MirAggregate [] != BVRepr 16
+[Crux]   bad MirAggregate merge: offset 0: entry size 1 != 2
 [Crux]   Context:
 [Crux]     test/symb_eval/union/init_cond.rs:20:2: 20:2: init_cond/<DISAMB>::foo[0]
 

--- a/crux-mir/test/symb_eval/union/same_repr.good
+++ b/crux-mir/test/symb_eval/union/same_repr.good
@@ -1,0 +1,14 @@
+test same_repr/<DISAMB>::crux_test[0]: u = {0..1 -> ite ccond@1:b 0x2a:[8] 0x54:[8]
+, 1..2 -> ite ccond@1:b 0x54:[8] 0x2a:[8]
+, size 2}
+[Crux] Attempting to prove verification conditions.
+ok
+
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] Goal status:
+[Crux]   Total: 2
+[Crux]   Proved: 2
+[Crux]   Disproved: 0
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
+[Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/union/same_repr.rs
+++ b/crux-mir/test/symb_eval/union/same_repr.rs
@@ -1,0 +1,41 @@
+// FAIL: attempt to mux differently-initialized unions
+
+extern crate crucible;
+use crucible::{crucible_assert, dump_rv, Symbolic as _};
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct S(u8);
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct X {
+    a: S,
+    b: S,
+}
+
+#[derive(Clone, Copy)]
+union U {
+    x: X,
+    y: [u8; 2],
+}
+
+#[cfg_attr(crux, crux::test)]
+fn crux_test() {
+    let x: X = X { a: S(42), b: S(84) };
+    let c = bool::symbolic("cond");
+    let u = if c { U { x } } else { U { y: [x.b.0, x.a.0] } };
+
+    dump_rv("u", u.clone());
+
+    let first = unsafe { *(&raw const u as *const u8) };
+    if c {
+        crucible_assert!(first == 42);
+    } else {
+        crucible_assert!(first == 84);
+    }
+}
+
+fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/symb_eval/union/same_repr.rs
+++ b/crux-mir/test/symb_eval/union/same_repr.rs
@@ -1,5 +1,3 @@
-// FAIL: attempt to mux differently-initialized unions
-
 extern crate crucible;
 use crucible::{crucible_assert, dump_rv, Symbolic as _};
 


### PR DESCRIPTION
This introduces an invariant to `MirAggregate`s that they are "flat," i.e. that they never contain immediate `MirAggregateEntry`s that are themselves `MirAggregate`s. This implements most of the remainder of #1499, though it does not wrap local variables in `MirAggregate`s, as that issue dictates.

This is in draft form right now because it's based on #1841, and because I  don't yet have a patch for `saw-script` to accommodate these changes. I've also held off on writing up these changes in `{crucible,crux}-mir`'s CHANGELOG, in case they need to be massaged when they get ported to `saw-script`. However, I believe it's otherwise ready for review.