### PR TITLE
`crucible-mir`: Support mir-json schema version 12

### DIFF
--- a/crucible-mir/CHANGELOG.md
+++ b/crucible-mir/CHANGELOG.md
@@ -1,7 +1,7 @@
 # next
 
 This release supports [version
-10](https://github.com/GaloisInc/mir-json/blob/master/SCHEMA_CHANGELOG.md#10) of
+12](https://github.com/GaloisInc/mir-json/blob/master/SCHEMA_CHANGELOG.md#12) of
 `mir-json`'s schema.
 
 * **BREAKING:** Remove prisms for `AdtKind` and the `Wrapped` instance for

--- a/crucible-mir/src/Mir/JSON.hs
+++ b/crucible-mir/src/Mir/JSON.hs
@@ -302,7 +302,6 @@ instance FromJSON StatementKind where
         Just (String "StorageLive") -> StorageLive <$> v .: "slvar"
         Just (String "StorageDead") -> StorageDead <$> v .: "sdvar"
         Just (String "Nop") -> pure Nop
-        Just (String "Deinit") -> pure Deinit
         Just (String "Intrinsic") -> do
            kind <- v .: "intrinsic_kind"
            ndi <- case kind of

--- a/crucible-mir/src/Mir/JSON.hs
+++ b/crucible-mir/src/Mir/JSON.hs
@@ -33,7 +33,6 @@ import qualified Data.Aeson.KeyMap as KM
 import qualified Data.HashMap.Lazy as HML
 #endif
 
-import Mir.DefId
 import Mir.Mir
 
 --------------------------------------------------------------------------------------
@@ -507,23 +506,9 @@ instance FromJSON CastKind where
 
 instance FromJSON Constant where
     parseJSON = withObject "Literal" $ \v -> do
-      ty <- v .: "ty"
-      mbRend <- v .:? "rendered"
-      mbInit <- v .:? "initializer"
-      case (mbRend, mbInit) of
-        (Just rend, _) ->
-            pure $ Constant ty rend
-        (Nothing, Just (RustcConstInitializer defid)) ->
-            pure $ Constant ty $ ConstInitializer defid
-        (Nothing, Nothing) ->
-            fail $ "need either rendered value or initializer in constant literal"
+      Constant <$> v .: "ty"
+               <*> v .: "rendered"
 
-
-data RustcConstInitializer = RustcConstInitializer DefId
-
-instance FromJSON RustcConstInitializer where
-    parseJSON = withObject "Initializer" $ \v ->
-        RustcConstInitializer <$> v .: "def_id"
 
 instance FromJSON ConstVal where
     parseJSON = withObject "ConstVal" $ \v ->

--- a/crucible-mir/src/Mir/JSON.hs
+++ b/crucible-mir/src/Mir/JSON.hs
@@ -353,16 +353,15 @@ instance FromJSON Rvalue where
                                               Just (String "Repeat") -> Repeat <$> v .: "op" <*> v .: "len"
                                               Just (String "Ref") ->  Ref <$> v .: "borrowkind" <*> v .: "refvar" <*> v .: "region"
                                               Just (String "AddressOf") ->  AddressOf <$> v .: "mutbl" <*> v .: "place"
-                                              Just (String "Len") -> Len <$> v .: "lv"
                                               Just (String "Cast") -> Cast <$> v .: "type" <*> v .: "op" <*> v .: "ty"
                                               Just (String "BinaryOp") -> BinaryOp <$> v .: "op" <*> v .: "L" <*> v .: "R"
                                               Just (String "UnaryOp") -> UnaryOp <$> v .: "uop" <*> v .: "op"
                                               Just (String "Discriminant") -> Discriminant <$> v .: "val" <*> v .: "ty"
                                               Just (String "Aggregate") -> Aggregate <$> v .: "akind" <*> v .: "ops"
                                               Just (String "AdtAg") -> RAdtAg <$> v .: "ag"
-                                              Just (String "ShallowInitBox") -> ShallowInitBox <$> v .: "ptr" <*> v .: "ty"
                                               Just (String "CopyForDeref") -> CopyForDeref <$> v .: "place"
                                               Just (String "ThreadLocalRef") -> ThreadLocalRef <$> v .: "def_id" <*> v .: "ty"
+                                              Just (String "WrapUnsafeBinder") -> WrapUnsafeBinder <$> v .: "op" <*> v .: "ty"
                                               k -> fail $ "unsupported RValue " ++ show k
 
 instance FromJSON AdtAg where

--- a/crucible-mir/src/Mir/JSON.hs
+++ b/crucible-mir/src/Mir/JSON.hs
@@ -61,8 +61,10 @@ instance FromJSON BaseSize where
 
 instance FromJSON FloatKind where
     parseJSON = withObject "FloatKind" $ \t -> case lookupKM "kind" t of
+                                                 Just (String "F16") -> pure F16
                                                  Just (String "F32") -> pure F32
                                                  Just (String "F64") -> pure F64
+                                                 Just (String "F128") -> pure F128
                                                  sz -> fail $ "unknown float type: " ++ show sz
 
 instance FromJSON Substs where
@@ -564,8 +566,10 @@ instance FromJSON ConstVal where
             size :: Int <- v .: "size"
             val <- v .: "val"
             fk <- case size of
+                2 -> pure F16
                 4 -> pure F32
                 8 -> pure F64
+                16 -> pure F128
                 _ -> fail $ "bad size " ++ show size ++ " for float literal"
             pure $ ConstFloat $ FloatLit fk (T.unpack val)
 

--- a/crucible-mir/src/Mir/JSON.hs
+++ b/crucible-mir/src/Mir/JSON.hs
@@ -143,7 +143,7 @@ instance FromJSON Instance where
             <$> v .: "def_id" <*> v .: "args"
         Just (String "Intrinsic") -> Instance IkIntrinsic
             <$> v .: "def_id" <*> v .: "args"
-        Just (String "VtableShim") -> Instance IkVtableShim
+        Just (String "VTableShim") -> Instance IkVtableShim
             <$> v .: "def_id" <*> v .: "args"
         Just (String "ReifyShim") -> Instance IkReifyShim
             <$> v .: "def_id" <*> v .: "args"

--- a/crucible-mir/src/Mir/JSON.hs
+++ b/crucible-mir/src/Mir/JSON.hs
@@ -410,7 +410,6 @@ instance FromJSON Operand where
 instance FromJSON BorrowKind where
     parseJSON = withText "BorrowKind" $ \t ->
            if t == "Shared" then pure Shared
-      else if t == "Unique" then pure Unique
       else if t == "Mut"    then pure Mutable
       -- s can be followed by "{ allow_two_phase_borrow: true }"
       else if T.isPrefixOf "Mut" t then pure Mutable

--- a/crucible-mir/src/Mir/JSON.hs
+++ b/crucible-mir/src/Mir/JSON.hs
@@ -393,6 +393,10 @@ instance FromJSON TerminatorKind where
         Just (String "Call") ->  Call <$> v .: "func" <*> v .: "args" <*> v .: "destination"
         Just (String "Assert") -> Assert <$> v .: "cond" <*> v .: "expected" <*> v .: "msg" <*> v .: "target"
         Just (String "InlineAsm") -> pure InlineAsm
+        Just (String "Yield") -> pure Yield
+        Just (String "FalseEdge") -> pure FalseEdge
+        Just (String "FalseUnwind") -> pure FalseUnwind
+        Just (String "CoroutineDrop") -> pure CoroutineDrop
         k -> fail $ "unsupported terminator kind" ++ show k
 
 instance FromJSON Operand where

--- a/crucible-mir/src/Mir/JSON.hs
+++ b/crucible-mir/src/Mir/JSON.hs
@@ -338,6 +338,8 @@ instance FromJSON PlaceElem where
         Just (String "ConstantIndex") -> ConstantIndex <$> v .: "offset" <*> v .: "min_length" <*> v .: "from_end"
         Just (String "Subslice") -> Subslice <$> v .: "from" <*> v .: "to" <*> v .: "from_end"
         Just (String "Downcast") -> Downcast <$> v .: "variant"
+        Just (String "OpaqueCast") -> OpaqueCast <$> v .: "variant"
+        Just (String "UnwrapUnsafeBinder") -> UnwrapUnsafeBinder <$> v .: "ty"
         x -> fail ("bad PlaceElem: " ++ show x)
 
 instance FromJSON Lvalue where

--- a/crucible-mir/src/Mir/JSON.hs
+++ b/crucible-mir/src/Mir/JSON.hs
@@ -203,9 +203,7 @@ instance FromJSON Field where
 
 instance FromJSON Mutability where
     parseJSON = withObject "Mutability" $ \v -> case lookupKM "kind" v of
-                                                Just (String "MutMutable") -> pure Mut
                                                 Just (String "Mut") -> pure Mut
-                                                Just (String "MutImmutable") -> pure Immut
                                                 Just (String "Not") -> pure Immut
                                                 x -> fail $ "bad mutability: " ++ show x
 

--- a/crucible-mir/src/Mir/JSON.hs
+++ b/crucible-mir/src/Mir/JSON.hs
@@ -109,6 +109,12 @@ instance FromJSON InlineTy where
       Just (String "Foreign") -> pure TyForeign
       Just (String "Pat") -> TyPat <$> v .: "ty"
       Just (String "Const") -> TyConst <$> v .: "constant"
+      Just (String "Error") -> pure TyError
+      Just (String "Infer") -> pure TyInfer
+      Just (String "Bound") -> pure TyBound
+      Just (String "Placeholder") -> pure TyPlaceholder
+      Just (String "CoroutineWitness") -> pure TyCoroutineWitness
+      Just (String "Alias") -> pure TyAlias
       r -> fail $ "unsupported ty: " ++ show r
 
 instance FromJSON NamedTy where

--- a/crucible-mir/src/Mir/JSON.hs
+++ b/crucible-mir/src/Mir/JSON.hs
@@ -314,6 +314,12 @@ instance FromJSON StatementKind where
 
            return $ StmtIntrinsic ndi
         Just (String "ConstEvalCounter") -> pure ConstEvalCounter
+        Just (String "FakeRead") -> pure FakeRead
+        Just (String "Retag") -> pure Retag
+        Just (String "PlaceMention") -> pure PlaceMention
+        Just (String "AscribeUserType") -> pure AscribeUserType
+        Just (String "Coverage") -> pure Coverage
+        Just (String "BackwardIncompatibleDropHint") -> pure BackwardIncompatibleDropHint
 
         k -> fail $ "kind not found for statement: " ++ show k
 

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -660,7 +660,6 @@ data ConstVal =
   | ConstCoroutineClosure [ConstVal]
   | ConstArray [ConstVal]
   | ConstRepeat ConstVal Int
-  | ConstInitializer DefId
   -- | A reference to a static, of type `&T`.
   | ConstStaticRef DefId
   | ConstZST

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -397,6 +397,14 @@ data StatementKind =
       | Nop
       | StmtIntrinsic NonDivergingIntrinsic
       | ConstEvalCounter
+
+        -- The following are not yet supported in crucible-mir translation
+      | FakeRead
+      | Retag
+      | PlaceMention
+      | AscribeUserType
+      | Coverage
+      | BackwardIncompatibleDropHint
     deriving (Show,Eq, Ord, Generic)
 
 data NonDivergingIntrinsic =

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -395,7 +395,6 @@ data StatementKind =
       | StorageLive { _slv :: Var }
       | StorageDead { _sdv :: Var }
       | Nop
-      | Deinit
       | StmtIntrinsic NonDivergingIntrinsic
       | ConstEvalCounter
     deriving (Show,Eq, Ord, Generic)

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -553,7 +553,6 @@ data RuntimeChecks =
 
 data BorrowKind =
         Shared
-      | Unique
       | Mutable
       deriving (Show,Eq, Ord, Generic)
 
@@ -864,7 +863,6 @@ instance TypeOf Rvalue where
   typeOf (Repeat a sz) = TyArray (typeOf a) (fromIntegral sz)
   typeOf (Ref Shared lv _)  = TyRef (typeOf lv) Immut
   typeOf (Ref Mutable lv _) = TyRef (typeOf lv) Mut
-  typeOf (Ref Unique lv _)  = TyRef (typeOf lv) Mut
   typeOf (AddressOf mutbl lv) = TyRawPtr (typeOf lv) mutbl
   typeOf (Cast _ _ ty) = ty
   typeOf (BinaryOp op x _y) =

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -520,11 +520,17 @@ data TerminatorKind =
                  _aexpected :: Bool,
                  _amsg      :: AssertMessage,
                  _atarget   :: BasicBlockInfo }
