### PR TITLE
`Mir.TransCustom`: Add `black_box` override

### DIFF
--- a/crucible-mir/CHANGELOG.md
+++ b/crucible-mir/CHANGELOG.md
@@ -13,6 +13,7 @@ This release supports [version
 * Add an intrinsic for [`align_of_val`](https://doc.rust-lang.org/std/intrinsics/fn.align_of_val.html),
   which computes the alignment of a value in bytes. This works for all sized types
   as well as a limited number of unsized types (currently, only slices).
+* Add an intrinsic for [`black_box`](https://doc.rust-lang.org/std/intrinsics/fn.black_box.html).
 * Extend the override for the `atomic_xchg` intrinsic to support storing
   pointer values in addition to integer values.
 * Support translating constant trait object values.

--- a/crucible-mir/src/Mir/TransCustom.hs
+++ b/crucible-mir/src/Mir/TransCustom.hs
@@ -126,6 +126,7 @@ customOpDefs = Map.fromList $ [
                          , align_of_val
                          , intrinsics_assume
                          , assert_inhabited
+                         , black_box
                          , unlikely
                          , bitreverse
                          , volatile_load
@@ -2177,13 +2178,24 @@ atomic_funcs =
 
 --------------------------------------------------------------------------------------------------------------------------
 
+black_box :: (ExplodedDefId, CustomRHS)
+black_box = (name, rhs)
+    where
+        name = ["core", "intrinsics", "black_box"]
+        rhs = identity_rhs "black_box"
+
 unlikely :: (ExplodedDefId, CustomRHS)
 unlikely = (name, rhs)
     where
         name = ["core", "intrinsics", "unlikely"]
-        rhs _substs = Just $ CustomOp $ \_ ops -> case ops of
-          [op] -> pure op
-          _ -> mirFail $ "bad arguments to intrinsics::unlikely: " ++ show ops
+        rhs = identity_rhs "unlikely"
+
+-- | An implementation for intrinsics whose overrides take a single argument
+-- and return it unchanged.
+identity_rhs :: String -> CustomRHS
+identity_rhs name _substs = Just $ CustomOp $ \_ ops -> case ops of
+    [op] -> pure op
+    _ -> mirFail $ "bad arguments to " ++ name ++ ": " ++ show ops
 
 
 

--- a/crucible-mir/src/Mir/TransCustom.hs
+++ b/crucible-mir/src/Mir/TransCustom.hs
@@ -2328,7 +2328,7 @@ coroutine_field = (["crucible", "coroutine", "coroutine_field"],
                     if actualU == expectU then
                         pure (MirExp MirReferenceRepr u)
                     else
-                        mirFail ("crucible::coroutine::coroutine_field expected type " ++ show expectU ++ " got type " ++ show actualU) 
+                        mirFail ("crucible::coroutine::coroutine_field expected type " ++ show expectU ++ " got type " ++ show actualU)
                 _ -> mirFail "BUG: coroutine_field pointer argument not a reference"
         _ -> Nothing
     )

--- a/crux-mir/test/conc_eval/stdlib/black_box.rs
+++ b/crux-mir/test/conc_eval/stdlib/black_box.rs
@@ -1,0 +1,17 @@
+// A regression test for #1855, which ensures that the `std::hint::black_box`
+// and `std::intrinsics::black_box` functions are supported.
+#![feature(core_intrinsics)]
+
+fn f(x: bool) {
+    assert_eq!(std::hint::black_box(42u8), 42u8);
+    assert_eq!(std::intrinsics::black_box(42u16), 42u16);
+}
+
+#[cfg_attr(crux, crux::test)]
+pub fn crux_test() {
+    f(false)
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}


### PR DESCRIPTION
Fixes #1855.