### PR TITLE
`crucible-llvm`: Fix `fpto{ui,si}` semantics

### DIFF
--- a/crucible-llvm/CHANGELOG.md
+++ b/crucible-llvm/CHANGELOG.md
@@ -30,6 +30,8 @@
 * **BREAKING**: Changed `lookupMetadata` to take the new `llvm-pretty`-provided
   `UnnamedMdIdx` rather than the older simple `Int` value to refer to the index
   of the metadata to be looked up.
+* **BREAKING**: `explainCex`, `concBadBehavior`, `concUB`, and `concPoison` now
+  take a `FloatModeRepr` argument.
 
 # 0.9 -- 2026-01-29
 

--- a/crucible-llvm/CHANGELOG.md
+++ b/crucible-llvm/CHANGELOG.md
@@ -32,6 +32,10 @@
   of the metadata to be looked up.
 * **BREAKING**: `explainCex`, `concBadBehavior`, `concUB`, and `concPoison` now
   take a `FloatModeRepr` argument.
+* Fix the semantics of the `fptoui` and `fptosi` instructions. These
+  instructions now round towards zero (previously, they incorrectly rounded
+  towards negative infinity), and they now report undefined behavior if the
+  input does not fit in the return type.
 
 # 0.9 -- 2026-01-29
 

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Errors.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Errors.hs
@@ -48,7 +48,7 @@ import           GHC.Generics (Generic)
 import           Prettyprinter
 
 import           What4.Interface