+
+        -- The following are not yet supported in crucible-mir translation
       | InlineAsm
         -- ^ @crucible-mir@ does not support simulating inline assembly, but we
         -- nevertheless include this as a 'TerminatorKind' so that we can
         -- successfully translate code that mentions it. Provided that that
         -- code is never simulated, this should work out.
+      | Yield
+      | FalseEdge
+      | FalseUnwind
+      | CoroutineDrop
       deriving (Show,Eq, Ord, Generic)
 
 data Operand =

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -426,6 +426,10 @@ data PlaceElem =
         -- beginning - so if @s@ has length @len@, elements are instead selected
         -- from the (still half-open) range @[from, len - to)@.
       | Downcast Integer
+
+        -- The following are not yet supported in crucible-mir translation
+      | OpaqueCast Ty
+      | UnwrapUnsafeBinder Ty
       deriving (Show, Eq, Ord, Generic)
 
 -- Called "Place" in rustc itself, hence the names of PlaceBase and PlaceElem
@@ -828,12 +832,14 @@ instance TypeOf Lvalue where
 
 typeOfProj :: PlaceElem -> Ty -> Ty
 typeOfProj elm baseTy = case elm of
-    PField _ t      -> t
-    Deref           -> peelRef baseTy
-    Index{}         -> peelIdx baseTy
-    ConstantIndex{} -> peelIdx baseTy
-    Downcast i      -> TyDowncast baseTy i   --- TODO: check this
-    Subslice{}      -> TySlice (peelIdx baseTy)
+    PField _ t           -> t
+    Deref                -> peelRef baseTy
+    Index{}              -> peelIdx baseTy
+    ConstantIndex{}      -> peelIdx baseTy
+    Downcast i           -> TyDowncast baseTy i   --- TODO: check this
+    Subslice{}           -> TySlice (peelIdx baseTy)
+    OpaqueCast t         -> t
+    UnwrapUnsafeBinder t -> t
   where
     peelRef :: Ty -> Ty
     peelRef (TyRef t _) = t

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -66,8 +66,10 @@ data BaseSize =
       deriving (Eq, Ord, Show, Generic)
 
 data FloatKind
