### PR TITLE
Update two support `mir-json` evaluating static initializers.

### DIFF
--- a/crucible-mir/src/Mir/JSON.hs
+++ b/crucible-mir/src/Mir/JSON.hs
@@ -708,7 +708,7 @@ instance FromJSON Static where
     Static <$> v .: "name"
            <*> v .: "ty"
            <*> v .: "mutable"
-           <*> v .:? "rendered"
+           <*> v .: "rendered"
 
 
 --  LocalWords:  initializer supertraits deserialization impls

--- a/crucible-mir/src/Mir/JSON.hs
+++ b/crucible-mir/src/Mir/JSON.hs
@@ -593,8 +593,10 @@ instance FromJSON ConstVal where
             variant <- v .: "variant"
             fields <- v .: "fields"
             return $ ConstEnum variant fields
-        Just (String "union") ->
-            pure ConstUnion
+        Just (String "union") -> do
+            variant <- v .: "variant"
+            val     <- v .: "val"
+            pure (ConstUnion variant val)
 
         Just (String "fndef") -> ConstFunction <$> v .: "def_id"
         Just (String "static_ref") -> ConstStaticRef <$> v .: "def_id"

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -719,8 +719,7 @@ data Static   = Static {
     _sName          :: DefId            -- ^ name of fn that initializes this static
   , _sTy            :: Ty
   , _sMutable       :: Bool             -- ^ true for "static mut"
-  , _sConstVal      :: Maybe ConstVal   -- ^ 'Just' if this static is initialized
-                                        -- with a constant value. 'Nothing' otherwise.
+  , _sConstVal      :: ConstVal         -- ^ Initial value
   }
   deriving (Show, Eq, Ord, Generic)
 

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -326,8 +326,7 @@ data Collection = Collection {
     -- ADTs, indexed by original (pre-monomorphization) DefId
     _adtsOrig  :: !(Map AdtName [Adt]),
     _traits    :: !(Map TraitName Trait),
-    -- Static decls, indexed by name.  For each of these, there is an
-    -- initializer in `functions` with the same name.
+    -- Static decls, indexed by name.
     _statics   :: !(Map DefId Static),
     _vtables   :: !(Map VtableName Vtable),
     _intrinsics :: !(Map IntrinsicName Intrinsic),

--- a/crucible-mir/src/Mir/Mir.hs
+++ b/crucible-mir/src/Mir/Mir.hs
@@ -687,7 +687,7 @@ data ConstVal =
   | ConstRawPtr Integer
   | ConstStruct [ConstVal]
   | ConstEnum Int [ConstVal]
-  | ConstUnion
+  | ConstUnion Int ConstVal
   | ConstFnPtr DefId
   -- | A reference to a trait object (e.g., @&dyn Trait@). The 'DefId' is the
   -- allocation backing the reference, the 'TraitName' is the name of the

--- a/crucible-mir/src/Mir/PP.hs
+++ b/crucible-mir/src/Mir/PP.hs
@@ -409,7 +409,7 @@ instance Pretty ConstVal where
     pretty (ConstRawPtr a) = pretty a
     pretty (ConstStruct fs) = pretty "struct" <> list (map pretty fs)
     pretty (ConstEnum v fs) = pretty "enum" <> list ((pretty "variant" <+> pretty v) : map pretty fs)
-    pretty ConstUnion = pretty "union"
+    pretty (ConstUnion v f) = pretty "union" <> list [pretty "variant" <+> pretty v, pretty f]
     pretty (ConstSliceRef a _len) = pretty "&" <> pr_id a
     pretty (ConstFnPtr i)   = pretty "fn_ptr" <> brackets (pretty i)
     pretty (ConstTraitObject a trait vtable) =

--- a/crucible-mir/src/Mir/PP.hs
+++ b/crucible-mir/src/Mir/PP.hs
@@ -442,9 +442,9 @@ instance Pretty Trait where
           rbrace]
 
 instance Pretty Static where
-  pretty (Static nm ty mut mbConst) =
+  pretty (Static nm ty mut constI) =
     pretty mut <+> pretty nm <+> pretty ":" <+> pretty ty <+>
-    maybe mempty (\c -> pretty "=" <+> pretty c) mbConst
+      pretty "=" <+> pretty constI
 
 instance Pretty Intrinsic where
   pretty (Intrinsic name inst) = pretty name <+> pretty "=" <+> pretty inst

--- a/crucible-mir/src/Mir/ParseTranslate.hs
+++ b/crucible-mir/src/Mir/ParseTranslate.hs
@@ -48,7 +48,7 @@ import Debug.Trace
 -- If you update the supported mir-json schema version below, make sure to also
 -- update the crux-mir README accordingly.
 supportedSchemaVersion :: Word64
