### PR TITLE
`crux-mir`: Use `nightly-2026-03-21` consistently in CI

### DIFF
--- a/.github/Dockerfile-crux-mir
+++ b/.github/Dockerfile-crux-mir
@@ -1,6 +1,6 @@
 # If you update this, make sure to also update RUST_TOOLCHAIN in
 # .github/workflows/crux-mir-build.yml
-ARG RUST_TOOLCHAIN="nightly-2025-09-14"
+ARG RUST_TOOLCHAIN="nightly-2026-03-21"
 ARG CRUX_BUILD_DIR=/crux-mir/build
 
 # Note that we intentionally do not use ubuntu:24.04 or later pending a

--- a/.github/workflows/crux-mir-build.yml
+++ b/.github/workflows/crux-mir-build.yml
@@ -31,7 +31,7 @@ env:
   CARGO_CACHE_VERSION: 1
   # If you update this, make sure to also update RUST_TOOLCHAIN in
   # .github/Dockerfile-crux-mir
-  RUST_TOOLCHAIN: "nightly-2025-09-14"
+  RUST_TOOLCHAIN: "nightly-2026-03-21"
 
 jobs:
   config:


### PR DESCRIPTION
A follow-up to https://github.com/GaloisInc/crucible/pull/1851.