-  = F32
+  = F16
+  | F32
   | F64
+  | F128
   deriving (Eq, Ord, Show, Generic)
 
 -- | Type parameters

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -124,6 +124,14 @@ data Ty =
       -- types.  These are all replaced with other variants in `uninternTys`,
       -- which runs just after JSON decoding is done.
       | TyInterned TyName
+
+        -- The following are not yet supported in crucible-mir translation
+      | TyError
+      | TyInfer
+      | TyBound
+      | TyPlaceholder
+      | TyCoroutineWitness
+      | TyAlias
       deriving (Eq, Ord, Show, Generic)
 
 -- | Details about a coroutine type.  See Note [coroutine representation] in

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -448,8 +448,6 @@ data Rvalue =
       | Repeat { _rop :: Operand, _rlen :: ConstUsize }
       | Ref { _rbk :: BorrowKind, _rvar :: Lvalue, _rregion :: Text }
       | AddressOf { _aomutbl :: Mutability, _aoplace :: Lvalue }
-      | Len { _lenvar :: Lvalue }
-        -- ^ load length from a slice
       | Cast { _cck :: CastKind, _cop :: Operand, _cty :: Ty }
       | BinaryOp { _bop :: BinOp, _bop1 :: Operand, _bop2 :: Operand }
       | UnaryOp { _unop :: UnOp, _unoperand :: Operand}
