### PR TITLE
Bump `mir-json` submodule to remove obsolete `mir-json` patches

### DIFF
--- a/crucible-mir/src/Mir/TransCustom.hs
+++ b/crucible-mir/src/Mir/TransCustom.hs
@@ -184,8 +184,6 @@ customOpDefs = Map.fromList $ [
                          , ptr_read
                          , ptr_write
                          , ptr_swap
-                         , ptr_null
-                         , ptr_null_mut
                          , drop_in_place_dyn
 
                          , intrinsics_copy
@@ -672,23 +670,6 @@ ptr_swap = ( ["core", "ptr", "swap"], \substs -> case substs of
             MirExp MirAggregateRepr <$> mirAggregate_zst
         _ -> mirFail $ "bad arguments for ptr::swap: " ++ show ops
     _ -> Nothing)
-
-ptr_null :: (ExplodedDefId, CustomRHS)
-ptr_null = ( ["core", "ptr", "null", "crucible_null_hook"]
-           , null_ptr_impl "ptr::null" )
-
-ptr_null_mut :: (ExplodedDefId, CustomRHS)
-ptr_null_mut = ( ["core", "ptr", "null_mut", "crucible_null_hook"]
-               , null_ptr_impl "ptr::null_mut" )
-
-null_ptr_impl :: String -> CustomRHS
-null_ptr_impl what substs = case substs of
-    Substs [_] -> Just $ CustomOp $ \_ ops -> case ops of
-        [] -> do
-            ref <- integerToMirRef $ R.App $ eBVLit knownNat 0
-            return $ MirExp MirReferenceRepr ref
-        _  -> mirFail $ "expected no arguments for " ++ what ++ ", received: " ++ show ops
-    _ -> Nothing
 
 -- | Experimentally, we've observed that rustc seems not to generate proper drop
 -- glue for @&dyn Trait@ drops. We get around this by overriding

--- a/crux-mir/test/conc_eval/vec/u8_array_init.rs
+++ b/crux-mir/test/conc_eval/vec/u8_array_init.rs
@@ -1,7 +1,5 @@
-//! This exercises `RawVec`'s `[u8; N]` allocation behavior, which had precisely
-//! the same `*const [u8; N]` to `*const u8` casting issue as `TypedAllocator`,
-//! as described and tested against in `u8_array_push.rs` in this directory. See
-//! https://github.com/GaloisInc/mir-json/pull/150.
+//! This exercises `RawVec`'s `[u8; N]` allocation behavior, which involves a
+//! `*const [u8; N]` to `*const u8` pointer cast.
 
 #[cfg_attr(crux, crux::test)]
 fn test() -> [u8; 4] {

--- a/crux-mir/test/conc_eval/vec/u8_array_push.rs
+++ b/crux-mir/test/conc_eval/vec/u8_array_push.rs
@@ -1,10 +1,5 @@
-//! This exercises `TypedAllocator`'s `[u8; N]` allocation behavior, which once
-//! involved a `*const [u8; N]` to `*const u8` pointer cast. Why is this cast
-//! different from all other casts? `crucible-mir`'s custom array representation
-//! means that it needs to insert an array-indexing operation in `*const [T; N]`
-//! to `*const T` casts, even though in this particular case, that operation
-//! results in a mistyped pointer, to which `[u8; N]`s cannot be written. See
-//! https://github.com/GaloisInc/mir-json/pull/148.
+//! This exercises `TypedAllocator`'s `[u8; N]` allocation behavior, which
+//! involves a `*const [u8; N]` to `*const u8` pointer cast.
 
 #[cfg_attr(crux, crux::test)]
 fn test() -> [u8; 4] {


### PR DESCRIPTION
This bumps the `mir-json` submodule to bring in the changes from https://github.com/GaloisInc/mir-json/pull/309, which removes a variety of `mir-json` standard library patches now made obsolete by `MirAggregate` flattening. The entirely of `crux-mir`'s test suite should continue passing as before.

I also:

* Revised some comments in certain tests to remove references to `mir-json` PRs that no longer correspond to actively maintained patches.
* Removed obsolete custom overrides for `ptr::null` and `ptr::null_mut`, now that we can simulate these functions' native implementations.