### PR TITLE
`crux-mir`: `symbolic_f{16,32,64,128}` overrides, `slice::fill` test case

### DIFF
--- a/crux-mir/src/Mir/Overrides.hs
+++ b/crux-mir/src/Mir/Overrides.hs
@@ -554,6 +554,10 @@ bindFn _symOnline _cs fn cfg =
             -> (ExplodedDefId, SomeTypedOverride (p sym) sym MIR)
     symb_bv edid n = (edid, SomeTypedOverride $ makeSymbolicVar (BaseBVRepr n))
 
+    symb_float :: ExplodedDefId
+               -> (ExplodedDefId, SomeTypedOverride (p sym) sym MIR)
+    symb_float edid = (edid, SomeTypedOverride $ makeSymbolicVar BaseRealRepr)
+
     overrides :: IsSymBackend sym bak'
               => bak'
               -> Map ExplodedDefId (SomeTypedOverride (p sym) sym MIR)
@@ -574,6 +578,10 @@ bindFn _symOnline _cs fn cfg =
                , symb_bv ["crucible", "bitvector", "make_symbolic_128"] (knownNat @128)
                , symb_bv ["crucible", "bitvector", "make_symbolic_256"] (knownNat @256)
                , symb_bv ["crucible", "bitvector", "make_symbolic_512"] (knownNat @512)
+               , symb_float ["crucible", "symbolic", "symbolic_f16"]
+               , symb_float ["crucible", "symbolic", "symbolic_f32"]
+               , symb_float ["crucible", "symbolic", "symbolic_f64"]
+               , symb_float ["crucible", "symbolic", "symbolic_f128"]
 
                , let argTys = (Empty :> BoolRepr :> strrepr :> strrepr :> u32repr :> u32repr)
                  in override ["crucible", "crucible_assert_impl"] argTys MirAggregateRepr $