@@ -465,9 +463,11 @@ data Rvalue =
                        _dty :: Ty }
       | Aggregate { _ak :: AggregateKind, _ops :: [Operand] }
       | RAdtAg AdtAg
-      | ShallowInitBox { _sibptr :: Operand, _sibty :: Ty }
       | CopyForDeref Lvalue
       | ThreadLocalRef DefId Ty
+
+        -- The following are not yet supported in crucible-mir translation
+      | WrapUnsafeBinder Operand Ty
     deriving (Show,Eq, Ord, Generic)
 
 -- | An aggregate ADT expression.
@@ -860,7 +860,6 @@ instance TypeOf Rvalue where
   typeOf (Ref Mutable lv _) = TyRef (typeOf lv) Mut
   typeOf (Ref Unique lv _)  = TyRef (typeOf lv) Mut
   typeOf (AddressOf mutbl lv) = TyRawPtr (typeOf lv) mutbl
-  typeOf (Len _) = TyUint USize
   typeOf (Cast _ _ ty) = ty
   typeOf (BinaryOp op x _y) =
     let ty = typeOf x
@@ -905,9 +904,9 @@ instance TypeOf Rvalue where
   typeOf (Aggregate (AKCoroutine ca) _ops) = TyCoroutine ca
   typeOf (Aggregate AKCoroutineClosure ops) = TyCoroutineClosure $ map typeOf ops
   typeOf (RAdtAg (AdtAg _ _ _ ty _)) = ty
-  typeOf (ShallowInitBox _ ty) = ty
   typeOf (CopyForDeref lv) = typeOf lv
   typeOf (ThreadLocalRef _ ty) = ty
+  typeOf (WrapUnsafeBinder _ ty) = ty
 
 instance TypeOf Operand where
     typeOf (Move lv) = typeOf lv

--- a/crucible-mir/src/Mir/PP.hs
+++ b/crucible-mir/src/Mir/PP.hs
@@ -224,16 +224,15 @@ instance Pretty Rvalue where
     pretty (Ref Mutable b _c) = pretty "&mut" <+> pretty b
     pretty (AddressOf Immut b) = pretty "&raw" <+> pretty b
     pretty (AddressOf Mut b) = pretty "&raw mut" <+> pretty b
-    pretty (Len a) = pretty_fn1 "len" a
     pretty (Cast a b c) = pretty_fn3 "Cast" a b c
     pretty (BinaryOp a b c) = pretty b <+> pretty a <+> pretty c
     pretty (UnaryOp a b) = pretty a <+> pretty b
     pretty (Discriminant a b) = pretty_fn2 "Discriminant" a b
     pretty (Aggregate a b) = pretty_fn2 "Aggregate" a b
     pretty (RAdtAg a) = pretty a
-    pretty (ShallowInitBox ptr ty) = pretty_fn2 "ShallowInitBox" ptr ty
     pretty (CopyForDeref lv) = pretty_fn1 "CopyForDeref" lv
     pretty (ThreadLocalRef a b) = pretty_fn2 "ThreadLocalRef" a b
+    pretty (WrapUnsafeBinder a b) = pretty_fn2 "WrapUnsafeBinder" a b
 
 instance Pretty AdtAg where
   pretty (AdtAg (Adt nm _kind _vs _ _ _ _) i ops _ optField) = case optField of

--- a/crucible-mir/src/Mir/PP.hs
+++ b/crucible-mir/src/Mir/PP.hs
@@ -391,7 +391,6 @@ instance Pretty ConstVal where
     pretty (ConstArray cs)     = list (map pretty cs)
     pretty (ConstRepeat cv i)  = brackets (pretty cv <> semi <+> pretty i)
     pretty (ConstFunction a)   = pr_id a
-    pretty (ConstInitializer a) = pr_id a
     pretty (ConstStaticRef a) = pretty "&" <> pr_id a
     pretty ConstZST =
       -- A ConstZST value represents a value with a zero-sized type, but we

--- a/crucible-mir/src/Mir/PP.hs
+++ b/crucible-mir/src/Mir/PP.hs
@@ -220,7 +220,6 @@ instance Pretty Rvalue where
     pretty (Use a) = pretty a
     pretty (Repeat a b) = brackets (pretty a <> semi <> pretty b)
     pretty (Ref Shared b _c) = pretty "&" <> pretty b
-    pretty (Ref Unique b _c) = pretty "&unique" <+> pretty b
     pretty (Ref Mutable b _c) = pretty "&mut" <+> pretty b
     pretty (AddressOf Immut b) = pretty "&raw" <+> pretty b
     pretty (AddressOf Mut b) = pretty "&raw mut" <+> pretty b

