### PR TITLE
`crucible-mir`: Partial support for raw pointer comparisons

### DIFF
--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -573,7 +573,64 @@ transBinOp bop op1 op2 = do
             elemSize <- tySizeM elemTy
             newRef <- mirRef_offsetWrap e1 e2 elemSize
             pure $ MirExp MirReferenceRepr newRef
+        -- Raw pointer inequality operations. Note that pointer /equality/
+        -- operations are included elsewhere (in evalBinOp).
+        Lt
+          | MirExp MirReferenceRepr e1 <- me1
+          , MirExp MirReferenceRepr e2 <- me2 -> do
+            offset <- evalPtrOffset e1 e2
+            let offsetNeg = R.App $ E.BVSlt (knownNat @SizeBits) offset zeroIsize
+            pure $ MirExp C.BoolRepr offsetNeg
+        Le
+          | MirExp MirReferenceRepr e1 <- me1
+          , MirExp MirReferenceRepr e2 <- me2 -> do
+            offset <- evalPtrOffset e1 e2
+            let offsetNonPos = R.App $ E.BVSle (knownNat @SizeBits) offset zeroIsize
+            pure $ MirExp C.BoolRepr offsetNonPos
+        Gt
+          | MirExp MirReferenceRepr e1 <- me1
+          , MirExp MirReferenceRepr e2 <- me2 -> do
+            offset <- evalPtrOffset e1 e2
+            let offsetPos = R.App $ E.BVSlt (knownNat @SizeBits) zeroIsize offset
+            pure $ MirExp C.BoolRepr offsetPos
+        Ge
+          | MirExp MirReferenceRepr e1 <- me1
+          , MirExp MirReferenceRepr e2 <- me2 -> do
+            offset <- evalPtrOffset e1 e2
+            let offsetNonNeg = R.App $ E.BVSle (knownNat @SizeBits) zeroIsize offset
+            pure $ MirExp C.BoolRepr offsetNonNeg
         _ -> fst <$> evalBinOp bop mat me1 me2
+  where
+    zeroIsize :: R.Expr MIR s IsizeType
+    zeroIsize = R.App $ isizeLit 0
+
+    -- Compute the offset (in bytes) between two raw pointers. If the two
+    -- pointers are not derived from the same allocation, raise an error.
+    --
+    -- This is used as a crude way to approximate the behavior of raw pointer
+    -- comparisons. In actual Rust code, pointer comparisons are implemented by
+    -- comparing the pointers' addresses, but MirReferences don't have
+    -- addresses. At the very least, we can simulate comparisons between
+    -- pointers derived from the same allocation, which is a reasonably common
+    -- use case.
+    --
+    -- Precondition: the types of the expressions must be raw pointer types.
+    evalPtrOffset ::
+      R.Expr MIR s MirReferenceType ->
+      R.Expr MIR s MirReferenceType ->
+      MirGenerator h s ret (R.Expr MIR s IsizeType)
+    evalPtrOffset e1 e2 = do
+        elemTy <- case typeOf op1 of
+            TyRawPtr ty _mut -> pure ty
+            t -> mirFail $
+              "Pointer comparison on expression with unexpected type: " <>
+              show (pretty t)
+        elemSize <- tySizeM elemTy
+        maybeOffset <- mirRef_tryOffsetFrom e1 e2 elemSize
+        let errMsg = R.App $ E.StringLit $ fromString $
+              "Pointer comparison (" ++ show (pretty bop) ++
+              ") between pointers not in same allocation"
+        pure $ R.App $ E.FromJustValue IsizeRepr maybeOffset errMsg
 
 -- Evaluate a binop, returning both the result and an overflow flag.
 evalBinOp :: forall h s ret. M.BinOp -> Maybe M.ArithType -> MirExp s -> MirExp s ->
@@ -701,6 +758,9 @@ evalBinOp bop mat me1 me2 =
             _ -> mirFail $ "No translation for real number binop: " ++ fmt bop
 
       (MirExp MirReferenceRepr e1, MirExp MirReferenceRepr e2) ->
+          -- Note that special cases for pointer inequality operations are
+          -- included elsewhere (in transBinOp), as they need to scrutinize the
+          -- MIR types of the operands.
           case bop of
             M.Beq -> do
                 eq <- mirRef_eq e1 e2