-supportedSchemaVersion = 12
+supportedSchemaVersion = 13
 
 -- | Parse a MIR JSON file to a 'Collection'. If parsing fails, attempt to give
 -- a more informative error message if the MIR JSON schema version is

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -2734,27 +2734,6 @@ transInstance colState (M.Intrinsic defId (M.Instance kind origDefId _substs))
       return $ Just (name, cfg, Just fti)
   | otherwise = return Nothing
 
-transStatic :: forall h.
-  ( HasCallStack, ?debug::Int, ?customOps::CustomOpMap, ?assertFalseOnError::Bool
-  , ?printCrucible::Bool)
-  => CollectionState
-  -> M.Static
-  -> ST h (Maybe (Text, Core.AnyCFG MIR, FnTransInfo))
-transStatic colState st
-  -- Statics with a `ConstVal` initializer don't need a CFG, and might not have
-  -- a MIR body in `functions`.
-  | Just _ <- st ^. M.sConstVal = return Nothing
-  | otherwise = do
-      let defId = st ^. M.sName
-      fn <- case colState ^. collection . M.functions . at defId of
-        Just x -> return x
-        -- For each entry in `statics`, there should be a corresponding entry
-        -- in `functions` giving the MIR body of the static initializer.
-        Nothing -> panic "transStatic" ["function " ++ show defId ++ " not found for static"]
-      (name, cfg, fti) <- transCommon colState defId (FnContext fn) (genFn fn)
-      return $ Just (name, cfg, fti)
-
-
 -- | Allocate method handles for each of the functions in the Collection
 mkHandleMap :: (HasCallStack) => Collection -> FH.HandleAllocator -> IO HandleMap
 mkHandleMap col halloc = mapM mkHandle (col ^. functions) where
@@ -3405,11 +3384,8 @@ transCollection col halloc = do
     -- translate all of the functions
     fnInfo <- Maybe.catMaybes <$>
       mapM (stToIO . transInstance colState) (Map.elems (col ^. M.intrinsics))
-    staticInfo <- Maybe.catMaybes <$>
-      mapM (stToIO . transStatic colState) (Map.elems (col ^. M.statics))
-    let allInfo = fnInfo ++ [(n, c, Just i) | (n, c, i) <- staticInfo]
-    let pairs1 = [(name, cfg) | (name, cfg, _) <- allInfo]
-    let transInfo' = Map.fromList [(name, fti) | (name, _, Just fti) <- allInfo]
+    let pairs1 = [(name, cfg) | (name, cfg, _) <- fnInfo]
+    let transInfo' = Map.fromList [(name, fti) | (name, _, Just fti) <- fnInfo]
     pairs2 <- mapM (stToIO . transVtable colState) (Map.elems (col ^. M.vtables))
 
     return $ RustModule
@@ -3432,35 +3408,22 @@ transStatics ::
   CollectionState -> FH.HandleAllocator -> IO (Core.AnyCFG MIR)
 transStatics colState halloc = do
   let sm = colState ^. staticMap
-  let hmap = colState ^. handleMap
   let initializeStatic :: forall h s r . Static -> MirGenerator h s r ()
       initializeStatic static =
         let staticName = static ^. sName in
         case Map.lookup staticName sm of
-          Just (StaticVar g) ->
-            let repr = G.globalType g in
-            if |  Just constval <- static ^. sConstVal
-               -> do let constty = static ^. sTy
-                     Some tpr <- tyToReprM constty
-                     MirExp constty' constval' <- transConstVal constty (Some tpr) constval
-                     case testEquality repr constty' of
-                       Just Refl -> G.writeGlobal g constval'
-                       Nothing -> error $ "BUG: invalid type for constant initializer " ++ fmt staticName
-                                       ++ ", expected " ++ show repr ++ ", got " ++ show constty'
+          Just (StaticVar g) -> do
+            let repr = G.globalType g
+                constval = static ^. sConstVal
+                constty = static ^. sTy
+            Some tpr <- tyToReprM constty
+            MirExp constty' constval' <- transConstVal constty (Some tpr) constval
+            case testEquality repr constty' of
+              Just Refl -> G.writeGlobal g constval'
+              Nothing -> error $ "BUG: invalid type for constant initializer " ++ fmt staticName
+                              ++ ", expected " ++ show repr ++ ", got " ++ show constty'
 
-               |  Just (MirHandle _ _ (handle :: FH.FnHandle init ret))
-                    <- Map.lookup staticName hmap
-               -> case ( testEquality repr        (FH.handleReturnType handle)
-                       , testEquality (Ctx.empty) (FH.handleArgTypes handle)
-                       ) of
-                    (Just Refl, Just Refl) -> do
-                      val <- G.call (G.App $ E.HandleLit handle) Ctx.empty
-                      G.writeGlobal g val
-
-                    _ -> error $ "BUG: invalid type for initializer function " ++ fmt staticName
-
-               |  otherwise
-               -> error $ "BUG: cannot find initializer for static " ++ fmt staticName
+             
           Nothing -> error $ "BUG: cannot find global for " ++ fmt staticName
 
   -- TODO: make the name of the static initialization function configurable