--- a/crucible-mir/src/Mir/PP.hs
+++ b/crucible-mir/src/Mir/PP.hs
@@ -260,6 +260,10 @@ instance Pretty TerminatorKind where
       pretty "assert" <+> pretty op <+> pretty "==" <+> pretty expect
                     <+> arrow <+> pretty target1
     pretty InlineAsm = pretty "inlineasm;"
+    pretty Yield = pretty "yield;"
+    pretty FalseEdge = pretty "falseEdge;"
+    pretty FalseUnwind = pretty "falseUnwind;"
+    pretty CoroutineDrop = pretty "coroutine_drop;"
 
 
 

--- a/crucible-mir/src/Mir/PP.hs
+++ b/crucible-mir/src/Mir/PP.hs
@@ -211,6 +211,10 @@ instance Pretty Lvalue where
       pretty lv <> brackets (pretty "-" <> pretty f <> dot <> dot <> pretty "-" <> pretty t)
     pretty (LProj lv (Downcast i)) =
       parens (pretty lv <+> pretty "as" <+> pretty i)
+    pretty (LProj lv (OpaqueCast ty)) =
+      parens (pretty lv <+> pretty "as" <+> pretty ty)
+    pretty (LProj lv (UnwrapUnsafeBinder _ty)) =
+      pretty "unwrap_binder!" <> parens (pretty lv)
 
 instance Pretty Rvalue where
     pretty (Use a) = pretty a

--- a/crucible-mir/src/Mir/PP.hs
+++ b/crucible-mir/src/Mir/PP.hs
@@ -98,6 +98,12 @@ instance Pretty Ty where
     pretty TyForeign = pretty "foreign"
     pretty TyErased = pretty "erased"
     pretty (TyInterned s) = pretty s
+    pretty TyError = pretty "error"
+    pretty TyInfer = pretty "infer"
+    pretty TyBound = pretty "bound"
+    pretty TyPlaceholder = pretty "placeholder"
+    pretty TyCoroutineWitness = pretty "coroutine_witness"
+    pretty TyAlias = pretty "alias"
 
 instance Pretty Adt where
    pretty (Adt nm kind vs _size reprTransparent origName origSubsts) =

--- a/crucible-mir/src/Mir/PP.hs
+++ b/crucible-mir/src/Mir/PP.hs
@@ -61,8 +61,10 @@ instance Pretty BaseSize where
     pretty = pretty . size_str
 
 instance Pretty FloatKind where
+    pretty F16 = pretty "f16"
     pretty F32 = pretty "f32"
     pretty F64 = pretty "f64"
+    pretty F128 = pretty "f128"
 
 instance Pretty Ty where
     pretty TyBool         = pretty "bool"

--- a/crucible-mir/src/Mir/PP.hs
+++ b/crucible-mir/src/Mir/PP.hs
@@ -184,7 +184,6 @@ instance Pretty StatementKind where
     pretty (StorageLive l) = pretty_fn1 "StorageLive" l <> semi
     pretty (StorageDead l) = pretty_fn1 "StorageDead" l <> semi
     pretty Nop = pretty "nop" <> semi
-    pretty Deinit = pretty "DeInit"
     pretty (StmtIntrinsic (NDIAssume op)) =
       pretty "Intrinsic" <> brackets (pretty "Assume") <> parens (pretty op) <> semi
     pretty (StmtIntrinsic (NDICopyNonOverlapping o1 o2 o3)) =

--- a/crucible-mir/src/Mir/PP.hs
+++ b/crucible-mir/src/Mir/PP.hs
@@ -191,6 +191,12 @@ instance Pretty StatementKind where
                          <> tupled (pretty <$> [o1, o2, o3])
                          <> semi
     pretty ConstEvalCounter = pretty "ConstEvalCounter"
+    pretty FakeRead = pretty "FakeRead"
+    pretty Retag = pretty "Retag"
+    pretty PlaceMention = pretty "PlaceMention"
+    pretty AscribeUserType = pretty "AscribeUserType"
+    pretty Coverage = pretty "Coverage"
+    pretty BackwardIncompatibleDropHint = pretty "BackwardIncompatibleDropHint"
 
 instance Pretty Lvalue where
     pretty (LBase base) = pretty base

--- a/crucible-mir/src/Mir/ParseTranslate.hs
+++ b/crucible-mir/src/Mir/ParseTranslate.hs
@@ -48,7 +48,7 @@ import Debug.Trace
 -- If you update the supported mir-json schema version below, make sure to also
 -- update the crux-mir README accordingly.
 supportedSchemaVersion :: Word64
-supportedSchemaVersion = 11
+supportedSchemaVersion = 12
 
 -- | Parse a MIR JSON file to a 'Collection'. If parsing fails, attempt to give
 -- a more informative error message if the MIR JSON schema version is

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -1510,29 +1510,34 @@ evalPlaceProj ::
   MirPlace s ->
   M.PlaceElem ->
   MirGenerator h s ret (MirPlace s)