--- a/crux-mir/test/conc_eval/ptr/cmp_different_allocation.rs
+++ b/crux-mir/test/conc_eval/ptr/cmp_different_allocation.rs
@@ -1,0 +1,24 @@
+// FAIL: comparing pointers derived from different allocations
+
+// This is a variant of the `cmp_same_allocation.rs` test case that tries to
+// compare two raw pointers that are not derived from the same allocation. This
+// is possible in native Rust, as comparing raw pointers amounts to comparing
+// their memory addresses, but this is not yet possible in crucible-mir, as its
+// model of raw pointers is too high-level to represent addresses.
+
+#[cfg_attr(crux, crux::test)]
+fn crux_test() {
+    let a: [u32; 3] = [1, 2, 3];
+    let a_s: &[u32] = &a;
+    let a_p: *const u32 = a_s.as_ptr();
+
+    let b: [u32; 3] = [4, 5, 6];
+    let b_s: &[u32] = &b;
+    let b_p: *const u32 = b_s.as_ptr();
+
+    assert!(b_p < a_p || b_p >= a_p);
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/conc_eval/ptr/cmp_same_allocation.rs
+++ b/crux-mir/test/conc_eval/ptr/cmp_same_allocation.rs
@@ -1,0 +1,31 @@
+// A test exercising the subset of raw pointer comparisons that crucible-mir
+// currently supports.
+
+#[cfg_attr(crux, crux::test)]
+fn crux_test() {
+    let a: [u32; 3] = [1, 2, 3];
+    let s: &[u32] = &a;
+    let p: *const u32 = s.as_ptr();
+    let q = unsafe { p.add(3) };
+
+    // Comparing a pointer to itself
+    assert!(!(p < p));
+    assert!(p <= p);
+    assert!(!(p > p));
+    assert!(p >= p);
+
+    assert!(!(q < q));
+    assert!(q <= q);
+    assert!(!(q > q));
+    assert!(q >= q);
+
+    // Comparing a pointer to another pointer derived from the same allocation
+    assert!(p < q);
+    assert!(p <= q);
+    assert!(!(p > q));
+    assert!(!(p >= q));
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/crux-mir/test/symb_eval/array/memchr_basic.good
+++ b/crux-mir/test/symb_eval/array/memchr_basic.good
@@ -1,0 +1,5 @@
+test memchr_basic/<DISAMB>::crux_test[0]: ok
+
+[Crux-MIR] ---- FINAL RESULTS ----
+[Crux] All goals discharged through internal simplification.
+[Crux] Overall status: Valid.

--- a/crux-mir/test/symb_eval/array/memchr_basic.rs
+++ b/crux-mir/test/symb_eval/array/memchr_basic.rs
@@ -1,0 +1,26 @@
+// A regression test for https://github.com/GaloisInc/mir-json/issues/311. This
+// simultaneously tests multiple things:
+//
+// * This tests that mir-json has patched its vendored-in copy of the `memchr`
+//   crate to replace its inline assembly-based `memchr` implementation (which
+//   crucible-mir has no hope of simulating) with a fallback implementation
+//   that works on all architectures.
+//
+// * Moreover, it ensures that crucible-mir is capable of simulating the
+//   fallback implementation, which relies on comparing pointers that are
+//   ultimately derived from the same backing allocation.
+#![feature(rustc_private)]
+
+extern crate crucible;
+use crucible::*;
+
+#[crux::test]
+fn crux_test() {
+    crucible_assert!(memchr::memchr(1, &[]) == None);
+    crucible_assert!(memchr::memchr(1, &[0]) == None);
+    crucible_assert!(memchr::memchr(1, &[0, 2]) == None);
+    crucible_assert!(memchr::memchr(1, &[1]) == Some(0));
+    crucible_assert!(memchr::memchr(1, &[1, 0]) == Some(0));
+    crucible_assert!(memchr::memchr(1, &[1, 1]) == Some(0));
+    crucible_assert!(memchr::memchr(1, &[0, 1]) == Some(1));
+}


### PR DESCRIPTION
Rust implements raw pointer comparisons by comparing the pointers' addresses, but `crucible-mir` references lack addresses. Previously, attempting to perform a raw pointer comparison would result in an immediate translation error in `crucible-mir`, but we now implement a partial approach that correctly handles cases where the two pointers are derived from the same allocation. (If the pointers are not derived from the same allocation, then translation fails as before.)

The primary motivation behind this improvement is being able to simulate the generic implementation of the `memchr` crate. This PR also bumps the `mir-json` submodule to bring in the changes from https://github.com/GaloisInc/mir-json/pull/312 and adds a test case confirming that `memchr` can now be simulated. As such, this PR fixes https://github.com/GaloisInc/mir-json/issues/311.