@@ -3468,26 +3431,11 @@ transStatics colState halloc = do
   initHandle <- FH.mkHandle' halloc initName Ctx.empty C.UnitRepr
   let allStatics :: [Static]
       allStatics = Map.elems (colState ^. collection.statics)
-  -- Partition the static items into those with constant initializer expressions
-  -- (constValStatics) and those with non-constant initializer expressions
-  -- (nonConstValStatics). We do this because nonConstValStatics can depend on
-  -- constValStatics, but because constValStatics typically use names like
-  -- {{alloc}}[0], their names are almost certain to be later alphabetically
-  -- than nonConstValStatics' names. This, in turn, is liable to trigger the
-  -- issues observed in #1108 when one tries to translate a nonConstValStatic
-  -- before the constValStatic that it depends on.
-  --
-  -- To work around #1108, we deliberately translate all constValStatics before
-  -- translating any nonConstValStatics. This is not a complete fix for #1108,
-  -- but it does make it far less likely to appear in practice.
-  let constValStatics, nonConstValStatics :: [Static]
-      (constValStatics, nonConstValStatics) =
-        List.partition (\s -> Maybe.isJust (s ^. sConstVal)) allStatics
+  
   let def :: G.FunctionDef MIR FnState Ctx.EmptyCtx C.UnitType (ST w)
       def _inputs = (s, f) where
           s = initFnState colState StaticContext
-          f = do mapM_ initializeStatic constValStatics
-                 mapM_ initializeStatic nonConstValStatics
+          f = do mapM_ initializeStatic allStatics
                  return (R.App $ E.EmptyApp)
   init_cfg <- stToIO $ do
     R.SomeCFG g <- defineFunctionNoAuxs initHandle def

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -3429,13 +3429,13 @@ transStatics colState halloc = do
   -- TODO: make the name of the static initialization function configurable
   let initName = FN.functionNameFromText "static_initializer"
   initHandle <- FH.mkHandle' halloc initName Ctx.empty C.UnitRepr
-  let allStatics :: [Static]
-      allStatics = Map.elems (colState ^. collection.statics)
+  let staticDecls :: [Static]
+      staticDecls = Map.elems (colState ^. collection.statics)
   
   let def :: G.FunctionDef MIR FnState Ctx.EmptyCtx C.UnitType (ST w)
       def _inputs = (s, f) where
           s = initFnState colState StaticContext
-          f = do mapM_ initializeStatic allStatics
+          f = do mapM_ initializeStatic staticDecls
                  return (R.App $ E.EmptyApp)
   init_cfg <- stToIO $ do
     R.SomeCFG g <- defineFunctionNoAuxs initHandle def

--- a/crucible-mir/src/Mir/Trans.hs
+++ b/crucible-mir/src/Mir/Trans.hs
@@ -292,6 +292,32 @@ transConstVal ty@(M.TyAdt aname _ _) tpr (ConstEnum variant fields) = do
             let fieldTys = map (\f -> f ^. fty) fieldDefs
             exps <- zipWithM (\val ty' -> tyToReprM ty' >>= \rpr -> transConstVal ty' rpr val) fields fieldTys
             buildEnum adt variant exps
+
+transConstVal (M.TyAdt aname _ _) tpr (ConstUnion variant val) = do
+    adt <- findAdt aname
+    col <- use (cs . collection)
+    let fieldDefs = adt ^. adtvariants . ix 0 . vfields
+    let fieldTys  = map (\f -> f ^. fty) fieldDefs
+    case findReprTransparentField col adt of
+        Just idx -> do
+            let ty' = fieldTys !! idx
+            if idx == variant
+              then transConstVal ty' tpr val
+              else
+                do
+                  -- XXX: this is not 100% correct as the value should
+                  -- be uninitialized, but we are initializing it, but it
+                  -- is not clear how to represent this case at the moment.
+                  mb <- initialValue ty'
+                  case mb of
+                    Nothing -> mirFail "uninitialized transparent union, without a standard default value"
+                    Just v  -> pure v
+
+        Nothing -> do
+            let ty' = fieldTys !! variant
+            ex <- tyToReprM ty' >>= \rpr -> transConstVal ty' rpr val
+            buildUnion adt variant ex
+
 transConstVal ty (Some MirReferenceRepr) cv = do
     let pointeeTy = M.typeOfProj M.Deref ty
     Some tpr <- tyToReprM pointeeTy


### PR DESCRIPTION
This bumps the expected `mir-json` schema to 13.

The main change is handling the values in union constants.