### PR TITLE
`crucible-mir`: `crucible::alloc::reallocate` doesn't reallocate in-place

### DIFF
--- a/crucible-mir/src/Mir/TransCustom.hs
+++ b/crucible-mir/src/Mir/TransCustom.hs
@@ -1979,12 +1979,13 @@ mkZero :: C.TypeRepr tp -> MirGenerator h s ret (R.Expr MIR s tp)
 mkZero (C.BVRepr w) = return $ R.App $ eBVLit w 0
 mkZero tpr = mirFail $ "don't know how to zero-initialize " ++ show tpr
 
--- fn reallocate<T>(ptr: *mut T, new_len: usize)
+-- fn reallocate<T>(ptr: *mut T, new_len: usize) -> *mut T
 reallocate :: (ExplodedDefId, CustomRHS)
 reallocate = (["crucible", "alloc", "reallocate"], \substs -> case substs of
     Substs [elemTy] -> Just $ CustomOp $ \_ ops -> case ops of
         [ MirExp MirReferenceRepr ptr, MirExp UsizeRepr newLen ] -> do
             elemSize <- tySizeM elemTy
+            Some elemTpr <- tyToReprM elemTy
 
             (agPtr, idx) <- mirRef_peelIndex ptr elemSize
 
@@ -1995,8 +1996,10 @@ reallocate = (["crucible", "alloc", "reallocate"], \substs -> case substs of
             oldAg <- readMirRef MirAggregateRepr agPtr
             let newSize = R.App (usizeMul newLen (R.App (usizeLit (fromIntegral elemSize))))
             newAg <- mirAggregate_resize oldAg newSize
-            writeMirRef MirAggregateRepr agPtr newAg
-            MirExp MirAggregateRepr <$> mirAggregate_zst
+            newAgPtr <- newMirRef MirAggregateRepr
+            writeMirRef MirAggregateRepr newAgPtr newAg
+            newAgElem <- mirRef_agElem idx elemSize elemTpr newAgPtr
+            return $ MirExp MirReferenceRepr newAgElem
         _ -> mirFail $ "BUG: invalid arguments to reallocate: " ++ show ops
     _ -> Nothing)
 

--- a/crux-mir/test/conc_eval/vec/reallocate.rs
+++ b/crux-mir/test/conc_eval/vec/reallocate.rs
@@ -1,0 +1,15 @@
+#[cfg_attr(crux, crux::test)]
+fn crux_test() -> (i32, i32) {
+    let orig_capacity = 1;
+    let mut v = Vec::with_capacity(orig_capacity);
+    while v.len() < v.capacity() {
+        v.push(0);
+    }
+    v.push(1);
+    assert_ne!(v.capacity(), orig_capacity);
+    (v[0], *v.last().unwrap())
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/symb_eval/debug/dump_rv.good
+++ b/crux-mir/test/symb_eval/debug/dump_rv.good
@@ -2,8 +2,8 @@ test dump_rv/<DISAMB>::test[0]: a = {0..4 -> 0x7b:[32], 4..8 -> 0x1c8:[32], size
 b = {0..4 -> cxy@7:bv, 4..8 -> cxy@8:bv, size 8}
 c = {0..4 -> cxy@7:bv, 4..8 -> cxy@8:bv, size 8}
 d = {0..1 -> 0x0:[8], 1..2 -> 0x1:[8], size 2}
-e = {0..1 -> 0x0:[8], 1..2 -> 0x1:[8], 2..3 -> 0x2a:[8], 3..4 -> 0x1b:[8], size 5}
-f = let -- test/symb_eval/debug/dump_rv.rs:30:19: 30:40
+e = {0..1 -> 0x0:[8], 1..2 -> 0x1:[8], 2..3 -> 0x2a:[8], 3..4 -> 0x1b:[8], size 4}
+f = let -- test/symb_eval/debug/dump_rv.rs:32:19: 32:40
     v15 = constArray 0x0:[8]
  in arrayMap [BV 2::[64]] 0x2a:[8] [BV 3::[64]] 0x1b:[8] v15
 ok

--- a/crux-mir/test/symb_eval/debug/dump_rv.rs
+++ b/crux-mir/test/symb_eval/debug/dump_rv.rs
@@ -18,14 +18,16 @@ fn test() {
     let mut v = [0u8, 1u8];
     dump_rv("d", v);
     let mut vp = v.as_mut_ptr();
-    crucible::alloc::reallocate(vp, 5);
+    vp = crucible::alloc::reallocate(vp, 4);
     unsafe {
         *vp.offset(2) = 42;
         if v[0] == 0 {
             *vp.offset(3) = 27;
         }
     }
-    crucible::dump_rv("e", v);
+    let v_slice: &[u8] = unsafe { std::slice::from_raw_parts(vp, 4) };
+    let v_array: [u8; 4] = v_slice.try_into().unwrap();
+    crucible::dump_rv("e", v_array);
 
     let mut arr = Array::<u8>::zeroed();
     arr = arr.update(2, 42);

--- a/crux-mir/test/symb_eval/debug/dump_rv.rs
+++ b/crux-mir/test/symb_eval/debug/dump_rv.rs
@@ -21,7 +21,7 @@ fn test() {
     vp = crucible::alloc::reallocate(vp, 4);
     unsafe {
         *vp.offset(2) = 42;
-        if v[0] == 0 {
+        if *vp == 0 {
             *vp.offset(3) = 27;
         }
     }


### PR DESCRIPTION
Accommodates https://github.com/GaloisInc/mir-json/pull/276.

The existing implementation of our `reallocate` override might overwrite a smaller `MirAggregate` with a larger one. With #1842's changes, this becomes an error.