### PR TITLE
update Rust to nightly 2026-03-21

### DIFF
--- a/crucible-mir/src/Mir/GenericOps.hs
+++ b/crucible-mir/src/Mir/GenericOps.hs
@@ -29,7 +29,6 @@ import Data.Text (Text)
 import Data.Vector(Vector)
 import qualified Data.Vector as V
 import Data.Word (Word64)
-import Lens.Micro ((^.))
 
 import Mir.DefId
 import Mir.Mir
@@ -56,37 +55,6 @@ class GenericOps a where
   default uninternTys :: (Generic a, GenericOps' (Rep a), HasCallStack) => (Text -> Ty) -> a -> a
   uninternTys f x = to (uninternTys' f (from x))
 
-
---------------------------------------------------------------------------------------
-
--- | Find the discriminant values used for each variant of an enum.  Some
--- generated `PartialEq` impls use `Rvalue::Discriminant` and compare the
--- result to the constants from the enum definition.
-adtIndices :: Adt -> Collection -> [Integer]
-adtIndices (Adt _aname _kind vars _ _ _ _) col = go 0 vars
-  where
-    go _ [] = []
-    go lastExplicit (v : vs) =
-        let discr = getDiscr lastExplicit v
-            lastExplicit' = if isExplicit v then discr else lastExplicit
-        in discr : go lastExplicit' vs
-
-    getDiscr _ (Variant _ _ _ _ (Just i) _) = i
-
-    getDiscr _ (Variant name (Explicit did) _fields _knd _ _) = case Map.lookup did (_functions col) of
-        Just fn -> case fn ^. fbody.mblocks of
-            ( BasicBlock _info (BasicBlockData [Statement (Assign _lhs (Use (OpConstant (Constant _ty (ConstInt i))))) _loc] _term) ):_ ->
-                fromIntegerLit i
-
-            _ -> error ("enum discriminant constant should only have one basic block [variant id:" ++ show _aname ++ " discr index:" ++ show name ++ "]")
-
-        Nothing -> error $ "cannot find discriminant constant " ++ show did ++
-            " for variant " ++ show name
-    getDiscr lastExplicit (Variant _vname (Relative i) _fields _kind _ _) =
-        lastExplicit + toInteger i
-
-    isExplicit (Variant _ (Explicit _) _ _ _ _) = True
-    isExplicit _ = False
 
 --------------------------------------------------------------------------------------
 
@@ -121,7 +89,6 @@ instance GenericOps BaseSize
 instance GenericOps FloatKind
 instance GenericOps FnSig
 instance GenericOps Adt
-instance GenericOps VariantDiscr
 instance GenericOps AdtKind
 instance GenericOps CtorKind
 instance GenericOps Variant

--- a/crucible-mir/src/Mir/GenericOps.hs
+++ b/crucible-mir/src/Mir/GenericOps.hs
@@ -110,7 +110,6 @@ instance GenericOps TerminatorKind
 instance GenericOps Operand
 instance GenericOps Constant
 instance GenericOps PlaceElem
-instance GenericOps NullOp
 instance GenericOps BorrowKind
 instance GenericOps UnOp
 instance GenericOps BinOp

--- a/crucible-mir/src/Mir/GenericOps.hs
+++ b/crucible-mir/src/Mir/GenericOps.hs
@@ -111,6 +111,7 @@ instance GenericOps Operand
 instance GenericOps Constant
 instance GenericOps PlaceElem
 instance GenericOps BorrowKind
+instance GenericOps RuntimeChecks
 instance GenericOps UnOp
 instance GenericOps BinOp
 instance GenericOps VtableItem

--- a/crucible-mir/src/Mir/JSON.hs
+++ b/crucible-mir/src/Mir/JSON.hs
@@ -349,7 +349,6 @@ instance FromJSON Rvalue where
                                               Just (String "Len") -> Len <$> v .: "lv"
                                               Just (String "Cast") -> Cast <$> v .: "type" <*> v .: "op" <*> v .: "ty"
                                               Just (String "BinaryOp") -> BinaryOp <$> v .: "op" <*> v .: "L" <*> v .: "R"
-                                              Just (String "NullaryOp") -> NullaryOp <$> v .: "op" <*> v .: "ty"
                                               Just (String "UnaryOp") -> UnaryOp <$> v .: "uop" <*> v .: "op"
                                               Just (String "Discriminant") -> Discriminant <$> v .: "val" <*> v .: "ty"
                                               Just (String "Aggregate") -> Aggregate <$> v .: "akind" <*> v .: "ops"
@@ -396,13 +395,6 @@ instance FromJSON Operand where
                                                Just (String "Copy") -> Copy <$> v .: "data"
                                                Just (String "Constant") -> OpConstant <$> v .: "data"
                                                x -> fail ("base operand: " ++ show x)
-
-instance FromJSON NullOp where
-    parseJSON = withObject "NullOp" $ \v -> case lookupKM "kind" v of
-                                             Just (String "SizeOf") -> pure SizeOf
-                                             Just (String "AlignOf") -> pure AlignOf
-                                             Just (String "UbChecks") -> pure UbChecks
-                                             x -> fail ("bad nullOp: " ++ show x)
 
 instance FromJSON BorrowKind where
     parseJSON = withText "BorrowKind" $ \t ->

--- a/crucible-mir/src/Mir/JSON.hs
+++ b/crucible-mir/src/Mir/JSON.hs
@@ -394,6 +394,7 @@ instance FromJSON Operand where
                                                Just (String "Move") -> Move <$> v .: "data"
                                                Just (String "Copy") -> Copy <$> v .: "data"
                                                Just (String "Constant") -> OpConstant <$> v .: "data"
+                                               Just (String "RuntimeChecks") -> OpRuntimeChecks <$> v .: "data"
                                                x -> fail ("base operand: " ++ show x)
 
 instance FromJSON BorrowKind where
@@ -405,6 +406,13 @@ instance FromJSON BorrowKind where
       else if T.isPrefixOf "Mut" t then pure Mutable
       else fail ("bad borrowKind: " ++ show t)
 
+instance FromJSON RuntimeChecks where
+    parseJSON = withObject "BinOp" $ \v ->
+        case lookupKM "kind" v of
+            Just (String "UbChecks") -> pure UbChecks
+            Just (String "ContractChecks") -> pure ContractChecks
+            Just (String "OverflowChecks") -> pure OverflowChecks
+            x -> fail ("bad RuntimeChecks variant: " ++ show x)
 
 
 

--- a/crucible-mir/src/Mir/JSON.hs
+++ b/crucible-mir/src/Mir/JSON.hs
@@ -333,7 +333,6 @@ instance FromJSON PlaceElem where
         Just (String "ConstantIndex") -> ConstantIndex <$> v .: "offset" <*> v .: "min_length" <*> v .: "from_end"
         Just (String "Subslice") -> Subslice <$> v .: "from" <*> v .: "to" <*> v .: "from_end"
         Just (String "Downcast") -> Downcast <$> v .: "variant"
-        Just (String "Subtype") -> Subtype <$> v .: "ty"
         x -> fail ("bad PlaceElem: " ++ show x)
 
 instance FromJSON Lvalue where
@@ -494,6 +493,7 @@ instance FromJSON CastKind where
             Just (String "PtrToPtr") -> pure Misc
             Just (String "FnPtrToPtr") -> pure Misc
             Just (String "Transmute") -> pure Transmute
+            Just (String "Subtype") -> pure Subtype
             x -> fail ("bad CastKind: " ++ show x)
 
 instance FromJSON Constant where

--- a/crucible-mir/src/Mir/JSON.hs
+++ b/crucible-mir/src/Mir/JSON.hs
@@ -182,12 +182,6 @@ instance FromJSON AdtKind where
         Just (String "Union") -> pure Union
         mbKind -> fail $ "unsupported adt kind " ++ show mbKind
 
-instance FromJSON VariantDiscr where
-    parseJSON = withObject "VariantDiscr" $ \v -> case lookupKM "kind" v of
-                                                    Just (String "Explicit") -> Explicit <$> v .: "name"
-                                                    Just (String "Relative") -> Relative <$> v .: "index"
-                                                    _ -> fail "unspported variant discriminator"
-
 instance FromJSON CtorKind where
     parseJSON = withObject "CtorKind" $ \v -> case lookupKM "kind" v of
                                                 Just (String "Fn") -> pure FnKind
@@ -196,11 +190,9 @@ instance FromJSON CtorKind where
 instance FromJSON Variant where
     parseJSON = withObject "Variant" $ \v ->
         Variant <$> v .: "name"
-                <*> v .: "discr"
                 <*> v .: "fields"
                 <*> v .: "ctor_kind"
-                <*> do  val <- v .:? "discr_value"
-                        convertIntegerText `traverse` val
+                <*> (v .: "discr_value" >>= convertIntegerText)
                 <*> v .: "inhabited"
 
 instance FromJSON Field where

--- a/crucible-mir/src/Mir/JSON.hs
+++ b/crucible-mir/src/Mir/JSON.hs
@@ -106,6 +106,7 @@ instance FromJSON InlineTy where
       Just (String "Float") -> TyFloat <$> v .: "size"
       Just (String "Never") -> pure TyNever
       Just (String "Foreign") -> pure TyForeign
+      Just (String "Pat") -> TyPat <$> v .: "ty"
       Just (String "Const") -> TyConst <$> v .: "constant"
       r -> fail $ "unsupported ty: " ++ show r
 

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -516,10 +516,17 @@ data Operand =
         Copy Lvalue
       | Move Lvalue
       | OpConstant Constant
+      | OpRuntimeChecks RuntimeChecks
       -- | The result of evaluating an Rvalue.  This never appears in
       -- rustc-generated MIR, but we produce them internally in some cases.
       | Temp Rvalue
       deriving (Show, Eq, Ord, Generic)
+
+data RuntimeChecks =
+        UbChecks
+      | ContractChecks
+      | OverflowChecks
+      deriving (Show,Eq, Ord, Generic)
 
 
 
@@ -873,6 +880,7 @@ instance TypeOf Operand where
     typeOf (Move lv) = typeOf lv
     typeOf (Copy lv) = typeOf lv
     typeOf (OpConstant c) = typeOf c
+    typeOf (OpRuntimeChecks _) = TyBool
     typeOf (Temp rv) = typeOf rv
 
 instance TypeOf Constant where

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -100,6 +100,7 @@ data Ty =
       | TyDowncast !Ty !Integer     -- result type of downcasting an ADT. Ty must be an ADT type
       | TyNever
       | TyForeign       -- External types, of unknown size and alignment
+      | TyPat !Ty       -- Pattern type.  We treat this as a new type and ignore the pattern.
 
       | TyConst !ConstVal
         -- ^ Represents constants in 'Substs'. This has no effect on the

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -256,11 +256,6 @@ isEnum :: AdtKind -> Bool
 isEnum (Enum {}) = True
 isEnum _ = False
 
-data VariantDiscr
-  = Explicit DefId
-  | Relative Int
-  deriving (Eq, Ord, Show, Generic)
-
 
 data CtorKind
   = FnKind
@@ -270,12 +265,11 @@ data CtorKind
 
 data Variant = Variant {
   _vname :: DefId,
-  _vdiscr :: VariantDiscr,
   -- | Fields of the variant.  For structs/variants with named fields, these go
   -- in declaration order.
   _vfields :: [Field],
   _vctorkind :: Maybe CtorKind,
-  _discrval :: Maybe Integer,
+  _discrval :: Integer,
   _vinhabited :: Bool }
     deriving (Eq, Ord,Show, Generic)
 

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -415,7 +415,6 @@ data PlaceElem =
         -- beginning - so if @s@ has length @len@, elements are instead selected
         -- from the (still half-open) range @[from, len - to)@.
       | Downcast Integer
-      | Subtype Ty
       deriving (Show, Eq, Ord, Generic)
 
 -- Called "Place" in rustc itself, hence the names of PlaceBase and PlaceElem
@@ -597,6 +596,7 @@ data CastKind =
   | UnsizeVtable VtableName
   | MutToConstPointer
   | Transmute
+  | Subtype
   deriving (Show,Eq, Ord, Generic)
 
 data Constant = Constant Ty ConstVal
@@ -807,7 +807,6 @@ typeOfProj elm baseTy = case elm of
     ConstantIndex{} -> peelIdx baseTy
     Downcast i      -> TyDowncast baseTy i   --- TODO: check this
     Subslice{}      -> TySlice (peelIdx baseTy)
-    Subtype t       -> t
   where
     peelRef :: Ty -> Ty
     peelRef (TyRef t _) = t

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -437,7 +437,6 @@ data Rvalue =
         -- ^ load length from a slice
       | Cast { _cck :: CastKind, _cop :: Operand, _cty :: Ty }
       | BinaryOp { _bop :: BinOp, _bop1 :: Operand, _bop2 :: Operand }
-      | NullaryOp { _nuop :: NullOp, _nty :: Ty }
       | UnaryOp { _unop :: UnOp, _unoperand :: Operand}
       | Discriminant { _dvar :: Lvalue,
                        -- | The type of the discriminant. That is, /not/ the
@@ -521,12 +520,6 @@ data Operand =
       -- rustc-generated MIR, but we produce them internally in some cases.
       | Temp Rvalue
       deriving (Show, Eq, Ord, Generic)
-
-data NullOp =
-        SizeOf
-      | AlignOf
-      | UbChecks
-      deriving (Show,Eq, Ord, Generic)
 
 
 
@@ -854,10 +847,6 @@ instance TypeOf Rvalue where
             Unchecked op'' -> f op''
             WithOverflow op'' -> TyTuple [f op'', TyBool]
     in f op
-  typeOf (NullaryOp op _ty) = case op of
-    SizeOf -> TyUint USize
-    AlignOf -> TyUint USize
-    UbChecks -> TyBool
   typeOf (UnaryOp op x) =
     let ty = typeOf x
     in case op of

--- a/crucible-mir/src/Mir/PP.hs
+++ b/crucible-mir/src/Mir/PP.hs
@@ -86,6 +86,7 @@ instance Pretty Ty where
     pretty (TyFloat floatKind) = pretty floatKind
     pretty (TyDowncast adt i)    = parens (pretty adt <+> pretty "as" <+> pretty i)
     pretty TyNever = pretty "never"
+    pretty (TyPat ty) = pretty "pat" <+> pretty ty
     pretty TyLifetime = pretty "lifetime"
     pretty (TyConst c) = braces (pretty c)
       -- Using braces is redundant for constants like `2`, but it would be

--- a/crucible-mir/src/Mir/PP.hs
+++ b/crucible-mir/src/Mir/PP.hs
@@ -204,8 +204,6 @@ instance Pretty Lvalue where
       pretty lv <> brackets (pretty "-" <> pretty f <> dot <> dot <> pretty "-" <> pretty t)
     pretty (LProj lv (Downcast i)) =
       parens (pretty lv <+> pretty "as" <+> pretty i)
-    pretty (LProj lv (Subtype ty)) =
-      parens (pretty lv <+> pretty "as subtype" <+> pretty ty)
 
 instance Pretty Rvalue where
     pretty (Use a) = pretty a

--- a/crucible-mir/src/Mir/PP.hs
+++ b/crucible-mir/src/Mir/PP.hs
@@ -258,6 +258,7 @@ instance Pretty Operand where
     pretty (OpConstant c) = pretty c
     pretty (Move c) = pretty_fn1 "move" c
     pretty (Copy c) = pretty_fn1 "copy" c
+    pretty (OpRuntimeChecks rc) = pretty_fn1 "runtime_checks" rc
     pretty (Temp c) = pretty_fn1 "temp" c
 
 instance Pretty Constant where
@@ -284,6 +285,9 @@ instance Pretty Constant where
           pretty_fn1 "const" b
 
 instance Pretty BorrowKind where
+    pretty = viaShow
+
+instance Pretty RuntimeChecks where
     pretty = viaShow
 
 

--- a/crucible-mir/src/Mir/PP.hs
+++ b/crucible-mir/src/Mir/PP.hs
@@ -217,7 +217,6 @@ instance Pretty Rvalue where
     pretty (Len a) = pretty_fn1 "len" a
     pretty (Cast a b c) = pretty_fn3 "Cast" a b c
     pretty (BinaryOp a b c) = pretty b <+> pretty a <+> pretty c
-    pretty (NullaryOp a _b) = pretty a
     pretty (UnaryOp a b) = pretty a <+> pretty b
     pretty (Discriminant a b) = pretty_fn2 "Discriminant" a b
     pretty (Aggregate a b) = pretty_fn2 "Aggregate" a b
@@ -283,11 +282,6 @@ instance Pretty Constant where
           pretty_fn1 "const" "<ZST:" <+> pretty a <> pretty ">"
         _ ->
           pretty_fn1 "const" b
-
-instance Pretty NullOp where
-    pretty SizeOf = pretty "sizeof"
-    pretty AlignOf = pretty "alignof"
-    pretty UbChecks = pretty "ub_checks"
 
 instance Pretty BorrowKind where
     pretty = viaShow

--- a/crucible-mir/src/Mir/PP.hs
+++ b/crucible-mir/src/Mir/PP.hs
@@ -105,10 +105,6 @@ instance Pretty Adt where
 instance Pretty AdtKind where
   pretty = viaShow
 
-instance Pretty VariantDiscr where
-  pretty (Explicit a) = pretty_fn1 "Explicit" a
-  pretty (Relative a) = pretty_fn1 "Relative" a
-
 instance Pretty CoroutineArgs where
   pretty (CoroutineArgs discrTy upvarTys savedTys fieldMap) =
     pretty discrTy
@@ -121,9 +117,9 @@ instance Pretty CtorKind where
   pretty = viaShow
 
 instance Pretty Variant where
-  pretty (Variant nm dscr flds knd mbVal inh) =
+  pretty (Variant nm flds knd discrVal inh) =
     pretty "Variant" <>
-      tupled [pretty nm, pretty dscr, pretty flds, pretty knd, pretty mbVal, pretty inh]
+      tupled [pretty nm, pretty flds, pretty knd, pretty discrVal, pretty inh]
 
 instance Pretty Field where
     pretty (Field nm ty) = pretty_fn2 "Field" nm ty

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -414,6 +414,15 @@ evalOperand (M.Move lv) = evalPlace lv >>= readPlace (M.typeOf lv)
 evalOperand (M.OpConstant (M.Constant conty constval)) = do
     Some tpr <- tyToReprM conty
     transConstVal conty (Some tpr) constval
+evalOperand (M.OpRuntimeChecks rc) = do
+    let enable = case rc of
+            -- Disable undefined behavior checks.
+            -- TODO: re-enable this later, and fix the tests that break
+            -- (see https://github.com/GaloisInc/mir-json/issues/107)
+            UbChecks -> False
+            ContractChecks -> True
+            OverflowChecks -> True
+    return $ MirExp C.BoolRepr $ R.App $ E.BoolLit enable
 evalOperand (M.Temp rv) = evalRval rv
 
 -- | Dereference a `MirExp` (which must be `MirReferenceRepr` pointing to a

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -101,7 +101,6 @@ import qualified Mir.DefId as M
 
 import Mir.Intrinsics
 import Mir.Generator
-import Mir.GenericOps
 import Mir.TransTy
 
 import Mir.PP (fmt, fmtDoc)
@@ -3079,7 +3078,7 @@ transVirtCall colState intrName' methName dynTraitName methIndex
 
 mkDiscrMap :: M.Collection -> Map M.AdtName [Integer]
 mkDiscrMap col = mconcat
-    [ Map.singleton (adt ^. M.adtname) (adtIndices adt col)
+    [ Map.singleton (adt ^. M.adtname) (map (\v -> v ^. M.discrval) $ adt ^. M.adtvariants)
     | adt <- Map.elems $ col ^. M.adts, M.isEnum (adt ^. M.adtkind) ]
 
 -- | Gather all of the 'M.DefId's in a 'M.Collection' and construct a

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -714,18 +714,6 @@ evalBinOp bop mat me1 me2 =
                 (S.app $ E.BVEq w y $ S.app $ eBVLit w ((1 `shiftL` w') - 1))
       where w' = fromIntegral $ intValue w
 
--- Nullary ops in rust are used for resource allocation, so are not interpreted
-transNullaryOp ::  M.NullOp -> M.Ty -> MirGenerator h s ret (MirExp s)
-transNullaryOp nop ty =
-  case nop of
-    M.AlignOf -> getLayoutFieldAsMirExp "AlignOf" layAlign ty
-    M.SizeOf -> getLayoutFieldAsMirExp "SizeOf" laySize ty
-    M.UbChecks -> do
-      -- Disable undefined behavior checks.
-      -- TODO: re-enable this later, and fix the tests that break
-      -- (see https://github.com/GaloisInc/mir-json/issues/107)
-      return $ MirExp C.BoolRepr $ R.App $ E.BoolLit False
-
 transUnaryOp :: M.UnOp -> M.Operand -> MirGenerator h s ret (MirExp s)
 transUnaryOp uop op = do
     mop <- evalOperand op
@@ -1373,7 +1361,6 @@ evalRval (M.Len lv) =
         ty -> mirFail $ "don't know how to take Len of " ++ show ty
 evalRval (M.Cast ck op ty) = evalCast ck op ty
 evalRval (M.BinaryOp binop op1 op2) = transBinOp binop op1 op2
-evalRval (M.NullaryOp nop nty) = transNullaryOp  nop nty
 evalRval (M.UnaryOp uop op) = transUnaryOp  uop op
 evalRval (M.Discriminant lv discrTy) = do
     let enumTy = typeOf lv

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -1034,6 +1034,10 @@ evalCast' ck ty1 e ty2  = do
       -- we decide to track that, this needs to be updated.
       (M.UnsafeFnPointer, _, _) | ty1 == ty2 -> pure e
 
+      -- Subtype is a no-op, as it is only present in the MIR to making subtyping
+      -- explicit during optimizations and codegen.
+      (M.Subtype, _, _) -> pure e
+
       _ -> mirFail $ "unimplemented cast: " ++ (show ck) ++
         "\n  ty: " ++ (show ty1) ++ "\n  as: " ++ (show ty2)
   where
@@ -1736,9 +1740,6 @@ evalPlaceProj ty (MirPlace tpr ref meta) (M.ConstantIndex idx _minLen fromEnd) =
 -- Downcast is a no-op - it only affects the type reported by `M.type_of`.  The
 -- `PField` case above looks for `TyDowncast` to handle enum accesses.
 evalPlaceProj _ pl (M.Downcast _idx) = return pl
--- Subtype is a no-op, as it is only present in the MIR to making subtyping
--- explicit during optimizations and codegen.
-evalPlaceProj _ pl (M.Subtype _ty) = return pl
 -- Subslicing is defined on slices and arrays. See the haddock for `Subslice`
 -- for details on the semantics of `fromIndex` and `toIndex`.
 evalPlaceProj ty (MirPlace tpr ref meta) (M.Subslice fromIndex toIndex fromEnd) =

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -1410,21 +1410,30 @@ evalRval rv@(M.Aggregate ak ops) =
             -- representation as tuples.
             evalTupleRval (typeOf rv) ops
         M.AKRawPtr ty _mutbl -> do
-            args <- mapM evalOperand ops
-            (MirExp tprPtr ptr, MirExp tprMeta meta) <- case args of
+            col <- use $ cs . collection
+            (opPtr, opMeta) <- case ops of
                 [p, m] -> return (p, m)
                 _ -> mirFail $ "evalRval: expected exactly two operands for " ++ show ak
-                    ++ ", but got " ++ show args
-            case ty of
-                TySlice _ -> case (tprPtr, tprMeta) of
-                    (MirReferenceRepr, UsizeRepr) -> do
-                        let tup = S.mkStruct
-                                (Ctx.Empty Ctx.:> MirReferenceRepr Ctx.:> knownRepr)
-                                (Ctx.Empty Ctx.:> ptr Ctx.:> meta)
-                        return $ MirExp MirSliceRepr tup
-                    _ -> mirFail $ "evalRval: unexpected reprs " ++ show (tprPtr, tprMeta)
-                        ++ " for aggregate " ++ show ak
-                _ -> mirFail $ "evalRval: unsupported output type for " ++ show ak
+                    ++ ", but got " ++ show ops
+            MirExp tprPtr ptr <- evalOperand opPtr
+            MirExp tprMeta meta <- evalOperand opMeta
+            case (ty, tprPtr, tprMeta) of
+                (TySlice _, MirReferenceRepr, UsizeRepr) -> do
+                    let tup = S.mkStruct
+                            (Ctx.Empty Ctx.:> MirReferenceRepr Ctx.:> knownRepr)
+                            (Ctx.Empty Ctx.:> ptr Ctx.:> meta)
+                    return $ MirExp MirSliceRepr tup
+                (TyStr, MirReferenceRepr, UsizeRepr) -> do
+                    let tup = S.mkStruct
+                            (Ctx.Empty Ctx.:> MirReferenceRepr Ctx.:> knownRepr)
+                            (Ctx.Empty Ctx.:> ptr Ctx.:> meta)
+                    return $ MirExp MirSliceRepr tup
+                (_, MirReferenceRepr, MirAggregateRepr)
+                  | Nothing <- findUnsizedTail col ty
+                  , TyTuple [] <- typeOf opMeta -> do
+                    return $ MirExp MirReferenceRepr ptr
+                _ -> mirFail $ "evalRval: AKRawPtr: unsupported input types "
+                    ++ show (typeOf opPtr, typeOf opMeta) ++ " and output type " ++ show ty
 evalRval (M.RAdtAg (M.AdtAg adt agv ops ty optField)) = do
     case ty of
       -- It's not legal to construct a MethodSpec using a Rust struct

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -1409,15 +1409,21 @@ evalRval rv@(M.Aggregate ak ops) =
             -- Closure environments have the same
             -- representation as tuples.
             evalTupleRval (typeOf rv) ops
+        -- `AKRawPtr` is the result of lowering `ptr::from_raw_parts`, which
+        -- combines a thin pointer and metadata.
         M.AKRawPtr ty _mutbl -> do
             col <- use $ cs . collection
             (opPtr, opMeta) <- case ops of
                 [p, m] -> return (p, m)
                 _ -> mirFail $ "evalRval: expected exactly two operands for " ++ show ak
                     ++ ", but got " ++ show ops
+            -- First argument should always be `MirReferenceRepr`, since the
+            -- intrinsic requires it to be a thin pointer.
             MirExp tprPtr ptr <- evalOperand opPtr
             MirExp tprMeta meta <- evalOperand opMeta
             case (ty, tprPtr, tprMeta) of
+                -- `usize` metadata can be used to produce a slice or str
+                -- pointer.
                 (TySlice _, MirReferenceRepr, UsizeRepr) -> do
                     let tup = S.mkStruct
                             (Ctx.Empty Ctx.:> MirReferenceRepr Ctx.:> knownRepr)
@@ -1428,10 +1434,16 @@ evalRval rv@(M.Aggregate ak ops) =
                             (Ctx.Empty Ctx.:> MirReferenceRepr Ctx.:> knownRepr)
                             (Ctx.Empty Ctx.:> ptr Ctx.:> meta)
                     return $ MirExp MirSliceRepr tup
+                -- Unit/`()` metadata can be used to produce a thin pointer
+                -- (possibly of a different Rust type).  In this case the
+                -- metadata is `MirAggregateRepr` representing the empty tuple.
                 (_, MirReferenceRepr, MirAggregateRepr)
                   | Nothing <- findUnsizedTail col ty
                   , TyTuple [] <- typeOf opMeta -> do
                     return $ MirExp MirReferenceRepr ptr
+                -- TODO: custom DSTs ending in slice/str
+                -- TODO: `dyn Trait` output type (`AnyRepr` metadata)
+                -- TODO: custom DSTs ending in `dyn Trait `(`AnyRepr` metadata)
                 _ -> mirFail $ "evalRval: AKRawPtr: unsupported input types "
                     ++ show (typeOf opPtr, typeOf opMeta) ++ " and output type " ++ show ty
 evalRval (M.RAdtAg (M.AdtAg adt agv ops ty optField)) = do

--- a/crucible-mir/src/Mir/TransCustom.hs
+++ b/crucible-mir/src/Mir/TransCustom.hs
@@ -114,6 +114,7 @@ customOpDefs = Map.fromList $ [
                          , unchecked_rem
                          , unchecked_shl
                          , unchecked_shr
+                         , carrying_mul_add
                          , ctlz
                          , ctlz_nonzero
                          , cttz
@@ -1028,6 +1029,39 @@ unchecked_shr =
     ( ["core","intrinsics", "unchecked_shr"]
     , makeUncheckedArith "unchecked_shr" Shr
     )
+
+
+carrying_mul_add :: (ExplodedDefId, CustomRHS)
+carrying_mul_add = (["core", "intrinsics", "carrying_mul_add"],
+  \substs -> case substs of
+    Substs [tyT, _] -> Just $ CustomOp $ \_ ops -> case ops of
+      [MirExp (C.BVRepr w) m1,
+          MirExp (C.BVRepr (testEquality w -> Just Refl)) m2,
+          MirExp (C.BVRepr (testEquality w -> Just Refl)) a1,
+          MirExp (C.BVRepr (testEquality w -> Just Refl)) a2]
+          -- Check `1 <= w`
+        | Just LeqProof <- testLeq (knownNat @1) w
+        -- Prove `w + 1 <= w + w`
+        , LeqProof <- leqAdd2 (leqProof w w) (leqProof (knownNat @1) w)
+        -- Prove `1 <= w + w`
+        , LeqProof <- leqAdd (leqProof (knownNat @1) w) w
+        -> do
+          let w2 = addNat w w
+          let bvExt = case tyT of
+                TyInt _ -> \bv -> R.App $ E.BVSext w2 w bv
+                TyUint _ -> \bv -> R.App $ E.BVZext w2 w bv
+                _ -> panic "carrying_mul_add" ["non-integer input type", show tyT]
+          let prodBv = R.App $ E.BVMul w2 (bvExt m1) (bvExt m2)
+          let sumBv = R.App $ E.BVAdd w2 (bvExt a1) (bvExt a2)
+          let result = R.App $ E.BVAdd w2 prodBv sumBv
+          let resultLo = R.App $ E.BVTrunc w w2 result
+          let resultHi = R.App $ E.BVSelect w w w2 result
+          buildTupleMaybeM (TyTuple [tyT, tyT]) $
+              [Just $ MirExp (C.BVRepr w) resultLo, Just $ MirExp (C.BVRepr w) resultHi]
+      _ -> mirFail $ "carrying_mul_add: bad arguments: " ++ show ops
+    _ -> Nothing)
+
+
 
 -- Implement the [`core::intrinsics::exact_div`] intrinsic.
 -- This operation performs integer division that triggers undefined behavior

--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -702,7 +702,7 @@ findUnsizedTailM ty = do
     return $ findUnsizedTail col ty
 
 variantFields :: TransTyConstraint => M.Collection -> M.Variant -> Either String (Some C.CtxRepr)
-variantFields col (M.Variant _vn _vd vfs _vct _mbVal _inh) = do
+variantFields col (M.Variant _vn vfs _vct _discrVal _inh) = do
     frs <- traverse (\field -> mapSome fieldType <$> tyToFieldRepr col (field ^. M.fty)) vfs
     tyReprListToCtx frs (\repr -> Right (Some repr))
 
@@ -738,7 +738,7 @@ tyToFieldRepr col ty
   | otherwise = viewSome (Some . FieldRepr . FkMaybe) <$> tyToRepr col ty
 
 variantFields' :: TransTyConstraint => M.Collection -> M.Variant -> Either String (Some FieldCtxRepr)
-variantFields' col (M.Variant _vn _vd vfs _vct _mbVal _inh) = do
+variantFields' col (M.Variant _vn vfs _vct _discrVal _inh) = do
     frs <- traverse (tyToFieldRepr col . (^. M.fty)) vfs
     return (fieldReprListToCtx frs Some)
 

--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -272,6 +272,11 @@ tyToRepr col t0 = case t0 of
     Some ctx <- coroutineFieldTypes col ca
     Right (Some (C.StructRepr ctx))
 
+  -- Use the same representation as the underlying type.  We still need to
+  -- track the types `t` and `TyPat t` separately because they may implement
+  -- different traits.
+  M.TyPat t -> tyToRepr col t
+
   M.TyLifetime -> Right (Some C.AnyRepr)
   M.TyForeign -> Right (Some C.AnyRepr)
   M.TyErased -> Right (Some C.AnyRepr)
@@ -545,6 +550,8 @@ canInitialize col ty = case ty of
     -- Others
     M.TyArray {} -> True
 
+    M.TyPat t -> canInitialize col t
+
     M.TyFnDef {} -> False
     M.TyNever {} -> False
     -- Note: `Mir.Trans.dispatchFromDyn` relies on `TyRef` and `TyRawPtr`
@@ -585,6 +592,7 @@ isZeroSized col = go
         | otherwise -> P.panic "isZeroSized" ["unknown ADT", show name]
       M.TyFnDef {} -> True
       M.TyNever -> True
+      M.TyPat t -> isZeroSized col t
 
       M.TyBool {} -> False
       M.TyChar {} -> False
@@ -2005,6 +2013,7 @@ initialValue (M.TyAdt nm _ _) = do
             in Just . MirExp MirAggregateRepr <$> mirAggregate_uninit_constSize unionSize
 initialValue (M.TyFnDef _) = Just . MirExp MirAggregateRepr <$> mirAggregate_zst
 initialValue M.TyNever     = Just . MirExp MirAggregateRepr <$> mirAggregate_zst
+initialValue (M.TyPat t) = initialValue t
 
 -- Remaining `Nothing` cases
 initialValue (M.TyRef {}) = return Nothing

--- a/crux-mir/test/conc_eval/any/type_id_eq.rs
+++ b/crux-mir/test/conc_eval/any/type_id_eq.rs
@@ -1,0 +1,13 @@
+use std::any::TypeId;
+
+#[cfg_attr(crux, crux::test)]
+fn crux_test() -> (bool, bool) {
+    let x = TypeId::of::<i32>();
+    let y = TypeId::of::<i32>();
+    let z = TypeId::of::<u32>();
+    (x == y, x != z)
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/conc_eval/array/from_slice.rs
+++ b/crux-mir/test/conc_eval/array/from_slice.rs
@@ -8,6 +8,8 @@ pub fn f() {
     let xs = [1, 2, 3, 4];
     let xs: &[u8] = &xs;
 
+    // During Rust toolchain upgrades, errors here most likely originate in
+    // `core::slice::as_array`, even though the immediate error location is in `core::array`.
     assert!(<&[u8; 3] as TryFrom<_>>::try_from(xs).is_err());
     assert!(<&[u8; 5] as TryFrom<_>>::try_from(xs).is_err());
     let ys = <&[u8; 4] as TryFrom<_>>::try_from(xs).unwrap();

--- a/crux-mir/test/conc_eval/ffi/c_str_from_bytes_with_nul.rs
+++ b/crux-mir/test/conc_eval/ffi/c_str_from_bytes_with_nul.rs
@@ -1,0 +1,14 @@
+use std::ffi::CStr;
+
+#[cfg_attr(crux, crux::test)]
+fn crux_test() -> usize {
+    let s1 = CStr::from_bytes_with_nul(b"123\0").unwrap();
+    let s2 = CStr::from_bytes_with_nul(
+        b"very long string in case there are heuristics in memchr that care about the input size\0",
+    ).unwrap();
+    s1.to_bytes().len() + s2.to_bytes().len()
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/conc_eval/hash/string.rs
+++ b/crux-mir/test/conc_eval/hash/string.rs
@@ -1,0 +1,24 @@
+use std::hash::{Hash, Hasher, DefaultHasher};
+
+/// The siphash implementation in the standard library has different code paths for short inputs
+/// that fit within an internal 8-byte buffer and longer inputs that exceed it.
+const S1: &str = "long test string that will overflow the hasher buffer";
+const S2: &str = "short";
+
+
+#[cfg_attr(crux, crux::test)]
+fn crux_test() -> (u64, u64) {
+    let mut h1 = DefaultHasher::new();
+    S1.hash(&mut h1);
+    let x1 = h1.finish();
+
+    let mut h2 = DefaultHasher::new();
+    S2.hash(&mut h2);
+    let x2 = h2.finish();
+
+    (x1, x2)
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/conc_eval/hash_map/string_insert_get.rs
+++ b/crux-mir/test/conc_eval/hash_map/string_insert_get.rs
@@ -1,0 +1,20 @@
+use std::collections::HashMap;
+
+const S1: &str = "long test string that will overflow the hasher buffer";
+const S2: &str = "short";
+const S3: &str = "other";
+
+
+#[cfg_attr(crux, crux::test)]
+fn crux_test() -> (i32, i32) {
+    let mut m = HashMap::new();
+    m.insert(S1.to_string(), 11);
+    m.insert(S2.to_string(), 12);
+    assert!(m.len() == 2);
+    assert!(m.get(S3).is_none());
+    (*m.get(S1).unwrap(), *m.get(S2).unwrap())
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/conc_eval/num/carrying_mul_add.rs
+++ b/crux-mir/test/conc_eval/num/carrying_mul_add.rs
@@ -1,0 +1,14 @@
+#[cfg_attr(crux, crux::test)]
+fn crux_test() -> (u8, u8) {
+    let (x1, x0) = (0x01, 0x23);
+    let y = 0x05;
+    let (z1, z0) = (0x01, 0x80);
+    // Bignum arithmetic: r = x * y + z
+    let (r0, c0) = u8::carrying_mul_add(x0, y, 0, z0);
+    let (r1, _c1) = u8::carrying_mul_add(x1, y, c0, z1);
+    (r1, r0)
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/conc_eval/slice/iter_zst.rs
+++ b/crux-mir/test/conc_eval/slice/iter_zst.rs
@@ -1,0 +1,12 @@
+#[cfg_attr(crux, crux::test)]
+fn crux_test() -> i32 {
+    let mut x = 0;
+    for &() in [(), (), ()].as_slice() {
+        x += 1;
+    }
+    x
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/conc_eval/sync/lazy_lock.rs
+++ b/crux-mir/test/conc_eval/sync/lazy_lock.rs
@@ -1,0 +1,19 @@
+use std::sync::LazyLock;
+use std::sync::atomic::{AtomicI32, Ordering};
+
+static X: AtomicI32 = AtomicI32::new(1);
+static LL: LazyLock<i32> = LazyLock::new(|| 2 + X.load(Ordering::Relaxed));
+
+#[cfg_attr(crux, crux::test)]
+fn crux_test() -> (i32, i32) {
+    X.store(2, Ordering::Relaxed);
+    let y = *LL;
+    X.store(3, Ordering::Relaxed);
+    let z = *LL;
+    // Both should be 4, since `X` was 2 at the time the `LazyLock` was forced.
+    (y, z)
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/conc_eval/sync/park.rs
+++ b/crux-mir/test/conc_eval/sync/park.rs
@@ -1,0 +1,13 @@
+use std::thread;
+
+#[cfg_attr(crux, crux::test)]
+fn crux_test() -> i32 {
+    thread::current().unpark();
+    // Since we called `unpark`, this call to `park` shouldn't block.
+    thread::park();
+    1
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/conc_eval/sync/thread_current.rs
+++ b/crux-mir/test/conc_eval/sync/thread_current.rs
@@ -1,0 +1,12 @@
+use std::thread;
+
+#[cfg_attr(crux, crux::test)]
+fn crux_test() -> bool {
+    let t1 = thread::current();
+    let t2 = thread::current();
+    t1.id() == t2.id()
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/conc_eval/sync/thread_local.rs
+++ b/crux-mir/test/conc_eval/sync/thread_local.rs
@@ -1,0 +1,17 @@
+use std::cell::Cell;
+
+thread_local! {
+    static X: Cell<i32> = Cell::new(123);
+}
+
+#[cfg_attr(crux, crux::test)]
+fn crux_test() -> i32 {
+    let x = X.get();
+    X.set(1);
+    let y = X.get();
+    x + y
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/conc_eval/sync/thread_local_drop.rs
+++ b/crux-mir/test/conc_eval/sync/thread_local_drop.rs
@@ -1,0 +1,15 @@
+use std::cell::RefCell;
+
+thread_local! {
+    static X: RefCell<Vec<i32>> = RefCell::new(vec![1, 2, 3]);
+}
+
+#[cfg_attr(crux, crux::test)]
+fn crux_test() -> i32 {
+    X.with_borrow_mut(|x| x.push(4));
+    X.with_borrow(|x| x.iter().copied().sum::<i32>())
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/conc_eval/sync/unpark.rs
+++ b/crux-mir/test/conc_eval/sync/unpark.rs
@@ -1,0 +1,11 @@
+use std::thread;
+
+#[cfg_attr(crux, crux::test)]
+fn crux_test() -> i32 {
+    thread::current().unpark();
+    1
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/coverage/coverage.good
+++ b/crux-mir/test/coverage/coverage.good
@@ -1,4 +1,4 @@
-warning: branch condition never has a value other than [1]
+warning: branch condition never has value false
    ┌─ test/coverage/coverage.rs:11:15
    │
 11 │     } else if x == 1 {

--- a/crux-mir/test/coverage/coverage_match.good
+++ b/crux-mir/test/coverage/coverage_match.good
@@ -10,7 +10,4 @@ warning: branch condition never has value 20
 21 │     let y = match e {
    │             ^^^^^^^
 
-❌   0% coverage_match/E[0]::A[0]::{constant#0}[0]: 0/0
-❌   0% coverage_match/E[0]::B[0]::{constant#0}[0]: 0/0
-❌   0% coverage_match/E[0]::C[0]::{constant#0}[0]: 0/0
 🚧  71% coverage_match/crux_test[0]: 5/7

--- a/crux-mir/test/coverage/coverage_shortcircuit.good
+++ b/crux-mir/test/coverage/coverage_shortcircuit.good
@@ -1,4 +1,4 @@
-warning: branch condition never has a value other than [0]
+warning: branch condition never has value false
   ┌─ test/coverage/coverage_shortcircuit.rs:9:8
   │
 9 │     if x == 0 || x == 1 {

--- a/crux-mir/test/symb_eval/concretize/assert_ok.good
+++ b/crux-mir/test/symb_eval/concretize/assert_ok.good
@@ -3,8 +3,8 @@ ok
 
 [Crux-MIR] ---- FINAL RESULTS ----
 [Crux] Goal status:
-[Crux]   Total: 175
-[Crux]   Proved: 175
+[Crux]   Total: 159
+[Crux]   Proved: 159
 [Crux]   Disproved: 0
 [Crux]   Incomplete: 0
 [Crux]   Unknown: 0

--- a/crux-mir/test/symb_eval/num/unchecked_arith.good
+++ b/crux-mir/test/symb_eval/num/unchecked_arith.good
@@ -13,42 +13,42 @@ failures:
 
 ---- unchecked_arith/<DISAMB>::add_test[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/core/src/num/uint_macros.rs:717:17: 717:53 !./libs/core/src/num/mod.rs:447:5: 468:6: error: in core/<DISAMB>::num[0]::{impl#6}[0]::unchecked_add[0]
+[Crux]   ./libs/core/src/num/uint_macros.rs:844:17: 844:53 !./libs/core/src/num/mod.rs:541:5: 565:6: error: in core/<DISAMB>::num[0]::{impl#6}[0]::unchecked_add[0]
 [Crux]   Binary operation (+) would overflow
 [Crux]   Context:
-[Crux]     ./libs/core/src/num/uint_macros.rs:717:17: 717:53 !./libs/core/src/num/mod.rs:447:5: 468:6: core/<DISAMB>::num[0]::{impl#6}[0]::unchecked_add[0]
+[Crux]     ./libs/core/src/num/uint_macros.rs:844:17: 844:53 !./libs/core/src/num/mod.rs:541:5: 565:6: core/<DISAMB>::num[0]::{impl#6}[0]::unchecked_add[0]
 [Crux]     test/symb_eval/num/unchecked_arith.rs:5:14: 5:38: unchecked_arith/<DISAMB>::add_test[0]
 
 ---- unchecked_arith/<DISAMB>::mul_test[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/core/src/num/uint_macros.rs:1105:17: 1105:53 !./libs/core/src/num/mod.rs:447:5: 468:6: error: in core/<DISAMB>::num[0]::{impl#6}[0]::unchecked_mul[0]
+[Crux]   ./libs/core/src/num/uint_macros.rs:1232:17: 1232:53 !./libs/core/src/num/mod.rs:541:5: 565:6: error: in core/<DISAMB>::num[0]::{impl#6}[0]::unchecked_mul[0]
 [Crux]   Binary operation (*) would overflow
 [Crux]   Context:
-[Crux]     ./libs/core/src/num/uint_macros.rs:1105:17: 1105:53 !./libs/core/src/num/mod.rs:447:5: 468:6: core/<DISAMB>::num[0]::{impl#6}[0]::unchecked_mul[0]
+[Crux]     ./libs/core/src/num/uint_macros.rs:1232:17: 1232:53 !./libs/core/src/num/mod.rs:541:5: 565:6: core/<DISAMB>::num[0]::{impl#6}[0]::unchecked_mul[0]
 [Crux]     test/symb_eval/num/unchecked_arith.rs:15:14: 15:38: unchecked_arith/<DISAMB>::mul_test[0]
 
 ---- unchecked_arith/<DISAMB>::shl_test[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/core/src/num/uint_macros.rs:1794:17: 1794:53 !./libs/core/src/num/mod.rs:447:5: 468:6: error: in core/<DISAMB>::num[0]::{impl#6}[0]::unchecked_shl[0]
+[Crux]   ./libs/core/src/num/uint_macros.rs:1916:17: 1916:53 !./libs/core/src/num/mod.rs:541:5: 565:6: error: in core/<DISAMB>::num[0]::{impl#6}[0]::unchecked_shl[0]
 [Crux]   Binary operation (<<) would overflow
 [Crux]   Context:
-[Crux]     ./libs/core/src/num/uint_macros.rs:1794:17: 1794:53 !./libs/core/src/num/mod.rs:447:5: 468:6: core/<DISAMB>::num[0]::{impl#6}[0]::unchecked_shl[0]
+[Crux]     ./libs/core/src/num/uint_macros.rs:1916:17: 1916:53 !./libs/core/src/num/mod.rs:541:5: 565:6: core/<DISAMB>::num[0]::{impl#6}[0]::unchecked_shl[0]
 [Crux]     test/symb_eval/num/unchecked_arith.rs:20:14: 20:38: unchecked_arith/<DISAMB>::shl_test[0]
 
 ---- unchecked_arith/<DISAMB>::shr_test[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/core/src/num/uint_macros.rs:1966:17: 1966:53 !./libs/core/src/num/mod.rs:447:5: 468:6: error: in core/<DISAMB>::num[0]::{impl#6}[0]::unchecked_shr[0]
+[Crux]   ./libs/core/src/num/uint_macros.rs:2101:17: 2101:53 !./libs/core/src/num/mod.rs:541:5: 565:6: error: in core/<DISAMB>::num[0]::{impl#6}[0]::unchecked_shr[0]
 [Crux]   Binary operation (>>) would overflow
 [Crux]   Context:
-[Crux]     ./libs/core/src/num/uint_macros.rs:1966:17: 1966:53 !./libs/core/src/num/mod.rs:447:5: 468:6: core/<DISAMB>::num[0]::{impl#6}[0]::unchecked_shr[0]
+[Crux]     ./libs/core/src/num/uint_macros.rs:2101:17: 2101:53 !./libs/core/src/num/mod.rs:541:5: 565:6: core/<DISAMB>::num[0]::{impl#6}[0]::unchecked_shr[0]
 [Crux]     test/symb_eval/num/unchecked_arith.rs:25:14: 25:38: unchecked_arith/<DISAMB>::shr_test[0]
 
 ---- unchecked_arith/<DISAMB>::sub_test[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/core/src/num/uint_macros.rs:896:17: 896:53 !./libs/core/src/num/mod.rs:447:5: 468:6: error: in core/<DISAMB>::num[0]::{impl#6}[0]::unchecked_sub[0]
+[Crux]   ./libs/core/src/num/uint_macros.rs:1023:17: 1023:53 !./libs/core/src/num/mod.rs:541:5: 565:6: error: in core/<DISAMB>::num[0]::{impl#6}[0]::unchecked_sub[0]
 [Crux]   Binary operation (-) would overflow
 [Crux]   Context:
-[Crux]     ./libs/core/src/num/uint_macros.rs:896:17: 896:53 !./libs/core/src/num/mod.rs:447:5: 468:6: core/<DISAMB>::num[0]::{impl#6}[0]::unchecked_sub[0]
+[Crux]     ./libs/core/src/num/uint_macros.rs:1023:17: 1023:53 !./libs/core/src/num/mod.rs:541:5: 565:6: core/<DISAMB>::num[0]::{impl#6}[0]::unchecked_sub[0]
 [Crux]     test/symb_eval/num/unchecked_arith.rs:10:14: 10:38: unchecked_arith/<DISAMB>::sub_test[0]
 
 [Crux-MIR] ---- FINAL RESULTS ----

--- a/crux-mir/test/symb_eval/panic/caller_location.good
+++ b/crux-mir/test/symb_eval/panic/caller_location.good
@@ -1,0 +1,5 @@
+test caller_location/<DISAMB>::crux_test[0]: returned 0, ok
+
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
+[Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/panic/caller_location.rs
+++ b/crux-mir/test/symb_eval/panic/caller_location.rs
@@ -1,0 +1,15 @@
+use std::panic::Location;
+
+#[track_caller]
+fn f() -> u32 {
+    Location::caller().line()
+}
+
+#[cfg_attr(crux, crux::test)]
+fn crux_test() -> u32 {
+    f()
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}


### PR DESCRIPTION
Most changes here are minor.  The most notable ones are:

* Remove variant `vdiscr` field (JSON: `discr`) in favor of `discrval` (JSON: `discr_value`).  `vdiscr` held the `DefId` of the MIR representation of the constant discriminant value, and we previously had some logic to pattern-match on the MIR and extract the actual integer value.  `discrval` holds the value directly.  This change was necessary because mir-json was failing to obtain the MIR representation for `vdiscr` in some cases after the toolchain upgrade.
* Add `str` and thin-pointer cases for `AKRawPtr` (rustc: `AggregateKind::RawPtr`), which implements `ptr::from_raw_parts`.  The `dyn Trait` case is still unimplemented, since we don't have any Crucible representation for vtable pointers.
* Add many new test cases for mir-json library patches.  Previously we had about 10 patches in mir-json that changed library behavior in ways that were completely untested in crux-mir, making it hard to tell whether the patch is correct and whether it's still needed.

mir-json PR: https://github.com/GaloisInc/mir-json/pull/277