### PR TITLE
`{crucible,crux}-mir`: Improve handling of floating point

### DIFF
--- a/crucible-concurrency/src/Cruces/ExploreCrux.hs
+++ b/crucible-concurrency/src/Cruces/ExploreCrux.hs
@@ -131,13 +131,13 @@ exploreCallback :: forall alg st.
   Crux.SimulatorCallbacks Crux.CruxLogMessage st Crux.Types.CruxSimulationResult
 exploreCallback cruxOpts ha outh mkSym =
   Crux.withCruxLogMessage $
-  Crux.SimulatorCallbacks $
+  Crux.SimulatorCallbacks $ \_fm ->
     return $
       Crux.SimulatorHooks
         { Crux.setupHook =
             \bak symOnline ->
               do (mainHdl, prims, globs, fns) <- mkSym bak
-                 p <- mkCruxPersonality 
+                 p <- mkCruxPersonality
                  let simCtx = initSimContext bak emptyIntrinsicTypes ha outh fns emptyExtensionImpl p
                      st0  = InitialState simCtx emptyGlobals defaultAbortHandler C.UnitRepr $
                                 runOverrideSim

--- a/crucible-go/tool/Main.hs
+++ b/crucible-go/tool/Main.hs
@@ -56,7 +56,7 @@ simulateGo ::
   GoOptions ->
   Crux.SimulatorCallbacks msgs st Crux.CruxSimulationResult
 simulateGo copts _opts =
-  Crux.SimulatorCallbacks $
+  Crux.SimulatorCallbacks $ \_fm ->
     return $
       Crux.SimulatorHooks
         { Crux.setupHook =

--- a/crucible-jvm/tool/Main.hs
+++ b/crucible-jvm/tool/Main.hs
@@ -192,7 +192,7 @@ instance Debug.HasContext (CruxJVM sym) Void sym JVM UnitType where
 
 simulateJVM :: Crux.CruxOptions -> JVMOptions -> Crux.SimulatorCallbacks msgs st Crux.CruxSimulationResult
 simulateJVM copts opts =
-  Crux.SimulatorCallbacks $
+  Crux.SimulatorCallbacks $ \_fm ->
     return $
       Crux.SimulatorHooks
         { Crux.setupHook =

--- a/crucible-mir/CHANGELOG.md
+++ b/crucible-mir/CHANGELOG.md
@@ -44,6 +44,9 @@ This release supports [version
   from/writing to references.
 * Remove the `mirRef_aggregateAsChunks*` family of intrinsics. The flattened
   aggregate representation is rich enough that these became no-ops.
+* Change the Crucible representation of floating-point types (e.g., `f32` and
+  `f64`) from `RealValType` to `FloatType`, the latter of which is more suited
+  to IEEE 754 floats.
 
 # 0.6 -- 2026-01-29
 

--- a/crucible-mir/crucible-mir.cabal
+++ b/crucible-mir/crucible-mir.cabal
@@ -124,6 +124,7 @@ library
                  parameterized-utils >= 2.3,
                  containers,
                  indexed-traversable,
+                 libBF,
                  microlens,
                  microlens-ghc,
                  microlens-mtl,

--- a/crucible-mir/src/Mir/GenericOps.hs
+++ b/crucible-mir/src/Mir/GenericOps.hs
@@ -29,6 +29,7 @@ import Data.Text (Text)
 import Data.Vector(Vector)
 import qualified Data.Vector as V
 import Data.Word (Word64)
+import LibBF (BigFloat)
 
 import Mir.DefId
 import Mir.Mir
@@ -158,6 +159,9 @@ instance GenericOps Text    where
 
 instance GenericOps B.ByteString where
    uninternTys = const id
+
+instance GenericOps BigFloat where
+  uninternTys = const id
 
 instance GenericOps b => GenericOps (Map.Map a b) where
    uninternTys f     = Map.map (uninternTys f)

--- a/crucible-mir/src/Mir/JSON.hs
+++ b/crucible-mir/src/Mir/JSON.hs
@@ -25,6 +25,9 @@ import qualified Data.Text as T
 import qualified Data.Text.Read  as T
 import Data.Word (Word64)
 import Lens.Micro ((^.))
+import LibBF (BigFloat)
+import qualified LibBF as BF
+import qualified What4.Utils.FloatHelpers as W4
 
 #if MIN_VERSION_aeson(2,0,0)
 import qualified Data.Aeson.Key as K (Key)
@@ -562,14 +565,14 @@ instance FromJSON ConstVal where
 
         Just (String "float") -> do
             size :: Int <- v .: "size"
-            val <- v .: "val"
             fk <- case size of
                 2 -> pure F16
                 4 -> pure F32
                 8 -> pure F64
                 16 -> pure F128
                 _ -> fail $ "bad size " ++ show size ++ " for float literal"
-            pure $ ConstFloat $ FloatLit fk (T.unpack val)
+            val <- convertFloatText fk =<< v .: "val"
+            pure $ ConstFloat $ FloatLit fk val
 
         Just (String "slice") -> do
             def_id <- v .: "def_id"
@@ -633,6 +636,31 @@ convertIntegerText t = do
   case (T.signed T.decimal) t of
     Right ((i :: Integer), _) -> return i
     Left _       -> fail $ "Cannot parse Integer value: " ++ T.unpack t
+
+-- mir-json floats are expressed as strings. The exact schema that is used for
+-- string formatting is hard to describe succintly, but if you want to learn
+-- the details, refer to the Display instance for the IeeeFloat type in rustc
+-- (https://docs.rs/rustc_apfloat/0.2.3+llvm-462a31f5a5ab/rustc_apfloat/ieee/struct.IeeeFloat.html).
+-- Some highlights are:
+--
+-- - NaN values are represented as "NaN"
+-- - Infinite values are represented as "+Inf" and "-Inf"
+-- - Other values are represented in decimal notation (e.g., "1.23")
+--
+-- As it turns out, LibBF's 'bfFromString' function is capable of parsing this
+-- format, so we use it below.
+--
+-- One downside to using 'bfFromString' is that it doesn't give an error if it
+-- finds a string that doesn't clearly correspond to a float value. Instead, it
+-- will just return NaN as a default value. This is arguably more permissive
+-- than we would like, so we may want to consider writing our own parser that
+-- is stricter if the current one proves insufficient.
+convertFloatText :: FloatKind -> Text -> Aeson.Parser BigFloat
+convertFloatText fk t =
+    pure $
+    W4.bfStatus $
+    BF.bfFromString 10 (floatKindBFOpts fk BF.NearEven) $
+    T.unpack t
 
 
 instance FromJSON AggregateKind where

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -36,6 +36,8 @@ import Data.Set (Set)
 import Data.Text (Text)
 import Data.Word (Word64)
 import Lens.Micro.TH (makeLenses)
+import LibBF (BFOpts, BigFloat, RoundMode)
+import qualified LibBF as BF
 
 import GHC.Generics
 
@@ -71,6 +73,17 @@ data FloatKind
   | F64
   | F128
   deriving (Eq, Ord, Show, Generic)
+
+floatKindBFOpts :: FloatKind -> RoundMode -> BFOpts
+floatKindBFOpts fk rm = opts rm <> BF.allowSubnormal
+  where
+    opts :: RoundMode -> BF.BFOpts
+    opts =
+      case fk of
+        F16 -> BF.float16
+        F32 -> BF.float32
+        F64 -> BF.float64
+        F128 -> BF.float128
 
 -- | Type parameters
 newtype Substs = Substs [Ty]
@@ -646,7 +659,7 @@ data IntLit
   deriving (Eq, Ord, Show, Generic)
 
 data FloatLit
-  = FloatLit FloatKind String
+  = FloatLit FloatKind BigFloat
   deriving (Eq, Ord, Show, Generic)
 
 

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -48,6 +48,7 @@ import Control.Monad.Writer
 import Lens.Micro ((^.), (^?), (%~), ix, to)
 import Lens.Micro.GHC (at)
 import Lens.Micro.Mtl (use, (.=), (%=))
+import qualified LibBF as BF
 
 import Data.Bits (shift, shiftL)
 import qualified Data.ByteString as BS
@@ -68,6 +69,7 @@ import Data.String (fromString)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Traversable as Trav
+import GHC.Float (double2Float)
 import Numeric
 import Numeric.Natural()
 
@@ -78,6 +80,7 @@ import qualified Lang.Crucible.CFG.Generator as G
 import qualified Lang.Crucible.FunctionHandle as FH
 import qualified What4.ProgramLoc as PL
 import qualified What4.FunctionName as FN
+import qualified What4.Utils.FloatHelpers as W4
 import qualified What4.Utils.StringLiteral as W4
 import qualified Lang.Crucible.CFG.Reg as R
 import qualified Lang.Crucible.CFG.SSAConversion as SSA
@@ -200,11 +203,59 @@ transConstVal tupleTy@(M.TyClosure _) (Some MirAggregateRepr) (M.ConstClosure up
 transConstVal tupleTy@(M.TyCoroutineClosure _) (Some MirAggregateRepr) (M.ConstCoroutineClosure upvar_vals) =
     transConstTuple tupleTy upvar_vals
 
-transConstVal _ty (Some (C.RealValRepr)) (M.ConstFloat (M.FloatLit _ str)) =
-    case reads str of
-      (d , _):_ -> let rat = toRational (d :: Double) in
-                   return (MirExp C.RealValRepr (S.app $ E.RationalLit rat))
-      []        -> mirFail $ "cannot parse float constant: " ++ show str
+transConstVal _ty (Some (C.FloatRepr fi)) (M.ConstFloat (M.FloatLit fk bf)) =
+    case fk of
+      -- F32 and F64 literals can be constructed directly with Crucible's
+      -- FloatLit and DoubleLit constructors.
+      F32
+        | C.SingleFloatRepr <- fi ->
+          pure $ MirExp (C.FloatRepr fi)
+               $ S.app
+               $ E.FloatLit
+                 -- NB: Use GHC.Float.double2Float to convert from a Double to
+                 -- Float, as this is careful to preserve special values like
+                 -- NaN and infinity. (It does not necessarily preserve NaN
+                 -- payloads, but SMT solvers don't model these anyway.)
+               $ double2Float
+               $ W4.bfStatus
+               $ BF.bfToDouble BF.NearEven bf
+        | otherwise -> die
+      F64
+        | C.DoubleFloatRepr <- fi ->
+          pure $ MirExp (C.FloatRepr fi)
+               $ S.app
+               $ E.DoubleLit
+               $ W4.bfStatus
+               $ BF.bfToDouble BF.NearEven bf
+        | otherwise -> die
+      -- F16 and F128 literals do not have direct counterparts in Crucible's
+      -- expression language, so we first convert the values to bits and then
+      -- construct corresponding floating-point values using FloatFromBinary.
+      -- This won't look as nice if you pretty-print the Crucible CFG, but we
+      -- expect F16 and F128 to be rare in practice.
+      F16
+        | C.HalfFloatRepr <- fi ->
+          pure $ MirExp (C.FloatRepr fi)
+               $ S.app
+               $ E.FloatFromBinary fi
+               $ S.app
+               $ eBVLit knownNat
+               $ BF.bfToBits (floatKindBFOpts fk BF.NearEven) bf
+        | otherwise -> die
+      F128
+        | C.QuadFloatRepr <- fi ->
+          pure $ MirExp (C.FloatRepr fi)
+               $ S.app
+               $ E.FloatFromBinary fi
+               $ S.app
+               $ eBVLit knownNat
+               $ BF.bfToBits (floatKindBFOpts fk BF.NearEven) bf
+        | otherwise -> die
+  where
+    die :: a
+    die = panic
+            "transConstVal"
+            [ "Unexpected FloatInfoRepr for " ++ show fk ++ ": " ++ show fi ]
 
 transConstVal _ty _ (ConstStaticRef did) =
     staticPlace did >>= addrOfPlace
@@ -628,21 +679,22 @@ evalBinOp bop mat me1 me2 =
             M.Lt  -> return (MirExp C.BoolRepr (S.app (E.And (S.app (E.Not e1)) e2)), noOverflow)
             M.Le  -> return (MirExp C.BoolRepr (S.app (E.Or  (S.app (E.Not e1)) e2)), noOverflow)
             _ -> mirFail $ "No translation for bool binop: " ++ fmt bop
-      (MirExp C.RealValRepr e1, MirExp C.RealValRepr e2) ->
+      (MirExp (C.FloatRepr fi1) e1, MirExp (C.FloatRepr fi2) e2)
+        | Just Refl <- testEquality fi1 fi2 ->
           case bop of
-            M.Beq -> return (MirExp C.BoolRepr (S.app $ E.RealEq e1 e2), noOverflow)
-            M.Lt -> return (MirExp C.BoolRepr (S.app $ E.RealLt e1 e2), noOverflow)
-            M.Le -> return (MirExp C.BoolRepr (S.app $ E.RealLe e1 e2), noOverflow)
-            M.Gt -> return (MirExp C.BoolRepr (S.app $ E.RealLt e2 e1), noOverflow)
-            M.Ge -> return (MirExp C.BoolRepr (S.app $ E.RealLe e2 e1), noOverflow)
-            M.Ne -> return (MirExp C.BoolRepr (S.app $ E.Not $ S.app $ E.RealEq e1 e2), noOverflow)
+            M.Beq -> return (MirExp C.BoolRepr (S.app $ E.FloatFpEq e1 e2), noOverflow)
+            M.Lt -> return (MirExp C.BoolRepr (S.app $ E.FloatLt e1 e2), noOverflow)
+            M.Le -> return (MirExp C.BoolRepr (S.app $ E.FloatLe e1 e2), noOverflow)
+            M.Gt -> return (MirExp C.BoolRepr (S.app $ E.FloatLt e2 e1), noOverflow)
+            M.Ge -> return (MirExp C.BoolRepr (S.app $ E.FloatLe e2 e1), noOverflow)
+            M.Ne -> return (MirExp C.BoolRepr (S.app $ E.Not $ S.app $ E.FloatFpEq e1 e2), noOverflow)
 
             -- Binops on floats never set the overflow flag
-            M.Add -> return (MirExp C.RealValRepr (S.app $ E.RealAdd e1 e2), noOverflow)
-            M.Sub -> return (MirExp C.RealValRepr (S.app $ E.RealSub e1 e2), noOverflow)
-            M.Mul -> return (MirExp C.RealValRepr (S.app $ E.RealMul e1 e2), noOverflow)
-            M.Div -> return (MirExp C.RealValRepr (S.app $ E.RealDiv e1 e2), noOverflow)
-            M.Rem -> return (MirExp C.RealValRepr (S.app $ E.RealMod e1 e2), noOverflow)
+            M.Add -> return (MirExp (C.FloatRepr fi1) (S.app $ E.FloatAdd fi1 E.RNE e1 e2), noOverflow)
+            M.Sub -> return (MirExp (C.FloatRepr fi1) (S.app $ E.FloatSub fi1 E.RNE e1 e2), noOverflow)
+            M.Mul -> return (MirExp (C.FloatRepr fi1) (S.app $ E.FloatMul fi1 E.RNE e1 e2), noOverflow)
+            M.Div -> return (MirExp (C.FloatRepr fi1) (S.app $ E.FloatDiv fi1 E.RNE e1 e2), noOverflow)
+            M.Rem -> return (MirExp (C.FloatRepr fi1) (S.app $ E.FloatRem fi1 e1 e2), noOverflow)
 
             _ -> mirFail $ "No translation for real number binop: " ++ fmt bop
 
@@ -730,7 +782,7 @@ transUnaryOp uop op = do
       (M.Not, MirExp (C.BVRepr n) e) -> return $ MirExp (C.BVRepr n) $ S.app $ E.BVNot n e
       (M.Neg, MirExp (C.BVRepr n) e) -> return $ MirExp (C.BVRepr n) (S.app $ E.BVSub n (S.app $ eBVLit n 0) e)
       (M.Neg, MirExp C.IntegerRepr e) -> return $ MirExp C.IntegerRepr $ S.app $ E.IntNeg e
-      (M.Neg, MirExp C.RealValRepr e) -> return $ MirExp C.RealValRepr $ S.app $ E.RealNeg e
+      (M.Neg, MirExp (C.FloatRepr fi) e) -> return $ MirExp (C.FloatRepr fi) $ S.app $ E.FloatNeg fi e
       (M.PtrMetadata, MirExp MirSliceRepr e) -> return $ MirExp UsizeRepr $ getSliceLen e
       (_ , MirExp ty _) -> mirFail $ "Unimplemented unary op `" ++ fmt uop ++ "' for " ++ show ty
 

--- a/crucible-mir/src/Mir/TransTy.hs
+++ b/crucible-mir/src/Mir/TransTy.hs
@@ -252,7 +252,12 @@ tyToRepr col t0 = case t0 of
         Right (Some MirAggregateRepr)
   M.TyDowncast _adt _i   -> Right (Some C.AnyRepr)
 
-  M.TyFloat _ -> Right (Some C.RealValRepr)
+  M.TyFloat fk ->
+    case fk of
+      M.F16 -> Right $ Some $ C.FloatRepr C.HalfFloatRepr
+      M.F32 -> Right $ Some $ C.FloatRepr C.SingleFloatRepr
+      M.F64 -> Right $ Some $ C.FloatRepr C.DoubleFloatRepr
+      M.F128 -> Right $ Some $ C.FloatRepr C.QuadFloatRepr
 
   -- Function types go to FunctionHandleRepr.  `RustCall` functions get special
   -- handling in `abiFnArgs`.

--- a/crucible-wasm/src/Lang/Crucible/Wasm/Main.hs
+++ b/crucible-wasm/src/Lang/Crucible/Wasm/Main.hs
@@ -89,7 +89,7 @@ simulateWasm ::
   WasmOptions ->
   Crux.SimulatorCallbacks msgs st Crux.Types.CruxSimulationResult
 simulateWasm cruxOpts _wasmOpts =
-  Crux.SimulatorCallbacks $
+  Crux.SimulatorCallbacks $ \_fm ->
     return $
       Crux.SimulatorHooks
         { Crux.setupHook =

--- a/crux-llvm/src/Crux/LLVM/Simulate.hs
+++ b/crux-llvm/src/Crux/LLVM/Simulate.hs
@@ -195,7 +195,7 @@ simulateLLVMFile ::
   LLVMOptions ->
   Crux.SimulatorCallbacks msgs st Crux.Types.CruxSimulationResult
 simulateLLVMFile llvm_file llvmOpts =
-  Crux.SimulatorCallbacks $
+  Crux.SimulatorCallbacks $ \_fm ->
     do bbMapRef <- newIORef (Map.empty :: LLVMAnnMap sym)
        let ?recordLLVMAnnotation =
              \callStack an bb ->

--- a/crux-mir/CHANGELOG.md
+++ b/crux-mir/CHANGELOG.md
@@ -4,6 +4,9 @@ This release supports [version
 12](https://github.com/GaloisInc/mir-json/blob/master/SCHEMA_CHANGELOG.md#12) of
 `mir-json`'s schema.
 
+* Float-typed results (e.g., `f32`s or `f64`s) in `crux::test`s now display as
+  IEEE-754 floats instead of as rationals.
+
 # 0.12 -- 2026-01-29
 
 This release supports [version

--- a/crux-mir/src/Mir/Language.hs
+++ b/crux-mir/src/Mir/Language.hs
@@ -368,7 +368,7 @@ runTestsWithExtraOverrides initS bindExtra (cruxOpts, mirOpts) = do
             }
 
     let simCallbacks fnName =
-          Crux.SimulatorCallbacks $
+          Crux.SimulatorCallbacks $ \_fm ->
             return $
               Crux.SimulatorHooks
                 { Crux.setupHook =

--- a/crux-mir/src/Mir/Language.hs
+++ b/crux-mir/src/Mir/Language.hs
@@ -220,7 +220,7 @@ runTestsWithExtraOverrides initS bindExtra (cruxOpts, mirOpts) = do
             Nothing -> C.ECCLimited 10
             Just (Left err) -> error err
             Just (Right config) -> config
-            
+
     let (filename, nameFilter) = case cargoTestFile mirOpts of
             -- This case is terrible a hack.  The goal is to mimic the behavior
             -- of the test binaries produced by `cargo test`, which take a test
@@ -299,15 +299,16 @@ runTestsWithExtraOverrides initS bindExtra (cruxOpts, mirOpts) = do
     -- for tests that failed.
 
     let ?bound = 0
-    let simTestBody :: forall sym bak p t fs.
+    let simTestBody :: forall sym bak p t fm.
             ( C.IsSymBackend sym bak
-            , sym ~ W4.ExprBuilder t st fs
+            , sym ~ W4.ExprBuilder t st (W4.Flags fm)
             ) =>
             bak ->
+            W4.FloatModeRepr fm ->
             Maybe (Crux.SomeOnlineSolver sym bak) ->
             DefId ->
             Fun p sym MIR Ctx.EmptyCtx C.UnitType
-        simTestBody bak symOnline fnName =
+        simTestBody bak fm symOnline fnName =
           do linkOverrides symOnline
              _ <- C.callCFG staticInitCfg C.emptyRegMap
 
@@ -332,11 +333,11 @@ runTestsWithExtraOverrides initS bindExtra (cruxOpts, mirOpts) = do
              -- TODO: think about if/how to present this information when concurrency
              -- is enabled.
              when (not (concurrency mirOpts) && printResultOnly mirOpts) $ do
-                 str <- showRegEntry (C.backendGetSym bak) col resTy res
+                 str <- showRegEntry (C.backendGetSym bak) fm col resTy res
                  liftIO $ outputLn str
 
              when (not (concurrency mirOpts) && not (printResultOnly mirOpts) && resTy /= TyTuple []) $ do
-                 str <- showRegEntry (C.backendGetSym bak) col resTy res
+                 str <- showRegEntry (C.backendGetSym bak) fm col resTy res
                  liftIO $ output $ "returned " ++ str ++ ", "
 
     let printTest :: DefId -> Fun p sym ext args C.UnitType
@@ -344,36 +345,37 @@ runTestsWithExtraOverrides initS bindExtra (cruxOpts, mirOpts) = do
           when (not $ printResultOnly mirOpts) $
             liftIO $ output $ "test " ++ show fnName ++ ": "
 
-    let simTest :: forall sym bak t fs.
+    let simTest :: forall sym bak t fm.
             ( C.IsSymBackend sym bak
-            , sym ~ W4.ExprBuilder t st fs
+            , sym ~ W4.ExprBuilder t st (W4.Flags fm)
             , Logs msgs
             , Log.SupportsCruxLogMessage msgs
             , Log.SupportsMirLogMessage msgs
             ) =>
             bak ->
+            W4.FloatModeRepr fm ->
             Maybe (Crux.SomeOnlineSolver sym bak) ->
             DefId ->
             SomeTestOvr DPOR sym Ctx.EmptyCtx C.UnitType
-        simTest bak symOnline fnName
+        simTest bak fm symOnline fnName
           | concurrency mirOpts = SomeTestOvr
             { testOvr = do printTest fnName
-                           exploreOvr bak symOnline cruxOpts $ simTestBody bak symOnline fnName
+                           exploreOvr bak symOnline cruxOpts $ simTestBody bak fm symOnline fnName
             , testFeatures = [scheduleFeature @_ @DPOR mirExplorePrimitives []]
             }
           | otherwise = SomeTestOvr
             { testOvr = do printTest fnName
-                           simTestBody bak symOnline fnName
+                           simTestBody bak fm symOnline fnName
             , testFeatures = []
             }
 
     let simCallbacks fnName =
-          Crux.SimulatorCallbacks $ \_fm ->
+          Crux.SimulatorCallbacks $ \fm ->
             return $
               Crux.SimulatorHooks
                 { Crux.setupHook =
                     \bak symOnline ->
-                      case simTest bak symOnline fnName of
+                      case simTest bak fm symOnline fnName of
                         SomeTestOvr testFn features -> do
                           personality <- mkCruxPersonality @DPOR
                           let outH = view outputHandle ?outputConfig
@@ -516,14 +518,17 @@ setSimulatorVerbosity verbosity sym = do
   return ()
 
 -------------------------------------------------------
-showRegEntry :: forall sym arg p rtp args ret
-   . C.IsSymInterface sym
+showRegEntry :: forall sym arg p rtp args ret t st fm.
+   ( C.IsSymInterface sym
+   , sym ~ W4.ExprBuilder t st (W4.Flags fm)
+   )
   => sym
+  -> W4.FloatModeRepr fm
   -> Collection
   -> Ty
   -> C.RegEntry sym arg
   -> C.OverrideSim p sym MIR rtp args ret String
-showRegEntry sym col mty entry@(C.RegEntry tp rv) =
+showRegEntry sym fm col mty entry@(C.RegEntry tp rv) =
   case (mty,tp) of
     {-
     Note [Printing flattened aggregates]
@@ -569,9 +574,19 @@ showRegEntry sym col mty entry@(C.RegEntry tp rv) =
     (TyUint _sz, C.BVRepr _w) -> return $ case W4.asBV rv of
                      Just i  -> show (BV.asUnsigned i)
                      Nothing -> "Symbolic BV"
-    (TyFloat _,  C.RealValRepr) -> return $ case W4.asRational rv of
-                     Just f -> show f
-                     Nothing -> "Symbolic real"
+    (TyFloat _,  C.FloatRepr _fi) -> return $ case fm of
+      W4.FloatIEEERepr ->
+        case W4.asFloat rv of
+          Just f -> show f
+          Nothing -> "Symbolic float"
+      W4.FloatUninterpretedRepr ->
+        case W4.asBV rv of
+          Just bv -> show (BV.asUnsigned bv)
+          Nothing -> "Symbolic float"
+      W4.FloatRealRepr ->
+        case W4.asRational rv of
+          Just r -> show r
+          Nothing -> "Symbolic float"
 
     (TyTuple _, MirAggregateRepr) -> do
       fields <- showAgFields mty ("tuple type " <> show (pretty mty)) rv
@@ -597,7 +612,7 @@ showRegEntry sym col mty entry@(C.RegEntry tp rv) =
         let showField fIdx fTy
               | Just transFieldIdx <- transFieldIdxM
               , fIdx == transFieldIdx =
-                showRegEntry sym col fTy entry
+                showRegEntry sym fm col fTy entry
               | otherwise =
                 showZSTValue fTy
         fieldStrs <- zipWithM showField [0..] fieldTys
@@ -643,7 +658,7 @@ showRegEntry sym col mty entry@(C.RegEntry tp rv) =
             Left err -> return err
             Right (variant, fieldStrs) -> showVariant variant fieldStrs
 
-    (TyRef ty Immut, _) -> showRegEntry sym col ty (C.RegEntry tp rv)
+    (TyRef ty Immut, _) -> showRegEntry sym fm col ty (C.RegEntry tp rv)
 
     (TyArray ty len, MirAggregateRepr) -> do
       tySize <- case tySizedness col ty of
@@ -653,7 +668,7 @@ showRegEntry sym col mty entry@(C.RegEntry tp rv) =
         -- See Note [Printing flattened aggregates]
         case mirAggregate_chunk (fromIntegral i * tySize) tySize rv of
           Left e -> return $ "error accessing " ++ show (pretty mty) ++ " aggregate: " ++ e
-          Right subAg -> showRegEntry sym col ty (C.RegEntry MirAggregateRepr subAg)
+          Right subAg -> showRegEntry sym fm col ty (C.RegEntry MirAggregateRepr subAg)
       return $ "[" ++ List.intercalate ", " values ++ "]"
 
     _ -> return $ "I don't know how to print result of type " ++ show (pretty mty, tp)
@@ -697,7 +712,7 @@ showRegEntry sym col mty entry@(C.RegEntry tp rv) =
       let fields = readFields fctx vs
       fieldStrs <-
         zipWithM
-          (\fieldTy (C.Some fieldEntry) -> showRegEntry sym col fieldTy fieldEntry)
+          (\fieldTy (C.Some fieldEntry) -> showRegEntry sym fm col fieldTy fieldEntry)
           (variant ^.. vfields . each . fty)
           fields
       return fieldStrs
@@ -715,7 +730,7 @@ showRegEntry sym col mty entry@(C.RegEntry tp rv) =
             -- See Note [Printing flattened aggregates]
             case mirAggregate_chunk off (fromIntegral sz) ag of
               Left err -> fail $ "showAgFields: error accessing aggregate: " <> show err
-              Right subAg -> showRegEntry sym col ty (C.RegEntry MirAggregateRepr subAg)
+              Right subAg -> showRegEntry sym fm col ty (C.RegEntry MirAggregateRepr subAg)
           Nothing -> fail $ "impossible: got field offsets for " ++ tyDesc
             ++ ", but no layout for element " ++ show ty ++ "?"
       return strs
@@ -729,7 +744,7 @@ showRegEntry sym col mty entry@(C.RegEntry tp rv) =
       case rvPart of
         W4.Unassigned -> return "<uninitialized>"
         W4.PE p rv'
-          | Just True <- W4.asConstantPred p -> showRegEntry sym col ty $ C.RegEntry tpr rv'
+          | Just True <- W4.asConstantPred p -> showRegEntry sym fm col ty $ C.RegEntry tpr rv'
           | otherwise ->return "<possibly uninitialized>"
 
     showVariant ::

--- a/crux-mir/src/Mir/Overrides.hs
+++ b/crux-mir/src/Mir/Overrides.hs
@@ -105,7 +105,20 @@ makeSymbolicVar ::
     BaseTypeRepr btp ->
     TypedOverride (p sym) sym MIR (EmptyCtx ::> MirSlice) (BaseToType btp)
 makeSymbolicVar btpr =
-  Crux.baseFreshOverride btpr strrepr $ \(RV strSlice) -> do
+  Crux.baseFreshOverride btpr MirSliceRepr getSymbolicVarName
+
+makeSymbolicFloatVar ::
+    IsSymInterface sym =>
+    FloatInfoRepr fi ->
+    TypedOverride (p sym) sym MIR (EmptyCtx ::> MirSlice) (FloatType fi)
+makeSymbolicFloatVar btpr =
+  Crux.baseFreshFloatOverride btpr MirSliceRepr getSymbolicVarName
+
+getSymbolicVarName ::
+    IsSymInterface sym =>
+    RegValue' sym MirSlice ->
+    OverrideSim p sym MIR rtp args ret SolverSymbol
+getSymbolicVarName (RV strSlice) = do
     mstr <- getString strSlice
     case mstr of
       Nothing -> fail "symbolic variable name must be a concrete string"
@@ -113,9 +126,6 @@ makeSymbolicVar btpr =
         case userSymbol (Text.unpack name) of
           Left err -> fail $ "invalid symbolic variable name " ++ show name ++ ": " ++ show err
           Right x -> return x
-  where
-    strrepr :: TypeRepr MirSlice
-    strrepr = knownRepr
 
 array_symbolic ::
   forall sym btp p .
@@ -554,9 +564,9 @@ bindFn _symOnline _cs fn cfg =
             -> (ExplodedDefId, SomeTypedOverride (p sym) sym MIR)
     symb_bv edid n = (edid, SomeTypedOverride $ makeSymbolicVar (BaseBVRepr n))
 
-    symb_float :: ExplodedDefId
+    symb_float :: ExplodedDefId -> FloatInfoRepr fi
                -> (ExplodedDefId, SomeTypedOverride (p sym) sym MIR)
-    symb_float edid = (edid, SomeTypedOverride $ makeSymbolicVar BaseRealRepr)
+    symb_float edid fi = (edid, SomeTypedOverride $ makeSymbolicFloatVar fi)
 
     overrides :: IsSymBackend sym bak'
               => bak'
@@ -578,10 +588,10 @@ bindFn _symOnline _cs fn cfg =
                , symb_bv ["crucible", "bitvector", "make_symbolic_128"] (knownNat @128)
                , symb_bv ["crucible", "bitvector", "make_symbolic_256"] (knownNat @256)
                , symb_bv ["crucible", "bitvector", "make_symbolic_512"] (knownNat @512)
-               , symb_float ["crucible", "symbolic", "symbolic_f16"]
-               , symb_float ["crucible", "symbolic", "symbolic_f32"]
-               , symb_float ["crucible", "symbolic", "symbolic_f64"]
-               , symb_float ["crucible", "symbolic", "symbolic_f128"]
+               , symb_float ["crucible", "symbolic", "symbolic_f16"] HalfFloatRepr
+               , symb_float ["crucible", "symbolic", "symbolic_f32"] SingleFloatRepr
+               , symb_float ["crucible", "symbolic", "symbolic_f64"] DoubleFloatRepr
+               , symb_float ["crucible", "symbolic", "symbolic_f128"] QuadFloatRepr
 
                , let argTys = (Empty :> BoolRepr :> strrepr :> strrepr :> u32repr :> u32repr)
                  in override ["crucible", "crucible_assert_impl"] argTys MirAggregateRepr $

--- a/crux-mir/src/Mir/Overrides.hs
+++ b/crux-mir/src/Mir/Overrides.hs
@@ -554,6 +554,10 @@ bindFn _symOnline _cs fn cfg =
             -> (ExplodedDefId, SomeTypedOverride (p sym) sym MIR)
     symb_bv edid n = (edid, SomeTypedOverride $ makeSymbolicVar (BaseBVRepr n))
 
+    symb_float :: ExplodedDefId
+               -> (ExplodedDefId, SomeTypedOverride (p sym) sym MIR)
+    symb_float edid = (edid, SomeTypedOverride $ makeSymbolicVar BaseRealRepr)
+
     overrides :: IsSymBackend sym bak'
               => bak'
               -> Map ExplodedDefId (SomeTypedOverride (p sym) sym MIR)
@@ -574,6 +578,10 @@ bindFn _symOnline _cs fn cfg =
                , symb_bv ["crucible", "bitvector", "make_symbolic_128"] (knownNat @128)
                , symb_bv ["crucible", "bitvector", "make_symbolic_256"] (knownNat @256)
                , symb_bv ["crucible", "bitvector", "make_symbolic_512"] (knownNat @512)
+               , symb_float ["crucible", "symbolic", "symbolic_f16"]
+               , symb_float ["crucible", "symbolic", "symbolic_f32"]
+               , symb_float ["crucible", "symbolic", "symbolic_f64"]
+               , symb_float ["crucible", "symbolic", "symbolic_f128"]
 
                , let argTys = (Empty :> BoolRepr :> strrepr :> strrepr :> u32repr :> u32repr)
                  in override ["crucible", "crucible_assert_impl"] argTys MirAggregateRepr $

--- a/crux-mir/test/conc_eval/float/special_values.rs
+++ b/crux-mir/test/conc_eval/float/special_values.rs
@@ -1,0 +1,35 @@
+#[cfg_attr(crux, crux::test)]
+pub fn crux_test() {
+    let pos_inf = f32::INFINITY;
+    assert_eq!(pos_inf, pos_inf);
+    assert!(0.0 < pos_inf);
+    assert!(pos_inf.is_infinite());
+    assert!(!pos_inf.is_nan());
+
+    let neg_inf = f32::NEG_INFINITY;
+    assert_eq!(neg_inf, neg_inf);
+    assert!(neg_inf < 0.0);
+    assert!(neg_inf.is_infinite());
+    assert!(!neg_inf.is_nan());
+
+    let nan = f32::NAN;
+    assert!(nan != nan);
+    assert!(!(nan <  nan));
+    assert!(!(nan <= nan));
+    assert!(!(nan >  nan));
+    assert!(!(nan >= nan));
+    assert!(!nan.is_infinite());
+    assert!(nan.is_nan());
+
+    let pos_zero = 0.0f32;
+    let neg_zero = -0.0f32;
+    assert_eq!(pos_zero, neg_zero);
+    assert!(!(pos_zero < neg_zero));
+    assert!(pos_zero <= neg_zero);
+    assert!(!(pos_zero > neg_zero));
+    assert!(pos_zero >= neg_zero);
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/conc_eval/slice/fill.rs
+++ b/crux-mir/test/conc_eval/slice/fill.rs
@@ -1,0 +1,22 @@
+fn slice_fill_test<T: Copy + PartialEq>(s: &mut [T], x: T) {
+    s.fill(x);
+    assert!(s.iter().all(|&y| x == y));
+}
+
+#[cfg_attr(crux, crux::test)]
+pub fn crux_test() {
+    slice_fill_test(&mut [0; 2], 1i8);
+    slice_fill_test(&mut [0; 2], 1i16);
+    slice_fill_test(&mut [0; 2], 1i32);
+    slice_fill_test(&mut [0; 2], 1i64);
+    slice_fill_test(&mut [0; 2], 1i128);
+    slice_fill_test(&mut [0; 2], 1u8);
+    slice_fill_test(&mut [0; 2], 1u16);
+    slice_fill_test(&mut [0; 2], 1u32);
+    slice_fill_test(&mut [0; 2], 1u64);
+    slice_fill_test(&mut [0; 2], 1u128);
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/symb_eval/concretize/assert.good
+++ b/crux-mir/test/symb_eval/concretize/assert.good
@@ -5,7 +5,7 @@ failures:
 
 ---- assert/<DISAMB>::crux_test[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:52:13: 59:14 !test/symb_eval/concretize/assert.rs:10:5: 10:81: error: in assert/<DISAMB>::crux_test[0]
+[Crux]   ./libs/crucible/lib.rs:54:13: 61:14 !test/symb_eval/concretize/assert.rs:10:5: 10:81: error: in assert/<DISAMB>::crux_test[0]
 [Crux]   MIR assertion at test/symb_eval/concretize/assert.rs:10:5:
 [Crux]   	100 + 157 == 1
 

--- a/crux-mir/test/symb_eval/concretize/assert_refs.good
+++ b/crux-mir/test/symb_eval/concretize/assert_refs.good
@@ -5,7 +5,7 @@ failures:
 
 ---- assert_refs/<DISAMB>::crux_test[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:52:13: 59:14 !test/symb_eval/concretize/assert_refs.rs:12:5: 12:67: error: in assert_refs/<DISAMB>::crux_test[0]
+[Crux]   ./libs/crucible/lib.rs:54:13: 61:14 !test/symb_eval/concretize/assert_refs.rs:12:5: 12:67: error: in assert_refs/<DISAMB>::crux_test[0]
 [Crux]   MIR assertion at test/symb_eval/concretize/assert_refs.rs:12:5:
 [Crux]   	42 42 [42] [42]
 

--- a/crux-mir/test/symb_eval/crux/early_fail.good
+++ b/crux-mir/test/symb_eval/crux/early_fail.good
@@ -14,7 +14,7 @@ failures:
 
 ---- early_fail/<DISAMB>::fail2[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/crux/early_fail.rs:17:5: 17:29: error: in early_fail/<DISAMB>::fail2[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/crux/early_fail.rs:17:5: 17:29: error: in early_fail/<DISAMB>::fail2[0]
 [Crux]   MIR assertion at test/symb_eval/crux/early_fail.rs:17:5:
 [Crux]   	x == 0
 

--- a/crux-mir/test/symb_eval/crux/fail_return.good
+++ b/crux-mir/test/symb_eval/crux/fail_return.good
@@ -12,7 +12,7 @@ failures:
 [Crux]   Context:
 [Crux]     test/symb_eval/crux/fail_return.rs:8:22: 8:27: fail_return/<DISAMB>::fail1[0]
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/crux/fail_return.rs:8:5: 8:32: error: in fail_return/<DISAMB>::fail1[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/crux/fail_return.rs:8:5: 8:32: error: in fail_return/<DISAMB>::fail1[0]
 [Crux]   MIR assertion at test/symb_eval/crux/fail_return.rs:8:5:
 [Crux]   	x + 1 > x
 
@@ -23,7 +23,7 @@ failures:
 [Crux]   Context:
 [Crux]     test/symb_eval/crux/fail_return.rs:15:22: 15:27: fail_return/<DISAMB>::fail2[0]
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/crux/fail_return.rs:15:5: 15:32: error: in fail_return/<DISAMB>::fail2[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/crux/fail_return.rs:15:5: 15:32: error: in fail_return/<DISAMB>::fail2[0]
 [Crux]   MIR assertion at test/symb_eval/crux/fail_return.rs:15:5:
 [Crux]   	x + 1 > x
 

--- a/crux-mir/test/symb_eval/crux/mixed_fail.good
+++ b/crux-mir/test/symb_eval/crux/mixed_fail.good
@@ -16,7 +16,7 @@ failures:
 [Crux]   Context:
 [Crux]     test/symb_eval/crux/mixed_fail.rs:8:22: 8:27: mixed_fail/<DISAMB>::fail1[0]
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/crux/mixed_fail.rs:8:5: 8:32: error: in mixed_fail/<DISAMB>::fail1[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/crux/mixed_fail.rs:8:5: 8:32: error: in mixed_fail/<DISAMB>::fail1[0]
 [Crux]   MIR assertion at test/symb_eval/crux/mixed_fail.rs:8:5:
 [Crux]   	x + 1 > x
 
@@ -27,7 +27,7 @@ failures:
 [Crux]   Context:
 [Crux]     test/symb_eval/crux/mixed_fail.rs:14:22: 14:27: mixed_fail/<DISAMB>::fail2[0]
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/crux/mixed_fail.rs:14:5: 14:32: error: in mixed_fail/<DISAMB>::fail2[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/crux/mixed_fail.rs:14:5: 14:32: error: in mixed_fail/<DISAMB>::fail2[0]
 [Crux]   MIR assertion at test/symb_eval/crux/mixed_fail.rs:14:5:
 [Crux]   	x + 2 > x
 

--- a/crux-mir/test/symb_eval/crux/multi.good
+++ b/crux-mir/test/symb_eval/crux/multi.good
@@ -14,7 +14,7 @@ failures:
 [Crux]   Context:
 [Crux]     test/symb_eval/crux/multi.rs:8:22: 8:27: multi/<DISAMB>::fail1[0]
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/crux/multi.rs:8:5: 8:32: error: in multi/<DISAMB>::fail1[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/crux/multi.rs:8:5: 8:32: error: in multi/<DISAMB>::fail1[0]
 [Crux]   MIR assertion at test/symb_eval/crux/multi.rs:8:5:
 [Crux]   	x + 1 > x
 
@@ -27,7 +27,7 @@ failures:
 
 ---- multi/<DISAMB>::fail3[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/crux/multi.rs:20:5: 20:29: error: in multi/<DISAMB>::assert_zero[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/crux/multi.rs:20:5: 20:29: error: in multi/<DISAMB>::assert_zero[0]
 [Crux]   MIR assertion at test/symb_eval/crux/multi.rs:20:5:
 [Crux]   	x == 0
 

--- a/crux-mir/test/symb_eval/crypto/bytes.good
+++ b/crux-mir/test/symb_eval/crypto/bytes.good
@@ -5,23 +5,23 @@ failures:
 
 ---- bytes/<DISAMB>::f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/crypto/bytes.rs:85:7: 85:37: error: in bytes/<DISAMB>::f[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/crypto/bytes.rs:85:7: 85:37: error: in bytes/<DISAMB>::f[0]
 [Crux]   MIR assertion at test/symb_eval/crypto/bytes.rs:85:7:
 [Crux]   	a[i] == b[i]
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/crypto/bytes.rs:85:7: 85:37: error: in bytes/<DISAMB>::f[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/crypto/bytes.rs:85:7: 85:37: error: in bytes/<DISAMB>::f[0]
 [Crux]   MIR assertion at test/symb_eval/crypto/bytes.rs:85:7:
 [Crux]   	a[i] == b[i]
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/crypto/bytes.rs:85:7: 85:37: error: in bytes/<DISAMB>::f[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/crypto/bytes.rs:85:7: 85:37: error: in bytes/<DISAMB>::f[0]
 [Crux]   MIR assertion at test/symb_eval/crypto/bytes.rs:85:7:
 [Crux]   	a[i] == b[i]
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/crypto/bytes.rs:85:7: 85:37: error: in bytes/<DISAMB>::f[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/crypto/bytes.rs:85:7: 85:37: error: in bytes/<DISAMB>::f[0]
 [Crux]   MIR assertion at test/symb_eval/crypto/bytes.rs:85:7:
 [Crux]   	a[i] == b[i]
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/crypto/bytes.rs:85:7: 85:37: error: in bytes/<DISAMB>::f[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/crypto/bytes.rs:85:7: 85:37: error: in bytes/<DISAMB>::f[0]
 [Crux]   MIR assertion at test/symb_eval/crypto/bytes.rs:85:7:
 [Crux]   	a[i] == b[i]
 

--- a/crux-mir/test/symb_eval/float/symbolic.good
+++ b/crux-mir/test/symb_eval/float/symbolic.good
@@ -1,0 +1,8 @@
+test symbolic/<DISAMB>::f128_test[0]: returned Symbolic real, ok
+test symbolic/<DISAMB>::f16_test[0]: returned Symbolic real, ok
+test symbolic/<DISAMB>::f32_test[0]: returned Symbolic real, ok
+test symbolic/<DISAMB>::f64_test[0]: returned Symbolic real, ok
+
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
+[Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/float/symbolic.good
+++ b/crux-mir/test/symb_eval/float/symbolic.good
@@ -1,8 +1,17 @@
-test symbolic/<DISAMB>::f128_test[0]: returned Symbolic real, ok
-test symbolic/<DISAMB>::f16_test[0]: returned Symbolic real, ok
-test symbolic/<DISAMB>::f32_test[0]: returned Symbolic real, ok
-test symbolic/<DISAMB>::f64_test[0]: returned Symbolic real, ok
+test symbolic/<DISAMB>::f128_test[0]: returned Symbolic float, [Crux] Attempting to prove verification conditions.
+ok
+test symbolic/<DISAMB>::f16_test[0]: returned Symbolic float, [Crux] Attempting to prove verification conditions.
+ok
+test symbolic/<DISAMB>::f32_test[0]: returned Symbolic float, [Crux] Attempting to prove verification conditions.
+ok
+test symbolic/<DISAMB>::f64_test[0]: returned Symbolic float, [Crux] Attempting to prove verification conditions.
+ok
 
 [Crux-MIR] ---- FINAL RESULTS ----
-[Crux] All goals discharged through internal simplification.
+[Crux] Goal status:
+[Crux]   Total: 4
+[Crux]   Proved: 4
+[Crux]   Disproved: 0
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/float/symbolic.rs
+++ b/crux-mir/test/symb_eval/float/symbolic.rs
@@ -1,0 +1,31 @@
+#![feature(f16)]
+#![feature(f128)]
+
+extern crate crucible;
+use crucible::*;
+
+fn symbolic_test<S: PartialEq + Symbolic>() -> S {
+    let x = S::symbolic("x");
+    crucible_assert!(x == x);
+    x
+}
+
+#[crux::test]
+fn f16_test() -> f16 {
+    symbolic_test()
+}
+
+#[crux::test]
+fn f32_test() -> f32 {
+    symbolic_test()
+}
+
+#[crux::test]
+fn f64_test() -> f64 {
+    symbolic_test()
+}
+
+#[crux::test]
+fn f128_test() -> f128 {
+    symbolic_test()
+}

--- a/crux-mir/test/symb_eval/float/symbolic.rs
+++ b/crux-mir/test/symb_eval/float/symbolic.rs
@@ -4,28 +4,33 @@
 extern crate crucible;
 use crucible::*;
 
-fn symbolic_test<S: PartialEq + Symbolic>() -> S {
-    let x = S::symbolic("x");
-    crucible_assert!(x == x);
-    x
+macro_rules! symbolic_test {
+    ($t:ty) => {
+        {
+            let x = <$t>::symbolic("x");
+            crucible_assume!(!x.is_nan()); // NaN is not equal to itself
+            crucible_assert!(x == x);
+            x
+        }
+    };
 }
 
 #[crux::test]
 fn f16_test() -> f16 {
-    symbolic_test()
+    symbolic_test!(f16)
 }
 
 #[crux::test]
 fn f32_test() -> f32 {
-    symbolic_test()
+    symbolic_test!(f32)
 }
 
 #[crux::test]
 fn f64_test() -> f64 {
-    symbolic_test()
+    symbolic_test!(f64)
 }
 
 #[crux::test]
 fn f128_test() -> f128 {
-    symbolic_test()
+    symbolic_test!(f128)
 }

--- a/crux-mir/test/symb_eval/overrides/bad_symb1.good
+++ b/crux-mir/test/symb_eval/overrides/bad_symb1.good
@@ -5,11 +5,11 @@ failures:
 
 ---- bad_symb1/<DISAMB>::crux_test[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/symbolic.rs:29:50: 29:61 !./libs/crucible/symbolic.rs:35:1: 42:2: error: in crucible/<DISAMB>::symbolic[0]::{impl#5}[0]::symbolic[0]
+[Crux]   ./libs/crucible/symbolic.rs:29:50: 29:61 !./libs/crucible/symbolic.rs:35:1: 46:2: error: in crucible/<DISAMB>::symbolic[0]::{impl#7}[0]::symbolic[0]
 [Crux]   symbolic variable name must be a concrete string
 [Crux]   Context:
 [Crux]     internal: crucible/<DISAMB>::symbolic[0]::symbolic_u8[0]
-[Crux]     ./libs/crucible/symbolic.rs:29:50: 29:61 !./libs/crucible/symbolic.rs:35:1: 42:2: crucible/<DISAMB>::symbolic[0]::{impl#5}[0]::symbolic[0]
+[Crux]     ./libs/crucible/symbolic.rs:29:50: 29:61 !./libs/crucible/symbolic.rs:35:1: 46:2: crucible/<DISAMB>::symbolic[0]::{impl#7}[0]::symbolic[0]
 [Crux]     test/symb_eval/overrides/bad_symb1.rs:7:13: 7:28: bad_symb1/<DISAMB>::crux_test[0]
 
 [Crux-MIR] ---- FINAL RESULTS ----

--- a/crux-mir/test/symb_eval/overrides/bad_symb2.good
+++ b/crux-mir/test/symb_eval/overrides/bad_symb2.good
@@ -5,11 +5,11 @@ failures:
 
 ---- bad_symb2/<DISAMB>::crux_test[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/symbolic.rs:29:50: 29:61 !./libs/crucible/symbolic.rs:35:1: 42:2: error: in crucible/<DISAMB>::symbolic[0]::{impl#5}[0]::symbolic[0]
+[Crux]   ./libs/crucible/symbolic.rs:29:50: 29:61 !./libs/crucible/symbolic.rs:35:1: 46:2: error: in crucible/<DISAMB>::symbolic[0]::{impl#7}[0]::symbolic[0]
 [Crux]   invalid symbolic variable name "\NUL:., /": Identifier must start with a letter.
 [Crux]   Context:
 [Crux]     internal: crucible/<DISAMB>::symbolic[0]::symbolic_u8[0]
-[Crux]     ./libs/crucible/symbolic.rs:29:50: 29:61 !./libs/crucible/symbolic.rs:35:1: 42:2: crucible/<DISAMB>::symbolic[0]::{impl#5}[0]::symbolic[0]
+[Crux]     ./libs/crucible/symbolic.rs:29:50: 29:61 !./libs/crucible/symbolic.rs:35:1: 46:2: crucible/<DISAMB>::symbolic[0]::{impl#7}[0]::symbolic[0]
 [Crux]     test/symb_eval/overrides/bad_symb2.rs:6:13: 6:36: bad_symb2/<DISAMB>::crux_test[0]
 
 [Crux-MIR] ---- FINAL RESULTS ----

--- a/crux-mir/test/symb_eval/overrides/override2.good
+++ b/crux-mir/test/symb_eval/overrides/override2.good
@@ -5,7 +5,7 @@ failures:
 
 ---- override2/<DISAMB>::f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/overrides/override2.rs:9:5: 9:49: error: in override2/<DISAMB>::f[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/overrides/override2.rs:9:5: 9:49: error: in override2/<DISAMB>::f[0]
 [Crux]   MIR assertion at test/symb_eval/overrides/override2.rs:9:5:
 [Crux]   	foo.wrapping_add(1) == foo
 

--- a/crux-mir/test/symb_eval/overrides/override5.good
+++ b/crux-mir/test/symb_eval/overrides/override5.good
@@ -5,7 +5,7 @@ failures:
 
 ---- override5/<DISAMB>::f[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/overrides/override5.rs:10:5: 10:47: error: in override5/<DISAMB>::f[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/overrides/override5.rs:10:5: 10:47: error: in override5/<DISAMB>::f[0]
 [Crux]   MIR assertion at test/symb_eval/overrides/override5.rs:10:5:
 [Crux]   	foo.wrapping_add(1) != 0
 

--- a/crux-mir/test/symb_eval/sym_bytes/construct.good
+++ b/crux-mir/test/symb_eval/sym_bytes/construct.good
@@ -5,7 +5,7 @@ failures:
 
 ---- construct/<DISAMB>::crux_test[0] counterexamples ----
 [Crux] Found counterexample for verification goal
-[Crux]   ./libs/crucible/lib.rs:48:9: 48:79 !test/symb_eval/sym_bytes/construct.rs:13:5: 13:35: error: in construct/<DISAMB>::crux_test[0]
+[Crux]   ./libs/crucible/lib.rs:50:9: 50:79 !test/symb_eval/sym_bytes/construct.rs:13:5: 13:35: error: in construct/<DISAMB>::crux_test[0]
 [Crux]   MIR assertion at test/symb_eval/sym_bytes/construct.rs:13:5:
 [Crux]   	sym2[0] == 0
 

--- a/crux/CHANGELOG.md
+++ b/crux/CHANGELOG.md
@@ -6,6 +6,7 @@
   `colorOptionsL`, `simVerboseL`, `printFailuresL`, `quietModeL` (from
   `Crux.Config.Common`), and `colorOptionsL`, `noColorsErrL`, `noColorsOutL`
   (from `Crux.Config.Load`).
+- Add a `FloatModeRepr` argument to `SimulatorCallbacks`.
 
 # 0.9 -- 2026-01-29
 

--- a/crux/CHANGELOG.md
+++ b/crux/CHANGELOG.md
@@ -7,6 +7,8 @@
   `Crux.Config.Common`), and `colorOptionsL`, `noColorsErrL`, `noColorsOutL`
   (from `Crux.Config.Load`).
 - Add a `FloatModeRepr` argument to `SimulatorCallbacks`.
+- Add `baseFreshFloatOverride` and `baseFreshFloatOverride'` to
+  `Crux.Overrides`.
 
 # 0.9 -- 2026-01-29
 

--- a/crux/src/Crux.hs
+++ b/crux/src/Crux.hs
@@ -133,12 +133,12 @@ data RunnableState sym where
 newtype SimulatorCallbacks msgs st r
   = SimulatorCallbacks
     { getSimulatorCallbacks ::
-        forall sym bak t fs.
+        forall sym bak t fm.
           ( IsSymBackend sym bak
           , Logs msgs
-          , sym ~ WE.ExprBuilder t st fs
+          , sym ~ WE.ExprBuilder t st (WE.Flags fm)
           ) =>
-          IO (SimulatorHooks sym bak t r)
+          WE.FloatModeRepr fm -> IO (SimulatorHooks sym bak t r)
     }
 
 
@@ -364,8 +364,10 @@ withSelectedOnlineBackend :: forall msgs scope st a.
     ( OnlineSolver solver
     , IsInterpretedFloatExprBuilder (WE.ExprBuilder scope st (WE.Flags fm))
     ) =>
-    (OnlineBackend solver scope st (WE.Flags fm) -> IO a)) ->
-    IO a
+    WE.FloatModeRepr fm ->
+    OnlineBackend solver scope st (WE.Flags fm) ->
+    IO a) ->
+  IO a
 withSelectedOnlineBackend cruxOpts nonceGen selectedSolver maybeExplicitFloatMode initSt k =
   case fromMaybe (floatMode cruxOpts) maybeExplicitFloatMode of
     "real" -> withOnlineBackendFM WE.FloatRealRepr
@@ -388,7 +390,7 @@ withSelectedOnlineBackend cruxOpts nonceGen selectedSolver maybeExplicitFloatMod
       IO a
     withOnlineBackendFM fm =
       do sym <- WE.newExprBuilder fm initSt nonceGen
-         withSelectedOnlineBackend' cruxOpts selectedSolver sym k
+         withSelectedOnlineBackend' cruxOpts selectedSolver sym $ k fm
 
 withSelectedOnlineBackend' ::
   Logs msgs =>
@@ -400,8 +402,9 @@ withSelectedOnlineBackend' ::
   WE.ExprBuilder scope st fs ->
   (forall solver.
     OnlineSolver solver =>
-    (OnlineBackend solver scope st fs -> IO a)) ->
-    IO a
+    OnlineBackend solver scope st fs ->
+    IO a) ->
+  IO a
 withSelectedOnlineBackend' cruxOpts selectedSolver sym k =
   let unsatCoreFeat | unsatCores cruxOpts
                     , not (yicesMCSat cruxOpts) = ProduceUnsatCores
@@ -631,14 +634,14 @@ runSimulatorWithUserState mkUser cruxOpts simCallback = do
   case CCS.parseSolverConfig cruxOpts of
 
     Right (CCS.SingleOnlineSolver onSolver) ->
-      withSelectedOnlineBackend cruxOpts nonceGen onSolver Nothing userState $ \bak -> do
+      withSelectedOnlineBackend cruxOpts nonceGen onSolver Nothing userState $ \fm bak -> do
         let monline = Just (SomeOnlineSolver bak)
         setupSolver cruxOpts (pathSatSolverOutput cruxOpts) (backendGetSym bak)
         (execFeatures, profInfo) <- setupExecutionFeatures cruxOpts bak monline
-        doSimWithResults cruxOpts simCallback bak execFeatures profInfo monline (proveGoalsOnline bak)
+        doSimWithResults cruxOpts simCallback fm bak execFeatures profInfo monline (proveGoalsOnline bak)
 
     Right (CCS.OnlineSolverWithOfflineGoals onSolver offSolver) ->
-      withSelectedOnlineBackend cruxOpts nonceGen onSolver Nothing userState $ \bak -> do
+      withSelectedOnlineBackend cruxOpts nonceGen onSolver Nothing userState $ \fm bak -> do
         let monline = Just (SomeOnlineSolver bak)
         setupSolver cruxOpts (pathSatSolverOutput cruxOpts) (backendGetSym bak)
         (execFeatures, profInfo) <- setupExecutionFeatures cruxOpts bak monline
@@ -649,7 +652,7 @@ runSimulatorWithUserState mkUser cruxOpts simCallback = do
           -- been a different solver)
           unless (CCS.sameSolver onSolver offSolver) $
             extendConfig (WS.solver_adapter_config_options adapter) (getConfiguration (backendGetSym bak))
-          doSimWithResults cruxOpts simCallback bak execFeatures profInfo monline (proveGoalsOffline [adapter])
+          doSimWithResults cruxOpts simCallback fm bak execFeatures profInfo monline (proveGoalsOffline [adapter])
 
     Right (CCS.OnlyOfflineSolvers offSolvers) ->
       withFloatRepr userState cruxOpts offSolvers $ \floatRepr -> do
@@ -661,18 +664,18 @@ runSimulatorWithUserState mkUser cruxOpts simCallback = do
           -- with the options taken from the solver adapter (e.g., solver path)
           extendConfig (WS.solver_adapter_config_options =<< adapters) (getConfiguration sym)
           (execFeatures, profInfo) <- setupExecutionFeatures cruxOpts bak Nothing
-          doSimWithResults cruxOpts simCallback bak execFeatures profInfo Nothing (proveGoalsOffline adapters)
+          doSimWithResults cruxOpts simCallback floatRepr bak execFeatures profInfo Nothing (proveGoalsOffline adapters)
 
     Right (CCS.OnlineSolverWithSeparateOnlineGoals pathSolver goalSolver) ->
       -- This case is probably the most complicated because it needs two
       -- separate online solvers.  The two must agree on the floating point
       -- mode.
-      withSelectedOnlineBackend cruxOpts nonceGen pathSolver Nothing userState $ \pathSatBak -> do
+      withSelectedOnlineBackend cruxOpts nonceGen pathSolver Nothing userState $ \fm pathSatBak -> do
         let sym = backendGetSym pathSatBak
         setupSolver cruxOpts (pathSatSolverOutput cruxOpts) sym
         (execFeatures, profInfo) <- setupExecutionFeatures cruxOpts pathSatBak (Just (SomeOnlineSolver pathSatBak))
         withSelectedOnlineBackend' cruxOpts goalSolver sym $ \goalBak -> do
-          doSimWithResults cruxOpts simCallback pathSatBak execFeatures profInfo (Just (SomeOnlineSolver pathSatBak)) (proveGoalsOnline goalBak)
+          doSimWithResults cruxOpts simCallback fm pathSatBak execFeatures profInfo (Just (SomeOnlineSolver pathSatBak)) (proveGoalsOnline goalBak)
 
     Left rsns -> fail ("Invalid solver configuration:\n" ++ unlines rsns)
 
@@ -687,13 +690,14 @@ runSimulatorWithUserState mkUser cruxOpts simCallback = do
 -- The main work in this function is setting up appropriate solver frames and
 -- traversing the goals tree, as well as handling some reporting.
 doSimWithResults ::
-  forall sym bak r t st fs msgs.
-  sym ~ WE.ExprBuilder t st fs =>
+  forall sym bak r t st fm msgs.
+  sym ~ WE.ExprBuilder t st (WE.Flags fm) =>
   IsSymBackend sym bak =>
   Logs msgs =>
   SupportsCruxLogMessage msgs =>
   CruxOptions ->
   SimulatorCallbacks msgs st r ->
+  WE.FloatModeRepr fm ->
   bak ->
   [GenericExecutionFeature sym] ->
   ProfData sym ->
@@ -702,14 +706,14 @@ doSimWithResults ::
     {- ^ The function to use to prove goals; this is intended to be
          one of 'proveGoalsOffline' or 'proveGoalsOnline' -} ->
   IO r
-doSimWithResults cruxOpts simCallback bak execFeatures profInfo monline goalProver = do
+doSimWithResults cruxOpts simCallback fm bak execFeatures profInfo monline goalProver = do
   compRef <- newIORef ProgramComplete
   glsRef <- newIORef Seq.empty
 
   frm <- pushAssumptionFrame bak
 
   SimulatorHooks setup onError interpretResult <-
-    getSimulatorCallbacks simCallback
+    getSimulatorCallbacks simCallback fm
   inFrame profInfo "<Crux>" $ do
     -- perform tool-specific setup
     RunnableStateWithExtensions initSt exts <- setup bak monline
@@ -756,7 +760,7 @@ doSimWithResults cruxOpts simCallback bak execFeatures profInfo monline goalProv
    -> IORef (Seq.Seq (ProcessedGoals, ProvedGoals))
    -> FrameIdentifier
    -> (Maybe (WE.GroundEvalFn t) -> LabeledPred (WE.Expr t BaseBoolType) SimError -> IO (Doc Void))
-   -> Result personality (WE.ExprBuilder t st fs)
+   -> Result personality (WE.ExprBuilder t st (WE.Flags fm))
    -> IO Bool
  resultCont compRef glsRef frm explainFailure (Result res) =
    do timedOut <-

--- a/crux/src/Crux/Overrides.hs
+++ b/crux/src/Crux/Overrides.hs
@@ -8,6 +8,8 @@ module Crux.Overrides
   , mkFreshFloat
   , baseFreshOverride
   , baseFreshOverride'
+  , baseFreshFloatOverride
+  , baseFreshFloatOverride'
   ) where
 
 import qualified Data.Parameterized.Context as Ctx
@@ -56,7 +58,7 @@ mkFreshFloat name fi =
 
 -- | Build an override that takes a string and returns a fresh constant with
 -- that string as its name.
-baseFreshOverride :: 
+baseFreshOverride ::
   C.IsSymInterface sym =>
   W4.BaseTypeRepr bty ->
   -- | The language's string type (e.g., @LLVMPointerType@ for LLVM)
@@ -76,7 +78,7 @@ baseFreshOverride bty sty getStr =
 -- | Build an override that takes no arguments and returns a fresh
 -- constant that uses the given name. Generally, frontends should prefer
 -- 'baseFreshOverride', to allow users to specify variable names.
-baseFreshOverride' :: 
+baseFreshOverride' ::
   C.IsSymInterface sym =>
   -- | Variable name
   W4.SolverSymbol ->
@@ -87,4 +89,40 @@ baseFreshOverride' nm bty =
   { C.typedOverrideHandler = \Ctx.Empty -> mkFresh nm bty
   , C.typedOverrideArgs = Ctx.Empty
   , C.typedOverrideRet = C.baseToType bty
+  }
+
+-- | Build an override that takes a string and returns a fresh floating-point
+-- constant with that string as its name.
+baseFreshFloatOverride ::
+  C.IsSymInterface sym =>
+  C.FloatInfoRepr fi ->
+  -- | The language's string type (e.g., @LLVMPointerType@ for LLVM)
+  C.TypeRepr stringTy ->
+  -- | Get the variable name as a concrete string from the override arguments
+  (C.RegValue' sym stringTy -> OverM p sym ext W4.SolverSymbol) ->
+  C.TypedOverride (p sym) sym ext (C.EmptyCtx C.::> stringTy) (C.FloatType fi)
+baseFreshFloatOverride fi sty getStr =
+  C.TypedOverride
+  { C.typedOverrideHandler = \(Ctx.Empty Ctx.:> strVal) -> do
+      str <- getStr strVal
+      mkFreshFloat str fi
+  , C.typedOverrideArgs = Ctx.Empty Ctx.:> sty
+  , C.typedOverrideRet = C.FloatRepr fi
+  }
+
+-- | Build an override that takes no arguments and returns a fresh
+-- floating-point constant that uses the given name. Generally, frontends
+-- should prefer 'baseFreshFloatOverride', to allow users to specify variable
+-- names.
+baseFreshFloatOverride' ::
+  C.IsSymInterface sym =>
+  -- | Variable name
+  W4.SolverSymbol ->
+  C.FloatInfoRepr fi ->
+  C.TypedOverride (p sym) sym ext C.EmptyCtx (C.FloatType fi)
+baseFreshFloatOverride' nm fi =
+  C.TypedOverride
+  { C.typedOverrideHandler = \Ctx.Empty -> mkFreshFloat nm fi
+  , C.typedOverrideArgs = Ctx.Empty
+  , C.typedOverrideRet = C.FloatRepr fi
   }


### PR DESCRIPTION
This changes the Crucible representation of primitive floating point types (e.g., `f32` and `f64`) from `RealValRepr` (i.e., rationals) to `FloatRepr`, the latter of which can properly handle the various nuances of IEEE-754 floats. I demonstrate the new capabilities in a slew of new test cases.

Fixes https://github.com/GaloisInc/crucible/issues/1865.

----

(Reviewer's note: this is based on top of https://github.com/GaloisInc/crucible/pull/1870. Only the last three commits in this series are unique to this PR.)