-evalPlaceProj ty (MirPlace tpr ref meta) M.Deref
-  | NoMeta <- meta =
-    -- In the general case (when T is a sized type), we have a MirPlace input of
-    -- the form:
-    --
-    --   MirPlace (*T) <expr: **T> NoMeta
-    --
-    -- And we want to produce output of the form:
-    --
-    --   MirPlace T <expr': *T> NoMeta
-    --
-    -- Where *T is hand-wavy syntax for reference types (e.g., &T and *const T).
-    -- Note the double indirection in <expr: **T>.
-    --
-    -- Things get a little bit trickier when dealing with unsized types,
-    -- however. See the comments below.
-    case ty of
-        M.TyRef t _ -> doRef t
-        M.TyRawPtr t _ -> doRef t
-        CTyBox t -> doRef t
-        _ -> mirFail $ "deref not supported on " ++ show ty
-  | otherwise = mirFail $ "deref not supported on " ++ show meta
+evalPlaceProj ty (MirPlace tpr ref meta) M.Deref =
+  case meta of
+    NoMeta ->
+      -- In the general case (when T is a sized type), we have a MirPlace input
+      -- of the form:
+      --
+      --   MirPlace (*T) <expr: **T> NoMeta
+      --
+      -- And we want to produce output of the form:
+      --
+      --   MirPlace T <expr': *T> NoMeta
+      --
+      -- Where *T is hand-wavy syntax for reference types (e.g., &T and
+      -- *const T). Note the double indirection in <expr: **T>.
+      --
+      -- Things get a little bit trickier when dealing with unsized types,
+      -- however. See the comments below.
+      case ty of
+          M.TyRef t _ -> doRef t
+          M.TyRawPtr t _ -> doRef t
+          CTyBox t -> doRef t
+          _ -> mirFail $ "deref not supported on " ++ show ty
+    SliceMeta {} -> unsupportedMeta
+    DynMeta {} -> unsupportedMeta
   where
+    unsupportedMeta :: MirGenerator h s ret a
+    unsupportedMeta = mirFail $ "deref not supported on " ++ show meta
+
     ptrBytes :: Word
     ptrBytes = fromIntegral (C.intValue (C.knownNat @SizeBits)) `div` 8
 

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -1791,6 +1791,10 @@ evalPlaceProj ty (MirPlace tpr ref meta) (M.Subslice fromIndex toIndex fromEnd) 
     mkLastIndex len
       | fromEnd = R.App (len `usizeSub` usize toIndex)
       | otherwise = usize toIndex
+evalPlaceProj _ _ (M.OpaqueCast {}) =
+    mirFail $ "evalPlaceProj: OpaqueCast not yet supported"
+evalPlaceProj _ _ (M.UnwrapUnsafeBinder {}) =
+    mirFail $ "evalPlaceProj: UnwrapUnsafeBinder not yet supported"
 
 --------------------------------------------------------------------------------------
 -- ** Statements

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -1524,7 +1524,8 @@ evalPlaceProj ::
   MirPlace s ->
   M.PlaceElem ->
   MirGenerator h s ret (MirPlace s)
-evalPlaceProj ty (MirPlace tpr ref NoMeta) M.Deref = do
+evalPlaceProj ty (MirPlace tpr ref meta) M.Deref
+  | NoMeta <- meta =
     -- In the general case (when T is a sized type), we have a MirPlace input of
     -- the form:
     --
@@ -1544,6 +1545,7 @@ evalPlaceProj ty (MirPlace tpr ref NoMeta) M.Deref = do
         M.TyRawPtr t _ -> doRef t
         CTyBox t -> doRef t
         _ -> mirFail $ "deref not supported on " ++ show ty
+  | otherwise = mirFail $ "deref not supported on " ++ show meta
   where
     ptrBytes :: Word
     ptrBytes = fromIntegral (C.intValue (C.knownNat @SizeBits)) `div` 8
@@ -1789,8 +1791,6 @@ evalPlaceProj ty (MirPlace tpr ref meta) (M.Subslice fromIndex toIndex fromEnd) 
     mkLastIndex len
       | fromEnd = R.App (len `usizeSub` usize toIndex)
       | otherwise = usize toIndex
-evalPlaceProj ty (MirPlace _ _ meta) proj =
-    mirFail $ "projection " ++ show proj ++ " not yet implemented for " ++ show (ty, meta)
 
 --------------------------------------------------------------------------------------
 -- ** Statements

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -206,8 +206,6 @@ transConstVal _ty (Some (C.RealValRepr)) (M.ConstFloat (M.FloatLit _ str)) =
                    return (MirExp C.RealValRepr (S.app $ E.RationalLit rat))
       []        -> mirFail $ "cannot parse float constant: " ++ show str
 
-transConstVal _ty _ (ConstInitializer funid) =
-    callExp funid []
 transConstVal _ty _ (ConstStaticRef did) =
     staticPlace did >>= addrOfPlace
 transConstVal ty _ ConstZST = initialValue ty >>= \case

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -2247,6 +2247,14 @@ transTerminatorKind M.Unreachable _tpos _tr = do
     G.reportError (S.litExpr "Unreachable!!!!!")
 transTerminatorKind M.InlineAsm _tpos _tr =
     mirFail "Inline assembly not supported"