-import           What4.Expr (GroundValue)
+import           What4.Expr (ExprBuilder, Flags, FloatModeRepr, GroundValue)
 
 import           Lang.Crucible.Simulator.RegValue (RegValue'(..))
 import qualified Lang.Crucible.LLVM.Errors.MemoryError as ME
@@ -66,13 +66,16 @@ data BadBehavior sym where
  deriving Typeable
 
 concBadBehavior ::
-  IsExprBuilder sym =>
+  ( IsExprBuilder sym
+  , sym ~ ExprBuilder t st (Flags fm)
+  ) =>
   sym ->
+  FloatModeRepr fm ->
   (forall tp. SymExpr sym tp -> IO (GroundValue tp)) ->
   BadBehavior sym -> IO (BadBehavior sym)
-concBadBehavior sym conc (BBUndefinedBehavior ub) =
-  BBUndefinedBehavior <$> UB.concUB sym conc ub
-concBadBehavior sym conc (BBMemoryError me) =
+concBadBehavior sym fm conc (BBUndefinedBehavior ub) =
+  BBUndefinedBehavior <$> UB.concUB sym fm conc ub
+concBadBehavior sym _fm conc (BBMemoryError me) =
   BBMemoryError <$> ME.concMemoryError sym conc me
 
 -- -----------------------------------------------------------------------

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Errors/Poison.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Errors/Poison.hs
@@ -49,14 +49,16 @@ import qualified Data.Parameterized.TraversableF as TF
 import           Data.Parameterized.TraversableF (FunctorF(..), FoldableF(..), TraversableF(..))
 import qualified Data.Parameterized.TH.GADT as U
 import           Data.Parameterized.ClassesC (TestEqualityC(..), OrdC(..))
-import           Data.Parameterized.Classes (OrderingF(..), toOrdering)
+import           Data.Parameterized.Classes (OrderingF(..), OrdF(..), toOrdering)
 
 import           Lang.Crucible.LLVM.Errors.Standards
 import           Lang.Crucible.LLVM.MemModel.Pointer (LLVMPointerType, concBV, concPtr', ppPtr)
 import           Lang.Crucible.Simulator.RegValue (RegValue'(..))
 import           Lang.Crucible.Types
 import qualified What4.Interface as W4I
-import           What4.Expr (GroundValue)
+import qualified What4.InterpretedFloatingPoint as W4IFP
+import           What4.Expr (ExprBuilder, Flags, FloatModeRepr(..), GroundValue)
+import qualified What4.Expr.GroundEval as W4GE
 
 data Poison (e :: CrucibleType -> Type) where
   -- | Arguments: @op1@, @op2@
@@ -136,6 +138,18 @@ data Poison (e :: CrucibleType -> Type) where
   UiToFpNonNegative   :: (1 <= w)
                       => e (BVType w)
                       -> Poison e
+  FpToUiNotRepresentable
+                      :: (1 <= w)
+                      => FloatInfoRepr fi
+                      -> e (FloatType fi)
+                      -> NatRepr w
+                      -> Poison e
+  FpToSiNotRepresentable
+                      :: (1 <= w)
+                      => FloatInfoRepr fi
+                      -> e (FloatType fi)
+                      -> NatRepr w
+                      -> Poison e
   TruncNoUnsignedWrap :: (1 <= w)
                       => e (BVType w)
                       -> Poison e
@@ -172,6 +186,8 @@ standard =
     GEPOutOfBounds _ _      -> LLVMRef LLVM8
     ZExtNonNegative _       -> LLVMRef LLVM18
     UiToFpNonNegative _     -> LLVMRef LLVM19
+    FpToUiNotRepresentable _ _ _ -> LLVMRef LLVM8
+    FpToSiNotRepresentable _ _ _ -> LLVMRef LLVM8
     TruncNoUnsignedWrap _   -> LLVMRef LLVM20
     TruncNoSignedWrap _     -> LLVMRef LLVM20
     ICmpSameSign _ _        -> LLVMRef LLVM20
@@ -201,6 +217,8 @@ cite =
     GEPOutOfBounds _ _      -> "‘getelementptr’ Instruction (Semantics)"
     ZExtNonNegative _       -> "‘zext’ Instruction (Semantics)"
     UiToFpNonNegative _     -> "‘uitofp’ Instruction (Semantics)"
+    FpToUiNotRepresentable _ _ _ -> "‘fptoui’ Instruction (Semantics)"
+    FpToSiNotRepresentable _ _ _ -> "‘fptosi’ Instruction (Semantics)"
     TruncNoUnsignedWrap _   -> "‘trunc’ Instruction (Semantics)"
     TruncNoSignedWrap _     -> "‘trunc’ Instruction (Semantics)"
     ICmpSameSign _ _        -> "‘icmp’ Instruction (Semantics)"
@@ -263,6 +281,14 @@ explain =
       "A negative integer was zero-extended even though the `nneg` flag was set"
     UiToFpNonNegative _ ->
       "A negative integer was converted to a floating-point value even though the `nneg` flag was set"
+    FpToUiNotRepresentable _ _ _ -> cat $
+      [ "A floating-point value was converted to an unsigned integer,"
+      , "even though the value does not fit in the unsigned integer's type"
+      ]
+    FpToSiNotRepresentable _ _ _ -> cat $
+      [ "A floating-point value was converted to a signed integer,"
+      , "even though the value does not fit in the signed integer's type"
+      ]
     TruncNoUnsignedWrap _ ->
       "Unsigned truncation caused wrapping even though the `nuw` flag was set"
     TruncNoSignedWrap _ ->
@@ -298,6 +324,16 @@ details =
       ]
     ZExtNonNegative v -> args [v]
     UiToFpNonNegative v -> args [v]
+    FpToUiNotRepresentable fi (RV float) bvW ->
+      [ "Floating-point type:" <+> pretty fi
+      , "Floating-point value:" <+> W4I.printSymExpr float
+      , "Unsigned integer size (in bits):" <+> viaShow bvW
+      ]
+    FpToSiNotRepresentable fi (RV float) bvW ->
+      [ "Floating-point type:" <+> pretty fi
+      , "Floating-point value:" <+> W4I.printSymExpr float
+      , "Signed integer size (in bits):" <+> viaShow bvW
+      ]
     TruncNoUnsignedWrap v -> args [v]
     TruncNoSignedWrap v -> args [v]
     ICmpSameSign v1 v2 -> args [v1, v2]
@@ -329,14 +365,35 @@ ppReg ::W4I.IsExpr (W4I.SymExpr sym) => Poison (RegValue' sym) -> Doc ann
 ppReg = pp details
 
 -- | Concretize a poison error message.
-concPoison :: forall sym.
-  W4I.IsExprBuilder sym =>
+concPoison :: forall sym t st fm.
+  ( W4I.IsExprBuilder sym
+  , sym ~ ExprBuilder t st (Flags fm)
+  ) =>
   sym ->
+  FloatModeRepr fm ->
   (forall tp. W4I.SymExpr sym tp -> IO (GroundValue tp)) ->
   Poison (RegValue' sym) -> IO (Poison (RegValue' sym))
-concPoison sym conc poison =
+concPoison sym fm conc poison =
   let bv :: forall w. (1 <= w) => RegValue' sym (BVType w) -> IO (RegValue' sym (BVType w))
-      bv (RV x) = RV <$> concBV sym conc x in
+      bv (RV x) = RV <$> concBV sym conc x
+
+      fp ::
+        forall fi.
+        FloatInfoRepr fi ->
+        RegValue' sym (FloatType fi) ->
+        IO (RegValue' sym (FloatType fi))
+      fp fi (RV x) = do
+        v <- conc x
+        rv <-
+          case fm of
+            FloatIEEERepr ->
+              W4I.floatLit sym (floatInfoToPrecisionRepr fi) v
+            FloatUninterpretedRepr -> do
+              sv <- W4GE.groundToSym sym (floatInfoToBVTypeRepr fi) v
+              W4IFP.iFloatFromBinary sym fi sv
+            FloatRealRepr ->
+              W4IFP.iFloatLitRational sym fi v
+        pure $ RV rv in
   case poison of
     AddNoUnsignedWrap v1 v2 ->
       AddNoUnsignedWrap <$> bv v1 <*> bv v2
@@ -380,6 +437,10 @@ concPoison sym conc poison =
       ZExtNonNegative <$> bv v
     UiToFpNonNegative v ->
       UiToFpNonNegative <$> bv v
+    FpToUiNotRepresentable v1 v2 v3 ->
+      FpToUiNotRepresentable v1 <$> fp v1 v2 <*> pure v3
+    FpToSiNotRepresentable v1 v2 v3 ->
+      FpToSiNotRepresentable v1 <$> fp v1 v2 <*> pure v3
     TruncNoUnsignedWrap v ->
       TruncNoUnsignedWrap <$> bv v
     TruncNoSignedWrap v ->
@@ -407,6 +468,8 @@ eqcPoison subterms =
            Nothing   -> Nothing
    in $(U.structuralTypeEquality [t|Poison|]
        [ ( U.DataArg 0 `U.TypeApp` U.AnyType, [| subterms' |])
+       , ( U.ConType [t| FloatInfoRepr |] `U.TypeApp` U.AnyType, [| testEquality |])
+       , ( U.ConType [t| NatRepr |] `U.TypeApp` U.AnyType, [| testEquality |])
        ])
 
 ordcPoison :: forall e f.
@@ -422,6 +485,8 @@ ordcPoison subterms =
 
    in $(U.structuralTypeOrd [t|Poison|]
        [ ( U.DataArg 0 `U.TypeApp` U.AnyType, [| subterms' |])
+       , ( U.ConType [t| FloatInfoRepr |] `U.TypeApp` U.AnyType, [| compareF |])
+       , ( U.ConType [t| NatRepr |] `U.TypeApp` U.AnyType, [| compareF |])
        ])
 
 instance TestEqualityC Poison where

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Errors/UndefinedBehavior.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Errors/UndefinedBehavior.hs
@@ -71,7 +71,7 @@ import           Data.Parameterized.TraversableF (FunctorF(..), FoldableF(..), T
 import qualified Data.Parameterized.TraversableF as TF
 
 import qualified What4.Interface as W4I
-import           What4.Expr (GroundValue)
+import           What4.Expr (ExprBuilder, Flags, FloatModeRepr, GroundValue)
 
 import           Lang.Crucible.Types
 import           Lang.Crucible.Simulator.RegValue (RegValue'(..))
@@ -560,12 +560,15 @@ instance TraversableF UndefinedBehavior where
      ) subterms
 
 
-concUB :: forall sym.
-  W4I.IsExprBuilder sym =>
+concUB :: forall sym t st fm.
+  ( W4I.IsExprBuilder sym
+  , sym ~ ExprBuilder t st (Flags fm)
+  ) =>
   sym ->
+  FloatModeRepr fm ->
   (forall tp. W4I.SymExpr sym tp -> IO (GroundValue tp)) ->
   UndefinedBehavior (RegValue' sym) -> IO (UndefinedBehavior (RegValue' sym))
-concUB sym conc ub =
+concUB sym fm conc ub =
   let bv :: forall w. (1 <= w) => RegValue' sym (BVType w) -> IO (RegValue' sym (BVType w))
       bv (RV x) = RV <$> concBV sym conc x in
   case ub of
@@ -614,4 +617,4 @@ concUB sym conc ub =
       AbsIntMin <$> bv v
 
     PoisonValueCreated poison ->
-      PoisonValueCreated <$> Poison.concPoison sym conc poison
+      PoisonValueCreated <$> Poison.concPoison sym fm conc poison

--- a/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Partial.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/MemModel/Partial.hs
@@ -130,13 +130,14 @@ instance Semigroup (CexExplanation sym BaseBoolType) where
   x <> NoExplanation = x
   DisjOfFailures xs <> DisjOfFailures ys = DisjOfFailures (xs ++ ys)
 
-explainCex :: forall t st fs sym.
-  (IsSymInterface sym, sym ~ ExprBuilder t st fs) =>
+explainCex :: forall t st fm sym.
+  (IsSymInterface sym, sym ~ ExprBuilder t st (Flags fm)) =>
   sym ->
+  FloatModeRepr fm ->
   LLVMAnnMap sym ->
   Maybe (GroundEvalFn t) ->
   IO (Pred sym -> IO (CexExplanation sym BaseBoolType))
-explainCex sym bbMap evalFn =
+explainCex sym fm bbMap evalFn =
   do posCache <- newIdxCache
      negCache <- newIdxCache
      pure (evalPos posCache negCache)
@@ -155,7 +156,7 @@ explainCex sym bbMap evalFn =
           Nothing -> evalPos posCache negCache e'
           Just (callStack, bb) ->
             do bb' <- case evalFn of
-                        Just f  -> concBadBehavior sym (groundEval f) bb
+                        Just f  -> concBadBehavior sym fm (groundEval f) bb
                         Nothing -> pure bb
                pure (DisjOfFailures [ (callStack, bb') ])
 

--- a/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Instruction.hs
+++ b/crucible-llvm/src/Lang/Crucible/LLVM/Translation/Instruction.hs
@@ -703,19 +703,41 @@ translateConversion instr op _inty x outty = do
            _ -> fail (unlines [unwords ["Invalid sitofp:", show op, show x, show outty], showI])
 
     L.FpToUi -> do
-       let demoteToInt :: (1 <= w) => NatRepr w -> Expr LLVM s (FloatType fi) -> LLVMExpr s arch
-           demoteToInt w v = BaseExpr (LLVMPointerRepr w) (BitvectorAsPointerExpr w $ App $ FloatToBV w RNE v)
        llvmTypeAsRepr outty $ \outty' ->
          case (asScalar x, outty') of
-           (Scalar _archProxy (FloatRepr _) x', LLVMPointerRepr w) -> return $ demoteToInt w x'
+           (Scalar _archProxy (FloatRepr fi) x', LLVMPointerRepr w) -> do
+             -- See Note [Checking for undefined behavior in fptoui and fptosi]
+             xBv <- fmap AtomExpr $ mkAtom $ app $ FloatToBV w RTZ x'
+             xRoundtrip <- fmap AtomExpr $ mkAtom $ app $ FloatFromBV fi RTZ xBv
+             xRounded <- fmap AtomExpr $ mkAtom $ app $ FloatRound fi RTZ x'
+             let noOverflow = app $ Or (app (FloatIsZero xRounded))
+                                       (app (FloatEq xRoundtrip xRounded))
+                 result = poisonSideCondition
+                            mvar
+                            (BVRepr w)
+                            (Poison.FpToUiNotRepresentable fi x' w)
+                            xBv
+                            noOverflow
+             return $ BaseExpr (LLVMPointerRepr w) (BitvectorAsPointerExpr w result)
            _ -> fail (unlines [unwords ["Invalid fptoui:", show op, show x, show outty], showI])
 
     L.FpToSi -> do
-       let demoteToInt :: (1 <= w) => NatRepr w -> Expr LLVM s (FloatType fi) -> LLVMExpr s arch
-           demoteToInt w v = BaseExpr (LLVMPointerRepr w) (BitvectorAsPointerExpr w $ App $ FloatToSBV w RNE v)
        llvmTypeAsRepr outty $ \outty' ->
          case (asScalar x, outty') of
-           (Scalar _archProxy (FloatRepr _) x', LLVMPointerRepr w) -> return $ demoteToInt w x'
+           (Scalar _archProxy (FloatRepr fi) x', LLVMPointerRepr w) -> do
+             -- See Note [Checking for undefined behavior in fptoui and fptosi]
+             xBv <- fmap AtomExpr $ mkAtom $ app $ FloatToSBV w RTZ x'
+             xRoundtrip <- fmap AtomExpr $ mkAtom $ app $ FloatFromSBV fi RTZ xBv
+             xRounded <- fmap AtomExpr $ mkAtom $ app $ FloatRound fi RTZ x'
+             let noOverflow = app $ Or (app (FloatIsZero xRounded))
+                                       (app (FloatEq xRoundtrip xRounded))
+                 result = poisonSideCondition
+                            mvar
+                            (BVRepr w)
+                            (Poison.FpToSiNotRepresentable fi x' w)
+                            xBv
+                            noOverflow
+             return $ BaseExpr (LLVMPointerRepr w) (BitvectorAsPointerExpr w result)
            _ -> fail (unlines [unwords ["Invalid fptosi:", show op, show x, show outty], showI])
 
     L.FpTrunc -> do
@@ -731,6 +753,112 @@ translateConversion instr op _inty x outty = do
            (Scalar _archProxy (FloatRepr _) x', FloatRepr fi) -> do
              return $ BaseExpr (FloatRepr fi) $ App $ FloatCast fi RNE x'
            _ -> fail (unlines [unwords ["Invalid fpext:", show op, show x, show outty], showI])
+
+{-
+Note [Checking for undefined behavior in fptoui and fptosi]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The `fptoui` and `fptosi` instructions convert a floating-point argument to an
+unsigned or signed integer value, respectively. Per the LLVM Language Reference
+Manual entries for `fptoui`
+(https://releases.llvm.org/22.1.0/docs/LangRef.html#fptoui-to-instruction) and
+`fptosi`
+(https://releases.llvm.org/22.1.0/docs/LangRef.html#fptosi-to-instruction),
+these instructions are partial and should return a poison value if the argument
+value cannot fit in the return type. For instance, `fptoui` should return a
+poison value if the argument value is NaN, infinite, is smaller than 0, or is
+larger than the maximum unsigned integer value.
+
+Note that Crucible's `FloatToBV` and `FloatToSBV` operations (which we use to
+implement `fptoui` and `fptosi`, respectively) do not check these edge cases,
+and they will simply return an unspecified value if the argument does not fit
+in the return type. (This behavior is inherited from SMT-LIB's `fp.to_ubv` and
+`fp.to_sbv` operations, which also return unspecified values if the argument
+does not fit.) As such, we must check the edge cases during crucible-llvm's
+translation in order to ensure that undefined behavior is reported as expected.
+
+Checking for NaN values or infinite values is straightforward enough, but
+checking if a float lies within the range of valid unsigned or signed integer
+values is surprisingly tricky. A naïve approach would be to convert the float
+to an integer (using `FloatTo{BV,SBV}`) and check to see if (1) it is greater
+than or equal to the minimum possible integer value, and (2) it is less than or
+equal to the maximum possible integer value. As noted above, however, if the
+float lies outside this range, then `FloatTo{BV,SBV}` is free to return
+whatever integer value it likes. This, in turn, can produce misleading results
+if you try to compare it to the minimum/maximum integer values.
+
+Another approach, which avoids the use of `FloatTo{BV,SBV}` for validation
+purposes, is to convert the argument float, the minimum integer value, and the
+maximum integer value to unbounded integers, and then check if the converted
+float lies within the range of possible bitvector values by using unbounded
+integer comparisons. There is no risk of unspecified conversion results here,
+as converting floats to unbounded integers is always well-defined. There are
+two notable downsides to this approach, however:
+
+1. This requires SMT-LIB's Ints theory, which is not supported by all SMT
+   solvers (e.g., Bitwuzla). Indeed, it's pretty surprising that `fpto{ui,si}`
+   would need unbounded integers, as nothing about the types of these
+   instructions would suggest this.
+
+2. Even if we restrict ourselves to solvers that do support unbounded integers
+   (e.g., CVC5 and Z3), these solvers' performance on unbounded integer
+   problems is usually much worse than problems that exclusively use bitvector
+   or floating-point types.
+
+Luckily, there is a third approach that is both correct and avoids the use of
+unbounded integers. The algorithm for checking the validity of `fpto{ui,si}` on
+an argument float `val` is as follows:
+
+1. If `val` is zero, then the cast is valid.
+2. Otherwise:
+  a. Compute `bv` by converting `val` to a bitvector using Crucible's
+     `FloatTo{BV,SBV}` operation with the RTZ (rounding towards zero) rounding
+     mode.
+  b. Compute `fp2` by converting `bv` back to a float using Crucible's
+     `FloatFrom{BV,SBV}` operation with the RTZ rounding mode.
+  c. Compute `val_rounded` by rounding `val` to the nearest integral value
+     that is representable in the `val`'s floating-point type. This is done by
+     using Crucible's `FloatRound` operation with the RTZ (rounding towards
+     zero) rounding mode.
+  d. If `fp2` equals `val_rounded` (according to logical floating-point
+     equality, i.e., Crucible's `FloatEq` operation), then the cast is valid.
+     Otherwise, it is invalid.
+
+Here is an argument for why this algorithm is correct:
+
+* As noted above, it is possible for `FloatTo{BV,SBV}` to return an unspecified
+  value if `val` lies outside the range of possible bitvectors. Steps (2)(b)
+  through (2)(d) are crucial for preventing unspecified values from producing
+  misleading results. Note that `FloatFrom{BV,SBV}` and `FloatRound` are
+  well-defined for all possible inputs, and because we are using the RTZ
+  rounding mode, they will never round a float up to positive infinity or down
+  to negative infinity. Moreover, `FloatFrom{BV,SBV}` will always return a
+  float that lies within the range of valid bitvectors.
+
+  If the equality check in step (2)(d) succeeds, then we know that
+  `FromTo{BV,SBV}` did not take a float lying outside the range of valid
+  bitvectors and turn it into a completely different bitvector. If it did, then
+  `FloatFrom{BV,SBV}` would produce a different float than what `FloatRound`
+  would produce. It is worth emphasizing that this trick only works with the
+  RTZ rounding mode, but thankfully, that is exactly the rounding mode that
+  `fpto{ui,si}` requires.
+
+* Why the special case for zero values in step (1)? It's because calling
+  `FloatTo{BV,SBV}` on negative zero will drop the negative sign, so converting
+  it back to a float with `FloatFrom{BV,SBV}` will return positive zero. On the
+  other hand, calling `FloatRound` on negative zero will return negative zero,
+  which is deemed logically unequal to positive zero.
+
+  An alternative approach would be to use IEEE floating-point equality (i.e.,
+  Crucible's `FloatFpEq` operation) instead of logical equality (i.e., the
+  `FloatEq` operation) in step (2)(d), as the former equates positive and
+  negative zero. On the other hand, we would need to change step (1) to add a
+  special case for NaN values, since NaN is deemded unequal to itself according
+  to IEEE equality. Either way, you need a special case of some sort.
+
+This approach is directly inspired by how the Alive2 translation validation
+tool for LLVM translates `fpto{ui,si}`. See
+https://github.com/AliveToolkit/alive2/blob/efddfc43bae2760cb5878b932a9c1a001fec374e/ir/instr.cpp#L2048-L2106
+-}
 
 
 --------------------------------------------------------------------------------

--- a/crucible/CHANGELOG.md
+++ b/crucible/CHANGELOG.md
@@ -17,6 +17,9 @@
   - `cfgBreakpoints` -> `cfgCutpoints`
   - `setFrameBreakpointPostdomInfo` -> `setFrameCutpointPostdomInfo`
 * Add `reverseSymSequence` to `Lang.Crucible.Simulator.SymSequence`
+* **BREAKING:** Add `FloatRound` constructor tp `App` in
+  `Lang.Crucible.CFG.Expr` for rounding floating-point values to the nearest
+  representable integral value.
 * **BREAKING:** Add `SequenceReverse` constructor to `App` in
   `Lang.Crucible.CFG.Expr` for reversing symbolic sequences.
 * **BREAKING:** Change the signature of `getRecordedTrace` in

--- a/crucible/src/Lang/Crucible/CFG/Expr.hs
+++ b/crucible/src/Lang/Crucible/CFG/Expr.hs
@@ -402,6 +402,11 @@ data App (ext :: Type) (f :: CrucibleType -> Type) (tp :: CrucibleType) where
     -> !RoundingMode
     -> !(f (FloatType fi'))
     -> App ext f (FloatType fi)
+  FloatRound
+    :: !(FloatInfoRepr fi)
+    -> !RoundingMode
+    -> !(f (FloatType fi))
+    -> App ext f (FloatType fi)
   FloatFromBinary
     :: !(FloatInfoRepr fi)
     -> !(f (BVType (FloatInfoToBitWidth fi)))
@@ -1181,6 +1186,7 @@ instance TypeApp (ExprExtension ext) => TypeApp (App ext) where
     FloatFpApart{} -> knownRepr
     FloatIte fi _ _ _ -> FloatRepr fi
     FloatCast fi _ _ -> FloatRepr fi
+    FloatRound fi _ _ -> FloatRepr fi
     FloatFromBinary fi _ -> FloatRepr fi
     FloatToBinary fi _ -> case floatInfoToBVTypeRepr fi of
       BaseBVRepr w -> BVRepr w

--- a/crucible/src/Lang/Crucible/Simulator/Evaluation.hs
+++ b/crucible/src/Lang/Crucible/Simulator/Evaluation.hs
@@ -649,6 +649,8 @@ evalApp bak itefns _logFn evalExt (evalSub :: forall tp. f tp -> IO (RegValue sy
       iFloatFpApart @_ @fi sym x y
     FloatCast fi rm (x_expr :: f (FloatType fi')) ->
       iFloatCast @_ @_ @fi' sym fi rm =<< evalSub x_expr
+    FloatRound _ rm (x_expr :: f (FloatType fi)) ->
+      iFloatRound @_ @fi sym rm =<< evalSub x_expr
     FloatFromBinary fi x_expr -> iFloatFromBinary sym fi =<< evalSub x_expr
     FloatToBinary fi x_expr -> iFloatToBinary sym fi =<< evalSub x_expr
     FloatFromBV fi rm x_expr -> iBVToFloat sym fi rm =<< evalSub x_expr

--- a/crux-llvm/CHANGELOG.md
+++ b/crux-llvm/CHANGELOG.md
@@ -1,6 +1,7 @@
 # next
 
 * Support LLVM 22.
+* **BREAKING**: `explainFailure` now takes a `FloatModeRepr` argument.
 
 # 0.12 -- 2026-01-29
 

--- a/crux-llvm/src/Crux/LLVM/Simulate.hs
+++ b/crux-llvm/src/Crux/LLVM/Simulate.hs
@@ -195,7 +195,7 @@ simulateLLVMFile ::
   LLVMOptions ->
   Crux.SimulatorCallbacks msgs st Crux.Types.CruxSimulationResult
 simulateLLVMFile llvm_file llvmOpts =
-  Crux.SimulatorCallbacks $ \_fm ->
+  Crux.SimulatorCallbacks $ \fm ->
     do bbMapRef <- newIORef (Map.empty :: LLVMAnnMap sym)
        let ?recordLLVMAnnotation =
              \callStack an bb ->
@@ -207,7 +207,7 @@ simulateLLVMFile llvm_file llvmOpts =
                  do halloc <- newHandleAllocator
                     setupFileSim halloc llvm_file llvmOpts bak maybeOnline
            , Crux.onErrorHook =
-               \bak -> return (explainFailure (backendGetSym bak) bbMapRef)
+               \bak -> return (explainFailure (backendGetSym bak) fm bbMapRef)
            , Crux.resultHook = \_sym result -> return result
            }
 
@@ -426,13 +426,14 @@ detailLimit :: Int
 detailLimit = 10
 
 explainFailure :: IsSymInterface sym
-               => sym ~ WEB.ExprBuilder t st fs
+               => sym ~ WEB.ExprBuilder t st (WEB.Flags fm)
                => sym
+               -> WEB.FloatModeRepr fm
                -> IORef (LLVMAnnMap sym)
                -> Crux.Explainer sym t ann
-explainFailure sym bbMapRef evalFn gl =
+explainFailure sym fm bbMapRef evalFn gl =
   do bb <- readIORef bbMapRef
-     ex <- explainCex sym bb evalFn >>= \f -> f (gl ^. labeledPred)
+     ex <- explainCex sym fm bb evalFn >>= \f -> f (gl ^. labeledPred)
      let details =
            case ex of
              NoExplanation -> mempty

--- a/crux-llvm/test-data/golden/fptoui-fptosi-correct.c
+++ b/crux-llvm/test-data/golden/fptoui-fptosi-correct.c
@@ -1,0 +1,12 @@
+#include <crucible.h>
+#include <stdint.h>
+
+int main(void) {
+  double d1 = 1.5;
+  check((uint64_t)d1 == 1);
+  check((int64_t)d1 == 1);
+
+  double d2 = -1.5;
+  check((int64_t)d2 == -1);
+  return 0;
+}

--- a/crux-llvm/test-data/golden/fptoui-fptosi-correct.config
+++ b/crux-llvm/test-data/golden/fptoui-fptosi-correct.config
@@ -1,0 +1,2 @@
+floating-point: "ieee"
+opt-level: 0

--- a/crux-llvm/test-data/golden/fptoui-fptosi-correct.z3.good
+++ b/crux-llvm/test-data/golden/fptoui-fptosi-correct.z3.good
@@ -1,0 +1,1 @@
+[Crux] Overall status: Valid.

--- a/crux-llvm/test-data/golden/fptoui-fptosi-incorrect.c
+++ b/crux-llvm/test-data/golden/fptoui-fptosi-incorrect.c
@@ -1,0 +1,17 @@
+#include <math.h>
+#include <stdint.h>
+
+int main(void) {
+  double d1 = NAN;
+  uint64_t u1 = (uint64_t)d1;
+  int64_t i1 = (int64_t)d1;
+
+  double d2 = -INFINITY;
+  uint64_t u2 = (uint64_t)d2;
+  int64_t i2 = (int64_t)d2;
+
+  double d3 = INFINITY;
+  uint64_t u3 = (uint64_t)d3;
+  int64_t i3 = (int64_t)d3;
+  return 0;
+}

--- a/crux-llvm/test-data/golden/fptoui-fptosi-incorrect.config
+++ b/crux-llvm/test-data/golden/fptoui-fptosi-incorrect.config
@@ -1,0 +1,2 @@
+floating-point: "ieee"
+opt-level: 0

--- a/crux-llvm/test-data/golden/fptoui-fptosi-incorrect.z3.good
+++ b/crux-llvm/test-data/golden/fptoui-fptosi-incorrect.z3.good
@@ -1,0 +1,97 @@
+[Crux] Found counterexample for verification goal
+[Crux]   test-data/golden/fptoui-fptosi-incorrect.c:6:17: error: in main
+[Crux]   Undefined behavior encountered
+[Crux]   Details:
+[Crux]     Poison value created
+[Crux]     A floating-point value was converted to an unsigned integer,
+[Crux]     even though the value does not fit in the unsigned integer's type
+[Crux]     Floating-point type: Double
+[Crux]     Floating-point value: NaN
+[Crux]     Unsigned integer size (in bits): 64
+[Crux]     Reference: 
+[Crux]       The LLVM language reference, version 8
+[Crux]       ‘fptoui’ Instruction (Semantics)
+[Crux]       Document URL: https://releases.llvm.org/8.0.0/docs/LangRef.html
+[Crux]     in context:
+[Crux]       main
+[Crux] Found counterexample for verification goal
+[Crux]   test-data/golden/fptoui-fptosi-incorrect.c:7:16: error: in main
+[Crux]   Undefined behavior encountered
+[Crux]   Details:
+[Crux]     Poison value created
+[Crux]     A floating-point value was converted to a signed integer,
+[Crux]     even though the value does not fit in the signed integer's type
+[Crux]     Floating-point type: Double
+[Crux]     Floating-point value: NaN
+[Crux]     Signed integer size (in bits): 64
+[Crux]     Reference: 
+[Crux]       The LLVM language reference, version 8
+[Crux]       ‘fptosi’ Instruction (Semantics)
+[Crux]       Document URL: https://releases.llvm.org/8.0.0/docs/LangRef.html
+[Crux]     in context:
+[Crux]       main
+[Crux] Found counterexample for verification goal
+[Crux]   test-data/golden/fptoui-fptosi-incorrect.c:10:17: error: in main
+[Crux]   Undefined behavior encountered
+[Crux]   Details:
+[Crux]     Poison value created
+[Crux]     A floating-point value was converted to an unsigned integer,
+[Crux]     even though the value does not fit in the unsigned integer's type
+[Crux]     Floating-point type: Double
+[Crux]     Floating-point value: -Inf
+[Crux]     Unsigned integer size (in bits): 64
+[Crux]     Reference: 
+[Crux]       The LLVM language reference, version 8
+[Crux]       ‘fptoui’ Instruction (Semantics)
+[Crux]       Document URL: https://releases.llvm.org/8.0.0/docs/LangRef.html
+[Crux]     in context:
+[Crux]       main
+[Crux] Found counterexample for verification goal
+[Crux]   test-data/golden/fptoui-fptosi-incorrect.c:11:16: error: in main
+[Crux]   Undefined behavior encountered
+[Crux]   Details:
+[Crux]     Poison value created
+[Crux]     A floating-point value was converted to a signed integer,
+[Crux]     even though the value does not fit in the signed integer's type
+[Crux]     Floating-point type: Double
+[Crux]     Floating-point value: -Inf
+[Crux]     Signed integer size (in bits): 64
+[Crux]     Reference: 
+[Crux]       The LLVM language reference, version 8
+[Crux]       ‘fptosi’ Instruction (Semantics)
+[Crux]       Document URL: https://releases.llvm.org/8.0.0/docs/LangRef.html
+[Crux]     in context:
+[Crux]       main
+[Crux] Found counterexample for verification goal
+[Crux]   test-data/golden/fptoui-fptosi-incorrect.c:14:17: error: in main
+[Crux]   Undefined behavior encountered
+[Crux]   Details:
+[Crux]     Poison value created
+[Crux]     A floating-point value was converted to an unsigned integer,
+[Crux]     even though the value does not fit in the unsigned integer's type
+[Crux]     Floating-point type: Double
+[Crux]     Floating-point value: Inf
+[Crux]     Unsigned integer size (in bits): 64
+[Crux]     Reference: 
+[Crux]       The LLVM language reference, version 8
+[Crux]       ‘fptoui’ Instruction (Semantics)
+[Crux]       Document URL: https://releases.llvm.org/8.0.0/docs/LangRef.html
+[Crux]     in context:
+[Crux]       main
+[Crux] Found counterexample for verification goal
+[Crux]   test-data/golden/fptoui-fptosi-incorrect.c:15:16: error: in main
+[Crux]   Undefined behavior encountered
+[Crux]   Details:
+[Crux]     Poison value created
+[Crux]     A floating-point value was converted to a signed integer,
+[Crux]     even though the value does not fit in the signed integer's type
+[Crux]     Floating-point type: Double
+[Crux]     Floating-point value: Inf
+[Crux]     Signed integer size (in bits): 64
+[Crux]     Reference: 
+[Crux]       The LLVM language reference, version 8
+[Crux]       ‘fptosi’ Instruction (Semantics)
+[Crux]       Document URL: https://releases.llvm.org/8.0.0/docs/LangRef.html
+[Crux]     in context:
+[Crux]       main
+[Crux] Overall status: Invalid.


### PR DESCRIPTION
These instructions now round toward zero (instead of towards negative infinity, as they previously did), and they now check for undefined behavior if the argument float does not fit in the return type. See the newly added `Note [Checking for undefined behavior in fptoui and fptosi]` for a more detailed explanation of how `crucible-llvm` checks for the latter.

Some API changes were needed to support this:

* `crucible`'s `App` type was missing a `FloatRound` constructor, which is needed to defined the undefined behavior checks for `fpto{ui,si}`. This is now added. (As far as I can tell, this was the only floating-point operation that was missing from `App`.)
* The `concPoison` function needs a `FloatModeRepr` value in order to concretize floating-point values, so a `FloatModeRepr` argument is now threaded through several functions in `crucible-llvm` and `crux-llvm`.

Fixes https://github.com/GaloisInc/crucible/issues/1875.