--- a/crux-mir/test/conc_eval/slice/fill.rs
+++ b/crux-mir/test/conc_eval/slice/fill.rs
@@ -1,0 +1,22 @@
+fn slice_fill_test<T: Copy + PartialEq>(s: &mut [T], x: T) {
+    s.fill(x);
+    assert!(s.iter().all(|&y| x == y));
+}
+
+#[cfg_attr(crux, crux::test)]
+pub fn crux_test() {
+    slice_fill_test(&mut [0; 2], 1i8);
+    slice_fill_test(&mut [0; 2], 1i16);
+    slice_fill_test(&mut [0; 2], 1i32);
+    slice_fill_test(&mut [0; 2], 1i64);
+    slice_fill_test(&mut [0; 2], 1i128);
+    slice_fill_test(&mut [0; 2], 1u8);
+    slice_fill_test(&mut [0; 2], 1u16);
+    slice_fill_test(&mut [0; 2], 1u32);
+    slice_fill_test(&mut [0; 2], 1u64);
+    slice_fill_test(&mut [0; 2], 1u128);
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/symb_eval/concretize/assert.good
+++ b/crux-mir/test/symb_eval/concretize/assert.good
@@ -5,7 +5,7 @@ failures:
 
 ---- assert/<DISAMB>::crux_test[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:52:13: 59:14 !test/symb_eval/concretize/assert.rs:10:5: 10:81: error: in assert/<DISAMB>::crux_test[0]
+[Crux]   ./libs/crucible/lib.rs:54:13: 61:14 !test/symb_eval/concretize/assert.rs:10:5: 10:81: error: in assert/<DISAMB>::crux_test[0]
 [Crux]   MIR assertion at test/symb_eval/concretize/assert.rs:10:5:
 [Crux]   	100 + 157 == 1
 

--- a/crux-mir/test/symb_eval/concretize/assert_refs.good
+++ b/crux-mir/test/symb_eval/concretize/assert_refs.good
@@ -5,7 +5,7 @@ failures:
 
 ---- assert_refs/<DISAMB>::crux_test[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:52:13: 59:14 !test/symb_eval/concretize/assert_refs.rs:12:5: 12:67: error: in assert_refs/<DISAMB>::crux_test[0]
+[Crux]   ./libs/crucible/lib.rs:54:13: 61:14 !test/symb_eval/concretize/assert_refs.rs:12:5: 12:67: error: in assert_refs/<DISAMB>::crux_test[0]
 [Crux]   MIR assertion at test/symb_eval/concretize/assert_refs.rs:12:5:
 [Crux]   	42 42 [42] [42]
 

--- a/crux-mir/test/symb_eval/crux/early_fail.good
+++ b/crux-mir/test/symb_eval/crux/early_fail.good
@@ -14,7 +14,7 @@ failures:
 
 ---- early_fail/<DISAMB>::fail2[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/crux/early_fail.rs:17:5: 17:29: error: in early_fail/<DISAMB>::fail2[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/crux/early_fail.rs:17:5: 17:29: error: in early_fail/<DISAMB>::fail2[0]
 [Crux]   MIR assertion at test/symb_eval/crux/early_fail.rs:17:5:
 [Crux]   	x == 0
 

--- a/crux-mir/test/symb_eval/crux/fail_return.good
+++ b/crux-mir/test/symb_eval/crux/fail_return.good
@@ -12,7 +12,7 @@ failures:
 [Crux]   Context:
 [Crux]     test/symb_eval/crux/fail_return.rs:8:22: 8:27: fail_return/<DISAMB>::fail1[0]
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/crux/fail_return.rs:8:5: 8:32: error: in fail_return/<DISAMB>::fail1[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/crux/fail_return.rs:8:5: 8:32: error: in fail_return/<DISAMB>::fail1[0]
 [Crux]   MIR assertion at test/symb_eval/crux/fail_return.rs:8:5:
 [Crux]   	x + 1 > x
 
@@ -23,7 +23,7 @@ failures:
 [Crux]   Context:
 [Crux]     test/symb_eval/crux/fail_return.rs:15:22: 15:27: fail_return/<DISAMB>::fail2[0]
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/crux/fail_return.rs:15:5: 15:32: error: in fail_return/<DISAMB>::fail2[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/crux/fail_return.rs:15:5: 15:32: error: in fail_return/<DISAMB>::fail2[0]
 [Crux]   MIR assertion at test/symb_eval/crux/fail_return.rs:15:5:
 [Crux]   	x + 1 > x
 

--- a/crux-mir/test/symb_eval/crux/mixed_fail.good
+++ b/crux-mir/test/symb_eval/crux/mixed_fail.good
@@ -16,7 +16,7 @@ failures:
 [Crux]   Context:
 [Crux]     test/symb_eval/crux/mixed_fail.rs:8:22: 8:27: mixed_fail/<DISAMB>::fail1[0]
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/crux/mixed_fail.rs:8:5: 8:32: error: in mixed_fail/<DISAMB>::fail1[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/crux/mixed_fail.rs:8:5: 8:32: error: in mixed_fail/<DISAMB>::fail1[0]
 [Crux]   MIR assertion at test/symb_eval/crux/mixed_fail.rs:8:5:
 [Crux]   	x + 1 > x
 
@@ -27,7 +27,7 @@ failures:
 [Crux]   Context:
 [Crux]     test/symb_eval/crux/mixed_fail.rs:14:22: 14:27: mixed_fail/<DISAMB>::fail2[0]
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/crux/mixed_fail.rs:14:5: 14:32: error: in mixed_fail/<DISAMB>::fail2[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/crux/mixed_fail.rs:14:5: 14:32: error: in mixed_fail/<DISAMB>::fail2[0]
 [Crux]   MIR assertion at test/symb_eval/crux/mixed_fail.rs:14:5:
 [Crux]   	x + 2 > x
 

--- a/crux-mir/test/symb_eval/crux/multi.good
+++ b/crux-mir/test/symb_eval/crux/multi.good
@@ -14,7 +14,7 @@ failures:
 [Crux]   Context:
 [Crux]     test/symb_eval/crux/multi.rs:8:22: 8:27: multi/<DISAMB>::fail1[0]
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/crux/multi.rs:8:5: 8:32: error: in multi/<DISAMB>::fail1[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/crux/multi.rs:8:5: 8:32: error: in multi/<DISAMB>::fail1[0]
 [Crux]   MIR assertion at test/symb_eval/crux/multi.rs:8:5:
 [Crux]   	x + 1 > x
 
@@ -27,7 +27,7 @@ failures:
 
 ---- multi/<DISAMB>::fail3[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/crux/multi.rs:20:5: 20:29: error: in multi/<DISAMB>::assert_zero[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/crux/multi.rs:20:5: 20:29: error: in multi/<DISAMB>::assert_zero[0]
 [Crux]   MIR assertion at test/symb_eval/crux/multi.rs:20:5:
 [Crux]   	x == 0
 

--- a/crux-mir/test/symb_eval/crypto/bytes.good
+++ b/crux-mir/test/symb_eval/crypto/bytes.good
@@ -5,23 +5,23 @@ failures:
 
 ---- bytes/<DISAMB>::f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/crypto/bytes.rs:85:7: 85:37: error: in bytes/<DISAMB>::f[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/crypto/bytes.rs:85:7: 85:37: error: in bytes/<DISAMB>::f[0]
 [Crux]   MIR assertion at test/symb_eval/crypto/bytes.rs:85:7:
 [Crux]   	a[i] == b[i]
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/crypto/bytes.rs:85:7: 85:37: error: in bytes/<DISAMB>::f[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/crypto/bytes.rs:85:7: 85:37: error: in bytes/<DISAMB>::f[0]
 [Crux]   MIR assertion at test/symb_eval/crypto/bytes.rs:85:7:
 [Crux]   	a[i] == b[i]
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/crypto/bytes.rs:85:7: 85:37: error: in bytes/<DISAMB>::f[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/crypto/bytes.rs:85:7: 85:37: error: in bytes/<DISAMB>::f[0]
 [Crux]   MIR assertion at test/symb_eval/crypto/bytes.rs:85:7:
 [Crux]   	a[i] == b[i]
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/crypto/bytes.rs:85:7: 85:37: error: in bytes/<DISAMB>::f[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/crypto/bytes.rs:85:7: 85:37: error: in bytes/<DISAMB>::f[0]
 [Crux]   MIR assertion at test/symb_eval/crypto/bytes.rs:85:7:
 [Crux]   	a[i] == b[i]
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/crypto/bytes.rs:85:7: 85:37: error: in bytes/<DISAMB>::f[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/crypto/bytes.rs:85:7: 85:37: error: in bytes/<DISAMB>::f[0]
 [Crux]   MIR assertion at test/symb_eval/crypto/bytes.rs:85:7:
 [Crux]   	a[i] == b[i]
 

--- a/crux-mir/test/symb_eval/float/symbolic.good
+++ b/crux-mir/test/symb_eval/float/symbolic.good
@@ -1,0 +1,8 @@
+test symbolic/<DISAMB>::f128_test[0]: returned Symbolic real, ok
+test symbolic/<DISAMB>::f16_test[0]: returned Symbolic real, ok
+test symbolic/<DISAMB>::f32_test[0]: returned Symbolic real, ok
+test symbolic/<DISAMB>::f64_test[0]: returned Symbolic real, ok
+
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
+[Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/float/symbolic.rs
+++ b/crux-mir/test/symb_eval/float/symbolic.rs
@@ -1,0 +1,31 @@
+#![feature(f16)]
+#![feature(f128)]
+
+extern crate crucible;
+use crucible::*;
+
+fn symbolic_test<S: PartialEq + Symbolic>() -> S {
+    let x = S::symbolic("x");
+    crucible_assert!(x == x);
+    x
+}
+
+#[crux::test]
+fn f16_test() -> f16 {
+    symbolic_test()
+}
+
+#[crux::test]
+fn f32_test() -> f32 {
+    symbolic_test()
+}
+
+#[crux::test]
+fn f64_test() -> f64 {
+    symbolic_test()
+}
+
+#[crux::test]
+fn f128_test() -> f128 {
+    symbolic_test()
+}

--- a/crux-mir/test/symb_eval/overrides/bad_symb1.good
+++ b/crux-mir/test/symb_eval/overrides/bad_symb1.good
@@ -5,11 +5,11 @@ failures:
 
 ---- bad_symb1/<DISAMB>::crux_test[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/symbolic.rs:29:50: 29:61 !./libs/crucible/symbolic.rs:35:1: 42:2: error: in crucible/<DISAMB>::symbolic[0]::{impl#5}[0]::symbolic[0]
+[Crux]   ./libs/crucible/symbolic.rs:29:50: 29:61 !./libs/crucible/symbolic.rs:35:1: 46:2: error: in crucible/<DISAMB>::symbolic[0]::{impl#7}[0]::symbolic[0]
 [Crux]   symbolic variable name must be a concrete string
 [Crux]   Context:
 [Crux]     internal: crucible/<DISAMB>::symbolic[0]::symbolic_u8[0]
-[Crux]     ./libs/crucible/symbolic.rs:29:50: 29:61 !./libs/crucible/symbolic.rs:35:1: 42:2: crucible/<DISAMB>::symbolic[0]::{impl#5}[0]::symbolic[0]
+[Crux]     ./libs/crucible/symbolic.rs:29:50: 29:61 !./libs/crucible/symbolic.rs:35:1: 46:2: crucible/<DISAMB>::symbolic[0]::{impl#7}[0]::symbolic[0]
 [Crux]     test/symb_eval/overrides/bad_symb1.rs:7:13: 7:28: bad_symb1/<DISAMB>::crux_test[0]
 
 [Crux-MIR] ---- FINAL RESULTS ----

--- a/crux-mir/test/symb_eval/overrides/bad_symb2.good
+++ b/crux-mir/test/symb_eval/overrides/bad_symb2.good
@@ -5,11 +5,11 @@ failures:
 
 ---- bad_symb2/<DISAMB>::crux_test[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/symbolic.rs:29:50: 29:61 !./libs/crucible/symbolic.rs:35:1: 42:2: error: in crucible/<DISAMB>::symbolic[0]::{impl#5}[0]::symbolic[0]
+[Crux]   ./libs/crucible/symbolic.rs:29:50: 29:61 !./libs/crucible/symbolic.rs:35:1: 46:2: error: in crucible/<DISAMB>::symbolic[0]::{impl#7}[0]::symbolic[0]
 [Crux]   invalid symbolic variable name "\NUL:., /": Identifier must start with a letter.
 [Crux]   Context:
 [Crux]     internal: crucible/<DISAMB>::symbolic[0]::symbolic_u8[0]
-[Crux]     ./libs/crucible/symbolic.rs:29:50: 29:61 !./libs/crucible/symbolic.rs:35:1: 42:2: crucible/<DISAMB>::symbolic[0]::{impl#5}[0]::symbolic[0]
+[Crux]     ./libs/crucible/symbolic.rs:29:50: 29:61 !./libs/crucible/symbolic.rs:35:1: 46:2: crucible/<DISAMB>::symbolic[0]::{impl#7}[0]::symbolic[0]
 [Crux]     test/symb_eval/overrides/bad_symb2.rs:6:13: 6:36: bad_symb2/<DISAMB>::crux_test[0]
 
 [Crux-MIR] ---- FINAL RESULTS ----

--- a/crux-mir/test/symb_eval/overrides/override2.good
+++ b/crux-mir/test/symb_eval/overrides/override2.good
@@ -5,7 +5,7 @@ failures:
 
 ---- override2/<DISAMB>::f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/overrides/override2.rs:9:5: 9:49: error: in override2/<DISAMB>::f[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/overrides/override2.rs:9:5: 9:49: error: in override2/<DISAMB>::f[0]
 [Crux]   MIR assertion at test/symb_eval/overrides/override2.rs:9:5:
 [Crux]   	foo.wrapping_add(1) == foo
 

--- a/crux-mir/test/symb_eval/overrides/override5.good
+++ b/crux-mir/test/symb_eval/overrides/override5.good
@@ -5,7 +5,7 @@ failures:
 
 ---- override5/<DISAMB>::f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/overrides/override5.rs:10:5: 10:47: error: in override5/<DISAMB>::f[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/overrides/override5.rs:10:5: 10:47: error: in override5/<DISAMB>::f[0]
 [Crux]   MIR assertion at test/symb_eval/overrides/override5.rs:10:5:
 [Crux]   	foo.wrapping_add(1) != 0
 

--- a/crux-mir/test/symb_eval/sym_bytes/construct.good
+++ b/crux-mir/test/symb_eval/sym_bytes/construct.good
@@ -5,7 +5,7 @@ failures:
 
 ---- construct/<DISAMB>::crux_test[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/sym_bytes/construct.rs:13:5: 13:35: error: in construct/<DISAMB>::crux_test[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/sym_bytes/construct.rs:13:5: 13:35: error: in construct/<DISAMB>::crux_test[0]
 [Crux]   MIR assertion at test/symb_eval/sym_bytes/construct.rs:13:5:
 [Crux]   	sym2[0] == 0
 


### PR DESCRIPTION
This bumps the `mir-json` submodule to bring in the changes from https://github.com/GaloisInc/mir-json/pull/303 and https://github.com/GaloisInc/mir-json/pull/300 and adds corresponding test cases. The former change requires adding `crux-mir` overrides to support the newly added `symbolic_f{16,32,64,128}` functions.