+transTerminatorKind M.Yield _tpos _tr =
+    mirFail "Yield not supported"
+transTerminatorKind M.FalseEdge _tpos _tr =
+    mirFail "FalseEdge not supported"
+transTerminatorKind M.FalseUnwind _tpos _tr =
+    mirFail "FalseUnwind not supported"
+transTerminatorKind M.CoroutineDrop _tpos _tr =
+    mirFail "CoroutineDrop not supported"
 
 
 --- translation of toplevel glue ---

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -1354,18 +1354,6 @@ evalRval (M.Use op) = evalOperand op
 evalRval (M.Repeat op size) = buildRepeat op size
 evalRval (M.Ref _bk lv _) = evalPlace lv >>= addrOfPlace
 evalRval (M.AddressOf _mutbl lv) = evalPlace lv >>= addrOfPlace
-evalRval (M.Len lv) =
-    case M.typeOf lv of
-        M.TyArray _ len ->
-            return $ MirExp UsizeRepr $ R.App $ usizeLit $ fromIntegral len
-        ty@(M.TySlice _) -> do
-            place <- evalPlace lv
-            meta <- case place of
-                MirPlace _tpr _ref meta -> pure meta
-            case meta of
-                SliceMeta len -> return $ MirExp UsizeRepr len
-                _ -> mirFail $ "bad metadata " ++ show meta ++ " for reference to " ++ show ty
-        ty -> mirFail $ "don't know how to take Len of " ++ show ty
 evalRval (M.Cast ck op ty) = evalCast ck op ty
 evalRval (M.BinaryOp binop op1 op2) = transBinOp binop op1 op2
 evalRval (M.UnaryOp uop op) = transUnaryOp  uop op
@@ -1498,9 +1486,6 @@ evalRval (M.ThreadLocalRef did _) = staticPlace did >>= addrOfPlace
 
 -- We treat CopyForDeref(lv) the same as Rvalue::Use(Operand::Copy(lv)).
 evalRval (M.CopyForDeref lv) = evalLvalue lv
-
-evalRval (M.ShallowInitBox {}) = mirFail
-    "evalRval: ShallowInitBox not supported"
 
 evalTupleRval :: HasCallStack => Ty -> [Operand] -> MirGenerator h s ret (MirExp s)
 evalTupleRval tupleTy ops = do

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -1487,6 +1487,9 @@ evalRval (M.ThreadLocalRef did _) = staticPlace did >>= addrOfPlace
 -- We treat CopyForDeref(lv) the same as Rvalue::Use(Operand::Copy(lv)).
 evalRval (M.CopyForDeref lv) = evalLvalue lv
 
+evalRval (M.WrapUnsafeBinder {}) =
+    mirFail "evalRval: WrapUnsafeBinder not supported"
+
 evalTupleRval :: HasCallStack => Ty -> [Operand] -> MirGenerator h s ret (MirExp s)
 evalTupleRval tupleTy ops = do
   exps <- mapM evalOperand ops

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -1864,7 +1864,6 @@ transStatementKind (M.SetDiscriminant lv i) = do
     -- simultaneously), then we could remove AllocateEnum.
     ty -> mirFail $ "don't know how to set discriminant of " ++ show ty
 transStatementKind M.Nop = return ()
-transStatementKind M.Deinit = return ()
 transStatementKind (M.StmtIntrinsic ndi) =
     case ndi of
         -- rustc uses assumptions from `assume` to optimize code. If we
@@ -3073,7 +3072,7 @@ transVirtCall :: forall h.
 transVirtCall colState intrName' methName dynTraitName methIndex
   | Just methMH <- Map.lookup intrName' (colState ^. handleMap)
   , MirHandle _hname _hsig (methFH :: FH.FnHandle args ret) <- methMH = do
-      AssignUncons recvTpr argTprs <- case assignUncons (FH.handleArgTypes methFH) of 
+      AssignUncons recvTpr argTprs <- case assignUncons (FH.handleArgTypes methFH) of
         Right x -> return x
         Left _ -> die ["method handle has no arguments"]
       let retTpr = FH.handleReturnType methFH

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -1895,6 +1895,18 @@ transStatementKind (M.StmtIntrinsic ndi) =
 -- Per the docs, this statement kind is only useful in the const eval
 -- interpreter, so it is a no-op for crucible-mir's purposes.
 transStatementKind M.ConstEvalCounter = return ()
+transStatementKind M.FakeRead =
+    mirFail "FakeRead not supported"
+transStatementKind M.Retag =
+    mirFail "Retag not supported"
+transStatementKind M.PlaceMention =
+    mirFail "PlaceMention not supported"
+transStatementKind M.AscribeUserType =
+    mirFail "AscribeUserType not supported"
+transStatementKind M.Coverage =
+    mirFail "Coverage not supported"
+transStatementKind M.BackwardIncompatibleDropHint =
+    mirFail "BackwardIncompatibleDropHint not supported"
 
 -- | Add a new `BranchTransInfo` entry for the current function.  Returns the
 -- index of the new entry.

--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -295,6 +295,14 @@ tyToRepr col t0 = case t0 of
                                    , show (pretty t)
                                    ]
 
+  -- Not currently supported
+  M.TyError -> Left "TyError not supported"
+  M.TyInfer -> Left "TyInfer not supported"
+  M.TyBound -> Left "TyBound not supported"
+  M.TyPlaceholder -> Left "TyPlaceholder not supported"
+  M.TyCoroutineWitness -> Left "TyCoroutineWitness not supported"
+  M.TyAlias -> Left "TyAlias not supported"
+
 -- | If the provided type is unsized/dynamically-sized, return the
 -- representation of a _reference to_ that type; else, 'Nothing'.
 tyToUnsizedRefRepr :: TransTyConstraint => M.Collection -> M.Ty -> Maybe (Some C.TypeRepr)
