### PR TITLE
crucible-mir: support subslicing projections on arrays

### DIFF
--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -862,7 +862,7 @@ typeOfProj elm baseTy = case elm of
     Index{}              -> peelIdx baseTy
     ConstantIndex{}      -> peelIdx baseTy
     Downcast i           -> TyDowncast baseTy i   --- TODO: check this
-    Subslice{}           -> TySlice (peelIdx baseTy)
+    Subslice f t e       -> subslice baseTy f t e
     OpaqueCast t         -> t
     UnwrapUnsafeBinder t -> t
   where
@@ -877,6 +877,16 @@ typeOfProj elm baseTy = case elm of
     peelIdx (TySlice t)   = t
     peelIdx (TyRef t m)   = TyRef (peelIdx t) m
     peelIdx t             = t
+
+    subslice :: Ty -> Int -> Int -> Bool -> Ty
+    subslice (TyArray elemTy len) fromIndex toIndex fromEnd =
+      let firstIndex = fromIndex
+          lastIndex
+            | fromEnd = len - toIndex
+            | otherwise = toIndex
+          newLen = lastIndex - firstIndex
+      in TyArray elemTy newLen
+    subslice t _ _ _ = t
 
 instance TypeOf Rvalue where
   typeOf (Use a) = typeOf a

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -1818,13 +1818,9 @@ evalPlaceProj ty (MirPlace tpr ref meta) (M.Subslice fromIndex toIndex fromEnd) 
       elemSize <- tySizeM elemTy
       MirPlace elemTpr <$> mirRef_offset headRef firstIndex elemSize <*> pure newMeta
 
-    -- TODO: https://github.com/GaloisInc/crucible/issues/1494
-    --
-    -- NB: after implementing this, update `Mir.Mir.typeOfProj`, which currently
-    -- declares that `Subslice` unconditionally yields a slice. This is
-    -- incorrect; `Subslice` applied to an array will yield an array.
-    (M.TyArray {}, _, _, _) -> mirFail
-      "evalPlaceProj: subslicing not yet supported on arrays"
+    (M.TyArray elemTy _, headRef, MirAggregateRepr, _) -> do
+      elemSize <- tySizeM elemTy
+      MirPlace MirAggregateRepr <$> mirRef_offset headRef firstIndex elemSize <*> pure NoMeta
 
     _ -> mirFail $
       "evalPlaceProj: subslicing not supported on " ++ show (ty, tpr, meta)

--- a/crux-mir/test/conc_eval/array/subslice.rs
+++ b/crux-mir/test/conc_eval/array/subslice.rs
@@ -1,5 +1,3 @@
-// FAIL: subslicing not yet supported on arrays
-
 #[cfg_attr(crux, crux::test)]
 fn crux_test() {
     let mut xs: [u32; 6] = [1, 2, 3, 4, 5, 6];


### PR DESCRIPTION
Fixes #1494.