### PR TITLE
`crucible-mir`: Support translating the `Cmp` binop

### DIFF
--- a/crucible-mir/CHANGELOG.md
+++ b/crucible-mir/CHANGELOG.md
@@ -14,6 +14,7 @@ This release supports [version
   which computes the alignment of a value in bytes. This works for all sized types
   as well as a limited number of unsized types (currently, only slices).
 * Add an intrinsic for [`black_box`](https://doc.rust-lang.org/std/intrinsics/fn.black_box.html).
+* Add an intrinsic for [`three_way_compare`](https://doc.rust-lang.org/std/intrinsics/fn.three_way_compare.html).
 * Extend the override for the `atomic_xchg` intrinsic to support storing
   pointer values in addition to integer values.
 * Support translating constant trait object values.

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -839,6 +839,29 @@ pattern CTyOrdering <- TyAdt _ $(explodedDefIdPat ["$lang", "OrderingEnum"]) (Su
           (textId "$lang/0::OrderingEnum")
           (Substs [])
 
+orderingExplodedDefId :: ExplodedDefId
+orderingExplodedDefId = ["$lang", "OrderingEnum"]
+
+-- Note that the values below are only meaningful for Crucible, which uses
+-- zero-based indexing to look up enum variants from discriminants. The actual
+-- implementation of Ordering in Rust uses different discriminant values:
+--
+-- #[repr(i8)]
+-- pub enum Ordering {
+--     Less = -1,
+--     Equal = 0,
+--     Greater = 1,
+-- }
+
+orderingDiscrLess :: Int
+orderingDiscrLess = 0
+
+orderingDiscrEqual :: Int
+orderingDiscrEqual = 1
+
+orderingDiscrGreater :: Int
+orderingDiscrGreater = 2
+
 --------------------------------------------------------------------------------------
 -- | TypeOf
 

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -663,6 +663,8 @@ evalBinOp bop mat me1 me2 =
               (M.Ge, Just M.Unsigned) -> return (MirExp (C.BoolRepr) (S.app $ E.BVUle n e2 e1), noOverflow)
               (M.Ge, Just M.Signed)   -> return (MirExp (C.BoolRepr) (S.app $ E.BVSle n e2 e1), noOverflow)
 
+              (M.Cmp, Just arithTy) -> threeWayCompare arithTy n e1 e2
+
               (M.Ne, _) -> return (MirExp (C.BoolRepr) (S.app $ E.Not $ S.app $ E.BVEq n e1 e2), noOverflow)
               (M.Beq, _) -> return (MirExp (C.BoolRepr) (S.app $ E.BVEq n e1 e2), noOverflow)
               _ -> mirFail $ "No translation for binop: " ++ show bop ++ " " ++ show mat
@@ -773,6 +775,55 @@ evalBinOp bop mat me1 me2 =
                 (S.app $ E.BVEq w x $ S.app $ eBVLit w (1 `shiftL` (w' - 1)))
                 (S.app $ E.BVEq w y $ S.app $ eBVLit w ((1 `shiftL` w') - 1))
       where w' = fromIntegral $ intValue w
+
+    -- Perform a three-way comparison between two unsigned or signed bitvector
+    -- values @x@ and @y@. Return @Ordering::Less@ if @x < y@,
+    -- @Ordering::Equal@ is @x == y@, and @Ordering::Greater@ if @x > y@, where
+    -- @x < y@ and @x > y@ perform unsigned or signed comparisons as
+    -- appropriate.
+    threeWayCompare ::
+        (1 <= w) =>
+        M.ArithType ->
+        NatRepr w ->
+        R.Expr MIR s (C.BVType w) ->
+        R.Expr MIR s (C.BVType w) ->
+        MirGenerator h s ret (MirExp s, R.Expr MIR s C.BoolType)
+    threeWayCompare arithTy w x y = do
+        orderingAdt <- findExplodedAdtInst orderingExplodedDefId (Substs [])
+        SomeRustEnumRepr
+          (orderingDiscrTpr :: C.TypeRepr orderingDiscrTp)
+          (orderingVariantsCtx :: C.CtxRepr orderingVariantsCtx) <-
+            enumVariantsM orderingAdt
+        let orderingEnumTpr = RustEnumRepr orderingDiscrTpr orderingVariantsCtx
+
+        let buildOrdering ::
+              Int ->
+              MirGenerator h s ret
+                (R.Expr MIR s (RustEnumType orderingDiscrTp orderingVariantsCtx))
+            buildOrdering discr = do
+              MirExp orderingTpr ordering <- buildEnum orderingAdt discr []
+              Refl <- expectEnumOrFail orderingDiscrTpr orderingVariantsCtx orderingTpr
+              pure ordering
+        let bvLt = case arithTy of
+                     M.Unsigned -> E.BVUlt
+                     M.Signed   -> E.BVSlt
+
+        -- We only check @x < y@ and @x == y@ below, and if neither are true,
+        -- then @x > y@ must hold. We are allowed to assume this because the
+        -- Cmp binop is restricted to primitive integral types that implement
+        -- Ord, so we don't have to worry about unusual comparisons where this
+        -- assumption doesn't hold (e.g., primitive float types).
+        ordering <-
+          G.ifte'
+            orderingEnumTpr
+            (S.app (bvLt w x y))
+            (buildOrdering orderingDiscrLess)
+            (G.ifte'
+              orderingEnumTpr
+              (S.app (E.BVEq w x y))
+              (buildOrdering orderingDiscrEqual)
+              (buildOrdering orderingDiscrGreater))
+        pure (MirExp orderingEnumTpr ordering, noOverflow)
 
 transUnaryOp :: M.UnOp -> M.Operand -> MirGenerator h s ret (MirExp s)
 transUnaryOp uop op = do

--- a/crux-mir/test/conc_eval/prim/three_way_compare.rs
+++ b/crux-mir/test/conc_eval/prim/three_way_compare.rs
@@ -1,0 +1,26 @@
+// A regression test for https://github.com/GaloisInc/crucible/issues/1765. The
+// implementations of `partial_cmp` and `cmp` for the char type and primitive
+// integer types are implemented in terms of the `three_way_compare` intrinsic.
+#![feature(core_intrinsics)]
+
+use std::cmp::Ordering;
+use std::intrinsics::three_way_compare;
+
+#[cfg_attr(crux, crux::test)]
+pub fn crux_test() {
+    assert!(three_way_compare(0u8, 1u8) == Ordering::Less);
+    assert!(three_way_compare(0u8, 0u8) == Ordering::Equal);
+    assert!(three_way_compare(1u8, 0u8) == Ordering::Greater);
+
+    assert!(three_way_compare(-1i8,  1i8) == Ordering::Less);
+    assert!(three_way_compare(-1i8, -1i8) == Ordering::Equal);
+    assert!(three_way_compare( 1i8, -1i8) == Ordering::Greater);
+
+    assert!(three_way_compare('a', 'b') == Ordering::Less);
+    assert!(three_way_compare('a', 'a') == Ordering::Equal);
+    assert!(three_way_compare('b', 'a') == Ordering::Greater);
+}
+
+pub fn main() {
+    println!("{:?}", crux_test())
+}


### PR DESCRIPTION
This is necessary to support invoking the `three_way_compare` intrinsic, which is used in the implementations of `partial_cmp` and `cmp` for primitive integer and char types. Eventually, this will allow us to remove the `mir-json` patch introduced in https://github.com/GaloisInc/mir-json/commit/16a6701ac35c0a714163946daf7192ec0a59c908.

Fixes #1765.