@@ -583,6 +591,12 @@ canInitialize col ty = case ty of
     M.TyCoroutine {} -> False
     M.TyErased {} -> False
     M.TyInterned {} -> False
+    M.TyError {} -> False
+    M.TyInfer {} -> False
+    M.TyBound {} -> False
+    M.TyPlaceholder {} -> False
+    M.TyCoroutineWitness {} -> False
+    M.TyAlias {} -> False
 
 isUnsized :: M.Ty -> Bool
 isUnsized ty = case ty of
@@ -625,6 +639,12 @@ isZeroSized col = go
       M.TyCoroutine {} -> False
       M.TyErased {} -> False
       M.TyInterned {} -> False
+      M.TyError {} -> False
+      M.TyInfer {} -> False
+      M.TyBound {} -> False
+      M.TyPlaceholder {} -> False
+      M.TyCoroutineWitness {} -> False
+      M.TyAlias {} -> False
 
 
 -- | Get the "ABI-level" function arguments for @sig@, which determines the
@@ -2035,6 +2055,12 @@ initialValue (M.TyLifetime {}) = return Nothing
 initialValue (M.TyCoroutine {}) = return Nothing
 initialValue (M.TyErased {}) = return Nothing
 initialValue (M.TyInterned {}) = return Nothing
+initialValue (M.TyError {}) = return Nothing
+initialValue (M.TyInfer {}) = return Nothing
+initialValue (M.TyBound {}) = return Nothing
+initialValue (M.TyPlaceholder {}) = return Nothing
+initialValue (M.TyCoroutineWitness {}) = return Nothing
+initialValue (M.TyAlias {}) = return Nothing
 
 initialTupleValue ::
   HasCallStack => M.Ty -> MirGenerator h s ret (Maybe (MirExp s))

--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -185,7 +185,10 @@ data BVSize where
 tyToRepr :: TransTyConstraint => M.Collection -> M.Ty -> Either String (Some C.TypeRepr)
 tyToRepr col t0 = case t0 of
   CTyInt512 -> Right (Some (C.BVRepr (knownNat :: NatRepr 512)))
-  CTyBv (tyBvSize -> Just (BVSize w)) -> Right (Some (C.BVRepr w))
+  CTyBv sz ->
+    case tyBvSize sz of
+      Just (BVSize w) -> Right (Some (C.BVRepr w))
+      Nothing -> Left $ "unsupported: Unsupported Bv size: " ++ show (pretty sz)
   CTyVector t -> do
     Some repr <- tyToRepr col t
     return (Some (C.VectorRepr repr))
@@ -280,7 +283,17 @@ tyToRepr col t0 = case t0 of
   M.TyLifetime -> Right (Some C.AnyRepr)
   M.TyForeign -> Right (Some C.AnyRepr)
   M.TyErased -> Right (Some C.AnyRepr)
-  _ -> Left (unwords ["unknown type?", show t0])
+
+  -- TyConst only occurs in generic argument lists, so it is never the type of
+  -- a value at runtime. As such, it has no TypeRepr.
+  M.TyConst c -> Left $ unwords [ "standalone use of const generic type"
+                                , show (pretty c)
+                                ]
+
+  -- TyInterned should not occur after parsing.
+  M.TyInterned t -> Left $ unwords [ "Unexpected use of TyInterned"
+                                   , show (pretty t)
+                                   ]
 
 -- | If the provided type is unsized/dynamically-sized, return the
 -- representation of a _reference to_ that type; else, 'Nothing'.

--- a/crux-mir/CHANGELOG.md
+++ b/crux-mir/CHANGELOG.md
@@ -1,7 +1,7 @@
 # next
 
 This release supports [version
-11](https://github.com/GaloisInc/mir-json/blob/master/SCHEMA_CHANGELOG.md#11) of
+12](https://github.com/GaloisInc/mir-json/blob/master/SCHEMA_CHANGELOG.md#12) of
 `mir-json`'s schema.
 
 # 0.12 -- 2026-01-29

--- a/crux-mir/README.md
+++ b/crux-mir/README.md
@@ -49,7 +49,7 @@ Next, navigate to the `crucible/dependencies/mir-json` directory. Install
 [the `mir-json` README][mir-json-readme].
 
 Currently, `crux-mir` supports [version
-11](https://github.com/GaloisInc/mir-json/blob/master/SCHEMA_CHANGELOG.md#11) of
+12](https://github.com/GaloisInc/mir-json/blob/master/SCHEMA_CHANGELOG.md#12) of
 `mir-json`'s schema. Note that the schema versions produced by `mir-json` can
 change over time as dictated by internal requirements and upstream changes. To
 help smooth this over:


### PR DESCRIPTION
Also ensure that we are up to date with what `mir-json` does (and does not) generate. This involves removing several `Mir.Mir` constructors that `mir-json` no longer produces and adding new constructors for recently-added `mir-json`  nodes (but not going as far as translating them into Crucible).

Fixes #1864.